### PR TITLE
MUL-6956: render custom status colors across Chat

### DIFF
--- a/packages/views/editor/extensions/mention-suggestion.test.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.test.tsx
@@ -55,6 +55,13 @@ vi.mock("@multica/core/platform", () => ({
   getCurrentWsId: () => "ws-1",
 }));
 
+vi.mock("@multica/core/issue-statuses/hooks", () => ({
+  useIssueStatuses: () => ({
+    colorOf: (status: string) =>
+      status === "awaiting_response" ? "#f97316" : null,
+  }),
+}));
+
 // Mock the API so we control search responses + observe calls.
 const searchIssuesMock = vi.fn();
 const searchProjectsMock = vi.fn();
@@ -629,6 +636,32 @@ describe("createMentionSuggestion", () => {
 
     const items = result as MentionItem[];
     expect(items.some((i) => i.type === "issue" && i.id === "i1")).toBe(true);
+  });
+
+  it("paints issue suggestions with their custom status color", () => {
+    render(
+      <I18nWrapper>
+        <MentionList
+          items={[
+            {
+              id: "issue-6956",
+              label: "MUL-6956",
+              type: "issue",
+              status: "awaiting_response",
+              statusCategory: "in_review",
+            },
+          ]}
+          query=""
+          command={vi.fn()}
+        />
+      </I18nWrapper>,
+    );
+
+    const statusIcon = screen
+      .getByText("MUL-6956")
+      .closest("button")
+      ?.querySelector("svg");
+    expect(statusIcon).toHaveStyle({ color: "#f97316" });
   });
 
   it("does not inject current/recent chat context into the normal @ results", () => {

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -14,6 +14,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { getCurrentWsId } from "@multica/core/platform";
 import { flattenIssueBuckets, issueKeys } from "@multica/core/issues/queries";
 import { issueStatusCategory } from "@multica/core/issues";
+import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import { useAuthStore } from "@multica/core/auth";
 import { canAssignAgentToIssue } from "@multica/core/permissions";
@@ -262,6 +263,7 @@ function demoteCancelledItems(items: MentionItem[], query: string): MentionItem[
 export const MentionList = forwardRef<MentionListRef, MentionListProps>(
   function MentionList({ items, query, command, includeProjectSearch = false }, ref) {
     const { t } = useT("editor");
+    const { colorOf: statusColorOf } = useIssueStatuses(getCurrentWsId() ?? "");
     // Selection is tracked by item identity, NOT by a positional index. The
     // list is re-bucketed by groupItems() and grows asynchronously (server
     // search results), so a slot index is not a stable target — the row under
@@ -469,6 +471,11 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
           <MentionRow
             key={`${item.type}-${item.id}`}
             item={item}
+            statusColor={
+              item.type === "issue" && item.status
+                ? statusColorOf(item.status)
+                : null
+            }
             selected={idx === selectedIndex}
             onSelect={() => selectItem(item)}
             buttonRef={(el) => { itemRefs.current[idx] = el; }}
@@ -517,11 +524,13 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
 
 function MentionRow({
   item,
+  statusColor,
   selected,
   onSelect,
   buttonRef,
 }: {
   item: MentionItem;
+  statusColor?: string | null;
   selected: boolean;
   onSelect: () => void;
   buttonRef: (el: HTMLButtonElement | null) => void;
@@ -547,6 +556,7 @@ function MentionRow({
             <StatusIcon
               status={item.status}
               category={item.statusCategory}
+              color={statusColor}
               className="h-3.5 w-3.5"
             />
           ) : (

--- a/packages/views/issues/components/issue-chip.test.tsx
+++ b/packages/views/issues/components/issue-chip.test.tsx
@@ -11,6 +11,13 @@ vi.mock("@multica/core/hooks", () => ({
   useWorkspaceId: () => "workspace-1",
 }));
 
+vi.mock("@multica/core/issue-statuses/hooks", () => ({
+  useIssueStatuses: () => ({
+    colorOf: (status: string) =>
+      status === "awaiting_response" ? "#f97316" : null,
+  }),
+}));
+
 vi.mock("@multica/core/issues/queries", () => ({
   issueListOptions: () => ({ queryKey: ["issues"] }),
   issueDetailOptions: (_workspaceId: string, issueId: string) => ({
@@ -19,8 +26,24 @@ vi.mock("@multica/core/issues/queries", () => ({
 }));
 
 vi.mock("./status-icon", () => ({
-  StatusIcon: ({ className }: { className?: string }) => (
-    <svg data-testid="status-icon" className={className} />
+  StatusIcon: ({
+    status,
+    category,
+    color,
+    className,
+  }: {
+    status: string;
+    category?: string;
+    color?: string | null;
+    className?: string;
+  }) => (
+    <svg
+      data-testid="status-icon"
+      data-status={status}
+      data-category={category}
+      data-color={color}
+      className={className}
+    />
   ),
 }));
 
@@ -37,6 +60,13 @@ describe("IssueChip", () => {
               identifier: "MUL-3405",
               title: "A very long issue title that should stay inside a narrow chat bubble",
               status: "todo",
+            },
+            {
+              id: "issue-2",
+              identifier: "MUL-6956",
+              title: "Custom status color in Chat",
+              status: "awaiting_response",
+              status_category: "in_review",
             },
           ],
         } as ReturnType<typeof useQuery>;
@@ -68,5 +98,22 @@ describe("IssueChip", () => {
 
     expect(screen.getByText("MUL-999999999999999999999999999999999"))
       .toHaveClass("min-w-0", "truncate");
+  });
+
+  it("paints a custom status with its catalog color instead of the category token", () => {
+    render(<IssueChip issueId="issue-2" />);
+
+    expect(screen.getByTestId("status-icon")).toHaveAttribute(
+      "data-status",
+      "awaiting_response",
+    );
+    expect(screen.getByTestId("status-icon")).toHaveAttribute(
+      "data-category",
+      "in_review",
+    );
+    expect(screen.getByTestId("status-icon")).toHaveAttribute(
+      "data-color",
+      "#f97316",
+    );
   });
 });

--- a/packages/views/issues/components/issue-chip.tsx
+++ b/packages/views/issues/components/issue-chip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { issueStatusCategory } from "@multica/core/issues";
+import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
 import type { ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { issueListOptions, issueDetailOptions } from "@multica/core/issues/queries";
@@ -57,6 +58,7 @@ export function IssueChip({
   className,
 }: IssueChipProps) {
   const wsId = useWorkspaceId();
+  const { colorOf: statusColorOf } = useIssueStatuses(wsId);
   const { data: issues = [] } = useQuery(issueListOptions(wsId));
   const listIssue = issues.find((i) => i.id === issueId);
 
@@ -88,6 +90,7 @@ export function IssueChip({
       <StatusIcon
         status={issue.status}
         category={issueStatusCategory(issue) ?? undefined}
+        color={statusColorOf(issue.status)}
         className="h-3.5 w-3.5 shrink-0"
       />
       <span className="font-medium text-muted-foreground shrink-0">

--- a/packages/views/issues/components/issue-hover-card.test.tsx
+++ b/packages/views/issues/components/issue-hover-card.test.tsx
@@ -20,6 +20,8 @@ vi.mock("@multica/core/issue-statuses/hooks", () => ({
     statuses: [],
     activeStatuses: [],
     categoryOf: (key: string) => key,
+    colorOf: (key: string) =>
+      key === "awaiting_response" ? "#f97316" : null,
     labelOf: (key: string) => key,
     entryOf: () => undefined,
     inCategory: () => [],
@@ -70,7 +72,22 @@ vi.mock("@multica/core/workspace/hooks", () => ({
 }));
 
 vi.mock("./status-icon", () => ({
-  StatusIcon: () => <svg data-testid="status-icon" />,
+  StatusIcon: ({
+    status,
+    category,
+    color,
+  }: {
+    status: string;
+    category?: string;
+    color?: string | null;
+  }) => (
+    <svg
+      data-testid="status-icon"
+      data-status={status}
+      data-category={category}
+      data-color={color}
+    />
+  ),
 }));
 
 vi.mock("./priority-icon", () => ({
@@ -86,6 +103,7 @@ type Issue = {
   identifier: string;
   title: string;
   status: string;
+  status_category?: string;
   priority: string;
   description?: string | null;
   assignee_type?: string | null;
@@ -228,6 +246,25 @@ describe("IssueHoverCard", () => {
     );
     expect(screen.getByLabelText("High")).toContainElement(
       screen.getByTestId("priority-icon"),
+    );
+  });
+
+  it("paints a custom status with its catalog color", async () => {
+    mockIssue({
+      ...BASE_ISSUE,
+      status: "awaiting_response",
+      status_category: "in_review",
+    });
+
+    await openCard();
+
+    expect(screen.getByTestId("status-icon")).toHaveAttribute(
+      "data-category",
+      "in_review",
+    );
+    expect(screen.getByTestId("status-icon")).toHaveAttribute(
+      "data-color",
+      "#f97316",
     );
   });
 

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { issueStatusCategory } from "@multica/core/issues";
+import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
 import { useStatusLabel } from "./../utils/status-label";
 import type { ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -117,6 +118,7 @@ function IssueHoverCardBody({
   fallbackLabel?: string;
 }) {
   const wsId = useWorkspaceId();
+  const { colorOf: statusColorOf } = useIssueStatuses(wsId);
   const resolveStatusLabel = useStatusLabel(wsId);
   const detail = useQuery(issueDetailOptions(wsId, issueId));
   // One workspace-wide progress snapshot shared with the issues list and issue
@@ -188,6 +190,7 @@ function IssueHoverCardBody({
           <StatusIcon
             status={issue.status}
             category={issueStatusCategory(issue) ?? undefined}
+            color={statusColorOf(issue.status)}
             className="h-3.5 w-3.5 shrink-0"
           />
         </span>


### PR DESCRIPTION
## Summary

- render workspace-defined status colors on inline issue references in Chat
- keep the same custom color in issue hover cards and the editor issue suggestion list
- preserve category-derived glyphs and theme-aware colors for built-in statuses
- add regressions for all three Chat render paths

## Testing

- pnpm --filter @multica/views exec vitest run issues/components/issue-chip.test.tsx issues/components/issue-hover-card.test.tsx editor/extensions/mention-suggestion.test.tsx --maxWorkers=1
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views exec eslint issues/components/issue-chip.tsx issues/components/issue-chip.test.tsx issues/components/issue-hover-card.tsx issues/components/issue-hover-card.test.tsx editor/extensions/mention-suggestion.tsx editor/extensions/mention-suggestion.test.tsx
- git diff --check

Closes MUL-6956