### PR TITLE
fix(codex): keep in-place brief out of tracked AGENTS.md

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5626,20 +5626,26 @@ func providerNeedsInlineSystemPrompt(provider string) bool {
 // flow can choose the delivery that does not write into the user's repository
 // (GitHub #7114).
 //
-// Membership is a property of this repository's backend code, not of the
-// vendor CLI, so it is verifiable by reading it: each provider below prepends
-// SystemPrompt to the prompt it sends (or passes it as --append-system-prompt)
-// whenever the field is non-empty — see grok.go, kimi.go, kiro.go, qoder.go,
-// qwenpaw.go, traecli.go, openclaw.go and codebuddy.go. Everything else is
-// absent deliberately: claude, pi, opencode, deveco and hermes each document
-// at their own call site why they drop the field, and a backend that ignored
-// it would leave the agent with no brief at all — which is why the default is
-// false and a new runtime has to opt in consciously.
-func providerSupportsInlineSystemPrompt(provider string) bool {
+// Membership is a property of this repository's backend code and, for Codex,
+// the installed protocol version. Each provider below consumes a non-empty
+// SystemPrompt through a verified instruction channel. Everything else is
+// absent deliberately: a backend that ignored it would leave the agent with no
+// brief at all, so the default is false and a new runtime has to opt in
+// consciously.
+const minCodexThreadInjectItemsVersion = "0.121.0"
+
+func providerSupportsInlineSystemPrompt(provider, codexVersion string) bool {
 	// Built-in runtime identities inherit their delivery from the protocol
 	// family they run on, the same resolution runtimeConfigPath does.
 	if desc, ok := agent.BuiltinRuntimeByID(provider); ok {
-		return providerSupportsInlineSystemPrompt(desc.ProtocolFamily)
+		return providerSupportsInlineSystemPrompt(desc.ProtocolFamily, codexVersion)
+	}
+	if provider == "codex" {
+		// thread/inject_items first appears in the v0.121.0 app-server
+		// protocol. Unknown and older versions keep file delivery: temporary
+		// repository pollution is preferable to silently dropping the brief or
+		// replacing the user's own developer_instructions.
+		return agent.CheckMinCLIVersionFor(codexVersion, minCodexThreadInjectItemsVersion) == nil
 	}
 	switch provider {
 	case "codebuddy", "grok", "kimi", "kiro", "openclaw", "qoder", "qoderclicn", "qwenpaw", "traecli":
@@ -5647,6 +5653,41 @@ func providerSupportsInlineSystemPrompt(provider string) bool {
 	default:
 		return false
 	}
+}
+
+type runtimeBriefDelivery struct {
+	brief           string
+	inline          bool
+	gitExcludePaths []string
+}
+
+// prepareRuntimeBriefDelivery is the production decision boundary between a
+// repository context file and an additive backend-native instruction. Keeping
+// the side effect and the allowlist decision together gives regression tests a
+// way to prove that Codex's in-place path never writes tracked AGENTS.md.
+func prepareRuntimeBriefDelivery(env *execenv.Environment, provider, codexVersion string, taskCtx execenv.TaskContextForEnv, logger *slog.Logger) runtimeBriefDelivery {
+	delivery := runtimeBriefDelivery{
+		inline:          env.LocalDirectory && providerSupportsInlineSystemPrompt(provider, codexVersion),
+		gitExcludePaths: env.SidecarPaths,
+	}
+	if delivery.inline {
+		delivery.brief = execenv.BuildRuntimeBrief(provider, taskCtx)
+		logger.Debug("execenv: delivering runtime brief inline; leaving the repository's runtime config file untouched",
+			"provider", provider, "work_dir", env.WorkDir)
+		return delivery
+	}
+
+	brief, created, err := execenv.InjectRuntimeConfigCreated(env.WorkDir, provider, taskCtx)
+	if err != nil {
+		logger.Warn("execenv: inject runtime config failed (non-fatal)", "error", err)
+	}
+	delivery.brief = brief
+	if created && env.LocalDirectory {
+		if path := execenv.RuntimeConfigPath(env.WorkDir, provider); path != "" {
+			delivery.gitExcludePaths = append(append([]string(nil), delivery.gitExcludePaths...), path)
+		}
+	}
+	return delivery
 }
 
 // gateResumeToReusedWorkdir clears the task's prior session unless this run
@@ -6761,29 +6802,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// agent runs mid-task commits it, which CleanupRuntimeConfig cannot undo
 	// after the fact (GitHub #7114). When the runtime can take the brief
 	// inline instead, take that route and leave the file untouched.
-	inlineBrief := env.LocalDirectory && providerSupportsInlineSystemPrompt(provider)
-	var runtimeBrief string
-	gitExcludePaths := env.SidecarPaths
-	if inlineBrief {
-		runtimeBrief = execenv.BuildRuntimeBrief(provider, taskCtx)
-		taskLog.Debug("execenv: delivering runtime brief inline; leaving the repository's runtime config file untouched",
-			"provider", provider, "work_dir", env.WorkDir)
-	} else {
-		brief, created, briefErr := execenv.InjectRuntimeConfigCreated(env.WorkDir, provider, taskCtx)
-		if briefErr != nil {
-			d.logger.Warn("execenv: inject runtime config failed (non-fatal)", "error", briefErr)
-		}
-		runtimeBrief = brief
-		// A config file WE created is an untracked new file in the user's
-		// repo, so it can be hidden from git alongside the sidecars. One that
-		// pre-existed is the user's own (usually tracked) and no ignore rule
-		// applies to it — only the marker block inside it is ours.
-		if created && env.LocalDirectory {
-			if path := execenv.RuntimeConfigPath(env.WorkDir, provider); path != "" {
-				gitExcludePaths = append(append([]string(nil), gitExcludePaths...), path)
-			}
-		}
-	}
+	delivery := prepareRuntimeBriefDelivery(env, provider, codexVersion, taskCtx, taskLog)
+	inlineBrief := delivery.inline
+	runtimeBrief := delivery.brief
+	gitExcludePaths := delivery.gitExcludePaths
 
 	// Keep the runtime's own files out of the git view the AGENT sees for the
 	// length of the run, so it cannot sweep them into a commit in the user's

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -736,47 +736,53 @@ func TestProviderSupportsInlineSystemPrompt(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		provider string
-		want     bool
+		provider     string
+		codexVersion string
+		want         bool
 	}{
 		// Backends that forward SystemPrompt into the turn.
-		{"grok", true},
-		{"kimi", true},
-		{"kiro", true},
-		{"openclaw", true},
-		{"qoder", true},
-		{"qoderclicn", true},
-		{"qwenpaw", true},
-		{"traecli", true},
-		{"codebuddy", true},
+		{"grok", "", true},
+		{"kimi", "", true},
+		{"kiro", "", true},
+		{"openclaw", "", true},
+		{"qoder", "", true},
+		{"qoderclicn", "", true},
+		{"qwenpaw", "", true},
+		{"traecli", "", true},
+		{"codebuddy", "", true},
+		// Codex uses additive thread/inject_items, available since v0.121.0.
+		{"codex", "codex-cli 0.121.0", true},
+		{"codex", "0.151.0-alpha.7.2", true},
+		{"codex", "0.120.0", false},
+		{"codex", "", false},
 		// Backends that documentedly drop it — these must keep getting the
 		// brief as a file, pollution or not, because inline delivery would
 		// silently deliver nothing.
-		{"claude", false},
-		{"pi", false},
-		{"opencode", false},
-		{"deveco", false},
-		{"hermes", false},
-		{"codex", false},
-		{"copilot", false},
-		{"cursor", false},
-		{"antigravity", false},
-		{"dsh", false},
-		{"reasonix", false},
-		{"qwen", false},
+		{"claude", "", false},
+		{"pi", "", false},
+		{"opencode", "", false},
+		{"deveco", "", false},
+		{"hermes", "", false},
+		{"copilot", "", false},
+		{"cursor", "", false},
+		{"antigravity", "", false},
+		{"dsh", "", false},
+		{"reasonix", "", false},
+		{"qwen", "", false},
 		// Built-in runtime identities inherit from their protocol family;
 		// omp is a pi fork, and pi drops the field.
-		{"omp", false},
+		{"omp", "", false},
 		// Unknown providers must never be assumed capable.
-		{"", false},
-		{"not-a-runtime", false},
+		{"", "", false},
+		{"not-a-runtime", "", false},
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.provider, func(t *testing.T) {
+		name := tc.provider + "_" + tc.codexVersion
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if got := providerSupportsInlineSystemPrompt(tc.provider); got != tc.want {
-				t.Fatalf("providerSupportsInlineSystemPrompt(%q) = %v, want %v", tc.provider, got, tc.want)
+			if got := providerSupportsInlineSystemPrompt(tc.provider, tc.codexVersion); got != tc.want {
+				t.Fatalf("providerSupportsInlineSystemPrompt(%q, %q) = %v, want %v", tc.provider, tc.codexVersion, got, tc.want)
 			}
 		})
 	}
@@ -792,9 +798,99 @@ func TestProvidersNeedingInlineAlsoSupportIt(t *testing.T) {
 		if !providerNeedsInlineSystemPrompt(provider) {
 			t.Fatalf("test list is stale: %q no longer needs inline delivery", provider)
 		}
-		if !providerSupportsInlineSystemPrompt(provider) {
+		if !providerSupportsInlineSystemPrompt(provider, "") {
 			t.Errorf("%q needs the brief inline but is not listed as supporting it", provider)
 		}
+	}
+}
+
+// This exercises the same delivery function runTask calls, rather than
+// manually rebuilding its intended branch from lower-level execenv helpers.
+// If Codex is removed from the allowlist or regresses below the additive
+// protocol floor, the helper writes AGENTS.md and this test fails on bytes.
+func TestPrepareRuntimeBriefDeliveryKeepsInPlaceCodexAgentsFileExact(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	repo := createDaemonTestRepo(t)
+	agentsPath := filepath.Join(repo, "AGENTS.md")
+	const projectInstructions = "# Project rules\n\nUse tabs.\n"
+	if err := os.WriteFile(agentsPath, []byte(projectInstructions), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit := func(extraEnv map[string]string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		cmd.Env = os.Environ()
+		for key, value := range extraEnv {
+			cmd.Env = append(cmd.Env, key+"="+value)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	runGit(map[string]string{}, "add", "AGENTS.md")
+	runGit(map[string]string{
+		"GIT_AUTHOR_NAME":     "test",
+		"GIT_AUTHOR_EMAIL":    "test@test.com",
+		"GIT_COMMITTER_NAME":  "test",
+		"GIT_COMMITTER_EMAIL": "test@test.com",
+	}, "commit", "-m", "add project instructions")
+
+	taskCtx := execenv.TaskContextForEnv{
+		IssueID: "11111111-2222-3333-4444-555555555555",
+		AgentID: "99999999-8888-7777-6666-555555555555",
+	}
+	env, err := execenv.Prepare(execenv.PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-gh7879-001",
+		TaskID:         "78790000-1111-2222-3333-444444444444",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		CodexVersion:   minCodexThreadInjectItemsVersion,
+		LocalWorkDir:   repo,
+		Task:           taskCtx,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	delivery := prepareRuntimeBriefDelivery(
+		env,
+		"codex",
+		minCodexThreadInjectItemsVersion,
+		taskCtx,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	if !delivery.inline {
+		t.Fatal("Codex v0.121.0 delivery was not inline")
+	}
+	if strings.TrimSpace(delivery.brief) == "" {
+		t.Fatal("inline runtime brief is empty")
+	}
+
+	protection, err := execenv.PrepareGitExcludes(env.RootDir, env.WorkDir, delivery.gitExcludePaths)
+	if err != nil {
+		t.Fatalf("PrepareGitExcludes: %v", err)
+	}
+	if err := protection.Verify(protection.Env); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if status := runGit(protection.Env, "status", "--porcelain"); status != "" {
+		t.Errorf("Codex sees a dirty repository before starting work:\n%s", status)
+	}
+	runGit(protection.Env, "add", "-A")
+	if staged := runGit(protection.Env, "diff", "--cached", "--name-only"); staged != "" {
+		t.Errorf("Codex staged runtime-owned files:\n%s", staged)
+	}
+
+	got, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != projectInstructions {
+		t.Fatalf("tracked AGENTS.md changed during delivery\nwant: %q\n got: %q", projectInstructions, got)
 	}
 }
 

--- a/server/internal/daemon/execenv/local_directory_git_hygiene_test.go
+++ b/server/internal/daemon/execenv/local_directory_git_hygiene_test.go
@@ -209,17 +209,17 @@ func TestPrepareCloudWorkdirReportsNoSidecarPaths(t *testing.T) {
 	}
 }
 
-// The runtime brief must not be written into a repository's tracked AGENTS.md
-// on the in_place path for a runtime that can receive it inline. This asserts
-// the execenv half of that contract: nothing writes the file unless asked.
-func TestBuildRuntimeBriefDoesNotTouchTheRepository(t *testing.T) {
+// Codex receives the runtime brief through app-server thread/inject_items on
+// the in-place path. Building that inline payload must leave the repository's
+// tracked AGENTS.md byte-exact throughout the task (GitHub #7879).
+func TestBuildCodexRuntimeBriefDoesNotTouchTrackedAgentsFile(t *testing.T) {
 	repo := newTestRepo(t)
 	agentsMD := filepath.Join(repo, "AGENTS.md")
 	writeFile(t, agentsMD, "# Project rules\n\nUse tabs.\n")
 	gitRun(t, repo, "add", "AGENTS.md")
 	gitRun(t, repo, "commit", "-m", "add agents.md")
 
-	brief := BuildRuntimeBrief("grok", TaskContextForEnv{
+	brief := BuildRuntimeBrief("codex", TaskContextForEnv{
 		IssueID: "11111111-2222-3333-4444-555555555555",
 		AgentID: "99999999-8888-7777-6666-555555555555",
 	})
@@ -228,5 +228,12 @@ func TestBuildRuntimeBriefDoesNotTouchTheRepository(t *testing.T) {
 	}
 	if status := gitRun(t, repo, "status", "--porcelain"); status != "" {
 		t.Errorf("building the brief modified the repository:\n%s", status)
+	}
+	got, err := os.ReadFile(agentsMD)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if want := "# Project rules\n\nUse tabs.\n"; string(got) != want {
+		t.Errorf("AGENTS.md changed while building inline brief\nwant: %q\n got: %q", want, got)
 	}
 }

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -25,11 +25,12 @@ type Backend interface {
 type ExecOptions struct {
 	Cwd   string
 	Model string
-	// SystemPrompt carries the Multica runtime brief for the few providers
-	// that cannot pick it up from disk. The daemon leaves it empty for every
-	// other provider (see daemon.providerNeedsInlineSystemPrompt), because the
-	// brief is already delivered as a per-task context file in the workdir —
-	// CLAUDE.md, AGENTS.md, CODEBUDDY.md or QWEN.md depending on the runtime.
+	// SystemPrompt carries the Multica runtime brief when a provider cannot
+	// pick it up from disk, or when an in-place task must keep the provider's
+	// context file out of the user's repository. The daemon leaves it empty for
+	// every other run because the brief is already delivered as a per-task
+	// context file in the workdir — CLAUDE.md, AGENTS.md, CODEBUDDY.md or QWEN.md
+	// depending on the runtime.
 	//
 	// A backend must therefore NOT assume this is populated, and adding a new
 	// backend that only reads SystemPrompt will silently receive nothing.

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -1446,6 +1446,36 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		} else {
 			b.cfg.Logger.Info("codex thread started", "thread_id", threadID)
 		}
+		if err := c.injectSystemPrompt(runCtx, threadID, opts.SystemPrompt); err != nil {
+			var handshakeErr *codexHandshakeTimeoutError
+			timedOut := errors.As(err, &handshakeErr) && handshakeErr.Method == "thread/inject_items"
+			if timedOut {
+				signalProcessGroup(cmd, syscall.SIGKILL)
+			}
+			drainAndWait()
+			finalStatus = "failed"
+			finalError = "codex runtime brief injection failed"
+			if timedOut {
+				finalError = fmt.Sprintf("%s: %v", finalError, err)
+			} else {
+				var rpcErr *codexRPCError
+				if errors.As(err, &rpcErr) {
+					finalError = fmt.Sprintf("%s (code=%d)", finalError, rpcErr.Code)
+				}
+			}
+			// The rejected request contains the full runtime brief. Do not persist
+			// the provider's error message or stderr here: either may echo that
+			// arbitrary user/project content, which pattern redaction cannot prove
+			// safe. The method and JSON-RPC code are enough to diagnose protocol
+			// compatibility without leaking instructions.
+			b.cfg.Logger.Warn("codex runtime brief injection failed",
+				"method", "thread/inject_items",
+				"code", codexRPCErrorCode(err),
+				"timed_out", timedOut,
+			)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
 
 		// 3. Send turn and wait for completion. When a resume was expected but we
 		// ended up on a fresh thread (the live thread/resume RPC was rejected — a
@@ -1786,6 +1816,31 @@ func codexTurnInput(prompt string, resumeExpected, resumed bool, notice string) 
 	return []map[string]any{{"type": "text", "text": text}}
 }
 
+// injectSystemPrompt appends Multica's runtime brief to the loaded thread as a
+// developer-role Responses API item. This is additive: unlike thread/start or
+// thread/resume developerInstructions, it does not replace developer
+// instructions loaded from the user's effective Codex config. Appending after
+// a resume also makes a changed brief visible on that run's first turn instead
+// of relying on the currently stale resume override path.
+func (c *codexClient) injectSystemPrompt(ctx context.Context, threadID, systemPrompt string) error {
+	if systemPrompt == "" {
+		return nil
+	}
+	_, err := c.request(ctx, "thread/inject_items", map[string]any{
+		"threadId": threadID,
+		"items": []map[string]any{
+			{
+				"type": "message",
+				"role": "developer",
+				"content": []map[string]any{
+					{"type": "input_text", "text": systemPrompt},
+				},
+			},
+		},
+	})
+	return err
+}
+
 // startOrResumeThread picks between Codex's thread/resume and thread/start
 // based on opts.ResumeSessionID. When a prior thread ID is provided it first
 // tries thread/resume; recoverable protocol errors (unknown thread, schema
@@ -1798,8 +1853,9 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 	if priorThreadID := opts.ResumeSessionID; priorThreadID != "" {
 		// thread/resume reuses the thread's persisted model and reasoning
 		// effort; only override fields the daemon actually cares about.
-		// developerInstructions stays nil for the reason given on thread/start
-		// below.
+		// developerInstructions stays nil so the effective Codex config remains
+		// authoritative. An in-place runtime brief is appended after resume by
+		// injectSystemPrompt instead (GitHub #7879).
 		resumeParams := map[string]any{
 			"threadId":              priorThreadID,
 			"cwd":                   opts.Cwd,
@@ -1828,12 +1884,12 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 		}
 	}
 
-	// developerInstructions is always nil: a thread started with this cwd loads
-	// the per-task AGENTS.md the daemon wrote there, so the runtime brief is
-	// already in context and inlining it would duplicate it on every turn.
-	// Confirmed end-to-end against codex-cli 0.144.6 driving the real
-	// app-server (thread/start -> turn/start) with developerInstructions unset
-	// (MUL-5392).
+	// Keep developerInstructions nil even when SystemPrompt is populated. Codex
+	// treats a non-nil value as an override of developer_instructions from the
+	// effective user/project config rather than an additive instruction. The
+	// in-place brief is appended after start by injectSystemPrompt instead.
+	// Ordinary file-based discovery was confirmed end-to-end against codex-cli
+	// 0.144.6 driving the real app-server (MUL-5392).
 	startParams := map[string]any{
 		"model":                  nilIfEmpty(opts.Model),
 		"modelProvider":          nil,
@@ -2273,6 +2329,24 @@ type rpcResult struct {
 	err    error
 }
 
+type codexRPCError struct {
+	Method  string
+	Code    int
+	Message string
+}
+
+func (e *codexRPCError) Error() string {
+	return fmt.Sprintf("%s: %s (code=%d)", e.Method, e.Message, e.Code)
+}
+
+func codexRPCErrorCode(err error) int {
+	var rpcErr *codexRPCError
+	if errors.As(err, &rpcErr) {
+		return rpcErr.Code
+	}
+	return 0
+}
+
 type codexHandshakeTimeoutError struct {
 	Method  string
 	Timeout time.Duration
@@ -2288,7 +2362,7 @@ func (e *codexHandshakeTimeoutError) Unwrap() error {
 
 func isCodexHandshakeRPC(method string) bool {
 	switch method {
-	case "initialize", "thread/start", "thread/resume", "thread/name/set", "turn/start":
+	case "initialize", "thread/start", "thread/resume", "thread/inject_items", "thread/name/set", "turn/start":
 		return true
 	default:
 		return false
@@ -2544,7 +2618,7 @@ func (c *codexClient) handleResponse(raw map[string]json.RawMessage) {
 			Message string `json:"message"`
 		}
 		_ = json.Unmarshal(errData, &rpcErr)
-		pr.ch <- rpcResult{err: fmt.Errorf("%s: %s (code=%d)", pr.method, rpcErr.Message, rpcErr.Code)}
+		pr.ch <- rpcResult{err: &codexRPCError{Method: pr.method, Message: rpcErr.Message, Code: rpcErr.Code}}
 	} else {
 		pr.ch <- rpcResult{result: raw["result"]}
 	}

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1926,13 +1926,13 @@ func TestCodexStartOrResumeThreadResumesPriorThread(t *testing.T) {
 }
 
 // codexRuntimeBriefCanary stands in for the Multica runtime brief the daemon
-// would inline if developerInstructions were ever wired back up.
+// sends inline for an in-place local_directory task.
 const codexRuntimeBriefCanary = "MULTICA-RUNTIME-BRIEF-CANARY"
 
-// assertNoDeveloperInstructions pins the MUL-5392 contract: Codex loads the
-// per-task AGENTS.md from the thread's cwd, so the daemon never inlines the
-// runtime brief here. The field must still be sent — the app-server treats a
-// missing key differently from an explicit null — but always as null.
+// assertNoDeveloperInstructions pins both instruction contracts: ordinary
+// tasks load AGENTS.md, while in-place tasks append the Multica brief with
+// thread/inject_items. Neither path may replace developer_instructions loaded
+// from the user's effective Codex config.
 func assertNoDeveloperInstructions(t *testing.T, params map[string]any) {
 	t.Helper()
 	got, ok := params["developerInstructions"]
@@ -1941,11 +1941,37 @@ func assertNoDeveloperInstructions(t *testing.T, params map[string]any) {
 		return
 	}
 	if got != nil {
-		t.Errorf("developerInstructions = %v, want null: the runtime brief is delivered via the workdir AGENTS.md, not inline (MUL-5392)", got)
+		t.Errorf("developerInstructions = %v, want null: non-null overrides the user's effective Codex config", got)
 	}
 }
 
-func TestCodexThreadStartNeverInlinesSystemPrompt(t *testing.T) {
+func assertInjectedDeveloperBrief(t *testing.T, params map[string]any) {
+	t.Helper()
+	if got := params["threadId"]; got != "thr_fresh" && got != "thr_prior" && got != "thr_new" && got != "thr-inline" {
+		t.Errorf("threadId = %v, want scripted thread", got)
+	}
+	items, ok := params["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("items = %#v, want one item", params["items"])
+	}
+	item, ok := items[0].(map[string]any)
+	if !ok {
+		t.Fatalf("item = %#v, want object", items[0])
+	}
+	if item["type"] != "message" || item["role"] != "developer" {
+		t.Errorf("item envelope = %#v, want developer message", item)
+	}
+	content, ok := item["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("content = %#v, want one item", item["content"])
+	}
+	textItem, ok := content[0].(map[string]any)
+	if !ok || textItem["type"] != "input_text" || textItem["text"] != codexRuntimeBriefCanary {
+		t.Errorf("content item = %#v, want runtime brief input_text", content[0])
+	}
+}
+
+func TestCodexThreadStartLeavesDeveloperInstructionsNullByDefault(t *testing.T) {
 	t.Parallel()
 
 	c, fs, _ := newTestCodexClient(t)
@@ -1959,7 +1985,29 @@ func TestCodexThreadStartNeverInlinesSystemPrompt(t *testing.T) {
 	})
 	defer wait()
 
-	// SystemPrompt is set deliberately; it must not reach the app-server.
+	if _, _, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{Cwd: "/work"},
+		slog.Default(),
+	); err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+}
+
+func TestCodexThreadStartKeepsDeveloperInstructionsNullWithSystemPrompt(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method:   "thread/start",
+			result:   json.RawMessage(`{"thread":{"id":"thr_fresh"}}`),
+			assertFn: assertNoDeveloperInstructions,
+		},
+	})
+	defer wait()
+
 	if _, _, err := c.startOrResumeThread(
 		context.Background(),
 		ExecOptions{Cwd: "/work", SystemPrompt: codexRuntimeBriefCanary},
@@ -1969,7 +2017,7 @@ func TestCodexThreadStartNeverInlinesSystemPrompt(t *testing.T) {
 	}
 }
 
-func TestCodexThreadResumeNeverInlinesSystemPrompt(t *testing.T) {
+func TestCodexThreadResumeKeepsDeveloperInstructionsNullWithSystemPrompt(t *testing.T) {
 	t.Parallel()
 
 	c, fs, _ := newTestCodexClient(t)
@@ -1983,10 +2031,32 @@ func TestCodexThreadResumeNeverInlinesSystemPrompt(t *testing.T) {
 	})
 	defer wait()
 
-	// SystemPrompt is set deliberately; it must not reach the app-server.
 	if _, _, err := c.startOrResumeThread(
 		context.Background(),
 		ExecOptions{Cwd: "/work", ResumeSessionID: "thr_prior", SystemPrompt: codexRuntimeBriefCanary},
+		slog.Default(),
+	); err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+}
+
+func TestCodexThreadResumeLeavesDeveloperInstructionsNullByDefault(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method:   "thread/resume",
+			result:   json.RawMessage(`{"thread":{"id":"thr_prior"}}`),
+			assertFn: assertNoDeveloperInstructions,
+		},
+	})
+	defer wait()
+
+	if _, _, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{Cwd: "/work", ResumeSessionID: "thr_prior"},
 		slog.Default(),
 	); err != nil {
 		t.Fatalf("startOrResumeThread: %v", err)
@@ -2024,6 +2094,169 @@ func TestCodexStartOrResumeThreadFallsBackOnResumeError(t *testing.T) {
 	}
 	if resumed {
 		t.Error("expected resumed=false after falling back to thread/start")
+	}
+}
+
+func TestCodexResumeFallbackKeepsDeveloperInstructionsNull(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method:   "thread/resume",
+			errMsg:   "unknown thread",
+			errCode:  -32602,
+			assertFn: assertNoDeveloperInstructions,
+		},
+		{
+			method:   "thread/start",
+			result:   json.RawMessage(`{"thread":{"id":"thr_new"}}`),
+			assertFn: assertNoDeveloperInstructions,
+		},
+	})
+	defer wait()
+
+	threadID, resumed, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{
+			Cwd:             "/work",
+			ResumeSessionID: "thr_stale",
+			SystemPrompt:    codexRuntimeBriefCanary,
+		},
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+	if threadID != "thr_new" {
+		t.Errorf("threadID = %q, want thr_new", threadID)
+	}
+	if resumed {
+		t.Error("expected resumed=false after falling back to thread/start")
+	}
+}
+
+func TestCodexInjectSystemPromptAppendsDeveloperHistory(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method:   "thread/inject_items",
+			result:   json.RawMessage(`{}`),
+			assertFn: assertInjectedDeveloperBrief,
+		},
+	})
+	defer wait()
+
+	if err := c.injectSystemPrompt(context.Background(), "thr_fresh", codexRuntimeBriefCanary); err != nil {
+		t.Fatalf("injectSystemPrompt: %v", err)
+	}
+}
+
+func TestCodexInjectSystemPromptEmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+	if err := c.injectSystemPrompt(context.Background(), "thr_fresh", ""); err != nil {
+		t.Fatalf("injectSystemPrompt: %v", err)
+	}
+	if lines := fs.Lines(); len(lines) != 0 {
+		t.Fatalf("empty prompt emitted RPCs: %v", lines)
+	}
+}
+
+func TestCodexExecuteInjectsBriefBetweenThreadStartAndFirstTurn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`DIR="$(dirname "$0")"`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line; printf '%s\n' "$line" > "$DIR/thread-start.json"`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-inline"}}}'`+"\n"+
+		`read line; printf '%s\n' "$line" > "$DIR/inject.json"`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`read line; printf '%s\n' "$line" > "$DIR/turn-start.json"`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":4,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-inline","turn":{"id":"turn-inline","status":"completed"}}}'`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		SystemPrompt:              codexRuntimeBriefCanary,
+		Timeout:                   5 * time.Second,
+		HandshakeTimeout:          time.Second,
+		SemanticInactivityTimeout: time.Second,
+	})
+	if result.Status != "completed" {
+		t.Fatalf("result = %+v", result)
+	}
+
+	readRequest := func(name string) (string, map[string]any) {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(filepath.Dir(fakePath), name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var request struct {
+			Method string         `json:"method"`
+			Params map[string]any `json:"params"`
+		}
+		if err := json.Unmarshal(data, &request); err != nil {
+			t.Fatalf("decode %s: %v", name, err)
+		}
+		return request.Method, request.Params
+	}
+
+	method, startParams := readRequest("thread-start.json")
+	if method != "thread/start" {
+		t.Fatalf("first captured method = %q, want thread/start", method)
+	}
+	assertNoDeveloperInstructions(t, startParams)
+
+	method, injectParams := readRequest("inject.json")
+	if method != "thread/inject_items" {
+		t.Fatalf("second captured method = %q, want thread/inject_items", method)
+	}
+	assertInjectedDeveloperBrief(t, injectParams)
+
+	method, _ = readRequest("turn-start.json")
+	if method != "turn/start" {
+		t.Fatalf("third captured method = %q, want turn/start", method)
+	}
+}
+
+func TestCodexExecuteInjectionFailureDoesNotPersistBrief(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-inline"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '`+codexRuntimeBriefCanary+`' >&2`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"error":{"code":-32600,"message":"rejected `+codexRuntimeBriefCanary+`"}}'`+"\n")
+
+	var logs bytes.Buffer
+	result, _ := executeFakeCodexCollectingMessagesWithConfig(
+		t,
+		fakePath,
+		Config{Logger: slog.New(slog.NewJSONHandler(&logs, nil))},
+		ExecOptions{SystemPrompt: codexRuntimeBriefCanary, Timeout: 5 * time.Second},
+		10*time.Second,
+	)
+	if result.Status != "failed" || !strings.Contains(result.Error, "code=-32600") {
+		t.Fatalf("result = %+v", result)
+	}
+	if combined := result.Error + "\n" + logs.String(); strings.Contains(combined, codexRuntimeBriefCanary) {
+		t.Fatalf("runtime brief leaked into persisted diagnostics: %s", combined)
 	}
 }
 
@@ -2420,6 +2653,19 @@ func TestCodexExecuteStartupRPCsHaveBoundedHandshakeTimeout(t *testing.T) {
 				`read line` + "\n" +
 				`read line` + "\n",
 			opts: ExecOptions{ResumeSessionID: "thr-prior"},
+		},
+		{
+			name:   "runtime brief injection",
+			method: "thread/inject_items",
+			body: "" +
+				`read line` + "\n" +
+				`echo '{"jsonrpc":"2.0","id":1,"result":{}}'` + "\n" +
+				`read line` + "\n" +
+				`read line` + "\n" +
+				`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-timeout"}}}'` + "\n" +
+				`read line` + "\n" +
+				`read line` + "\n",
+			opts: ExecOptions{SystemPrompt: codexRuntimeBriefCanary},
 		},
 		{
 			name:   "turn start",


### PR DESCRIPTION
> [!NOTE]
> This is a stacked draft on #7123. Review the single commit after `bc545fe0a`; the base PR supplies the task-scoped Git protection for runtime sidecars.

Fixes #7879.

## Problem

A Codex task using `local_directory` in `in_place` mode appended the Multica runtime brief to the repository's tracked `AGENTS.md`. During the run, agent-side Git therefore saw the daemon's own modification and safety-oriented agents refused to start work.

The first inline implementation used app-server `developerInstructions`. Upstream Codex treats that field as a replacement for effective `developer_instructions`, not an additive layer, and the resume override can be stale for the first resumed turn. That would keep `AGENTS.md` clean at the cost of silently dropping user/project instructions.

## Change

- Keep `developerInstructions: null` on both `thread/start` and `thread/resume`, preserving the user's effective Codex configuration.
- For Codex CLI >= `0.121.0`, append the Multica runtime brief as a developer-role Responses API item with `thread/inject_items` after start/resume and before the first turn.
- Keep file delivery for unknown or older Codex versions, where `thread/inject_items` does not exist. This deliberately prefers temporary repository pollution over losing either instruction source.
- Bound brief injection with the startup handshake timeout and fail closed if it is rejected. Diagnostics retain only the method/code/timeout classification, never a provider message or stderr that could echo the brief.
- Factor the daemon's real file-vs-inline decision into one production helper and test that exact boundary against a real Git repository with a tracked `AGENTS.md`.

## Verification

- `go test ./pkg/agent -run 'TestCodex|TestIsCodex|TestApplyCodex|TestExtractThreadID|TestNilIfEmpty' -count=1` (pass, 94.985s)
- `go test ./internal/daemon/execenv -count=1` (pass, 31.508s)
- `go test ./internal/daemon -count=1` (pass, 46.445s)
- `go test -race ./pkg/agent -run 'TestCodex(ThreadStartKeepsDeveloperInstructionsNullWithSystemPrompt|ThreadResumeKeepsDeveloperInstructionsNullWithSystemPrompt|InjectSystemPromptAppendsDeveloperHistory|ExecuteInjectsBriefBetweenThreadStartAndFirstTurn|ExecuteInjectionFailureDoesNotPersistBrief)' -count=1`
- `go test -race ./internal/daemon -run 'TestProviderSupportsInlineSystemPrompt|TestPrepareRuntimeBriefDeliveryKeepsInPlaceCodexAgentsFileExact' -count=1`
- `go vet ./pkg/agent ./internal/daemon/execenv ./internal/daemon`
- `git diff --check`

A first combined daemon run hit the pre-existing timing-sensitive `TestRunTask_PrepareTimeoutStopsLeaseDuringBlockedStartTask`; it passed 10 consecutive isolated runs, and the subsequent full daemon run passed.

Real protocol smoke against Codex CLI `0.151.0-alpha.7.2` passed: `thread/inject_items` accepted a developer-role item, persisted it, and the rollout contained both a user-config `developer_instructions` canary and the Multica runtime-brief canary. Source/tag inspection confirms the method is absent through `0.120.0` and present in `0.121.0`.

Negative controls also discriminate the fixes:

- Restoring non-null `thread/start`/`thread/resume.developerInstructions` fails both config-preservation tests.
- Removing Codex from the version-aware inline branch fails the daemon delivery regression before the tracked-file guarantee can pass.

The broad `go test ./pkg/agent -count=1` was attempted before this re-review and remains timing-sensitive on this host: unrelated 5-second backend fixtures can exceed their setup window under package-wide load. The complete Codex-focused set above passes.

## Stack status

#7123 still conflicts with the latest `main` in its daemon/execenv base changes. This PR remains draft and should be rebased or retargeted only after that foundation is updated or merged.
