### PR TITLE
MUL-6954 fix(daemon): send private chat deltas on resume

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -7774,7 +7774,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if env.LocalWorktree != nil && len(env.LocalWorktree.ReplayConflicts) > 0 {
 		promptOptions = append(promptOptions, WithWorktreeReplayConflicts(env.LocalWorktree.ReplayConflicts))
 	}
-	prompt := BuildPrompt(task, provider, promptOptions...)
+	prompt := buildTaskExecutionPrompt(task, provider, promptOptions...)
 
 	// Pass task-scoped auth credentials and context so the spawned agent CLI
 	// can call the Multica API and the local daemon (e.g. `multica repo checkout`).
@@ -8144,7 +8144,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 				execOpts.SystemPrompt = runtimeBrief
 			}
 		}
-		freshPrompt := BuildPrompt(task, provider, promptOptions...)
+		freshPrompt := buildTaskExecutionPrompt(task, provider, promptOptions...)
 
 		retryResult, retryTools, retryErr := d.executeAndDrain(ctx, backend, freshPrompt, execOpts, taskLog, task.ID, env.CodexHome, &msgSeq)
 		if retryErr != nil {

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -640,56 +640,9 @@ func buildChatPrompt(task Task) string {
 		fmt.Fprintf(&b, "Reply to %s with the final outcome only. Do NOT narrate planned or in-progress steps (\"我先读取…\"); completed actions are part of the outcome.\n", platform)
 		b.WriteString("\n")
 	}
-	if task.Agent != nil && len(task.Agent.Skills) > 0 {
-		refs := ExtractSlashSkills(task.ChatMessage)
-		if len(refs) > 0 {
-			agentSkills := make(map[string]string, len(task.Agent.Skills))
-			for _, s := range task.Agent.Skills {
-				agentSkills[s.ID] = s.Name
-			}
-
-			selected := make([]string, 0, len(refs))
-			seen := make(map[string]struct{}, len(refs))
-			for _, ref := range refs {
-				name, ok := agentSkills[ref.ID]
-				if !ok {
-					continue
-				}
-				if _, ok := seen[ref.ID]; ok {
-					continue
-				}
-				seen[ref.ID] = struct{}{}
-				selected = append(selected, name)
-			}
-
-			if len(selected) > 0 {
-				b.WriteString("Explicitly selected skills:\n")
-				for _, name := range selected {
-					fmt.Fprintf(&b, "- %s\n", name)
-				}
-				b.WriteString("\n")
-			}
-		}
-	}
+	writeExplicitChatSkills(&b, task)
 	fmt.Fprintf(&b, "User message:\n%s\n", task.ChatMessage)
-	// List attachments by id + filename so the agent can fetch them via
-	// the CLI. We deliberately do NOT inline the URL: chat attachments
-	// live behind a signed CDN with a short TTL, so by the time the agent
-	// has finished thinking the URL embedded in the markdown body may
-	// have expired. `multica attachment download <id>` re-signs at click
-	// time and is the only reliable path.
-	if len(task.ChatMessageAttachments) > 0 {
-		b.WriteString("\nAttachments on this message:\n")
-		for _, a := range task.ChatMessageAttachments {
-			if a.ContentType != "" {
-				fmt.Fprintf(&b, "- id=%s filename=%q content_type=%s\n", a.ID, a.Filename, a.ContentType)
-			} else {
-				fmt.Fprintf(&b, "- id=%s filename=%q\n", a.ID, a.Filename)
-			}
-		}
-		b.WriteString("Use `multica attachment download <id>` to fetch each file locally before referring to it.\n")
-		b.WriteString("When creating an issue that should preserve one of these attachments, pass `--attachment-id <id>` to `multica issue create` in addition to keeping the attachment markdown inline.\n")
-	}
+	writeInboundChatAttachments(&b, task)
 	// Outbound attachments: how the agent puts an image/file INTO its reply.
 	// This is the DELIVERY layer of the channel policy, and it has three
 	// answers, not two (MUL-4899). `attachment upload` binds a file to the
@@ -717,6 +670,118 @@ func buildChatPrompt(task Task) string {
 		fmt.Fprintf(&b, "\nThis reply is delivered to %s as text. You cannot attach a file to it: `multica attachment upload` binds to a Multica chat reply, which this is not. If you produce a file, describe it in words — never write its local path as a link, and never upload it and then write as though it arrived.\n", channelDisplayName(task.ChatChannelType))
 	}
 	return b.String()
+}
+
+func writeExplicitChatSkills(b *strings.Builder, task Task) {
+	if task.Agent != nil && len(task.Agent.Skills) > 0 {
+		refs := ExtractSlashSkills(task.ChatMessage)
+		if len(refs) > 0 {
+			agentSkills := make(map[string]string, len(task.Agent.Skills))
+			for _, s := range task.Agent.Skills {
+				agentSkills[s.ID] = s.Name
+			}
+
+			selected := make([]string, 0, len(refs))
+			seen := make(map[string]struct{}, len(refs))
+			for _, ref := range refs {
+				name, ok := agentSkills[ref.ID]
+				if !ok {
+					continue
+				}
+				if _, ok := seen[ref.ID]; ok {
+					continue
+				}
+				seen[ref.ID] = struct{}{}
+				selected = append(selected, name)
+			}
+
+			if len(selected) > 0 {
+				b.WriteString("Explicitly selected skills:\n")
+				for _, name := range selected {
+					fmt.Fprintf(b, "- %s\n", name)
+				}
+				b.WriteString("\n")
+			}
+		}
+	}
+	return
+}
+
+func writeInboundChatAttachments(b *strings.Builder, task Task) {
+	// List attachments by id + filename so the agent can fetch them via
+	// the CLI. We deliberately do NOT inline the URL: chat attachments
+	// live behind a signed CDN with a short TTL, so by the time the agent
+	// has finished thinking the URL embedded in the markdown body may
+	// have expired. `multica attachment download <id>` re-signs at click
+	// time and is the only reliable path.
+	if len(task.ChatMessageAttachments) > 0 {
+		b.WriteString("\nAttachments on this message:\n")
+		for _, a := range task.ChatMessageAttachments {
+			if a.ContentType != "" {
+				fmt.Fprintf(b, "- id=%s filename=%q content_type=%s\n", a.ID, a.Filename, a.ContentType)
+			} else {
+				fmt.Fprintf(b, "- id=%s filename=%q\n", a.ID, a.Filename)
+			}
+		}
+		b.WriteString("Use `multica attachment download <id>` to fetch each file locally before referring to it.\n")
+		b.WriteString("When creating an issue that should preserve one of these attachments, pass `--attachment-id <id>` to `multica issue create` in addition to keeping the attachment markdown inline.\n")
+	}
+}
+
+// buildResumedWebDirectPrompt is the confirmed-resume input for creator-only
+// web/mobile chats. The original thread already carries its audience,
+// initiator, Multica role and outbound-delivery capability, so replaying those
+// stable facts on every turn only pollutes the transcript. Keep only the new
+// message plus genuinely turn-scoped data.
+func buildResumedWebDirectPrompt(task Task, options ...PromptOption) string {
+	var opts promptOpts
+	for _, apply := range options {
+		apply(&opts)
+	}
+
+	var b strings.Builder
+	writeExplicitChatSkills(&b, task)
+	b.WriteString(task.ChatMessage)
+	writeInboundChatAttachments(&b, task)
+
+	var blocks strings.Builder
+	blocks.WriteString(buildSharedLocalDirectoryBlock(opts.sharedLocalDirectory))
+	blocks.WriteString(buildWorktreeReplayConflictBlock(opts.worktreeReplayConflicts))
+	if task.PriorSessionResumeUnavailable {
+		blocks.WriteString(sessionContinuityNoticeFor(task))
+	}
+	blocks.WriteString(execenv.BuildConnectedAppsBlock(task.ConnectedApps))
+	if extra := blocks.String(); extra != "" {
+		if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n\n") {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(extra)
+	}
+	return b.String()
+}
+
+// buildTaskExecutionPrompt selects the prompt sent to every provider. A
+// resumed creator-only web/mobile chat gets only its new turn data; all other
+// executions keep BuildPrompt's full surface and runtime context.
+func buildTaskExecutionPrompt(task Task, provider string, options ...PromptOption) string {
+	if shouldUseResumedWebDirectPrompt(task) {
+		return buildResumedWebDirectPrompt(task, options...)
+	}
+	return BuildPrompt(task, provider, options...)
+}
+
+// shouldUseResumedWebDirectPrompt limits the compact follow-up to resumed chats
+// on Multica's creator-only web/mobile surface. Channel-backed conversations
+// keep their per-turn audience and delivery instructions, including p2p rooms.
+// A first turn has no prior session ID and keeps the full prompt. If a provider
+// rejects the resume, runTask clears that ID and rebuilds the full prompt for
+// its existing one-shot fresh-session retry.
+func shouldUseResumedWebDirectPrompt(task Task) bool {
+	return task.ChatSessionID != "" &&
+		task.PriorSessionID != "" &&
+		task.ChatChannelType == "" &&
+		execenv.AudienceOf(task.ChatChannelType, task.ChatType) == execenv.ChatAudienceDirect &&
+		!task.ChatIntro
 }
 
 // channelDisplayName renders a chat_channel_type for prompt copy. The mapping

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -897,6 +897,180 @@ func TestBuildChatPromptAudience(t *testing.T) {
 	}
 }
 
+func TestBuildResumedWebDirectPromptOnlySendsTurnDelta(t *testing.T) {
+	t.Parallel()
+
+	const message = "你的工作目录是？"
+	got := buildResumedWebDirectPrompt(Task{
+		ChatSessionID:  "chat-1",
+		ChatMessage:    message,
+		InitiatorType:  "member",
+		InitiatorName:  "mrlonely1226",
+		InitiatorEmail: "mrlonely1226@outlook.com",
+	})
+	if got != message {
+		t.Fatalf("resumed web direct prompt = %q, want raw user message %q", got, message)
+	}
+	for _, stale := range []string{
+		"You are running as a chat assistant",
+		"Audience: direct room",
+		"User message:",
+		"multica attachment upload",
+		"## Task Initiator",
+		"mrlonely1226@outlook.com",
+	} {
+		if strings.Contains(got, stale) {
+			t.Errorf("resumed web direct prompt replayed stable context %q\n---\n%s", stale, got)
+		}
+	}
+}
+
+func TestBuildResumedWebDirectPromptKeepsTurnScopedContext(t *testing.T) {
+	t.Parallel()
+
+	got := buildResumedWebDirectPrompt(Task{
+		ChatSessionID: "chat-1",
+		ChatMessage:   "看下这个截图",
+		ChatMessageAttachments: []ChatAttachmentMeta{{
+			ID:          "attachment-1",
+			Filename:    "screen.png",
+			ContentType: "image/png",
+		}},
+		ConnectedApps: []ConnectedAppData{{
+			Provider:    "composio",
+			ServerName:  "composio",
+			ToolkitSlug: "notion",
+			ToolkitName: "Notion",
+		}},
+	})
+	for _, want := range []string{
+		"看下这个截图",
+		"id=attachment-1",
+		"filename=\"screen.png\"",
+		"multica attachment download",
+		"## Connected Apps",
+		"Notion",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("resumed web direct prompt lost turn-scoped context %q\n---\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "multica attachment upload") {
+		t.Errorf("resumed web direct prompt replayed stable outbound upload tutorial\n---\n%s", got)
+	}
+}
+
+func TestBuildResumedWebDirectPromptKeepsWorktreeConflictContext(t *testing.T) {
+	t.Parallel()
+
+	got := buildResumedWebDirectPrompt(
+		Task{ChatSessionID: "chat-1", ChatMessage: "继续"},
+		WithWorktreeReplayConflicts([]string{"parser/parse.go"}),
+	)
+	for _, want := range []string{
+		"继续",
+		"## Unresolved merge in your working tree",
+		`"parser/parse.go"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("resumed web direct prompt lost worktree conflict context %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestShouldUseResumedWebDirectPrompt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		task Task
+		want bool
+	}{
+		{
+			name: "resumed web direct chat",
+			task: Task{ChatSessionID: "chat-1", PriorSessionID: "session-1"},
+			want: true,
+		},
+		{
+			name: "first turn",
+			task: Task{ChatSessionID: "chat-1"},
+		},
+		{
+			name: "channel-backed p2p chat",
+			task: Task{
+				ChatSessionID:   "chat-1",
+				PriorSessionID:  "session-1",
+				ChatChannelType: execenv.ChannelTypeFeishu,
+				ChatType:        execenv.ChatTypeP2P,
+			},
+		},
+		{
+			name: "group chat",
+			task: Task{
+				ChatSessionID:  "chat-1",
+				PriorSessionID: "session-1",
+				ChatType:       execenv.ChatTypeGroup,
+			},
+		},
+		{
+			name: "intro turn",
+			task: Task{ChatSessionID: "chat-1", PriorSessionID: "session-1", ChatIntro: true},
+		},
+		{
+			name: "non-chat task",
+			task: Task{PriorSessionID: "session-1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldUseResumedWebDirectPrompt(tc.task); got != tc.want {
+				t.Fatalf("shouldUseResumedWebDirectPrompt() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildTaskExecutionPromptUsesPrivateChatDeltaForEveryProvider(t *testing.T) {
+	t.Parallel()
+
+	task := Task{
+		ChatSessionID:  "chat-1",
+		PriorSessionID: "session-1",
+		ChatMessage:    "只保留这条消息",
+		InitiatorName:  "stable-initiator",
+	}
+	for _, provider := range []string{"codex", "claude", "pi", "cursor", "future-provider"} {
+		provider := provider
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+			if got := buildTaskExecutionPrompt(task, provider); got != task.ChatMessage {
+				t.Fatalf("resumed private-chat prompt for %s = %q, want raw message %q", provider, got, task.ChatMessage)
+			}
+		})
+	}
+}
+
+func TestBuildTaskExecutionPromptKeepsFullContextWithoutPriorSession(t *testing.T) {
+	t.Parallel()
+
+	got := buildTaskExecutionPrompt(Task{
+		ChatSessionID: "chat-1",
+		ChatMessage:   "第一轮",
+	}, "claude")
+	for _, want := range []string{
+		"You are running as a chat assistant",
+		"Audience: direct room",
+		"User message:\n第一轮",
+		"multica attachment upload",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("fresh private-chat prompt missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
 func TestBuildChatPromptAgentIntro(t *testing.T) {
 	// Historical proactive-introduction sessions remain readable even though
 	// new agent creation no longer creates one. Their message-less first turn


### PR DESCRIPTION
## What does this PR do?

Stops replaying stable Multica private-chat instructions on every resumed turn.

A web/mobile direct-chat follow-up currently repeats the assistant role, `Audience: direct room`, outbound attachment tutorial, and `Task Initiator` block even though the provider session already contains those facts from the first turn. Besides spending tokens, this places platform boilerplate between every pair of user and assistant messages in the provider transcript.

The daemon now sends only the new turn data when a creator-only web/mobile private chat has a prior provider session. This selection happens before the provider backend, so it applies equally to Codex, Claude, Pi, Cursor, and future providers.

## Scope

The compact prompt is gated by all of these facts:

- the task belongs to a Multica chat session;
- a prior provider session is available;
- the chat has no external channel binding;
- the audience is direct;
- the task is not the initial proactive-introduction turn.

Group rooms and channel-backed conversations keep their existing per-turn audience and delivery instructions.

The first turn keeps the complete chat prompt. When a provider rejects a stale resume, the existing fresh-session retry clears the prior session ID and rebuilds the complete prompt before starting the replacement session.

## Turn-scoped context retained

The resumed private-chat prompt still includes data that can change each turn:

- the new user message;
- explicitly selected skills;
- inbound attachment download metadata;
- connected apps;
- shared-working-directory warnings;
- local worktree replay conflicts;
- a continuity notice when applicable.

Stable role, audience, initiator, and outbound-upload guidance remain in the provider session from the first turn and are omitted from successful follow-ups.

## Verification

- `cd server && go test ./internal/daemon -parallel=1 -count=1`
- `cd server && go test -race ./internal/daemon -run 'Test(BuildResumedWebDirectPrompt|ShouldUseResumedWebDirectPrompt|BuildTaskExecutionPrompt|BuildChatPrompt)' -count=1`
- `cd server && go vet ./internal/daemon`

All pass locally.

Tests also pin the provider-independent behavior, the full first-turn prompt, exclusion of group/channel-backed chats, and preservation of worktree-conflict context added on current `main`.

## Risk and fallback

The change is limited to resumed creator-only web/mobile chats. A missing prior session, a rejected resume, a group room, an external channel, or an intro turn uses the existing complete prompt. No provider session protocol or cancellation behavior changes.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Approach:** Traced prompt construction through `runTask`, separated stable private-chat context from turn-scoped data, moved the selection above provider backends for provider-independent coverage, and verified both the compact resume path and full-prompt fallbacks.
