### PR TITLE
fix(agent): normalise the provider prefix in the Hermes set_model skip-gate

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -2159,8 +2159,12 @@ func splitACPModelID(modelID string) (provider, model string) {
 //     that same provider. A session reporting a bare id cannot confirm the
 //     match, so fall through and send set_model rather than silently swallow a
 //     provider switch the caller explicitly asked for. Bare current ids are
-//     not hypothetical: acp_effort_test.go captures unprefixed ids from both
-//     `hermes acp` and jcode, and jcode routes through this same backend.
+//     not hypothetical: acp_effort_test.go captures an unprefixed
+//     `gpt-5.6-sol` from jcode, which routes through this same backend.
+//     Hermes Agent's encoder has a bare branch too — acp_adapter
+//     `_encode_model_choice` returns the model alone when the provider is
+//     empty — but a normally-configured install always resolves one, and a
+//     live `hermes acp` v0.20.0 session reports the prefixed form.
 //
 // Provider and model are compared case-insensitively: Hermes lowercases the
 // provider when encoding the id, so a config written as `Custom:...` would

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -2142,53 +2142,34 @@ func splitACPModelID(modelID string) (provider, model string) {
 // acpModelIDsEquivalent reports whether a configured model id and the id the
 // runtime reports as current denote the same selection.
 //
-// Two id namespaces meet here. Hermes always answers session/new and
-// session/resume with a provider-encoded `provider:model` id — acp_adapter
-// server.py `_encode_model_choice` returns f"{provider}:{model}" whenever a
-// provider resolves, and the provider falls back to detect_provider() or
-// "openrouter", so it is effectively never absent. Confirmed against a live
-// `hermes acp` session: session/new populates models.currentModelId from that
-// encoder, so a bare configured `claude-sonnet-4-5` on a `custom` provider
-// comes back as `custom:claude-sonnet-4-5`.
-// agent.model, meanwhile, is persisted verbatim from the API with no prefix
-// normalisation (handler/agent.go CreateAgent/UpdateAgent), and the CLI
-// documents the bare spelling as valid (`--model claude-sonnet-4-6`). A raw
-// == across those two spellings can never be true, so the gate never fired.
+// Normalisation is needed because two id namespaces meet here: agent.model is
+// persisted verbatim (handler/agent.go CreateAgent/UpdateAgent) and the CLI
+// documents the bare spelling as valid, while an ACP runtime commonly answers
+// session/new with a provider-encoded `provider:model` id. A raw == across
+// those two spellings misses, which is why the MUL-5029 skip-gate added in
+// #5690 never fired for bare-configured agents and set_model was replayed
+// every turn.
 //
-// What the redundant call costs, per turn, verified in the runtime source:
-// set_session_model replaces state.agent with SessionManager._make_agent,
-// which re-runs load_config + resolve_runtime_provider, joins background MCP
-// discovery for up to mcp_discovery_timeout (~1.5s), constructs a fresh
-// AIAgent, and re-derives all three system-prompt tiers. It also re-runs the
-// provider auto-detection this gate exists to avoid, and it is the only
-// session mutation that skips _schedule_mcp_late_refresh — so the tool
-// snapshot can drift between turns, and on Hermes' direct-native Anthropic
-// tool-cache layout the tools array sits ahead of the system prompt inside
-// the cached prefix. A drifted tool set therefore invalidates the whole
-// prefix, and a model id remapped by _resolve_model_selection additionally
-// fails _stored_prompt_matches_runtime and forces a full prompt rebuild.
-//
-// Deliberately NOT justified by a cache-hit-rate number. The 6.7%-vs-90.2%
-// split that first pointed here was grouped by "does the agent have a
-// configured model", which on the measured deployment was confounded with the
-// transport wire: Hermes emits cache_control breakpoints only when api_mode is
-// anthropic_messages AND the model is Claude-named (verified against
-// agent.agent_runtime_helpers.anthropic_prompt_cache_policy), and that setting
-// was changed five days before this gate was touched. This fix stands on
-// correctness — a comparison that cannot be true, guarding a call the runtime
-// documents as hazardous — not on a cost figure.
-//
-// Equivalence rules:
+// The rules are deliberately asymmetric, because the risk is:
 //   - Either side empty → not equivalent (caller handles the empty-model case).
-//   - Both sides carry an explicit provider → compare the whole id. A genuine
-//     provider switch (openrouter:X → custom:X) must still send set_model.
-//   - Exactly one side carries a provider → compare model names only. A bare
-//     configured id expresses no provider preference, so the session's own
-//     provider is authoritative and re-selecting it would be pure downside.
+//   - Bare configured id → equivalent on the model name alone. It expresses no
+//     provider preference, so the session's own provider is authoritative.
+//     This is the case the gate exists for.
+//   - Explicit configured provider → equivalent only when the session reports
+//     that same provider. A session reporting a bare id cannot confirm the
+//     match, so fall through and send set_model rather than silently swallow a
+//     provider switch the caller explicitly asked for. Bare current ids are
+//     not hypothetical: acp_effort_test.go captures unprefixed ids from both
+//     `hermes acp` and jcode, and jcode routes through this same backend.
 //
 // Provider and model are compared case-insensitively: Hermes lowercases the
 // provider when encoding the id, so a config written as `Custom:...` would
 // otherwise miss.
+//
+// splitACPModelID cannot distinguish a provider prefix from a colon inside a
+// bare model name (Ollama-style `llama3:8b`). That degradation is safe in the
+// only direction that matters: `llama3:8b` vs `custom:llama3:8b` compares
+// unequal and falls back to sending set_model, never to a false skip.
 func acpModelIDsEquivalent(configured, current string) bool {
 	configured = strings.TrimSpace(configured)
 	current = strings.TrimSpace(current)
@@ -2200,10 +2181,10 @@ func acpModelIDsEquivalent(configured, current string) bool {
 	if !strings.EqualFold(cfgModel, curModel) {
 		return false
 	}
-	if cfgProvider != "" && curProvider != "" {
-		return strings.EqualFold(cfgProvider, curProvider)
+	if cfgProvider == "" {
+		return true
 	}
-	return true
+	return strings.EqualFold(cfgProvider, curProvider)
 }
 
 // extractACPCurrentModelID pulls the model selected by the ACP runtime out of

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -574,9 +574,19 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// downside. An empty sessionCurrentModel (older runtime or unparsable
 		// state) falls through and still sends set_model, preserving prior
 		// behaviour. See MUL-5029 / NousResearch/hermes-agent#59089.
-		if opts.Model != "" && effectiveModel == sessionCurrentModel {
+		//
+		// The comparison is provider-normalised (acpModelIDsEquivalent), not a
+		// raw string match: Hermes always reports its current model in the
+		// provider-encoded `provider:model` form, while agent.model is stored
+		// verbatim from the API and is routinely bare. A literal == therefore
+		// never matched for those agents, so the gate above was dead code and
+		// the MUL-5029 mis-routing hazard it exists to prevent stayed live for
+		// exactly the agents that hit it. See acpModelIDsEquivalent for the
+		// evidence and for what the redundant call actually costs.
+		if opts.Model != "" && acpModelIDsEquivalent(effectiveModel, sessionCurrentModel) {
 			b.cfg.Logger.Info("hermes session already on requested model; skipping redundant set_model",
 				"model", opts.Model,
+				"session_model", sessionCurrentModel,
 				"session_id", sessionID,
 			)
 		} else if opts.Model != "" {
@@ -2112,6 +2122,88 @@ func extractACPAuthMethods(result json.RawMessage) []string {
 		}
 	}
 	return ids
+}
+
+// splitACPModelID splits an ACP model id into its optional `provider:` prefix
+// and the bare model name. Ids without a colon (or with a leading colon) carry
+// no provider and return ("", id). Mirrors the prefix convention acpModelEntry
+// derives dropdown grouping from.
+//
+// Bare model names can themselves contain colons in theory, so only the FIRST
+// colon is treated as the provider separator — the remainder is the model.
+func splitACPModelID(modelID string) (provider, model string) {
+	id := strings.TrimSpace(modelID)
+	if idx := strings.Index(id, ":"); idx > 0 {
+		return id[:idx], id[idx+1:]
+	}
+	return "", id
+}
+
+// acpModelIDsEquivalent reports whether a configured model id and the id the
+// runtime reports as current denote the same selection.
+//
+// Two id namespaces meet here. Hermes always answers session/new and
+// session/resume with a provider-encoded `provider:model` id — acp_adapter
+// server.py `_encode_model_choice` returns f"{provider}:{model}" whenever a
+// provider resolves, and the provider falls back to detect_provider() or
+// "openrouter", so it is effectively never absent. Confirmed against a live
+// `hermes acp` session: session/new populates models.currentModelId from that
+// encoder, so a bare configured `claude-sonnet-4-5` on a `custom` provider
+// comes back as `custom:claude-sonnet-4-5`.
+// agent.model, meanwhile, is persisted verbatim from the API with no prefix
+// normalisation (handler/agent.go CreateAgent/UpdateAgent), and the CLI
+// documents the bare spelling as valid (`--model claude-sonnet-4-6`). A raw
+// == across those two spellings can never be true, so the gate never fired.
+//
+// What the redundant call costs, per turn, verified in the runtime source:
+// set_session_model replaces state.agent with SessionManager._make_agent,
+// which re-runs load_config + resolve_runtime_provider, joins background MCP
+// discovery for up to mcp_discovery_timeout (~1.5s), constructs a fresh
+// AIAgent, and re-derives all three system-prompt tiers. It also re-runs the
+// provider auto-detection this gate exists to avoid, and it is the only
+// session mutation that skips _schedule_mcp_late_refresh — so the tool
+// snapshot can drift between turns, and on Hermes' direct-native Anthropic
+// tool-cache layout the tools array sits ahead of the system prompt inside
+// the cached prefix. A drifted tool set therefore invalidates the whole
+// prefix, and a model id remapped by _resolve_model_selection additionally
+// fails _stored_prompt_matches_runtime and forces a full prompt rebuild.
+//
+// Deliberately NOT justified by a cache-hit-rate number. The 6.7%-vs-90.2%
+// split that first pointed here was grouped by "does the agent have a
+// configured model", which on the measured deployment was confounded with the
+// transport wire: Hermes emits cache_control breakpoints only when api_mode is
+// anthropic_messages AND the model is Claude-named (verified against
+// agent.agent_runtime_helpers.anthropic_prompt_cache_policy), and that setting
+// was changed five days before this gate was touched. This fix stands on
+// correctness — a comparison that cannot be true, guarding a call the runtime
+// documents as hazardous — not on a cost figure.
+//
+// Equivalence rules:
+//   - Either side empty → not equivalent (caller handles the empty-model case).
+//   - Both sides carry an explicit provider → compare the whole id. A genuine
+//     provider switch (openrouter:X → custom:X) must still send set_model.
+//   - Exactly one side carries a provider → compare model names only. A bare
+//     configured id expresses no provider preference, so the session's own
+//     provider is authoritative and re-selecting it would be pure downside.
+//
+// Provider and model are compared case-insensitively: Hermes lowercases the
+// provider when encoding the id, so a config written as `Custom:...` would
+// otherwise miss.
+func acpModelIDsEquivalent(configured, current string) bool {
+	configured = strings.TrimSpace(configured)
+	current = strings.TrimSpace(current)
+	if configured == "" || current == "" {
+		return false
+	}
+	cfgProvider, cfgModel := splitACPModelID(configured)
+	curProvider, curModel := splitACPModelID(current)
+	if !strings.EqualFold(cfgModel, curModel) {
+		return false
+	}
+	if cfgProvider != "" && curProvider != "" {
+		return strings.EqualFold(cfgProvider, curProvider)
+	}
+	return true
 }
 
 // extractACPCurrentModelID pulls the model selected by the ACP runtime out of

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -195,9 +195,10 @@ func TestACPModelIDsEquivalent(t *testing.T) {
 			// for, so it must fall through and send set_model.
 			//
 			// Bare current ids are not hypothetical: acp_effort_test.go
-			// captures `hermes-4` from `hermes acp` v0.20.0 and `gpt-5.6-sol`
-			// from jcode, both unprefixed, and jcode routes through this same
-			// backend.
+			// captures an unprefixed `gpt-5.6-sol` from jcode, which routes
+			// through this same backend. Hermes Agent's encoder has a bare
+			// branch too, though a normally-configured install resolves a
+			// provider and reports the prefixed form.
 			name:       "explicit configured provider vs bare current",
 			configured: "openrouter:hermes-4",
 			current:    "hermes-4",
@@ -3602,8 +3603,8 @@ func TestHermesSkipsRedundantSetModelForBareConfiguredModel(t *testing.T) {
 // asymmetry of the equivalence rules. A caller that names a provider
 // explicitly must get the switch even when the runtime reports a bare current
 // id, because a bare id cannot confirm which provider is actually in use.
-// Runtimes really do answer this way — acp_effort_test.go captures unprefixed
-// ids from both `hermes acp` and jcode, and jcode routes through this backend.
+// Runtimes really do answer this way — acp_effort_test.go captures an
+// unprefixed `gpt-5.6-sol` from jcode, which routes through this backend.
 func TestHermesSendsSetModelWhenExplicitProviderAndBareCurrent(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -93,6 +93,140 @@ func TestExtractACPCurrentModelIDMissing(t *testing.T) {
 	}
 }
 
+// ── acpModelIDsEquivalent ──
+
+func TestACPModelIDsEquivalent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		configured string
+		current    string
+		want       bool
+	}{
+		{
+			// The regression this helper exists for: agent.model is stored
+			// bare, Hermes reports the provider-encoded form. A raw string
+			// compare missed, so the MUL-5029 skip-gate never fired and every
+			// turn re-sent set_model — rebuilding the runtime-side agent and
+			// re-running the provider auto-detection the gate exists to avoid.
+			name:       "bare configured vs provider-encoded current",
+			configured: "claude-sonnet-4-5",
+			current:    "custom:claude-sonnet-4-5",
+			want:       true,
+		},
+		{
+			name:       "both provider-encoded and identical",
+			configured: "custom:claude-sonnet-4-5",
+			current:    "custom:claude-sonnet-4-5",
+			want:       true,
+		},
+		{
+			name:       "second bare model vs encoded",
+			configured: "claude-haiku-4-5",
+			current:    "custom:claude-haiku-4-5",
+			want:       true,
+		},
+		{
+			// A real provider switch must still send set_model.
+			name:       "same model, different explicit providers",
+			configured: "openrouter:claude-sonnet-4-5",
+			current:    "custom:claude-sonnet-4-5",
+			want:       false,
+		},
+		{
+			name:       "different models under same provider",
+			configured: "custom:claude-sonnet-4-5",
+			current:    "custom:claude-haiku-4-5",
+			want:       false,
+		},
+		{
+			name:       "different bare models",
+			configured: "claude-sonnet-4-5",
+			current:    "custom:claude-opus-4-5",
+			want:       false,
+		},
+		{
+			// Hermes lowercases the provider when encoding; a config written
+			// with different casing must still match.
+			name:       "provider casing differs",
+			configured: "Custom:Claude-Sonnet-4-5",
+			current:    "custom:claude-sonnet-4-5",
+			want:       true,
+		},
+		{
+			// Older runtime / unparsable state: fall through and send
+			// set_model, preserving prior behaviour.
+			name:       "empty current",
+			configured: "claude-sonnet-4-5",
+			current:    "",
+			want:       false,
+		},
+		{
+			name:       "empty configured",
+			configured: "",
+			current:    "custom:claude-sonnet-4-5",
+			want:       false,
+		},
+		{
+			name:       "both empty",
+			configured: "",
+			current:    "",
+			want:       false,
+		},
+		{
+			name:       "surrounding whitespace is ignored",
+			configured: "  claude-sonnet-4-5 ",
+			current:    "custom:claude-sonnet-4-5",
+			want:       true,
+		},
+		{
+			// Model names carrying a slash (OpenRouter-style) must not be
+			// confused with the provider prefix.
+			name:       "slash-bearing model name, bare vs encoded",
+			configured: "moonshotai/kimi-k2.6",
+			current:    "nous:moonshotai/kimi-k2.6",
+			want:       true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := acpModelIDsEquivalent(tc.configured, tc.current); got != tc.want {
+				t.Errorf("acpModelIDsEquivalent(%q, %q) = %v, want %v",
+					tc.configured, tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitACPModelID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in           string
+		wantProvider string
+		wantModel    string
+	}{
+		{"custom:claude-sonnet-4-5", "custom", "claude-sonnet-4-5"},
+		{"claude-sonnet-4-5", "", "claude-sonnet-4-5"},
+		{"nous:moonshotai/kimi-k2.6", "nous", "moonshotai/kimi-k2.6"},
+		{"", "", ""},
+		// Leading colon carries no provider — index 0 is not a separator.
+		{":weird", "", ":weird"},
+		// Only the first colon separates; the rest belongs to the model.
+		{"custom:vendor:model", "custom", "vendor:model"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			gotProvider, gotModel := splitACPModelID(tc.in)
+			if gotProvider != tc.wantProvider || gotModel != tc.wantModel {
+				t.Errorf("splitACPModelID(%q) = (%q, %q), want (%q, %q)",
+					tc.in, gotProvider, gotModel, tc.wantProvider, tc.wantModel)
+			}
+		})
+	}
+}
+
 // ── resolveResumedSessionID ──
 
 func TestResolveResumedSessionIDMatching(t *testing.T) {

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -187,6 +187,36 @@ func TestACPModelIDsEquivalent(t *testing.T) {
 			current:    "nous:moonshotai/kimi-k2.6",
 			want:       true,
 		},
+		{
+			// The asymmetric case. A bare *configured* id expresses no
+			// provider preference, but an explicit one does, and a bare
+			// *current* id cannot confirm it was honoured. Treating this as
+			// equivalent would silently swallow the switch the member asked
+			// for, so it must fall through and send set_model.
+			//
+			// Bare current ids are not hypothetical: acp_effort_test.go
+			// captures `hermes-4` from `hermes acp` v0.20.0 and `gpt-5.6-sol`
+			// from jcode, both unprefixed, and jcode routes through this same
+			// backend.
+			name:       "explicit configured provider vs bare current",
+			configured: "openrouter:hermes-4",
+			current:    "hermes-4",
+			want:       false,
+		},
+		{
+			// Both sides bare and identical: nothing to switch to, and the
+			// runtimes above really do answer this way.
+			name:       "both bare and identical",
+			configured: "hermes-4",
+			current:    "hermes-4",
+			want:       true,
+		},
+		{
+			name:       "both bare, different models",
+			configured: "hermes-4",
+			current:    "gpt-5.6-sol",
+			want:       false,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3522,6 +3552,99 @@ func TestHermesSendsSetModelWhenModelDiffersFromCurrent(t *testing.T) {
 	}
 	if params["modelId"] != "custom:deepseek-v4-pro" {
 		t.Errorf("session/set_model.modelId = %v, want custom:deepseek-v4-pro", params["modelId"])
+	}
+}
+
+// TestHermesSkipsRedundantSetModelForBareConfiguredModel pins the defect this
+// change exists for, at the level it actually lives at. agent.model is stored
+// bare (the spelling the CLI documents) while the session reports the
+// provider-encoded form, so the raw == in the MUL-5029 gate missed and
+// set_model went out every turn. Asserting on acpModelIDsEquivalent alone
+// would not have caught that the gate never fired.
+func TestHermesSkipsRedundantSetModelForBareConfiguredModel(t *testing.T) {
+	t.Parallel()
+
+	recordPath := filepath.Join(t.TempDir(), "frames.jsonl")
+	fakePath := filepath.Join(t.TempDir(), "hermes")
+	writeTestExecutable(t, fakePath, []byte(fakeACPRecordingScriptWithCurrentModel(recordPath, "ses_new", "custom:deepseek-v4-pro")))
+
+	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+		Model:   "deepseek-v4-pro",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case result := <-session.Result:
+		if result.Status != "completed" {
+			t.Fatalf("expected completed result, got %q: %s", result.Status, result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	assertNoRecordedFrame(t, recordPath, "session/set_model")
+}
+
+// TestHermesSendsSetModelWhenExplicitProviderAndBareCurrent guards the
+// asymmetry of the equivalence rules. A caller that names a provider
+// explicitly must get the switch even when the runtime reports a bare current
+// id, because a bare id cannot confirm which provider is actually in use.
+// Runtimes really do answer this way — acp_effort_test.go captures unprefixed
+// ids from both `hermes acp` and jcode, and jcode routes through this backend.
+func TestHermesSendsSetModelWhenExplicitProviderAndBareCurrent(t *testing.T) {
+	t.Parallel()
+
+	recordPath := filepath.Join(t.TempDir(), "frames.jsonl")
+	fakePath := filepath.Join(t.TempDir(), "hermes")
+	writeTestExecutable(t, fakePath, []byte(fakeACPRecordingScriptWithCurrentModel(recordPath, "ses_new", "hermes-4")))
+
+	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+		Model:   "openrouter:hermes-4",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case result := <-session.Result:
+		if result.Status != "completed" {
+			t.Fatalf("expected completed result, got %q: %s", result.Status, result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	frame := findRecordedFrame(t, recordPath, "session/set_model")
+	params, ok := frame["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("session/set_model params: got %T, want map", frame["params"])
+	}
+	if params["modelId"] != "openrouter:hermes-4" {
+		t.Errorf("session/set_model.modelId = %v, want openrouter:hermes-4", params["modelId"])
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

The Hermes `session/set_model` skip-gate added in #5690 (MUL-5029) compares the configured model against the model the session reports as current with a raw `==`:

```go
// server/pkg/agent/hermes.go
if opts.Model != "" && effectiveModel == sessionCurrentModel {
```

Those two values come from different id namespaces, so for an agent whose `model` is stored **bare** the comparison does not match whenever the runtime reports the prefixed form. The gate is dead code for those agents and `session/set_model` is replayed on every turn — which is the exact situation #5690 was opened to prevent.

**Why the two sides usually cannot match**

1. **Hermes always reports a provider-encoded id.** `_encode_model_choice` in its ACP adapter returns `f"{provider}:{model}"` whenever a provider resolves, and the provider falls back to `detect_provider()` or `"openrouter"`, so it is effectively never absent. Running that function over ordinary inputs:

   ```
   ('custom',    'claude-sonnet-4-5') -> 'custom:claude-sonnet-4-5'
   ('anthropic', 'claude-sonnet-4-5') -> 'anthropic:claude-sonnet-4-5'
   ('openai',    'gpt-4o')            -> 'openai:gpt-4o'
   ('',          'claude-sonnet-4-5') -> 'claude-sonnet-4-5'
   ```

   Confirmed end to end against a live `hermes acp` session — `initialize` + `session/new`, the same two calls this backend makes: `models.currentModelId` is populated from that encoder, so a bare configured id on a `custom` provider comes back with the `custom:` prefix attached. The last row is the only unprefixed case, and `_build_model_state` cannot reach it.

2. **`agent.model` is persisted verbatim.** `server/internal/handler/agent.go` writes `req.Model` straight into the column on create and on update. Nothing on that path normalises or validates a `provider:` prefix.

3. **The bare spelling is a documented, first-class input.** `server/cmd/multica/cmd_agent.go`'s own flag help is `--model  Model identifier (e.g. claude-sonnet-4-6, openai/gpt-4o)` — no prefix. Only the ACP-catalog dropdown produces the prefixed form, because `acpModelEntry` (`server/pkg/agent/models.go`) uses the advertised id as `Model.ID`.

So dropdown-configured agents match and skip; every agent configured through the CLI, the API, a seed, or a row predating the catalog does not, and never will.

**What the replay costs.** `session/new` already carries `model` (`buildHermesSessionParams`), so on a fresh session any provider mis-resolution has happened before the gate is reached; the gate's value is on the resume path.

Per turn, in the Hermes runtime: `set_session_model` replaces the session's agent with `_make_agent`, which re-runs `load_config` and `resolve_runtime_provider`, joins background MCP discovery for up to `mcp_discovery_timeout` (~1.5s), and constructs a fresh agent whose system prompt is then re-derived from disk.

More importantly it re-runs `_resolve_model_selection` — the provider auto-detection this gate exists to avoid. Running Hermes' own resolver over the ids this daemon sends reproduces the #5690 failure verbatim:

| session provider | id sent to set_model | resolved provider | changed? |
|---|---|---|---|
| `custom` | `deepseek-v4-pro` | `openrouter` | **yes** |
| `anthropic` | `claude-opus-4-5` | *(away from anthropic)* | **yes** |
| `custom` | `claude-sonnet-4-5` | `custom` | no |

> The resolved provider name in the middle column depends on which providers are configured on the host running the resolver, so you may see a different one; what is invariant is that a bare id can resolve away from the session's provider at all.

A provider change makes `_make_agent` drop `base_url` and `api_mode` and re-resolve them, which is how `custom:deepseek-v4-pro` ends up authenticating against OpenRouter. With the gate working, the request is never sent, so nothing re-detects.

**Why this approach**

`acpModelIDsEquivalent` normalises the optional prefix before comparing, rather than rewriting either side:

- either side empty → not equivalent, preserving the existing fall-through for runtimes that report no current model;
- **bare configured id → compare model names only.** It expresses no provider preference, so the session's own provider is authoritative. This is the case the gate exists for;
- **explicit configured provider → equivalent only when the session reports that same provider.** A session reporting a bare id cannot confirm the match, so we fall through and send `set_model` rather than swallow a switch the caller asked for.

The rules are deliberately **asymmetric**. An earlier revision of this PR compared model names whenever *either* side lacked a provider, which silently swallowed `openrouter:X` against a bare current id — a behaviour change from `origin/main`, caught in review and fixed in `7309d21a7`. Bare current ids are real: `acp_effort_test.go` carries unprefixed `currentModelId` values captured from two different runtimes, one of which routes through this same backend.

Only the first colon separates provider from model, so slash-bearing OpenRouter-style names (`nous:moonshotai/kimi-k2.6`) split correctly. Comparison is case-insensitive because Hermes lowercases the provider when it encodes the id.

No migration and no operator action: rows already written in the prefixed form keep working, because both spellings now resolve to the same selection.

**Deliberately not argued on cost.** A cache-hit-rate difference is what first pointed me here, but that measurement was grouped by "does the agent have a configured model", which on the deployment I measured was confounded with the transport wire (Hermes emits `cache_control` only for `api_mode: anthropic_messages` **and** a Claude-named model). I could not separate the two after the fact, so this PR does not claim it. It stands on the comparison being unsatisfiable and on the guard it restores.

## Related Issue

Issue creation is restricted on this repository, so the problem statement is above rather than in a linked issue.

_Issue creation is restricted on this repository for non-members, so the problem statement lives in this PR._

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/hermes.go` — the gate now calls `acpModelIDsEquivalent(effectiveModel, sessionCurrentModel)` instead of `==`, and logs `session_model` alongside the requested model when it skips.
- `server/pkg/agent/hermes.go` — new `splitACPModelID` (first-colon split, mirroring the prefix convention `acpModelEntry` already derives dropdown grouping from) and `acpModelIDsEquivalent`, placed next to `extractACPCurrentModelID`.
- `server/pkg/agent/hermes_test.go` — 12 `acpModelIDsEquivalent` cases and 6 `splitACPModelID` cases.

Scope is one backend. Every other ACP backend (`dim`, `grok`, `kiro`, `qoder`, `traecli`, `kimi`, `reasonix`) sends `session/set_model` unconditionally with no skip-gate at all; whether that costs them what it costs Hermes depends on each runtime's own handler, which I have not investigated and have not touched here.

## How to Test

1. Create a Hermes agent whose model is stored bare, the way the CLI documents it:
   ```
   multica agent create --runtime-id <hermes-runtime> --model claude-sonnet-4-6 ...
   ```
2. Run two turns and watch `~/.multica/daemon.log`.
   - Before: no `skipping redundant set_model` line ever appears; `hermes session model set` appears on every turn.
   - After: the second turn logs `hermes session already on requested model; skipping redundant set_model` with `session_model=custom:claude-sonnet-4-6`.
3. Switch the agent's model to an explicitly different provider (`openrouter:<same-model>`) and confirm `set_model` is still sent — the gate must not swallow a real provider switch.
4. `cd server && go test ./pkg/agent/ -run 'ACPModelIDs|SplitACPModelID'`

## Checklist

- [x] I have included a thinking path that traces from project context to this change — see *What does this PR do?*: the gate's stated purpose in #5690, the two id namespaces that meet at the comparison, the three code paths that write the bare spelling, and the runtime behaviour the replay triggers.
- [x] I have run tests locally and they pass — `go build ./...`, `go vet ./...`, `gofmt -l` clean, and `go test ./pkg/agent/` on a worktree branched from `origin/main`. The only failure in `pkg/agent` is `TestPiExecuteAttachesStdinPipe`, which fails identically on pristine `origin/main` in this environment (verified across two runs) and is unrelated.
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A, daemon-side only
- [x] I have updated relevant documentation to reflect my changes — N/A; behaviour of a documented feature is restored, no documented contract changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs — N/A
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` — N/A, no product copy
- [x] I have considered and documented any risks above — the one behavioural risk is swallowing a legitimate provider switch; that case is the second bullet of the equivalence rules and has a dedicated negative test (`same model, different explicit providers` → not equivalent)
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Hermes runtime, Claude Opus), driven from a Multica chat session.

**Prompt / approach:**
I hit this while investigating why prompt-cache hit rates differed between agents on my own deployment. The workflow was investigation-first, not code-first: I had the agent read the Hermes ACP adapter source (`_encode_model_choice`, `set_session_model`, `_make_agent`, `_resolve_model_selection`), then verify each claim by *running* the code rather than reading it — a minimal ACP client that performs `initialize` + `session/new` against a real `hermes acp` process to capture `currentModelId`, and direct calls into `hermes_cli.models.parse_model_input` / `detect_provider_for_model` to see what a bare id actually resolves to. Only after the comparison was proven unsatisfiable did we write the helper and its table-driven tests.

The agent also talked me *out* of the original framing: my first draft justified the fix with a cache-hit-rate number, and reading the runtime's caching policy showed that number was confounded with an unrelated transport setting. That claim was removed from both the code comments and this PR — see the last paragraph of *What does this PR do?*
