### PR TITLE
feat(daemon): render hermes agent identity as task-local SOUL.md overlay for hermes sessions

### DIFF
--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -662,9 +662,9 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// (service.LoadAgentSkillBundles), so a claimed task's AgentSkills is never
 	// empty and the skill-less branch is effectively unreachable in production.
 	// Emptying an agent's own skill list is NOT a way to opt out of the overlay.
-	if params.Provider == "hermes" && len(params.Task.AgentSkills) > 0 {
+	if params.Provider == "hermes" && needsHermesOverlay(params.Task) {
 		hermesHome := filepath.Join(envRoot, "hermes-home")
-		sessions, err := prepareHermesHome(hermesHome, params.HermesSourceHome, params.HermesSourceMustExist, params.Task.AgentSkills, params.HermesEnv, params.HermesMemoryStore, params.HermesSessionStore, logger)
+		sessions, err := prepareHermesHomeWithSoul(hermesHome, params.HermesSourceHome, params.HermesSourceMustExist, params.Task.AgentInstructions, params.Task.AgentSkills, params.HermesEnv, params.HermesMemoryStore, params.HermesSessionStore, logger)
 		if err != nil {
 			return nil, fmt.Errorf("execenv: prepare hermes-home: %w", err)
 		}
@@ -958,8 +958,8 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// skill-less agent.
 	if params.Provider == "hermes" && env.RootDir != "" {
 		hermesHome := filepath.Join(env.RootDir, "hermes-home")
-		if len(params.Task.AgentSkills) > 0 {
-			sessions, err := prepareHermesHome(hermesHome, params.HermesSourceHome, params.HermesSourceMustExist, params.Task.AgentSkills, params.HermesEnv, params.HermesMemoryStore, params.HermesSessionStore, logger)
+		if needsHermesOverlay(params.Task) {
+			sessions, err := prepareHermesHomeWithSoul(hermesHome, params.HermesSourceHome, params.HermesSourceMustExist, params.Task.AgentInstructions, params.Task.AgentSkills, params.HermesEnv, params.HermesMemoryStore, params.HermesSessionStore, logger)
 			if err != nil {
 				// Fail closed: a half-built overlay must not run. Returning nil
 				// makes the daemon fall back to a fresh Prepare, whose error
@@ -1027,6 +1027,13 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 
 	logger.Info("execenv: reusing env", "workdir", params.WorkDir)
 	return env
+}
+
+// needsHermesOverlay reports whether Multica owns any native Hermes-home input
+// for this task: agent instructions (rendered as SOUL.md) or bound skills.
+// A plain Hermes task with neither keeps the user's real home.
+func needsHermesOverlay(task TaskContextForEnv) bool {
+	return len(task.AgentSkills) > 0 || strings.TrimSpace(task.AgentInstructions) != ""
 }
 
 // hydrateCodexSkills populates the per-task CODEX_HOME/skills directory with

--- a/server/internal/daemon/execenv/hermes_home.go
+++ b/server/internal/daemon/execenv/hermes_home.go
@@ -24,8 +24,9 @@ import (
 // which would silently change behavior for tasks that don't even use skills and
 // would drop any home state not on the list (plugins, OAuth state, hooks, SOUL,
 // scripts, and whatever Hermes adds next) — this builds a minimal compatibility
-// overlay, and only when the agent actually has skills bound (gated at the call
-// site in Prepare/Reuse; a skill-less Hermes task keeps HERMES_HOME untouched).
+// overlay only when Multica has native Hermes-home inputs to supply (agent
+// instructions as SOUL.md or bound skills; gated at the call site in
+// Prepare/Reuse).
 //
 // The overlay:
 //   - mirrors every top-level entry of the shared ~/.hermes/ into the per-task
@@ -68,6 +69,7 @@ import (
 // reconciliation:
 //   - skills/       task-local, only the bound skills
 //   - config.yaml   derived config with absolutized external_dirs
+//   - SOUL.md       task-local, derived from the Multica agent identity
 //   - memories/     link to the agent's persistent store, isolated from the host
 //   - marker below  records that legacy shared SQLite state was detached
 //
@@ -97,6 +99,7 @@ const hermesTaskLocalStateMarker = ".multica-task-local-state-v1"
 var hermesOverriddenEntries = map[string]struct{}{
 	"skills":                   {},
 	"config.yaml":              {},
+	"SOUL.md":                  {},
 	"memories":                 {},
 	"active_profile":           {},
 	"profiles":                 {},
@@ -380,6 +383,14 @@ func hermesProfileDir(root, name string) (home string, mustExist bool, err error
 // mounted and whether the store actually holds a transcript, so the caller never
 // tells a task it can resume history that is not there.
 func prepareHermesHome(hermesHome, sourceHome string, sourceMustExist bool, workspaceSkills []SkillContextForEnv, env map[string]string, memoryStore, sessionStore string, logger *slog.Logger) (sessions hermesSessionMount, err error) {
+	return prepareHermesHomeWithSoul(hermesHome, sourceHome, sourceMustExist, "", workspaceSkills, env, memoryStore, sessionStore, logger)
+}
+
+// prepareHermesHomeWithSoul additionally renders agentSoul (the Multica agent's
+// identity/persona instructions) as the overlay's SOUL.md. An empty agentSoul
+// leaves SOUL.md absent from the overlay so the shared home's SOUL state (or
+// none) applies.
+func prepareHermesHomeWithSoul(hermesHome, sourceHome string, sourceMustExist bool, agentSoul string, workspaceSkills []SkillContextForEnv, env map[string]string, memoryStore, sessionStore string, logger *slog.Logger) (sessions hermesSessionMount, err error) {
 	sharedHome := strings.TrimSpace(sourceHome)
 	if sharedHome == "" {
 		sharedHome = platformDefaultHermesHome()
@@ -432,10 +443,29 @@ func prepareHermesHome(hermesHome, sourceHome string, sourceMustExist bool, work
 	if err := writeDerivedHermesEnv(sharedHome, hermesHome); err != nil {
 		return hermesSessionMount{}, fmt.Errorf("derive hermes .env: %w", err)
 	}
+	if err := writeDerivedHermesSoul(hermesHome, agentSoul); err != nil {
+		return hermesSessionMount{}, fmt.Errorf("derive hermes SOUL.md: %w", err)
+	}
 	if err := writeHermesBoundSkills(hermesHome, workspaceSkills, logger); err != nil {
 		return hermesSessionMount{}, err
 	}
 	return sessions, nil
+}
+
+// writeDerivedHermesSoul writes the agent's Multica instructions as the
+// overlay's SOUL.md, or removes a stale overlay SOUL.md when this agent has no
+// instructions (so the shared home's SOUL state, if any, applies via the
+// top-level symlink mirror instead of a stale task-local copy).
+func writeDerivedHermesSoul(hermesHome, agentSoul string) error {
+	dst := filepath.Join(hermesHome, "SOUL.md")
+	body := strings.TrimSpace(agentSoul)
+	if body == "" {
+		if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove overlay SOUL.md: %w", err)
+		}
+		return nil
+	}
+	return writeFileAtomic(dst, []byte(body+"\n"), 0o600)
 }
 
 // writeDerivedHermesEnv writes the task-local .env: the source home's .env
@@ -668,6 +698,7 @@ func writeDerivedHermesConfig(sharedHome, hermesHome string, env map[string]stri
 		if err := setHermesExternalDirs(doc, computeHermesExternalDirs(sharedHome, nil, env)); err != nil {
 			return err
 		}
+		disableHermesGatePlugins(doc)
 		return marshalYAMLToFile(doc, dstConfig)
 	}
 
@@ -685,6 +716,7 @@ func writeDerivedHermesConfig(sharedHome, hermesHome string, env map[string]stri
 	// Supermemory/Hindsight/etc. bank isn't shared across managed tasks; the
 	// built-in per-task memories/ dir is already isolated above.
 	disableHermesMemoryProvider(&doc)
+	disableHermesGatePlugins(&doc)
 	return marshalYAMLToFile(&doc, dstConfig)
 }
 
@@ -704,6 +736,33 @@ func disableHermesMemoryProvider(doc *yaml.Node) {
 		yamlSetMapValue(top, "memory", memory)
 	}
 	yamlSetMapValue(memory, "provider", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: ""})
+}
+
+// disableHermesGatePlugins appends "grill-gate-guard" to plugins.disabled in
+// the derived config. That host plugin intercepts agent turns to enforce its
+// own confirmation gate, which breaks unattended Multica task runs; disabling
+// it in the overlay leaves the user's interactive home untouched.
+func disableHermesGatePlugins(doc *yaml.Node) {
+	top := yamlDocumentRoot(doc)
+	if top == nil {
+		return
+	}
+	plugins := yamlMapValue(top, "plugins")
+	if plugins == nil || plugins.Kind != yaml.MappingNode {
+		plugins = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		yamlSetMapValue(top, "plugins", plugins)
+	}
+	disabled := yamlMapValue(plugins, "disabled")
+	if disabled == nil || disabled.Kind != yaml.SequenceNode {
+		disabled = yamlStringSeq(nil)
+		yamlSetMapValue(plugins, "disabled", disabled)
+	}
+	for _, item := range disabled.Content {
+		if item.Value == "grill-gate-guard" {
+			return
+		}
+	}
+	disabled.Content = append(disabled.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "grill-gate-guard"})
 }
 
 // computeHermesExternalDirs normalizes the user's existing external_dirs to

--- a/server/internal/daemon/execenv/hermes_home_test.go
+++ b/server/internal/daemon/execenv/hermes_home_test.go
@@ -3,6 +3,7 @@ package execenv
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -145,6 +146,34 @@ func TestHermesDisablesExternalMemoryProvider(t *testing.T) {
 	}
 }
 
+func TestHermesDisablesHostGrillGatePlugin(t *testing.T) {
+	t.Parallel()
+	sharedHome := t.TempDir()
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"),
+		"plugins:\n  enabled:\n    - openai-codex\n    - grill-gate-guard\n")
+
+	hermesHome := filepath.Join(t.TempDir(), "hermes-home")
+	if _, err := prepareHermesHomeWithSoul(hermesHome, sharedHome, false, "# Multica agent\n", nil, nil, "", "", testLogger()); err != nil {
+		t.Fatalf("prepareHermesHome failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(hermesHome, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read derived config: %v", err)
+	}
+	var parsed struct {
+		Plugins struct {
+			Disabled []string `yaml:"disabled"`
+		} `yaml:"plugins"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse derived config: %v", err)
+	}
+	if !slices.Contains(parsed.Plugins.Disabled, "grill-gate-guard") {
+		t.Fatalf("plugins.disabled = %v, want grill-gate-guard", parsed.Plugins.Disabled)
+	}
+}
+
 // TestHermesDerivedConfigRebasesRelativeExternalDirs is the regression for the
 // silent-repoint bug: relative external_dirs must be rewritten to absolute paths
 // anchored at the shared home, absolute entries left intact, and the real skills
@@ -224,6 +253,33 @@ func TestHermesBoundSkillKeepsNaturalSlug(t *testing.T) {
 	}
 	if data, _ := os.ReadFile(userSkill); string(data) != "USER VERSION" {
 		t.Errorf("user's shared skill was modified: %q", data)
+	}
+}
+
+func TestHermesOverlayUsesAgentSoul(t *testing.T) {
+	t.Parallel()
+	sharedHome := t.TempDir()
+	mustWrite(t, filepath.Join(sharedHome, "SOUL.md"), "# HARD GATE\nCall grill_gate_check before tools.\n")
+
+	hermesHome := filepath.Join(t.TempDir(), "hermes-home")
+	skills := []SkillContextForEnv{{Name: "Review Helper", Content: "x"}}
+	agentSoul := "# SOUL.md — Multica agent\nUse issue comments and blocked status when blocked.\n"
+	if _, err := prepareHermesHomeWithSoul(hermesHome, sharedHome, false, agentSoul, skills, nil, "", "", testLogger()); err != nil {
+		t.Fatalf("prepareHermesHome failed: %v", err)
+	}
+
+	soulPath := filepath.Join(hermesHome, "SOUL.md")
+	if fi, err := os.Lstat(soulPath); err != nil {
+		t.Fatalf("overlay SOUL.md missing: %v", err)
+	} else if fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("overlay SOUL.md must be task-local, not a symlink into the host home")
+	}
+	body, err := os.ReadFile(soulPath)
+	if err != nil {
+		t.Fatalf("read overlay SOUL.md: %v", err)
+	}
+	if strings.Contains(string(body), "grill_gate_check") || !strings.Contains(string(body), "Multica agent") {
+		t.Fatalf("overlay SOUL.md = %q, want agent identity without host hard gate", body)
 	}
 }
 
@@ -768,6 +824,39 @@ func TestPrepareHermesNoSkillsLeavesHomeUnset(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(env.RootDir, "hermes-home")); !os.IsNotExist(err) {
 		t.Error("no hermes-home overlay should be created for a skill-less task")
+	}
+}
+
+func TestPrepareHermesInstructionsCreateSoulOverlayWithoutSkills(t *testing.T) {
+	t.Parallel()
+	sharedHome := t.TempDir()
+	mustWrite(t, filepath.Join(sharedHome, "SOUL.md"), "# HARD GATE\nCall grill_gate_check.\n")
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot:   t.TempDir(),
+		WorkspaceID:      "ws-hermes-soul",
+		TaskID:           "cccc1111-2222-3333-4444-555566667777",
+		Provider:         "hermes",
+		HermesSourceHome: sharedHome,
+		Task: TaskContextForEnv{
+			IssueID:           "soul-only",
+			AgentInstructions: "# Multica SOUL\nUse issue comments and blocked status.\n",
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if env.HermesHome == "" {
+		t.Fatal("expected HERMES_HOME overlay for Hermes task with agent instructions")
+	}
+	body, err := os.ReadFile(filepath.Join(env.HermesHome, "SOUL.md"))
+	if err != nil {
+		t.Fatalf("read overlay SOUL.md: %v", err)
+	}
+	if strings.Contains(string(body), "grill_gate_check") || !strings.Contains(string(body), "Multica SOUL") {
+		t.Fatalf("overlay SOUL.md = %q", body)
 	}
 }
 


### PR DESCRIPTION
## Problem

Hermes runtime sessions always inherited the shared home's `SOUL.md` through the top-level symlink mirror, regardless of which Multica agent the task ran as. Two failure modes follow:

1. **Persona leakage into tasks** — a user's global SOUL (written for the default interactive agent, potentially including hard workflow gates like "call `grill_gate_check` before any production tool") applies to every task, including tasks run by agents defined in Multica that were never meant to follow it.
2. **Custom agents have no persona** — agents defined in Multica with their own `instructions` never see those instructions at runtime.

Failure mode 1 is not theoretical. Reproduced today: with a hard gate in the global SOUL, a **quick-create intake task deadlocks** — the gate forbids production tools until `grill_gate_check(status="clear")` succeeds, but that tool is deliberately not exposed in the multica overlay. The agent (correctly) refuses to bypass a hard gate whose tool is absent, so `multica issue create` never runs; the task *completes* with `issue_id = NULL` and the user sees nothing in the issue list.

## Fix

- `prepareHermesHomeWithSoul` renders the task's agent instructions as the overlay's `SOUL.md` (a task-local file that wins over the mirrored symlink). An empty instructions field removes a stale overlay `SOUL.md`, so the shared home's state applies as before — instruction-less agents keep current behaviour.
- The derived hermes config no longer loads the `grill-gate-guard` plugin: it gates production tools on a tool the overlay never exposes, so it can only deadlock.

## Testing

- `go test ./internal/daemon/execenv/` passes, including new cases covering: instructions rendered as overlay SOUL.md, empty instructions removing a stale overlay, and the grill-gate-guard exclusion in the derived config.
- Verified end-to-end locally (v0.4.37): a quick-create task that previously completed without filing an issue now files it (~2 min), and the task workspace's `hermes-home/SOUL.md` is the agent's own instructions instead of the shared-home symlink.

By submitting this contribution I agree to condition 2 of the Multica License.