### PR TITLE
MUL-6969: fix(agent): anchor hermes ACP error-sniffer detail regex; terminal markers only on header lines

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -2755,7 +2755,12 @@ var acpErrorHeaderRe = regexp.MustCompile(`(?:⚠️|❌|\[ERROR\]).*(?:BadReque
 // acpErrorDetailRe pulls the most useful single-line messages out of
 // the subsequent lines of the error block (the one whose "Error:" or
 // "Details:" tag actually spells out what happened).
-var acpErrorDetailRe = regexp.MustCompile(`(?:Error:|detail:|Details:)\s*(.+)`)
+// Anchored to the line start (an optional 📝 marker and a bare identifier
+// prefix like "RuntimeError:"/"JSONDecodeError:" are allowed) so an "Error:"
+// substring in the middle of an echoed conversation/tool line cannot pose as
+// a diagnostic; the identifier prefix keeps real exception lines capturable
+// (GH #6150's "RuntimeError: No LLM provider configured").
+var acpErrorDetailRe = regexp.MustCompile(`^(?:📝\s*)?(?:\w*Error:|detail:|Details:)\s*(.+)$`)
 
 // acpTerminalErrorRe matches markers that only appear when the
 // adapter has *given up* on the upstream call — either after
@@ -2863,10 +2868,13 @@ func (s *acpProviderErrorSniffer) Write(p []byte) (int, error) {
 				continue
 			}
 		}
-		if !(acpErrorHeaderRe.MatchString(line) || acpErrorDetailRe.MatchString(line)) {
+		isHeader := acpErrorHeaderRe.MatchString(line)
+		if !(isHeader || acpErrorDetailRe.MatchString(line)) {
 			continue
 		}
-		if acpTerminalErrorRe.MatchString(line) {
+		// Terminal markers belong to header lines; a detail line that merely
+		// echoes a terminal marker substring must not flip the flag.
+		if isHeader && acpTerminalErrorRe.MatchString(line) {
 			s.terminal = true
 		}
 		if s.seen[line] {

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1780,8 +1780,7 @@ func TestParseACPTokenUsageCostIsOptional(t *testing.T) {
 // TestParseACPModelIDFromMeta covers the shapes the `_meta` model id can
 // arrive in, and confirms a missing one degrades to empty rather than
 // inventing an attribution.
-func TestParseACPModelIDFromMeta(t *testing.T) {
-	t.Parallel()
+func TestParseACPModelIDFromMeta(t *testing.T) {	t.Parallel()
 
 	for _, tc := range []struct {
 		name string
@@ -1984,6 +1983,22 @@ func TestHermesProviderErrorSnifferHandlesPartialLines(t *testing.T) {
 	msg := s.message()
 	if !strings.Contains(msg, "something went wrong") {
 		t.Errorf("expected buffered line to be captured, got %q", msg)
+	}
+}
+
+func TestHermesProviderErrorSnifferIgnoresToolTracebacks(t *testing.T) {
+	t.Parallel()
+
+	s := newACPProviderErrorSniffer("hermes")
+	s.Write([]byte("[ERROR] mcp.client.stdio: Failed to parse JSONRPC message from server\n"))
+	s.Write([]byte("pydantic_core.ValidationError: 1 validation error for JSONRPCMessage\n"))
+	s.Write([]byte("[ERROR] tools.vision_tools: Error analyzing image: Error code: 400\n"))
+
+	if msg := s.message(); msg != "" {
+		t.Errorf("tool tracebacks are not provider errors, got %q", msg)
+	}
+	if msg := s.terminalMessage(); msg != "" {
+		t.Errorf("tool tracebacks must not fail an otherwise completed run, got %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Problem

The hermes ACP provider error sniffer misclassifies ordinary conversation echo as upstream errors:

1. `acpErrorDetailRe` matched an `Error:` / `Details:` substring **anywhere** in a line, so a tool-output or assistant line that merely contains the word (e.g. an echoed log entry) posed as a diagnostic line.
2. Terminal give-up markers flipped the sniffer's `terminal` flag even when they appeared on a **detail** line that was echoing them, not on an actual header (`⚠️`/`❌`/`[ERROR]`) line — aborting a call that had not actually given up.

## Fix

- Anchor `acpErrorDetailRe` to the line start, allowing an optional marker plus a bare identifier prefix (`RuntimeError:`, `JSONDecodeError:`, …) so real exception lines stay capturable (cf. GH #6150's `RuntimeError: No LLM provider configured`).
- Compute `isHeader` once; only header lines can flip the terminal flag.

## Testing

- `go test ./pkg/agent/ -run 'ACP|ErrorSniffer|Error'` passes; full `./pkg/agent/` suite passes locally.
- Added/updated regex cases cover identifier-prefixed detail lines and terminal-marker echo on detail lines.

By submitting this contribution I agree to condition 2 of the Multica License.