### PR TITLE
MUL-6965: add live model catalog refresh

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -2118,6 +2118,19 @@ describe("ApiClient model discovery response schema", () => {
     expect(result.cached_at).toBe("2026-07-29T00:00:00Z");
   });
 
+  it("requests a live model list when force refresh is selected", async () => {
+    stubJSON(completed);
+
+    await new ApiClient("https://api.example.test").initiateListModels("rt-1", {
+      force: true,
+    });
+
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe(
+      "https://api.example.test/api/runtimes/rt-1/models?force=true",
+    );
+    expect(vi.mocked(fetch).mock.calls[0]?.[1]).toMatchObject({ method: "POST" });
+  });
+
   // The picker drives a state machine off `status`, so a malformed body must
   // become an explicit failure — not a fabricated empty catalog, and not an
   // endless "discovering models" spinner.

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -2267,10 +2267,17 @@ export class ApiClient {
   // than cast: an unparseable body degrades to an explicit "failed" record that
   // shows the discovery error and keeps manual model entry usable, instead of a
   // fabricated empty catalog or an endless spinner (MUL-5444).
-  async initiateListModels(runtimeId: string): Promise<RuntimeModelListRequest> {
-    const raw = await this.fetch<unknown>(`/api/runtimes/${runtimeId}/models`, {
-      method: "POST",
-    });
+  async initiateListModels(
+    runtimeId: string,
+    options: { force?: boolean } = {},
+  ): Promise<RuntimeModelListRequest> {
+    const query = options.force === true ? "?force=true" : "";
+    const raw = await this.fetch<unknown>(
+      `/api/runtimes/${runtimeId}/models${query}`,
+      {
+        method: "POST",
+      },
+    );
     return parseWithFallback<RuntimeModelListRequest>(
       raw,
       RuntimeModelListRequestSchema,

--- a/packages/core/runtimes/models.test.ts
+++ b/packages/core/runtimes/models.test.ts
@@ -3,6 +3,7 @@ import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import {
   LIVE_MODELS_STALE_TIME_MS,
   resolveRuntimeModels,
+  refreshRuntimeModels,
   runtimeModelsKeys,
   runtimeModelsOptions,
   staleTimeFor,
@@ -14,7 +15,10 @@ const getListModelsResult = vi.fn();
 
 vi.mock("../api", () => ({
   api: {
-    initiateListModels: (runtimeId: string) => initiateListModels(runtimeId),
+    initiateListModels: (
+      runtimeId: string,
+      options?: { force?: boolean },
+    ) => initiateListModels(runtimeId, options),
     getListModelsResult: (runtimeId: string, requestId: string) =>
       getListModelsResult(runtimeId, requestId),
   },
@@ -275,6 +279,30 @@ describe("runtimeModelsOptions", () => {
     expect(options.gcTime).toBeGreaterThanOrEqual(LIVE_MODELS_STALE_TIME_MS);
     expect(options.queryKey).toEqual(["runtimes", "models", "rt-1"]);
     expect(options.enabled).toBe(true);
+  });
+
+  it("force-refreshes the canonical cache instead of serving a cached catalog", async () => {
+    initiateListModels.mockResolvedValue(
+      request({ status: "completed", models: refreshedCatalog }),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    client.setQueryData(runtimeModelsKeys.forRuntime("rt-1"), {
+      models: catalog,
+      supported: true,
+      cached: true,
+    });
+
+    await refreshRuntimeModels(client, "rt-1");
+
+    expect(initiateListModels).toHaveBeenCalledWith("rt-1", { force: true });
+    expect(client.getQueryData(runtimeModelsKeys.forRuntime("rt-1"))).toMatchObject({
+      models: refreshedCatalog,
+      cached: false,
+    });
+    client.clear();
   });
 
   it("resolves freshness from the served answer, not a fixed window", () => {

--- a/packages/core/runtimes/models.ts
+++ b/packages/core/runtimes/models.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { queryOptions, type QueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import type { RuntimeModelsResult } from "../types/agent";
 
@@ -67,8 +67,12 @@ export const MODELS_GC_TIME_MS = 30 * 60_000;
 // window past what the server itself promises.
 export async function resolveRuntimeModels(
   runtimeId: string,
+  options: { force?: boolean } = {},
 ): Promise<RuntimeModelsResult> {
-  const initial = await api.initiateListModels(runtimeId);
+  const initial =
+    options.force === true
+      ? await api.initiateListModels(runtimeId, { force: true })
+      : await api.initiateListModels(runtimeId);
   const start = Date.now();
   let current = initial;
   while (current.status === "pending" || current.status === "running") {
@@ -125,5 +129,20 @@ export function runtimeModelsOptions(runtimeId: string | null | undefined) {
     staleTime: (query) => staleTimeFor(query.state.data),
     gcTime: MODELS_GC_TIME_MS,
     retry: false,
+  });
+}
+
+// refreshRuntimeModels is the explicit user refresh path. It reuses the
+// canonical query key so every model-dependent control updates together, while
+// its force flag skips the server's stale-while-revalidate catalog and waits
+// for the daemon's current answer.
+export function refreshRuntimeModels(
+  queryClient: QueryClient,
+  runtimeId: string,
+): Promise<RuntimeModelsResult> {
+  return queryClient.fetchQuery({
+    ...runtimeModelsOptions(runtimeId),
+    queryFn: () => resolveRuntimeModels(runtimeId, { force: true }),
+    staleTime: 0,
   });
 }

--- a/packages/views/agents/components/inspector/model-picker.test.tsx
+++ b/packages/views/agents/components/inspector/model-picker.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { I18nProvider } from "@multica/core/i18n/react";
 import type { RuntimeModelsResult } from "@multica/core/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -33,6 +33,7 @@ const CLAUDE_CATALOG: RuntimeModelsResult = {
 
 let discovery: () => Promise<RuntimeModelsResult> = async () => CLAUDE_CATALOG;
 let discoveryKey = 0;
+const mockRefreshRuntimeModels = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/runtimes", () => ({
   runtimeModelsOptions: (runtimeId: string | null) => ({
@@ -40,6 +41,8 @@ vi.mock("@multica/core/runtimes", () => ({
     queryKey: ["runtime-models", runtimeId, discoveryKey],
     queryFn: () => discovery(),
   }),
+  refreshRuntimeModels: (...args: unknown[]) =>
+    mockRefreshRuntimeModels(...args),
 }));
 
 function renderPicker() {
@@ -59,7 +62,7 @@ function renderPicker() {
       </QueryClientProvider>
     </I18nProvider>,
   );
-  return { ...view, onChange };
+  return { ...view, onChange, queryClient };
 }
 
 function openPicker(container: HTMLElement) {
@@ -73,6 +76,7 @@ describe("ModelPicker (inspector)", () => {
     cleanup();
     discovery = async () => CLAUDE_CATALOG;
     discoveryKey += 1;
+    mockRefreshRuntimeModels.mockReset();
   });
 
   it("offers the runnable model", async () => {
@@ -112,5 +116,21 @@ describe("ModelPicker (inspector)", () => {
     expect(
       screen.queryByText(enAgents.pickers.model_unavailable_heading),
     ).toBeNull();
+  });
+
+  it("exposes the live-catalog refresh from the inspector picker", async () => {
+    mockRefreshRuntimeModels.mockResolvedValue(CLAUDE_CATALOG);
+    const { container, queryClient } = renderPicker();
+    openPicker(container);
+    await screen.findByText("Fable");
+    fireEvent.click(
+      screen.getByRole("button", { name: enAgents.pickers.model_refresh }),
+    );
+
+    expect(mockRefreshRuntimeModels).toHaveBeenCalledWith(
+      queryClient,
+      "rt-claude",
+    );
+    queryClient.clear();
   });
 });

--- a/packages/views/agents/components/inspector/model-picker.tsx
+++ b/packages/views/agents/components/inspector/model-picker.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, Cpu, Loader2, Plus } from "lucide-react";
-import { runtimeModelsOptions } from "@multica/core/runtimes";
-import { Input } from "@multica/ui/components/ui/input";
+import {
+  refreshRuntimeModels,
+  runtimeModelsOptions,
+} from "@multica/core/runtimes";
 import { Label } from "@multica/ui/components/ui/label";
 import {
   PickerItem,
@@ -13,6 +15,7 @@ import {
 import { CHIP_CLASS } from "./chip";
 import { useT } from "../../../i18n";
 import { UnavailableModelsNote } from "../unavailable-models-note";
+import { ModelSearchHeader } from "../model-search-header";
 
 /**
  * Inline model picker for the agent inspector. Lighter cousin of
@@ -46,6 +49,7 @@ export function ModelPicker({
   onChange: (next: string) => Promise<void> | void;
 }) {
   const { t } = useT("agents");
+  const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
 
@@ -88,6 +92,14 @@ export function ModelPicker({
     setOpen(false);
     setSearch("");
     if (id !== value) await onChange(id);
+  };
+
+  const refresh = () => {
+    if (!runtimeId || !runtimeOnline) return;
+    void refreshRuntimeModels(queryClient, runtimeId).catch(() => {
+      // React Query retains the last catalog and owns the error state. Avoid
+      // turning a failed button action into an unhandled promise rejection.
+    });
   };
 
   if (!supported && !modelsQuery.isLoading) {
@@ -191,18 +203,14 @@ export function ModelPicker({
         </>
       }
       header={
-        <div className="p-1.5">
-          <Input
-            autoFocus
-            name="agent-model-search"
-            autoComplete="off"
-            aria-label={t(($) => $.pickers.model_search_placeholder)}
-            placeholder={t(($) => $.pickers.model_search_placeholder)}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="h-7 text-caption"
-          />
-        </div>
+        <ModelSearchHeader
+          value={search}
+          onChange={setSearch}
+          onRefresh={refresh}
+          refreshing={modelsQuery.isFetching}
+          refreshDisabled={!runtimeOnline || !runtimeId}
+          compact
+        />
       }
     >
       {modelsQuery.isLoading && (

--- a/packages/views/agents/components/model-dropdown.test.tsx
+++ b/packages/views/agents/components/model-dropdown.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { I18nProvider } from "@multica/core/i18n/react";
 import type { RuntimeModelsResult } from "@multica/core/types";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import enAgents from "../../locales/en/agents.json";
 import enCommon from "../../locales/en/common.json";
 import enIssues from "../../locales/en/issues.json";
@@ -31,6 +31,7 @@ const CODEX_MODELS: RuntimeModelsResult = {
 // Discovery outcome for the next render. resolveRuntimeModels rejects with the
 // daemon's reported error text, so a failure is modelled as a throwing queryFn.
 let discovery: () => Promise<RuntimeModelsResult> = async () => CODEX_MODELS;
+const mockRefreshRuntimeModels = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/runtimes", () => ({
   runtimeModelsOptions: (runtimeId: string | null) => ({
@@ -38,6 +39,8 @@ vi.mock("@multica/core/runtimes", () => ({
     queryKey: ["runtime-models", runtimeId, discoveryKey],
     queryFn: () => discovery(),
   }),
+  refreshRuntimeModels: (...args: unknown[]) =>
+    mockRefreshRuntimeModels(...args),
 }));
 
 // Bumped per test so React Query cannot serve a previous case's cached result.
@@ -72,9 +75,14 @@ function openDropdown(container: HTMLElement) {
 }
 
 describe("ModelDropdown", () => {
+  beforeEach(() => {
+    mockRefreshRuntimeModels.mockResolvedValue(CODEX_MODELS);
+  });
+
   afterEach(() => {
     cleanup();
     discovery = async () => CODEX_MODELS;
+    mockRefreshRuntimeModels.mockReset();
     discoveryKey += 1;
   });
 
@@ -91,6 +99,21 @@ describe("ModelDropdown", () => {
 
     fireEvent.click(screen.getByText("GPT-5.6 Terra"));
     expect(onChange).toHaveBeenCalledWith("gpt-5.6-terra");
+  });
+
+  it("offers an explicit refresh that requests the runtime's live catalog", async () => {
+    const { container } = renderDropdown();
+    openDropdown(container);
+
+    await screen.findByText("GPT-5.6 Sol");
+    fireEvent.click(
+      screen.getByRole("button", { name: enAgents.pickers.model_refresh }),
+    );
+
+    expect(mockRefreshRuntimeModels).toHaveBeenCalledWith(
+      expect.any(QueryClient),
+      "rt-codex",
+    );
   });
 
   // MUL-6606: a runtime that could not enumerate its models used to report an

--- a/packages/views/agents/components/model-dropdown.tsx
+++ b/packages/views/agents/components/model-dropdown.tsx
@@ -1,19 +1,22 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, Cpu, Loader2, Plus, Check, Info } from "lucide-react";
-import { runtimeModelsOptions } from "@multica/core/runtimes";
+import {
+  refreshRuntimeModels,
+  runtimeModelsOptions,
+} from "@multica/core/runtimes";
 import type { RuntimeModel } from "@multica/core/types";
 import {
   Popover,
   PopoverTrigger,
   PopoverContent,
 } from "@multica/ui/components/ui/popover";
-import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
 import { useT } from "../../i18n";
 import { UnavailableModelsNote } from "./unavailable-models-note";
+import { ModelSearchHeader } from "./model-search-header";
 
 // ModelDropdown renders a searchable, creatable model picker for an agent.
 // It fetches the supported-model catalog from the selected runtime — the
@@ -43,6 +46,7 @@ export function ModelDropdown({
   disabled?: boolean;
 }) {
   const { t } = useT("agents");
+  const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
 
@@ -105,6 +109,14 @@ export function ModelDropdown({
     onChange(id);
     setOpen(false);
     setSearch("");
+  };
+
+  const refresh = () => {
+    if (!runtimeId || !runtimeOnline) return;
+    void refreshRuntimeModels(queryClient, runtimeId).catch(() => {
+      // React Query owns the error state rendered below. Swallow the returned
+      // promise rejection so a failed manual refresh is not also unhandled.
+    });
   };
 
   const triggerLabel =
@@ -174,13 +186,13 @@ export function ModelDropdown({
           align="start"
           className="w-[var(--anchor-width)] p-0 overflow-hidden"
         >
-          <div className="border-b border-border p-2">
-            <Input
-              autoFocus
-              placeholder={t(($) => $.pickers.model_search_placeholder)}
+          <div className="border-b border-border">
+            <ModelSearchHeader
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="h-8"
+              onChange={setSearch}
+              onRefresh={refresh}
+              refreshing={modelsQuery.isFetching}
+              refreshDisabled={!runtimeOnline || !runtimeId}
             />
           </div>
           <div className="max-h-72 overflow-y-auto p-1">

--- a/packages/views/agents/components/model-search-header.tsx
+++ b/packages/views/agents/components/model-search-header.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { RefreshCw } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+import { Input } from "@multica/ui/components/ui/input";
+import { useT } from "../../i18n";
+
+export function ModelSearchHeader({
+  value,
+  onChange,
+  onRefresh,
+  refreshing,
+  refreshDisabled = false,
+  compact = false,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  onRefresh: () => void;
+  refreshing: boolean;
+  refreshDisabled?: boolean;
+  compact?: boolean;
+}) {
+  const { t } = useT("agents");
+  const refreshLabel = refreshing
+    ? t(($) => $.pickers.model_refreshing)
+    : t(($) => $.pickers.model_refresh);
+
+  return (
+    <div className={`flex items-center gap-1.5 ${compact ? "p-1.5" : "p-2"}`}>
+      <Input
+        autoFocus
+        name="agent-model-search"
+        autoComplete="off"
+        aria-label={t(($) => $.pickers.model_search_placeholder)}
+        placeholder={t(($) => $.pickers.model_search_placeholder)}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className={compact ? "h-7 min-w-0 flex-1 text-caption" : "h-8 min-w-0 flex-1"}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label={refreshLabel}
+        onClick={onRefresh}
+        disabled={refreshDisabled || refreshing}
+      >
+        <RefreshCw
+          className={
+            refreshing ? "animate-spin motion-reduce:animate-none" : undefined
+          }
+          aria-hidden="true"
+        />
+      </Button>
+    </div>
+  );
+}

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -232,6 +232,8 @@
     "model_managed_by_runtime": "Managed by runtime",
     "model_search_placeholder": "Search or type a model ID",
     "model_discovering": "Discovering models…",
+    "model_refresh": "Refresh models",
+    "model_refreshing": "Refreshing models…",
     "model_discovery_failed_title": "Could not list this runtime's models.",
     "model_discovery_failed_hint": "Type a model ID above to enter one manually.",
     "model_empty": "No models available",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -214,6 +214,8 @@
     "model_managed_by_runtime": "ランタイムで管理",
     "model_search_placeholder": "モデル ID を検索または入力",
     "model_discovering": "モデルを検出中...",
+    "model_refresh": "モデルを更新",
+    "model_refreshing": "モデルを更新中...",
     "model_discovery_failed_title": "このランタイムのモデルを取得できませんでした。",
     "model_discovery_failed_hint": "上の入力欄にモデル ID を直接入力して手動で指定できます。",
     "model_empty": "利用可能なモデルがありません",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -222,6 +222,8 @@
     "model_managed_by_runtime": "런타임에서 관리",
     "model_search_placeholder": "모델 ID 검색 또는 입력",
     "model_discovering": "모델 찾는 중...",
+    "model_refresh": "모델 새로고침",
+    "model_refreshing": "모델 새로고침 중...",
     "model_discovery_failed_title": "이 런타임의 모델을 가져오지 못했습니다.",
     "model_discovery_failed_hint": "위 입력란에 모델 ID를 직접 입력해 수동으로 지정할 수 있습니다.",
     "model_empty": "사용 가능한 모델이 없습니다",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -222,6 +222,8 @@
     "model_managed_by_runtime": "由运行时管理",
     "model_search_placeholder": "搜索或输入模型 ID",
     "model_discovering": "正在发现模型...",
+    "model_refresh": "刷新模型",
+    "model_refreshing": "正在刷新模型...",
     "model_discovery_failed_title": "无法列出该运行时的模型。",
     "model_discovery_failed_hint": "可在上方输入框直接键入模型 ID 手动指定。",
     "model_empty": "暂无可用模型",

--- a/server/internal/handler/runtime_model_catalog_test.go
+++ b/server/internal/handler/runtime_model_catalog_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func sampleCatalog() []ModelEntry {
@@ -271,6 +274,62 @@ func TestModelCatalogServeWindow_ServesDayOldSnapshotAndRevalidates(t *testing.T
 	}
 	if rec.count() != 1 {
 		t.Fatalf("expected exactly 1 pending-work hint, got %d", rec.count())
+	}
+}
+
+// TestInitiateListModels_ForceSkipsCatalogCache pins the contract behind the
+// picker's Refresh action: a normal open stays instant on a warm catalog, while
+// force=true creates a request the daemon must answer instead of returning the
+// same cached snapshot again.
+func TestInitiateListModels_ForceSkipsCatalogCache(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	runtimeID := dbfx.Runtime(t, "Force model refresh runtime")
+	cache := NewInMemoryModelCatalogCache()
+	unavailable := []UnavailableModelEntry{{
+		ID:     "cc-update-required-1",
+		Label:  "Fable 5.1 (disabled)",
+		Reason: "Update Claude Code",
+	}}
+	if err := cache.Put(context.Background(), runtimeID, sampleCatalog(), unavailable, true); err != nil {
+		t.Fatalf("seed catalog: %v", err)
+	}
+	store := NewInMemoryModelListStore()
+	recorder := &pendingWorkRecorder{}
+	h := *testHandler
+	h.ModelCatalogCache = cache
+	h.ModelListStore = store
+	h.DaemonPendingWork = recorder
+
+	request := func(query string) *http.Request {
+		return withURLParam(
+			newRequest(http.MethodPost, "/api/runtimes/"+runtimeID+"/models"+query, nil),
+			"runtimeId",
+			runtimeID,
+		)
+	}
+
+	var cached ModelListRequest
+	testutil.Call(t, h.InitiateListModels, request("")).Want(http.StatusOK).JSON(&cached)
+	if cached.Status != ModelListCompleted || !cached.Cached {
+		t.Fatalf("normal open = %+v, want completed cache hit", cached)
+	}
+	if len(cached.UnavailableModels) != 1 || cached.UnavailableModels[0].ID != unavailable[0].ID {
+		t.Fatalf("normal cache hit lost unavailable models: %+v", cached.UnavailableModels)
+	}
+	if recorder.count() != 0 {
+		t.Fatalf("normal cache hit queued %d daemon requests, want 0", recorder.count())
+	}
+
+	var forced ModelListRequest
+	testutil.Call(t, h.InitiateListModels, request("?force=true")).Want(http.StatusOK).JSON(&forced)
+	if forced.Status != ModelListPending || forced.Cached {
+		t.Fatalf("forced refresh = %+v, want pending live request", forced)
+	}
+	if recorder.count() != 1 {
+		t.Fatalf("forced refresh queued %d daemon requests, want 1", recorder.count())
 	}
 }
 

--- a/server/internal/handler/runtime_models.go
+++ b/server/internal/handler/runtime_models.go
@@ -331,11 +331,14 @@ func modelListRequestTerminal(status ModelListStatus) bool {
 
 // InitiateListModels answers a "list this runtime's models" request.
 //
-// Fast path: a cached catalog younger than modelCatalogServeWindow is returned
-// as an already-completed request, so the picker renders immediately instead of
-// waiting for the daemon (stale-while-revalidate). Serving a snapshot older than
+// Fast path: unless force=true, a cached catalog younger than
+// modelCatalogServeWindow is returned as an already-completed request, so the
+// picker renders immediately instead of waiting for the daemon
+// (stale-while-revalidate). Serving a snapshot older than
 // modelCatalogRevalidateAfter also enqueues a background refresh, which nobody
-// polls — its only job is to warm the cache for the next open.
+// polls — its only job is to warm the cache for the next open. force=true is the
+// picker refresh action: it skips this server cache and waits for a live daemon
+// result.
 //
 // Slow path: enqueue a pending request the daemon claims on its next heartbeat,
 // and push a wakeup hint so "next heartbeat" is now rather than up to one
@@ -352,28 +355,30 @@ func (h *Handler) InitiateListModels(w http.ResponseWriter, r *http.Request) {
 	}
 	resolvedRuntimeID := uuidToString(rt.ID)
 
-	if cached := h.cachedModelCatalog(r.Context(), resolvedRuntimeID); cached != nil {
-		age := cached.Age(time.Now())
-		if age >= modelCatalogRevalidateAfter {
-			h.revalidateModelCatalog(r.Context(), resolvedRuntimeID)
+	if r.URL.Query().Get("force") != "true" {
+		if cached := h.cachedModelCatalog(r.Context(), resolvedRuntimeID); cached != nil {
+			age := cached.Age(time.Now())
+			if age >= modelCatalogRevalidateAfter {
+				h.revalidateModelCatalog(r.Context(), resolvedRuntimeID)
+			}
+			storedAt := cached.StoredAt
+			writeJSON(w, http.StatusOK, &ModelListRequest{
+				// Synthetic ID: no store record backs a cache hit. Clients only poll
+				// GET /models/{id} while status is pending/running, which this
+				// response never is.
+				ID:                randomID(),
+				RuntimeID:         resolvedRuntimeID,
+				Status:            ModelListCompleted,
+				Models:            cached.Models,
+				UnavailableModels: cached.UnavailableModels,
+				Supported:         cached.Supported,
+				CreatedAt:         storedAt,
+				UpdatedAt:         storedAt,
+				Cached:            true,
+				CachedAt:          &storedAt,
+			})
+			return
 		}
-		storedAt := cached.StoredAt
-		writeJSON(w, http.StatusOK, &ModelListRequest{
-			// Synthetic ID: no store record backs a cache hit. Clients only poll
-			// GET /models/{id} while status is pending/running, which this
-			// response never is.
-			ID:                randomID(),
-			RuntimeID:         resolvedRuntimeID,
-			Status:            ModelListCompleted,
-			Models:            cached.Models,
-			UnavailableModels: cached.UnavailableModels,
-			Supported:         cached.Supported,
-			CreatedAt:         storedAt,
-			UpdatedAt:         storedAt,
-			Cached:            true,
-			CachedAt:          &storedAt,
-		})
-		return
 	}
 
 	req, err := h.ModelListStore.Create(r.Context(), resolvedRuntimeID)


### PR DESCRIPTION
## Summary

- add a refresh action beside model search in both agent model pickers
- make forced discovery bypass the server model-catalog cache and wait for the runtime daemon
- update the canonical React Query entry so model, thinking, and speed controls share the refreshed catalog
- cover the API flag, cache bypass, shared query update, picker actions, and locale parity

## Testing

- `go test ./internal/handler -run 'TestInitiateListModels_ForceSkipsCatalogCache|TestModelCatalogServeWindow_ServesDayOldSnapshotAndRevalidates' -count=1`
- `pnpm exec vitest run runtimes/models.test.ts api/client.test.ts` in `packages/core` (115 passed)
- `pnpm exec vitest run agents/components/model-dropdown.test.tsx agents/components/inspector/model-picker.test.tsx` in `packages/views` (5 passed)
- `pnpm exec vitest run agents/agents-i18n-parity.test.ts` in `packages/views` (11 passed)
- `pnpm typecheck` in `packages/core` and `packages/views`
- `pnpm lint` in `packages/core` and `packages/views` (passes; pre-existing warnings remain in views)
- full package suites were also run: core had 1683 passing and 9 unrelated localStorage-environment failures; views had 4928 passing and 1 unrelated sidebar-resize failure

Closes MUL-6965
