### PR TITLE
MUL-6959: WS-4679: block done while linked PRs remain open

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -240,6 +240,65 @@ func writeIssueStatusRaceError(w http.ResponseWriter, err error) bool {
 	return false
 }
 
+// issueDoneBlockedByOpenPullRequestsError is returned when a manual status
+// write would claim delivery while a linked working PR is still in flight.
+// Reference-only links are deliberately absent from OpenCount because they are
+// hidden from the issue's PR list and do not represent work on the issue.
+type issueDoneBlockedByOpenPullRequestsError struct {
+	OpenCount int64
+}
+
+func (e *issueDoneBlockedByOpenPullRequestsError) Error() string {
+	return fmt.Sprintf(
+		"cannot move issue to a done status while %d linked pull request(s) are open or draft; merge or close them first",
+		e.OpenCount,
+	)
+}
+
+// assertIssueCanEnterStatus prevents a manual transition into the done
+// category while any linked GitHub or self-hosted working PR remains open or
+// draft. Custom statuses inherit the guard through their category. The
+// webhook auto-advance path already applies the same combined-provider open
+// count before it writes literal `done`; keeping the manual path aligned closes
+// the ghost-delivery hole where an issue could be marked done merely because a
+// PR existed rather than because it had reached a terminal state.
+func assertIssueCanEnterStatus(ctx context.Context, q *db.Queries, issue db.Issue, targetStatus string) error {
+	if targetStatus == "" || targetStatus == issue.Status {
+		return nil
+	}
+	if issuestatus.Effective(ctx, q, issue.WorkspaceID, targetStatus) != issuestatus.Done {
+		return nil
+	}
+	// Moving between two done-category labels does not make a new delivery
+	// claim, so an open PR discovered after the original transition must not
+	// make presentation-only relabeling impossible.
+	if issuestatus.Effective(ctx, q, issue.WorkspaceID, issue.Status) == issuestatus.Done {
+		return nil
+	}
+
+	counts, err := q.GetIssueCombinedPullRequestCloseAggregate(ctx, issue.ID)
+	if err != nil {
+		return fmt.Errorf("count linked pull request states before done transition: %w", err)
+	}
+	if counts.OpenCount > 0 {
+		return &issueDoneBlockedByOpenPullRequestsError{OpenCount: counts.OpenCount}
+	}
+	return nil
+}
+
+func writeIssueDoneBlockedByOpenPullRequests(w http.ResponseWriter, err error) bool {
+	var blocked *issueDoneBlockedByOpenPullRequestsError
+	if !errors.As(err, &blocked) {
+		return false
+	}
+	writeJSON(w, http.StatusConflict, map[string]any{
+		"error":                   blocked.Error(),
+		"code":                    "open_pull_requests_block_done",
+		"open_pull_request_count": blocked.OpenCount,
+	})
+	return true
+}
+
 func validateIssueEnum(w http.ResponseWriter, field, value string, allowed []string) bool {
 	for _, a := range allowed {
 		if value == a {
@@ -3264,6 +3323,9 @@ func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.
 	if err != nil {
 		return db.Issue{}, db.Issue{}, false, fmt.Errorf("lock issue for update: %w", err)
 	}
+	if err := assertIssueCanEnterStatus(ctx, qtx, current, statusKey); err != nil {
+		return db.Issue{}, current, false, err
+	}
 
 	if params.Title.Valid && titleBase != nil && current.Title != *titleBase && current.Title != params.Title.String {
 		return db.Issue{}, current, false, errIssueFieldConflict
@@ -3557,14 +3619,20 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			prevIssue = lockedPrev
 		}
 	} else {
-		err = h.runWithIssueStatusGuard(r.Context(), prevIssue.WorkspaceID, statusKeyForGuard, func(q *db.Queries) error {
-			var innerErr error
-			issue, innerErr = q.UpdateIssue(r.Context(), params)
-			return innerErr
-		})
+		err = assertIssueCanEnterStatus(r.Context(), h.Queries, prevIssue, statusKeyForGuard)
+		if err == nil {
+			err = h.runWithIssueStatusGuard(r.Context(), prevIssue.WorkspaceID, statusKeyForGuard, func(q *db.Queries) error {
+				var innerErr error
+				issue, innerErr = q.UpdateIssue(r.Context(), params)
+				return innerErr
+			})
+		}
 	}
 	if err != nil {
 		if writeIssueStatusRaceError(w, err) {
+			return
+		}
+		if writeIssueDoneBlockedByOpenPullRequests(w, err) {
 			return
 		}
 		if errors.Is(err, errIssueFieldConflict) {
@@ -4102,6 +4170,33 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Preflight every valid target before applying the first batch mutation.
+	// Without this pass a later issue with an open PR could reject after earlier
+	// siblings had already moved to done, turning one logical batch into a
+	// misleading partial delivery claim.
+	if batchStatusKey != "" && issuestatus.Effective(r.Context(), h.Queries, wsUUID, batchStatusKey) == issuestatus.Done {
+		for _, issueID := range req.IssueIDs {
+			issueUUID, parseErr := util.ParseUUID(issueID)
+			if parseErr != nil {
+				continue
+			}
+			issue, loadErr := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+				ID:          issueUUID,
+				WorkspaceID: wsUUID,
+			})
+			if loadErr != nil {
+				continue
+			}
+			if gateErr := assertIssueCanEnterStatus(r.Context(), h.Queries, issue, batchStatusKey); gateErr != nil {
+				if writeIssueDoneBlockedByOpenPullRequests(w, gateErr) {
+					return
+				}
+				slog.Warn("batch update: validate done transition", "issue_id", issueID, "error", gateErr)
+				writeError(w, http.StatusInternalServerError, "failed to validate linked pull request states")
+				return
+			}
+		}
+	}
 	// The batch shares one project_id, so it is checked once here rather than
 	// per issue, and rejected instead of skipped like the per-item guards in
 	// the loop: a foreign project invalidates the whole request.
@@ -4299,17 +4394,23 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 				prevIssue = lockedPrev
 			}
 		} else {
-			err = h.runWithIssueStatusGuard(r.Context(), wsUUID, batchStatusKey, func(q *db.Queries) error {
-				var innerErr error
-				issue, innerErr = q.UpdateIssue(r.Context(), params)
-				return innerErr
-			})
+			err = assertIssueCanEnterStatus(r.Context(), h.Queries, prevIssue, batchStatusKey)
+			if err == nil {
+				err = h.runWithIssueStatusGuard(r.Context(), wsUUID, batchStatusKey, func(q *db.Queries) error {
+					var innerErr error
+					issue, innerErr = q.UpdateIssue(r.Context(), params)
+					return innerErr
+				})
+			}
 		}
 		if err != nil {
 			// The archive race is a property of the batch's shared target
 			// status, not of one issue, so every remaining item would fail the
 			// same way. Abort with 409 instead of reporting a partial update.
 			if writeIssueStatusRaceError(w, err) {
+				return
+			}
+			if writeIssueDoneBlockedByOpenPullRequests(w, err) {
 				return
 			}
 			slog.Warn("batch update issue failed", "issue_id", issueID, "error", err)

--- a/server/internal/handler/issue_done_pr_gate_test.go
+++ b/server/internal/handler/issue_done_pr_gate_test.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/issuestatus"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestManualDoneTransitionRequiresTerminalWorkingPRs pins the manual half of
+// the PR close contract. Webhook auto-advance already waits for every visible
+// working PR to leave open/draft; a human, agent, or batch status write must
+// not be able to bypass that same gate.
+func TestManualDoneTransitionRequiresTerminalWorkingPRs(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	secret := "manual-done-pr-gate-secret"
+	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
+
+	create := func(title string) IssueResponse {
+		t.Helper()
+		w := testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
+			"title": title, "status": "in_progress",
+		})).Want(http.StatusCreated)
+		var issue IssueResponse
+		if err := json.NewDecoder(w.Body).Decode(&issue); err != nil {
+			t.Fatalf("decode created issue: %v", err)
+		}
+		t.Cleanup(func() {
+			testPool.Exec(ctx, `DELETE FROM activity_log WHERE issue_id = $1`, parseUUID(issue.ID))
+			testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, parseUUID(issue.ID))
+		})
+		return issue
+	}
+	updateStatus := func(issue IssueResponse, status string, description bool) *testutil.Response {
+		t.Helper()
+		body := map[string]any{"status": status}
+		if description {
+			body["description"] = "status update with an atomic description write"
+		}
+		return testutil.Call(t, testHandler.UpdateIssue, withURLParam(
+			newRequest(http.MethodPatch, "/api/issues/"+issue.ID, body), "id", issue.ID))
+	}
+	assertStatus := func(issue IssueResponse, want string) {
+		t.Helper()
+		got, err := testHandler.Queries.GetIssue(ctx, parseUUID(issue.ID))
+		if err != nil {
+			t.Fatalf("get issue %s: %v", issue.Identifier, err)
+		}
+		if got.Status != want {
+			t.Fatalf("issue %s status = %q, want %q", issue.Identifier, got.Status, want)
+		}
+	}
+	assertBlocked := func(w *testutil.Response) {
+		t.Helper()
+		if w.Code != http.StatusConflict {
+			t.Fatalf("done transition status = %d, want 409: %s", w.Code, w.Body.String())
+		}
+		var body struct {
+			Code                 string `json:"code"`
+			OpenPullRequestCount int64  `json:"open_pull_request_count"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode conflict: %v", err)
+		}
+		if body.Code != "open_pull_requests_block_done" || body.OpenPullRequestCount != 1 {
+			t.Fatalf("conflict = %+v, want open_pull_requests_block_done with count 1", body)
+		}
+	}
+
+	const installationID int64 = 30264979
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		AccountLogin:   "manual-done-pr-gate-acct",
+		AccountType:    "User",
+	}); err != nil {
+		t.Fatalf("CreateGitHubInstallation: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE pull_request_id IN (SELECT id FROM github_pull_request WHERE installation_id = $1)`, installationID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE installation_id = $1`, installationID)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE installation_id = $1`, installationID)
+	})
+
+	builtIn := create("built-in done gate")
+	custom := create("custom done gate")
+	batchClear := create("batch all-or-nothing gate")
+	customDone := createTestCustomStatus(t, "verified_done_gate", issuestatus.Done)
+
+	// One visible working PR links both delivery issues and blocks built-in and
+	// custom done-category transitions. The custom case also exercises the
+	// atomic description-update path.
+	firePRWebhook(t, secret, installationID, 9101,
+		"Work on "+builtIn.Identifier+" and "+custom.Identifier,
+		"No close intent yet", "feat/manual-done-gate", "opened")
+
+	assertBlocked(updateStatus(builtIn, "done", false))
+	assertStatus(builtIn, "in_progress")
+	assertBlocked(updateStatus(custom, customDone.Key, true))
+	assertStatus(custom, "in_progress")
+
+	// The preflight pass checks the whole batch before the first write. Put the
+	// unblocked issue first so this fails if the implementation regresses to a
+	// partial, per-item gate.
+	batch := testutil.Call(t, testHandler.BatchUpdateIssues, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
+		"issue_ids": []string{batchClear.ID, builtIn.ID},
+		"updates":   map[string]any{"status": "done"},
+	}))
+	assertBlocked(batch)
+	assertStatus(batchClear, "in_progress")
+	assertStatus(builtIn, "in_progress")
+
+	// Closing without merging is still a terminal PR outcome. The source issue
+	// may then be closed manually after the user has decided the work is no
+	// longer required.
+	firePRWebhook(t, secret, installationID, 9101,
+		"Work on "+builtIn.Identifier+" and "+custom.Identifier,
+		"No close intent yet", "feat/manual-done-gate", "closed")
+	testutil.Call(t, testHandler.UpdateIssue, withURLParam(
+		newRequest(http.MethodPatch, "/api/issues/"+builtIn.ID, map[string]any{"status": "done"}),
+		"id", builtIn.ID)).Want(http.StatusOK)
+	assertStatus(builtIn, "done")
+
+	// A bare body mention is reference-only and hidden from the issue PR list;
+	// it must not become an invisible blocker for a manual done transition.
+	referenceOnly := create("reference-only link stays non-blocking")
+	firePRWebhook(t, secret, installationID, 9102,
+		"Unrelated cleanup", "Context: see "+referenceOnly.Identifier,
+		"feat/unrelated-cleanup", "opened")
+	testutil.Call(t, testHandler.UpdateIssue, withURLParam(
+		newRequest(http.MethodPatch, "/api/issues/"+referenceOnly.ID, map[string]any{"status": "done"}),
+		"id", referenceOnly.ID)).Want(http.StatusOK)
+	assertStatus(referenceOnly, "done")
+}

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -220,6 +220,15 @@ close intent writes the literal `done` key.
 - **`done`** on a child issue posts a system comment on its parent. If a PR
   carries close intent (`Closes MUL-XXXX`), it advances the issue to `done`
   itself on merge — you do not also need to flip it manually.
+- **Manual transitions into `done` are fail-closed on linked PR state.** The
+  issue API rejects the write with `open_pull_requests_block_done` while any
+  visible working PR is still `open` or `draft`, across GitHub and self-hosted
+  VCS providers. Custom statuses in the `done` category inherit the same gate,
+  and batch updates preflight every target before changing any of them. Merge
+  or close each working PR first; bare body mentions are reference-only and do
+  not block because they are hidden from the issue's PR list. This gate proves
+  terminal PR state, not whether closing an unmerged PR was the right product
+  decision — record that rationale in the issue comment.
 - **`cancelled`** is a terminal, user-driven decision to close the issue. Like
   `done` it enqueues no new agent work, but it does **not** stop tasks already in
   flight — a run in progress keeps going (MUL-4465). To stop a running task,

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -131,6 +131,7 @@ and is hidden from the PR list.
 | Status change (incl. → `cancelled`) does NOT cancel in-flight tasks; only issue deletion does (MUL-4465) | no-cancel note in `server/internal/handler/issue.go:2652-2658` (`UpdateIssue`) and `:3170-3171` (`BatchUpdateIssues`); deletion still cancels at `:2863` (`DeleteIssue`) / `:3239` (`BatchDeleteIssues`) via `CancelTasksForIssue` (`server/internal/service/task.go:1229`) | new citation |
 | `StartTask` / `CompleteTask` do not write issue status (agent CLI owns progress) | `server/internal/service/task.go` (`StartTask` / `CompleteTask` comments) | new citation |
 | Runtime brief: status written whenever the work changes it, mid-turn included — starting the issue's own ask → `in_progress` immediately (workflow step 3); delivery → `in_review`, continuing → `in_progress`, stuck → `blocked`; a turn producing none of the issue's own deliverable → no write at any point; the activity kind never decides (research/design/planning/review count as work when they are the ask); no assignee gate; squad leader dispatch is not delivery (MUL-6417) | `server/internal/daemon/execenv/runtime_config_sections.go` (`writeWorkflowIssue`) | new citation |
+| Manual transition into a built-in or custom done-category status rejects visible working PRs still open/draft; combined GitHub + self-hosted VCS count; batch preflights all targets | `server/internal/handler/issue.go` (`assertIssueCanEnterStatus`, `writeIssueDoneBlockedByOpenPullRequests`, `UpdateIssue`, `BatchUpdateIssues`) | new citation |
 | Failed task may roll `in_progress` → `todo` when no active task remains | `server/internal/service/task.go` (`HandleFailedTasks`) | new citation |
 | Custom statuses inherit their category's behavior in full; enqueue/park contracts resolve the effective category via `issuestatus.Effective` / `Resolve` (MUL-6243) | `server/internal/issuestatus/issuestatus.go` (`Effective`, `Resolve`) | new citation |
 | Runtime brief lists the workspace's active custom statuses grouped by category; catalog rides the claim payload (MUL-6460) | `server/internal/daemon/execenv/runtime_config_sections.go` (`writeIssueStatusCommand`); claim injection in `server/internal/handler/daemon.go` (`buildClaimedTaskResponse`, status catalog block) | new citation |
@@ -147,6 +148,15 @@ active task on it (the old #940 behavior). MUL-4465 removed that from both
 never cancels tasks now. `CancelTasksForIssue` fires only from the issue-deletion
 paths (`DeleteIssue` / `BatchDeleteIssues`), where the owning issue row is going
 away, so no task is left orphaned.
+
+Moving an issue manually into the `done` category first reads
+`GetIssueCombinedPullRequestCloseAggregate`. If any non-reference-only GitHub
+or self-hosted PR is `open`/`draft`, the API returns HTTP 409 with stable code
+`open_pull_requests_block_done` and leaves the issue unchanged. The batch path
+checks every valid target before the first mutation so one blocked issue cannot
+produce a partial batch. A closed-but-unmerged PR is terminal for this machine
+gate; the issue comment remains the audit surface for why that repair was no
+longer needed.
 
 ## Ownership-only assignment and duplicate-run awareness
 


### PR DESCRIPTION
## Summary

- reject manual transitions into built-in or custom done-category statuses while any visible GitHub or self-hosted working PR is open or draft
- return HTTP 409 with stable code open_pull_requests_block_done and the blocking PR count
- preflight all batch targets before the first mutation to prevent partial delivery claims
- keep reference-only body mentions non-blocking and document the new contract in the built-in issue workflow skill

## Verification

- focused database regression: PASS
- full server/internal/handler suite: PASS (47.457s)
- broad go test ./...: changed handler, status, VCS integration, service, migration, and all other non-CLI packages passed; server/cmd/multica failed only because this daemon-managed task workdir marker intentionally rejects tests that assume an ordinary human CLI context

Issue: WS-4679