### PR TITLE
MUL-6846: feat(cli): expose active and cross-issue agent runs on `issue runs`

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -701,6 +701,15 @@ multica issue runs <issue-id>
 multica issue runs <issue-id> --full-id
 multica issue runs <issue-id> --output json
 
+# Only work in flight (queued / dispatched / running / waiting_local_directory)
+multica issue runs <issue-id> --active --output json
+
+# ...and across the sub-issue family: the issue's parent (or itself, when it has
+# no parent) plus every child of that parent, each row labelled with its issue.
+# Answers "is another agent already working next to me?" before you start
+# overlapping code or PR work. Advisory only — it reserves nothing.
+multica issue runs <issue-id> --siblings --output json
+
 # View messages for a specific execution run
 multica issue run-messages <task-id>
 multica issue run-messages <short-task-id> --issue <issue-id>

--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -709,7 +709,11 @@ multica issue runs <issue-id> --active --output json
 # Answers "is another agent already working next to me?" before you start
 # overlapping code or PR work. Advisory only — it reserves nothing.
 #
-# Ordered running-first, newest-first within a status, capped at 50 rows. When
+# Returns a compact per-run row — task_id, issue_id, issue_identifier,
+# issue_title, agent_id, status, created_at, started_at — not the full
+# execution-log record. Follow a task_id with `issue run-messages` for detail.
+#
+# Ordered running-first, newest-first within a status, capped at 20 rows. When
 # the cap truncates the answer the server sets X-Active-Runs-Truncated and the
 # CLI warns on stderr, so a short list is never mistaken for a complete one.
 multica issue runs <issue-id> --siblings --output json

--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -708,6 +708,10 @@ multica issue runs <issue-id> --active --output json
 # no parent) plus every child of that parent, each row labelled with its issue.
 # Answers "is another agent already working next to me?" before you start
 # overlapping code or PR work. Advisory only — it reserves nothing.
+#
+# Ordered running-first, newest-first within a status, capped at 50 rows. When
+# the cap truncates the answer the server sets X-Active-Runs-Truncated and the
+# CLI warns on stderr, so a short list is never mistaken for a complete one.
 multica issue runs <issue-id> --siblings --output json
 
 # View messages for a specific execution run

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -321,8 +321,13 @@ var issueSubscriberRemoveCmd = &cobra.Command{
 var issueRunsCmd = &cobra.Command{
 	Use:   "runs <issue-id>",
 	Short: "List execution history for an issue",
-	Args:  exactArgs(1),
-	RunE:  runIssueRuns,
+	Long: "List agent task runs for an issue.\n\n" +
+		"Defaults to this issue's full execution history, newest first. Narrow it to " +
+		"work in flight with --active, or widen it across the sub-issue family with " +
+		"--siblings when you need to know whether another agent is already working " +
+		"next to you.",
+	Args: exactArgs(1),
+	RunE: runIssueRuns,
 }
 
 var issueRunMessagesCmd = &cobra.Command{
@@ -566,6 +571,8 @@ func init() {
 	// issue runs
 	issueRunsCmd.Flags().String("output", "table", "Output format: table or json")
 	issueRunsCmd.Flags().Bool("full-id", false, "Show full task UUIDs in table output")
+	issueRunsCmd.Flags().Bool("active", false, "Only in-flight runs (queued, dispatched, running, waiting_local_directory) instead of the full execution history. Answers \"is an agent working on this right now\" without pulling every past run.")
+	issueRunsCmd.Flags().Bool("siblings", false, "Widen to this issue's sub-issue family — its parent (or itself, when it has no parent) plus every child of that parent — so you can see whether another run is already working alongside you before starting overlapping code or PR work. Implies --active; adds an ISSUE column. Advisory only: it reports work in flight, it does not reserve or serialise anything.")
 
 	// issue usage
 	issueUsageCmd.Flags().String("output", "table", "Output format: table or json")
@@ -2146,8 +2153,26 @@ func runIssueRuns(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolve issue: %w", err)
 	}
 
+	activeOnly, _ := cmd.Flags().GetBool("active")
+	siblings, _ := cmd.Flags().GetBool("siblings")
+
+	params := url.Values{}
+	if siblings {
+		// The server implies active for a family read, so --siblings alone is
+		// enough; sending both keeps the request self-describing.
+		params.Set("scope", "family")
+		params.Set("active", "true")
+	} else if activeOnly {
+		params.Set("active", "true")
+	}
+
+	path := "/api/issues/" + issueRef.ID + "/task-runs"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
 	var runs []map[string]any
-	if err := client.GetJSON(ctx, "/api/issues/"+issueRef.ID+"/task-runs", &runs); err != nil {
+	if err := client.GetJSON(ctx, path, &runs); err != nil {
 		return fmt.Errorf("list runs: %w", err)
 	}
 
@@ -2158,7 +2183,13 @@ func runIssueRuns(cmd *cobra.Command, args []string) error {
 
 	actors := loadActorDisplayLookup(ctx, client)
 	fullID, _ := cmd.Flags().GetBool("full-id")
+	// A family read mixes runs from several issues, so the row has to say which
+	// one it belongs to. On a single-issue read that column would repeat the
+	// argument on every line, so it stays off.
 	headers := []string{"ID", "AGENT", "STATUS", "STARTED", "COMPLETED", "ERROR"}
+	if siblings {
+		headers = []string{"ID", "ISSUE", "AGENT", "STATUS", "STARTED", "COMPLETED", "ERROR"}
+	}
 	rows := make([][]string, 0, len(runs))
 	for _, r := range runs {
 		started := strVal(r, "started_at")
@@ -2174,14 +2205,18 @@ func runIssueRuns(cmd *cobra.Command, args []string) error {
 			runes := []rune(errMsg)
 			errMsg = string(runes[:47]) + "..."
 		}
-		rows = append(rows, []string{
-			displayID(strVal(r, "id"), fullID),
+		row := []string{displayID(strVal(r, "id"), fullID)}
+		if siblings {
+			row = append(row, strVal(r, "issue_identifier"))
+		}
+		row = append(row,
 			actors.agent(strVal(r, "agent_id")),
 			strVal(r, "status"),
 			started,
 			completed,
 			errMsg,
-		})
+		)
+		rows = append(rows, row)
 	}
 	cli.PrintTable(os.Stdout, headers, rows)
 	return nil

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -578,7 +578,7 @@ func init() {
 	issueRunsCmd.Flags().String("output", "table", "Output format: table or json")
 	issueRunsCmd.Flags().Bool("full-id", false, "Show full task UUIDs in table output")
 	issueRunsCmd.Flags().Bool("active", false, "Only in-flight runs (queued, dispatched, running, waiting_local_directory) instead of the full execution history. Answers \"is an agent working on this right now\" without pulling every past run.")
-	issueRunsCmd.Flags().Bool("siblings", false, "Widen to this issue's sub-issue family — its parent (or itself, when it has no parent) plus every child of that parent — so you can see whether another run is already working alongside you before starting overlapping code or PR work. Implies --active; adds an ISSUE column. Ordered running-first, newest-first within a status, and capped at 50 rows; when the cap truncates the answer the CLI says so on stderr, so a short list is never mistaken for a complete one. Advisory only: it reports work in flight, it does not reserve or serialise anything.")
+	issueRunsCmd.Flags().Bool("siblings", false, "Widen to this issue's sub-issue family — its parent (or itself, when it has no parent) plus every child of that parent — so you can see whether another run is already working alongside you before starting overlapping code or PR work. Implies --active. Returns a compact per-run row (task, issue, agent, status, started) rather than the full execution-log record. Ordered running-first, newest-first within a status, and capped at 20 rows; when the cap truncates the answer the CLI says so on stderr, so a short list is never mistaken for a complete one. Advisory only: it reports work in flight, it does not reserve or serialise anything.")
 
 	// issue usage
 	issueUsageCmd.Flags().String("output", "table", "Output format: table or json")
@@ -2199,13 +2199,33 @@ func runIssueRuns(cmd *cobra.Command, args []string) error {
 
 	actors := loadActorDisplayLookup(ctx, client)
 	fullID, _ := cmd.Flags().GetBool("full-id")
-	// A family read mixes runs from several issues, so the row has to say which
-	// one it belongs to. On a single-issue read that column would repeat the
-	// argument on every line, so it stays off.
-	headers := []string{"ID", "AGENT", "STATUS", "STARTED", "COMPLETED", "ERROR"}
+
+	// The family read returns a different, deliberately smaller row than the
+	// execution log — no completed_at or error, because every row in it is
+	// still in flight — and it spans issues, so it needs a column saying which.
+	// On a single-issue read that column would repeat the argument on every
+	// line, so it stays off there.
 	if siblings {
-		headers = []string{"ID", "ISSUE", "AGENT", "STATUS", "STARTED", "COMPLETED", "ERROR"}
+		headers := []string{"TASK", "ISSUE", "AGENT", "STATUS", "STARTED"}
+		rows := make([][]string, 0, len(runs))
+		for _, r := range runs {
+			started := strVal(r, "started_at")
+			if len(started) >= 16 {
+				started = started[:16]
+			}
+			rows = append(rows, []string{
+				displayID(strVal(r, "task_id"), fullID),
+				strVal(r, "issue_identifier"),
+				actors.agent(strVal(r, "agent_id")),
+				strVal(r, "status"),
+				started,
+			})
+		}
+		cli.PrintTable(os.Stdout, headers, rows)
+		return nil
 	}
+
+	headers := []string{"ID", "AGENT", "STATUS", "STARTED", "COMPLETED", "ERROR"}
 	rows := make([][]string, 0, len(runs))
 	for _, r := range runs {
 		started := strVal(r, "started_at")
@@ -2221,18 +2241,14 @@ func runIssueRuns(cmd *cobra.Command, args []string) error {
 			runes := []rune(errMsg)
 			errMsg = string(runes[:47]) + "..."
 		}
-		row := []string{displayID(strVal(r, "id"), fullID)}
-		if siblings {
-			row = append(row, strVal(r, "issue_identifier"))
-		}
-		row = append(row,
+		rows = append(rows, []string{
+			displayID(strVal(r, "id"), fullID),
 			actors.agent(strVal(r, "agent_id")),
 			strVal(r, "status"),
 			started,
 			completed,
 			errMsg,
-		)
-		rows = append(rows, row)
+		})
 	}
 	cli.PrintTable(os.Stdout, headers, rows)
 	return nil

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -318,6 +318,12 @@ var issueSubscriberRemoveCmd = &cobra.Command{
 
 // Execution history subcommands.
 
+// headerActiveRunsTruncated mirrors handler.HeaderActiveRunsTruncated. Declared
+// as a literal rather than imported because the CLI does not depend on the
+// handler package (same convention as headerTimelineTruncated in
+// `issue timeline`).
+const headerActiveRunsTruncated = "X-Active-Runs-Truncated"
+
 var issueRunsCmd = &cobra.Command{
 	Use:   "runs <issue-id>",
 	Short: "List execution history for an issue",
@@ -572,7 +578,7 @@ func init() {
 	issueRunsCmd.Flags().String("output", "table", "Output format: table or json")
 	issueRunsCmd.Flags().Bool("full-id", false, "Show full task UUIDs in table output")
 	issueRunsCmd.Flags().Bool("active", false, "Only in-flight runs (queued, dispatched, running, waiting_local_directory) instead of the full execution history. Answers \"is an agent working on this right now\" without pulling every past run.")
-	issueRunsCmd.Flags().Bool("siblings", false, "Widen to this issue's sub-issue family — its parent (or itself, when it has no parent) plus every child of that parent — so you can see whether another run is already working alongside you before starting overlapping code or PR work. Implies --active; adds an ISSUE column. Advisory only: it reports work in flight, it does not reserve or serialise anything.")
+	issueRunsCmd.Flags().Bool("siblings", false, "Widen to this issue's sub-issue family — its parent (or itself, when it has no parent) plus every child of that parent — so you can see whether another run is already working alongside you before starting overlapping code or PR work. Implies --active; adds an ISSUE column. Ordered running-first, newest-first within a status, and capped at 50 rows; when the cap truncates the answer the CLI says so on stderr, so a short list is never mistaken for a complete one. Advisory only: it reports work in flight, it does not reserve or serialise anything.")
 
 	// issue usage
 	issueUsageCmd.Flags().String("output", "table", "Output format: table or json")
@@ -2172,8 +2178,18 @@ func runIssueRuns(cmd *cobra.Command, args []string) error {
 	}
 
 	var runs []map[string]any
-	if err := client.GetJSON(ctx, path, &runs); err != nil {
+	respHeaders, err := client.GetJSONWithHeaders(ctx, path, &runs)
+	if err != nil {
 		return fmt.Errorf("list runs: %w", err)
+	}
+	// A truncated coordination read and a complete one look identical in the
+	// body, and reading the first as the second is exactly the wrong
+	// conclusion: "no run on that sibling" when the answer was simply cut off.
+	// Same stderr convention as the comment-list paging cursors.
+	if respHeaders.Get(headerActiveRunsTruncated) == "true" {
+		fmt.Fprintln(os.Stderr,
+			"warning: active runs truncated by the server cap: more runs are in flight than this read returns. "+
+				"\"No run on that issue\" cannot be concluded from this read.")
 	}
 
 	output, _ := cmd.Flags().GetString("output")

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -4138,3 +4138,57 @@ func TestRunIssueRunsSiblingsTableCarriesIssueColumn(t *testing.T) {
 		t.Fatalf("single-issue table should not carry an issue column:\n%s", out)
 	}
 }
+
+// A capped family read and a complete one are identical in the body. If the CLI
+// swallows the server's truncation header, an agent reads "no run on that
+// sibling" off a list that was simply cut off — the one wrong conclusion this
+// command exists to prevent.
+func TestRunIssueRunsWarnsOnTruncatedFamilyRead(t *testing.T) {
+	issueID := "1881a167-4bb6-4602-944b-f40ce4192fe6"
+
+	for _, tc := range []struct {
+		name      string
+		truncated bool
+	}{
+		{"truncated read warns", true},
+		{"complete read stays quiet", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/issues/" + issueID + "/task-runs":
+					if tc.truncated {
+						w.Header().Set(headerActiveRunsTruncated, "true")
+					}
+					_ = json.NewEncoder(w).Encode([]map[string]any{{
+						"id": "abcd1234-0000-0000-0000-000000000000", "status": "running",
+					}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			t.Setenv("MULTICA_SERVER_URL", srv.URL)
+			t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+			t.Setenv("MULTICA_TOKEN", "test-token")
+
+			cmd := newIssueRunsTestCmd(t, "json")
+			if err := cmd.Flags().Set("siblings", "true"); err != nil {
+				t.Fatalf("set --siblings: %v", err)
+			}
+
+			capture := captureStderr(t)
+			_, err := captureStdout(t, func() error { return runIssueRuns(cmd, []string{issueID}) })
+			stderr := capture.read()
+			if err != nil {
+				t.Fatalf("issue runs: %v", err)
+			}
+
+			warned := strings.Contains(stderr, "truncated")
+			if warned != tc.truncated {
+				t.Fatalf("warned = %v, want %v; stderr was %q", warned, tc.truncated, stderr)
+			}
+		})
+	}
+}

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -4087,22 +4087,33 @@ func TestRunIssueRunsScopeFlagsBuildQuery(t *testing.T) {
 	}
 }
 
-// A family read mixes runs from several issues, so every row has to name its
-// own issue. Without the column the table is a list of task ids the reader
-// cannot attribute — which is the entire question --siblings was added to
-// answer.
-func TestRunIssueRunsSiblingsTableCarriesIssueColumn(t *testing.T) {
+// The two modes return different payloads, so they render through different
+// column sets. The family row names its issue — without that the table is a
+// list of task ids the reader cannot attribute, which is the whole question
+// --siblings answers — and it drops COMPLETED / ERROR, which are empty on
+// every row of a read that only returns work still in flight.
+func TestRunIssueRunsSiblingsTableRendersFamilyColumns(t *testing.T) {
 	issueID := "1881a167-4bb6-4602-944b-f40ce4192fe6"
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/issues/" + issueID + "/task-runs":
+			if r.URL.Query().Get("scope") == "family" {
+				_ = json.NewEncoder(w).Encode([]map[string]any{{
+					"task_id":          "abcd1234-0000-0000-0000-000000000000",
+					"issue_id":         "5678abcd-0000-0000-0000-000000000000",
+					"issue_identifier": "MUL-7001",
+					"issue_title":      "sibling work",
+					"agent_id":         "agent-1",
+					"status":           "running",
+					"created_at":       "2026-09-02T07:00:00Z",
+					"started_at":       "2026-09-02T07:00:01Z",
+				}})
+				return
+			}
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
-				"id":               "abcd1234-0000-0000-0000-000000000000",
-				"agent_id":         "agent-1",
-				"status":           "running",
-				"issue_identifier": "MUL-7001",
-				"issue_title":      "sibling work",
+				"id": "abcd1234-0000-0000-0000-000000000000", "agent_id": "agent-1",
+				"status": "completed", "error": "boom",
 			}})
 		default:
 			// Actor lookups for the AGENT column are best-effort; 404 is fine.
@@ -4123,12 +4134,20 @@ func TestRunIssueRunsSiblingsTableCarriesIssueColumn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("issue runs: %v", err)
 	}
-	if !strings.Contains(out, "ISSUE") || !strings.Contains(out, "MUL-7001") {
-		t.Fatalf("table output missing issue column:\n%s", out)
+	// The task id has to survive the new payload's task_id key — reading `id`
+	// here would render a column of blanks and lose the run-messages target.
+	for _, want := range []string{"TASK", "ISSUE", "MUL-7001", "abcd1234"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("family table missing %q:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{"COMPLETED", "ERROR"} {
+		if strings.Contains(out, unwanted) {
+			t.Fatalf("family table carries %q, which is empty on every in-flight row:\n%s", unwanted, out)
+		}
 	}
 
-	// The same rows without --siblings come from one known issue, so repeating
-	// it on every line would be noise.
+	// The execution log keeps its own columns: same command, different question.
 	plain := newIssueRunsTestCmd(t, "table")
 	out, err = captureStdout(t, func() error { return runIssueRuns(plain, []string{issueID}) })
 	if err != nil {
@@ -4136,6 +4155,9 @@ func TestRunIssueRunsSiblingsTableCarriesIssueColumn(t *testing.T) {
 	}
 	if strings.Contains(out, "ISSUE") {
 		t.Fatalf("single-issue table should not carry an issue column:\n%s", out)
+	}
+	if !strings.Contains(out, "ERROR") || !strings.Contains(out, "boom") {
+		t.Fatalf("execution log lost its error column:\n%s", out)
 	}
 }
 

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -4011,3 +4011,130 @@ func TestIsTerminalChildIssue(t *testing.T) {
 		})
 	}
 }
+
+// `issue runs` answers three different questions off one endpoint, and the only
+// thing telling them apart is the query string the CLI builds (#7768). These
+// tests pin that translation: a plain read must stay a plain read — the
+// short-task-ID resolver and the execution log both depend on the unfiltered
+// history — while --active and --siblings must actually reach the server.
+
+// newIssueRunsTestCmd mirrors the real flag set registered on issueRunsCmd.
+func newIssueRunsTestCmd(t *testing.T, output string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "runs"}
+	cmd.Flags().String("output", output, "")
+	cmd.Flags().Bool("full-id", false, "")
+	cmd.Flags().Bool("active", false, "")
+	cmd.Flags().Bool("siblings", false, "")
+	return cmd
+}
+
+func TestRunIssueRunsScopeFlagsBuildQuery(t *testing.T) {
+	issueID := "1881a167-4bb6-4602-944b-f40ce4192fe6"
+
+	for _, tc := range []struct {
+		name  string
+		flags []string
+		want  url.Values
+	}{
+		// No flags means no params: the resolver and the sidebar read the same
+		// full history they always have.
+		{"default reads full history", nil, url.Values{}},
+		{"active narrows to in-flight", []string{"active"}, url.Values{"active": {"true"}}},
+		// --siblings implies active. The CLI sends both so the request says what
+		// it means without the reader having to know the server's default.
+		{"siblings widens to the family", []string{"siblings"},
+			url.Values{"scope": {"family"}, "active": {"true"}}},
+		{"siblings wins over a redundant active", []string{"siblings", "active"},
+			url.Values{"scope": {"family"}, "active": {"true"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotQuery url.Values
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/issues/" + issueID + "/task-runs":
+					gotQuery = r.URL.Query()
+					_ = json.NewEncoder(w).Encode([]map[string]any{})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			t.Setenv("MULTICA_SERVER_URL", srv.URL)
+			t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+			t.Setenv("MULTICA_TOKEN", "test-token")
+
+			cmd := newIssueRunsTestCmd(t, "json")
+			for _, flag := range tc.flags {
+				if err := cmd.Flags().Set(flag, "true"); err != nil {
+					t.Fatalf("set --%s: %v", flag, err)
+				}
+			}
+			if _, err := captureStdout(t, func() error { return runIssueRuns(cmd, []string{issueID}) }); err != nil {
+				t.Fatalf("issue runs: %v", err)
+			}
+
+			if len(gotQuery) != len(tc.want) {
+				t.Fatalf("query = %v, want %v", gotQuery, tc.want)
+			}
+			for key, want := range tc.want {
+				if got := gotQuery.Get(key); got != want[0] {
+					t.Fatalf("query %s = %q, want %q (full query %v)", key, got, want[0], gotQuery)
+				}
+			}
+		})
+	}
+}
+
+// A family read mixes runs from several issues, so every row has to name its
+// own issue. Without the column the table is a list of task ids the reader
+// cannot attribute — which is the entire question --siblings was added to
+// answer.
+func TestRunIssueRunsSiblingsTableCarriesIssueColumn(t *testing.T) {
+	issueID := "1881a167-4bb6-4602-944b-f40ce4192fe6"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/issues/" + issueID + "/task-runs":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"id":               "abcd1234-0000-0000-0000-000000000000",
+				"agent_id":         "agent-1",
+				"status":           "running",
+				"issue_identifier": "MUL-7001",
+				"issue_title":      "sibling work",
+			}})
+		default:
+			// Actor lookups for the AGENT column are best-effort; 404 is fine.
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newIssueRunsTestCmd(t, "table")
+	if err := cmd.Flags().Set("siblings", "true"); err != nil {
+		t.Fatalf("set --siblings: %v", err)
+	}
+	out, err := captureStdout(t, func() error { return runIssueRuns(cmd, []string{issueID}) })
+	if err != nil {
+		t.Fatalf("issue runs: %v", err)
+	}
+	if !strings.Contains(out, "ISSUE") || !strings.Contains(out, "MUL-7001") {
+		t.Fatalf("table output missing issue column:\n%s", out)
+	}
+
+	// The same rows without --siblings come from one known issue, so repeating
+	// it on every line would be noise.
+	plain := newIssueRunsTestCmd(t, "table")
+	out, err = captureStdout(t, func() error { return runIssueRuns(plain, []string{issueID}) })
+	if err != nil {
+		t.Fatalf("issue runs: %v", err)
+	}
+	if strings.Contains(out, "ISSUE") {
+		t.Fatalf("single-issue table should not carry an issue column:\n%s", out)
+	}
+}

--- a/server/cmd/server/cors_headers_test.go
+++ b/server/cmd/server/cors_headers_test.go
@@ -32,8 +32,8 @@ func TestCORSAllowedHeaders_IncludeIdempotencyKey(t *testing.T) {
 	}
 }
 
-// Timeline and comment-list endpoints report defensive hard-cap clamps with
-// custom response headers.
+// Timeline, comment-list and active-run reads report defensive hard-cap clamps
+// with custom response headers.
 // Custom response headers are not readable from browser JS unless the server
 // exposes them, and only the CORS-safelisted headers are exposed by default — so
 // an entry missing here is not a degraded signal, it is no signal at all: the
@@ -42,6 +42,7 @@ func TestCORSExposedHeaders_IncludeTruncationSignals(t *testing.T) {
 	for _, want := range []string{
 		handler.HeaderCommentsTruncated,
 		handler.HeaderTimelineTruncated,
+		handler.HeaderActiveRunsTruncated,
 	} {
 		if !slices.Contains(corsExposedHeaders, want) {
 			t.Errorf("%s missing from CORS exposed headers: %v", want, corsExposedHeaders)

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -96,6 +96,7 @@ var corsExposedHeaders = []string{
 	"X-Request-ID",
 	handler.HeaderCommentsTruncated,
 	handler.HeaderTimelineTruncated,
+	handler.HeaderActiveRunsTruncated,
 }
 
 func registerPluginActionRoutes(r chi.Router, h *handler.Handler) {

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -354,13 +354,18 @@ type TaskIssueStatusData struct {
 }
 
 type AgentTaskResponse struct {
-	ID                   string                 `json:"id"`
-	AgentID              string                 `json:"agent_id"`
-	RuntimeID            string                 `json:"runtime_id"`
-	IssueID              string                 `json:"issue_id"`
-	WorkspaceID          string                 `json:"workspace_id"`
-	WorkspaceSlug        string                 `json:"workspace_slug,omitempty"`
-	IssueIdentifier      string                 `json:"issue_identifier,omitempty"`
+	ID              string `json:"id"`
+	AgentID         string `json:"agent_id"`
+	RuntimeID       string `json:"runtime_id"`
+	IssueID         string `json:"issue_id"`
+	WorkspaceID     string `json:"workspace_id"`
+	WorkspaceSlug   string `json:"workspace_slug,omitempty"`
+	IssueIdentifier string `json:"issue_identifier,omitempty"`
+	// IssueTitle is set only on the cross-issue coordination read
+	// (`GET /api/issues/{id}/task-runs?scope=family`), where rows span several
+	// issues and cannot be labelled from the task alone. Absent everywhere
+	// else, including the daemon claim payload.
+	IssueTitle           string                 `json:"issue_title,omitempty"`
 	RemoteMCPConnections []remotemcp.Connection `json:"remote_mcp_connections,omitempty"`
 	// PluginHookTools are the workspace's agent-trigger plugin hooks, which the
 	// daemon renders as MCP tools for this task. Resolved at claim time so

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -354,18 +354,13 @@ type TaskIssueStatusData struct {
 }
 
 type AgentTaskResponse struct {
-	ID              string `json:"id"`
-	AgentID         string `json:"agent_id"`
-	RuntimeID       string `json:"runtime_id"`
-	IssueID         string `json:"issue_id"`
-	WorkspaceID     string `json:"workspace_id"`
-	WorkspaceSlug   string `json:"workspace_slug,omitempty"`
-	IssueIdentifier string `json:"issue_identifier,omitempty"`
-	// IssueTitle is set only on the cross-issue coordination read
-	// (`GET /api/issues/{id}/task-runs?scope=family`), where rows span several
-	// issues and cannot be labelled from the task alone. Absent everywhere
-	// else, including the daemon claim payload.
-	IssueTitle           string                 `json:"issue_title,omitempty"`
+	ID                   string                 `json:"id"`
+	AgentID              string                 `json:"agent_id"`
+	RuntimeID            string                 `json:"runtime_id"`
+	IssueID              string                 `json:"issue_id"`
+	WorkspaceID          string                 `json:"workspace_id"`
+	WorkspaceSlug        string                 `json:"workspace_slug,omitempty"`
+	IssueIdentifier      string                 `json:"issue_identifier,omitempty"`
 	RemoteMCPConnections []remotemcp.Connection `json:"remote_mcp_connections,omitempty"`
 	// PluginHookTools are the workspace's agent-trigger plugin hooks, which the
 	// daemon renders as MCP tools for this task. Resolved at claim time so

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -4882,18 +4882,22 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 
 // familyActiveRunCap bounds a scope=family read.
 //
-// A runaway guard, not a display limit. Real concurrency in a family is bounded
-// far below this by runtime capacity and per-agent task limits, so 50 is chosen
-// to sit above any legitimate answer while still capping what a parent that
-// fanned out hundreds of children can make one advisory read return. The
-// coordination question is answered by the first few rows, and the query orders
-// running-first, so what the cap drops is the least decision-relevant.
+// It is a response-size budget, chosen so one advisory read stays small enough
+// for an agent to hold in context — NOT a bound derived from how much work can
+// really be in flight. A family can legitimately exceed it: a single agent may
+// be configured up to agentconfig.MaxMaxConcurrentTasks (50) on its own, this
+// feature exists precisely for the case where SEVERAL agents work a family at
+// once, and the returned set includes queued / dispatched /
+// waiting_local_directory rows, which no execution-slot limit bounds at all —
+// a parent that fans out 200 children can have 200 of them enqueued.
 //
-// A cap that silently truncates would be worse than no cap: "I saw no run on
-// that sibling" and "the answer was cut off" would look identical, and an agent
-// would read the second as the first. So the handler asks for one row more than
-// it will return, and says so in HeaderActiveRunsTruncated when that extra row
-// comes back.
+// So truncation here is an ordinary outcome, not a pathological one, and that
+// is exactly why it must be reported. A cap that truncated silently would be
+// worse than no cap: "I saw no run on that sibling" and "the answer was cut
+// off" would look identical, and an agent would read the second as the first.
+// The handler asks for one row more than it will return and sets
+// HeaderActiveRunsTruncated when that extra row comes back. The query orders
+// running-first, so what the budget drops is the least decision-relevant.
 const familyActiveRunCap = 50
 
 // HeaderActiveRunsTruncated tells a caller its coordination read hit

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -4882,14 +4882,15 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 
 // familyActiveRunCap bounds a scope=family read.
 //
-// It is a response-size budget, chosen so one advisory read stays small enough
-// for an agent to hold in context — NOT a bound derived from how much work can
-// really be in flight. A family can legitimately exceed it: a single agent may
-// be configured up to agentconfig.MaxMaxConcurrentTasks (50) on its own, this
-// feature exists precisely for the case where SEVERAL agents work a family at
-// once, and the returned set includes queued / dispatched /
-// waiting_local_directory rows, which no execution-slot limit bounds at all —
-// a parent that fans out 200 children can have 200 of them enqueued.
+// It is a response-size budget set to the shape of the normal case — a handful
+// of runs in flight at once (maintainer call, MUL-6846) — NOT a bound derived
+// from how much work can really be in flight. A family can legitimately exceed
+// it by a lot: a single agent may be configured up to
+// agentconfig.MaxMaxConcurrentTasks (50) on its own, this feature exists
+// precisely for the case where SEVERAL agents work a family at once, and the
+// returned set includes queued / dispatched / waiting_local_directory rows,
+// which no execution-slot limit bounds at all — a parent that fans out 200
+// children can have 200 of them enqueued.
 //
 // So truncation here is an ordinary outcome, not a pathological one, and that
 // is exactly why it must be reported. A cap that truncated silently would be
@@ -4898,7 +4899,7 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 // The handler asks for one row more than it will return and sets
 // HeaderActiveRunsTruncated when that extra row comes back. The query orders
 // running-first, so what the budget drops is the least decision-relevant.
-const familyActiveRunCap = 50
+const familyActiveRunCap = 20
 
 // HeaderActiveRunsTruncated tells a caller its coordination read hit
 // familyActiveRunCap and is therefore an incomplete picture of who is working
@@ -4906,6 +4907,33 @@ const familyActiveRunCap = 50
 // signal rides a header because the response body is a bare array that existing
 // callers parse positionally.
 const HeaderActiveRunsTruncated = "X-Active-Runs-Truncated"
+
+// ActiveRunSummary is one in-flight run as the coordination read reports it:
+// which issue, which agent, what state, since when, and the task id to follow
+// up with `multica issue run-messages`.
+//
+// Deliberately NOT AgentTaskResponse. That type is the execution log's row —
+// result, work_dir, attribution, coalesced comment ids — and it costs roughly
+// 5x the bytes of this one. A caller asking "is anyone working next to me?"
+// reads none of those fields, and it is an agent spending its own context on
+// the answer, so the payload is cut to what the question needs.
+//
+// It is also not ActiveSiblingRunData, which the daemon claim payload uses.
+// That one describes the claiming agent's OWN other runs, so it has no agent
+// field; this read spans agents, and which agent is on a sibling is the answer.
+// Sharing one struct across both would put an optional field on it that only
+// one caller ever sets — the exact shape this change removed from
+// AgentTaskResponse.
+type ActiveRunSummary struct {
+	TaskID          string  `json:"task_id"`
+	IssueID         string  `json:"issue_id"`
+	IssueIdentifier string  `json:"issue_identifier"`
+	IssueTitle      string  `json:"issue_title"`
+	AgentID         string  `json:"agent_id"`
+	Status          string  `json:"status"`
+	CreatedAt       string  `json:"created_at"`
+	StartedAt       *string `json:"started_at,omitempty"`
+}
 
 // ListTasksByIssue returns tasks for an issue — the execution history behind
 // the issue-detail sidebar, and the coordination reads behind
@@ -4977,16 +5005,25 @@ func (h *Handler) ListTasksByIssue(w http.ResponseWriter, r *http.Request) {
 			rows = rows[:familyActiveRunCap]
 			w.Header().Set(HeaderActiveRunsTruncated, "true")
 		}
-		resp := make([]AgentTaskResponse, len(rows))
+		summaries := make([]ActiveRunSummary, len(rows))
 		for i, row := range rows {
-			resp[i] = taskToResponse(row.AgentTaskQueue, workspaceID)
-			// Rows span several issues here, so each one has to carry the issue
-			// it belongs to — a caller cannot label it from the task alone.
-			resp[i].IssueIdentifier = service.IssueIdentifier(row.IssuePrefix, row.IssueNumber)
-			resp[i].IssueTitle = row.IssueTitle
+			summaries[i] = ActiveRunSummary{
+				TaskID:  uuidToString(row.TaskID),
+				IssueID: uuidToString(row.IssueID),
+				// Rows span several issues here, so each one has to carry the
+				// issue it belongs to — a caller cannot label it from the task.
+				IssueIdentifier: service.IssueIdentifier(row.IssuePrefix, row.IssueNumber),
+				IssueTitle:      row.IssueTitle,
+				AgentID:         uuidToString(row.AgentID),
+				Status:          row.Status,
+				CreatedAt:       timestampToString(row.CreatedAt),
+				StartedAt:       timestampToPtr(row.StartedAt),
+			}
 		}
-		h.hydrateTaskAttributions(r.Context(), attributionsOf(resp))
-		writeJSON(w, http.StatusOK, resp)
+		// No attribution hydration either: it was the single largest field on
+		// the old payload and needed its own query, and "on behalf of whom" is
+		// an execution-log question, not a coordination one.
+		writeJSON(w, http.StatusOK, summaries)
 		return
 	}
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -4880,13 +4880,28 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// familyActiveRunCap bounds a scope=family read. A defensive ceiling, not a
-// product limit: the coordination question ("is anyone else already working in
-// this sub-issue family?") is answered by the first few rows, and a parent that
-// fanned out hundreds of children must not be able to turn one advisory read
-// into an unbounded response. The query orders running-first so the rows this
-// drops are the least interesting ones.
+// familyActiveRunCap bounds a scope=family read.
+//
+// A runaway guard, not a display limit. Real concurrency in a family is bounded
+// far below this by runtime capacity and per-agent task limits, so 50 is chosen
+// to sit above any legitimate answer while still capping what a parent that
+// fanned out hundreds of children can make one advisory read return. The
+// coordination question is answered by the first few rows, and the query orders
+// running-first, so what the cap drops is the least decision-relevant.
+//
+// A cap that silently truncates would be worse than no cap: "I saw no run on
+// that sibling" and "the answer was cut off" would look identical, and an agent
+// would read the second as the first. So the handler asks for one row more than
+// it will return, and says so in HeaderActiveRunsTruncated when that extra row
+// comes back.
 const familyActiveRunCap = 50
+
+// HeaderActiveRunsTruncated tells a caller its coordination read hit
+// familyActiveRunCap and is therefore an incomplete picture of who is working
+// in this family. Same shape and convention as HeaderTimelineTruncated: the
+// signal rides a header because the response body is a bare array that existing
+// callers parse positionally.
+const HeaderActiveRunsTruncated = "X-Active-Runs-Truncated"
 
 // ListTasksByIssue returns tasks for an issue — the execution history behind
 // the issue-detail sidebar, and the coordination reads behind
@@ -4915,7 +4930,22 @@ func (h *Handler) ListTasksByIssue(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "scope must be 'issue' or 'family'")
 		return
 	}
-	activeOnly := r.URL.Query().Get("active") == "true"
+	// Parse rather than compare. `active=tru` answering with the full history
+	// under a 200 is the same silent-downgrade failure the unknown-scope check
+	// above rejects: the caller asked who is here NOW and would be handed every
+	// run that ever finished, which reads as "nobody is here" only after it has
+	// paid for the whole log. Same shape as the comment-list boolean params.
+	activeOnly := false
+	if activeStr := r.URL.Query().Get("active"); activeStr != "" {
+		switch activeStr {
+		case "true":
+			activeOnly = true
+		case "false":
+		default:
+			writeError(w, http.StatusBadRequest, "invalid active parameter; expected boolean")
+			return
+		}
+	}
 
 	workspaceID := uuidToString(issue.WorkspaceID)
 
@@ -4928,27 +4958,30 @@ func (h *Handler) ListTasksByIssue(w http.ResponseWriter, r *http.Request) {
 		if issue.ParentIssueID.Valid {
 			root = issue.ParentIssueID
 		}
+		// One row beyond the cap, so a full page can be told apart from a
+		// truncated one without a second count query.
 		rows, err := h.Queries.ListActiveTasksByIssueFamily(r.Context(), db.ListActiveTasksByIssueFamilyParams{
 			WorkspaceID: issue.WorkspaceID,
 			RootIssueID: root,
-			RowLimit:    familyActiveRunCap,
+			RowLimit:    familyActiveRunCap + 1,
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to list tasks")
 			return
+		}
+		if len(rows) > familyActiveRunCap {
+			rows = rows[:familyActiveRunCap]
+			w.Header().Set(HeaderActiveRunsTruncated, "true")
 		}
 		resp := make([]AgentTaskResponse, len(rows))
 		for i, row := range rows {
 			resp[i] = taskToResponse(row.AgentTaskQueue, workspaceID)
 			// Rows span several issues here, so each one has to carry the issue
 			// it belongs to — a caller cannot label it from the task alone.
-			resp[i].IssueIdentifier = fmt.Sprintf("%s-%d", row.IssuePrefix, row.IssueNumber)
+			resp[i].IssueIdentifier = service.IssueIdentifier(row.IssuePrefix, row.IssueNumber)
 			resp[i].IssueTitle = row.IssueTitle
 		}
 		h.hydrateTaskAttributions(r.Context(), attributionsOf(resp))
-		// No usage hydration: ListIssueTaskUsage is keyed by a single issue, so
-		// a family read would need one query per issue to fill a column that is
-		// near-empty for in-flight runs anyway.
 		writeJSON(w, http.StatusOK, resp)
 		return
 	}
@@ -4973,7 +5006,14 @@ func (h *Handler) ListTasksByIssue(w http.ResponseWriter, r *http.Request) {
 	// issue-facing surface must resolve initiator/originator names (departed-safe,
 	// one batch) — otherwise the badge falls back to "someone" on issue detail.
 	h.hydrateTaskAttributions(r.Context(), attributionsOf(resp))
-	h.hydrateTaskUsage(r.Context(), issue.ID, resp)
+	// Usage belongs to the execution log, not to a coordination read.
+	// ListIssueTaskUsage returns a row per (task, provider, model) for EVERY
+	// task the issue ever ran, so hydrating it on the active path would keep
+	// paying the full-history cost this filter exists to remove — and pay it
+	// for a column that is near-empty on runs that have not finished.
+	if !activeOnly {
+		h.hydrateTaskUsage(r.Context(), issue.ID, resp)
+	}
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -4880,7 +4880,29 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// ListTasksByIssue returns all tasks (any status) for an issue — used for execution history.
+// familyActiveRunCap bounds a scope=family read. A defensive ceiling, not a
+// product limit: the coordination question ("is anyone else already working in
+// this sub-issue family?") is answered by the first few rows, and a parent that
+// fanned out hundreds of children must not be able to turn one advisory read
+// into an unbounded response. The query orders running-first so the rows this
+// drops are the least interesting ones.
+const familyActiveRunCap = 50
+
+// ListTasksByIssue returns tasks for an issue — the execution history behind
+// the issue-detail sidebar, and the coordination reads behind
+// `multica issue runs --active` / `--siblings`.
+//
+// Two optional query params narrow or widen it; with neither, the response is
+// byte-identical to what it has always been (full history, newest first), which
+// is what the UI and the CLI's short-task-ID resolver both depend on:
+//
+//   - active=true — restrict to in-flight statuses, the same set the
+//     issue-detail "agent live" banner calls active.
+//   - scope=family — widen from this issue to its sub-issue family: the
+//     issue's parent (or the issue itself, when it has no parent) plus every
+//     child of that parent. Implies active=true, because a full execution
+//     history across a whole family is unbounded and answers no question anyone
+//     asked.
 func (h *Handler) ListTasksByIssue(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "id")
 	issue, ok := h.loadIssueForUser(w, r, issueID)
@@ -4888,13 +4910,61 @@ func (h *Handler) ListTasksByIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tasks, err := h.Queries.ListTasksByIssue(r.Context(), issue.ID)
+	scope := r.URL.Query().Get("scope")
+	if scope != "" && scope != "issue" && scope != "family" {
+		writeError(w, http.StatusBadRequest, "scope must be 'issue' or 'family'")
+		return
+	}
+	activeOnly := r.URL.Query().Get("active") == "true"
+
+	workspaceID := uuidToString(issue.WorkspaceID)
+
+	if scope == "family" {
+		// Root the family at the parent when there is one, so a child sees its
+		// siblings; at the issue itself otherwise, so a parent sees its children
+		// and a standalone issue degenerates to its own active runs. One rule,
+		// both directions.
+		root := issue.ID
+		if issue.ParentIssueID.Valid {
+			root = issue.ParentIssueID
+		}
+		rows, err := h.Queries.ListActiveTasksByIssueFamily(r.Context(), db.ListActiveTasksByIssueFamilyParams{
+			WorkspaceID: issue.WorkspaceID,
+			RootIssueID: root,
+			RowLimit:    familyActiveRunCap,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to list tasks")
+			return
+		}
+		resp := make([]AgentTaskResponse, len(rows))
+		for i, row := range rows {
+			resp[i] = taskToResponse(row.AgentTaskQueue, workspaceID)
+			// Rows span several issues here, so each one has to carry the issue
+			// it belongs to — a caller cannot label it from the task alone.
+			resp[i].IssueIdentifier = fmt.Sprintf("%s-%d", row.IssuePrefix, row.IssueNumber)
+			resp[i].IssueTitle = row.IssueTitle
+		}
+		h.hydrateTaskAttributions(r.Context(), attributionsOf(resp))
+		// No usage hydration: ListIssueTaskUsage is keyed by a single issue, so
+		// a family read would need one query per issue to fill a column that is
+		// near-empty for in-flight runs anyway.
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	var tasks []db.AgentTaskQueue
+	var err error
+	if activeOnly {
+		tasks, err = h.Queries.ListActiveTasksByIssue(r.Context(), issue.ID)
+	} else {
+		tasks, err = h.Queries.ListTasksByIssue(r.Context(), issue.ID)
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list tasks")
 		return
 	}
 
-	workspaceID := uuidToString(issue.WorkspaceID)
 	resp := make([]AgentTaskResponse, len(tasks))
 	for i, t := range tasks {
 		resp[i] = taskToResponse(t, workspaceID)

--- a/server/internal/handler/task_runs_scope_test.go
+++ b/server/internal/handler/task_runs_scope_test.go
@@ -67,10 +67,30 @@ func runsRequest(t *testing.T, issueID, query string) []AgentTaskResponse {
 	return out
 }
 
+// familyRequest decodes the family read's own payload. It is a different,
+// deliberately smaller type than the execution log's row, so the tests decode
+// it as one rather than through AgentTaskResponse — a struct that silently
+// accepted both would stop noticing if the two shapes merged again.
+func familyRequest(t *testing.T, issueID, query string) []ActiveRunSummary {
+	t.Helper()
+	var out []ActiveRunSummary
+	runsResponse(t, issueID, query).Want(http.StatusOK).JSON(&out)
+	return out
+}
+
 func taskIDs(runs []AgentTaskResponse) []string {
 	ids := make([]string, len(runs))
 	for i, r := range runs {
 		ids[i] = r.ID
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func summaryIDs(runs []ActiveRunSummary) []string {
+	ids := make([]string, len(runs))
+	for i, r := range runs {
+		ids[i] = r.TaskID
 	}
 	sort.Strings(ids)
 	return ids
@@ -145,16 +165,18 @@ func TestListTasksByIssueFamilyScopeSpansSiblings(t *testing.T) {
 	f.task(t, f.childB, "completed")
 	f.task(t, f.unrelated, "running")
 
-	runs := runsRequest(t, f.childA, "scope=family&active=true")
-	if want := sortedCopy(onSelf, onSibling, onParent); !sameIDs(taskIDs(runs), want) {
+	runs := familyRequest(t, f.childA, "scope=family&active=true")
+	if want := sortedCopy(onSelf, onSibling, onParent); !sameIDs(summaryIDs(runs), want) {
 		t.Fatalf("family runs = %v, want %v (self + sibling + parent, no terminal, no unrelated issue)",
-			taskIDs(runs), want)
+			summaryIDs(runs), want)
 	}
 
 	for _, run := range runs {
-		if run.IssueIdentifier == "" || run.IssueTitle == "" {
-			t.Fatalf("run %s carries no issue identity (%q / %q); a family row cannot be labelled from the task alone",
-				run.ID, run.IssueIdentifier, run.IssueTitle)
+		// Issue identity labels the row; agent identity IS the answer, since
+		// this read exists to find the agent working next to you.
+		if run.IssueIdentifier == "" || run.IssueTitle == "" || run.AgentID == "" {
+			t.Fatalf("run %s carries no issue/agent identity (%q / %q / %q); a family row cannot be attributed from the task alone",
+				run.TaskID, run.IssueIdentifier, run.IssueTitle, run.AgentID)
 		}
 	}
 }
@@ -171,7 +193,7 @@ func TestListTasksByIssueFamilyScopeFromParentSeesChildren(t *testing.T) {
 	onParent := f.task(t, f.parentID, "queued")
 	f.task(t, f.unrelated, "running")
 
-	got := taskIDs(runsRequest(t, f.parentID, "scope=family"))
+	got := summaryIDs(familyRequest(t, f.parentID, "scope=family"))
 	if want := sortedCopy(onChild, onParent); !sameIDs(got, want) {
 		t.Fatalf("family runs from parent = %v, want %v", got, want)
 	}
@@ -189,7 +211,7 @@ func TestListTasksByIssueFamilyScopeOnStandaloneIssue(t *testing.T) {
 	f.task(t, f.unrelated, "completed")
 	f.task(t, f.childA, "running")
 
-	got := taskIDs(runsRequest(t, f.unrelated, "scope=family"))
+	got := summaryIDs(familyRequest(t, f.unrelated, "scope=family"))
 	if want := sortedCopy(own); !sameIDs(got, want) {
 		t.Fatalf("family runs from standalone issue = %v, want %v", got, want)
 	}
@@ -287,7 +309,7 @@ func TestListTasksByIssueFamilyScopeReportsTruncation(t *testing.T) {
 	if got := full.Header().Get(HeaderActiveRunsTruncated); got != "" {
 		t.Fatalf("truncation header = %q on an exactly-full page, want empty", got)
 	}
-	var atCap []AgentTaskResponse
+	var atCap []ActiveRunSummary
 	full.JSON(&atCap)
 	if len(atCap) != familyActiveRunCap {
 		t.Fatalf("rows at cap = %d, want %d", len(atCap), familyActiveRunCap)
@@ -299,9 +321,47 @@ func TestListTasksByIssueFamilyScopeReportsTruncation(t *testing.T) {
 	if got := over.Header().Get(HeaderActiveRunsTruncated); got != "true" {
 		t.Fatalf("truncation header = %q past the cap, want \"true\"", got)
 	}
-	var truncated []AgentTaskResponse
+	var truncated []ActiveRunSummary
 	over.JSON(&truncated)
 	if len(truncated) != familyActiveRunCap {
 		t.Fatalf("rows past cap = %d, want them trimmed to %d", len(truncated), familyActiveRunCap)
+	}
+}
+
+// The family read's payload is its product, not an implementation detail: it is
+// an agent spending its own context on the answer. The execution-log row costs
+// roughly 5x the bytes — attribution alone was the largest field on it and
+// needed a second query — and a caller asking "who else is here?" reads none of
+// it. Pinning the exact key set is what stops the two shapes from quietly
+// merging back together the next time someone reuses taskToResponse here.
+func TestListTasksByIssueFamilyScopePayloadStaysLean(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+	f.task(t, f.childB, "running")
+
+	var raw []map[string]any
+	runsResponse(t, f.childA, "scope=family").Want(http.StatusOK).JSON(&raw)
+	if len(raw) != 1 {
+		t.Fatalf("family rows = %d, want 1", len(raw))
+	}
+
+	want := map[string]bool{
+		"task_id": true, "issue_id": true, "issue_identifier": true,
+		"issue_title": true, "agent_id": true, "status": true,
+		"created_at": true, "started_at": true,
+	}
+	for key := range raw[0] {
+		if !want[key] {
+			t.Errorf("family row carries execution-log field %q; this read is a coordination payload", key)
+		}
+	}
+	// started_at is omitempty (a queued run has none), so only the rest are
+	// guaranteed present on a running row.
+	for key := range want {
+		if _, ok := raw[0][key]; !ok && key != "started_at" {
+			t.Errorf("family row missing %q", key)
+		}
 	}
 }

--- a/server/internal/handler/task_runs_scope_test.go
+++ b/server/internal/handler/task_runs_scope_test.go
@@ -1,0 +1,206 @@
+package handler
+
+import (
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+// GET /api/issues/{id}/task-runs answers three different questions depending on
+// its query params (#7768): the execution history the issue sidebar renders,
+// "is anyone working on THIS issue right now", and "is anyone working anywhere
+// in this sub-issue family right now". These tests pin the boundaries between
+// them, because the only thing separating a cheap coordination read from a full
+// history dump is a query param the caller may forget.
+
+// familyFixture builds the shape the family read exists for: one parent, two
+// children, and an unrelated issue in the same workspace that must never appear.
+type familyFixture struct {
+	agentID   string
+	parentID  string
+	childA    string
+	childB    string
+	unrelated string
+}
+
+func newFamilyFixture(t *testing.T) familyFixture {
+	t.Helper()
+	f := familyFixture{
+		agentID:  createHandlerTestAgent(t, "FamilyRunsAgent", []byte("[]")),
+		parentID: dbfx.Issue(t, "family-parent"),
+	}
+	f.childA = dbfx.Issue(t, "family-child-a", testutil.Cols{"parent_issue_id": f.parentID})
+	f.childB = dbfx.Issue(t, "family-child-b", testutil.Cols{"parent_issue_id": f.parentID})
+	f.unrelated = dbfx.Issue(t, "family-unrelated")
+	return f
+}
+
+func (f familyFixture) task(t *testing.T, issueID, status string) string {
+	t.Helper()
+	return dbfx.Task(t, f.agentID, testutil.Cols{
+		"issue_id":   issueID,
+		"status":     status,
+		"runtime_id": handlerTestRuntimeID(t),
+	})
+}
+
+// runsRequest drives the handler the way the router does: path params carry the
+// issue, the raw query string carries the scope.
+func runsRequest(t *testing.T, issueID, query string) []AgentTaskResponse {
+	t.Helper()
+	path := "/api/issues/" + issueID + "/task-runs"
+	if query != "" {
+		path += "?" + query
+	}
+	var out []AgentTaskResponse
+	testutil.Call(t, testHandler.ListTasksByIssue,
+		withURLParam(newRequest(http.MethodGet, path, nil), "id", issueID),
+	).Want(http.StatusOK).JSON(&out)
+	return out
+}
+
+func taskIDs(runs []AgentTaskResponse) []string {
+	ids := make([]string, len(runs))
+	for i, r := range runs {
+		ids[i] = r.ID
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func sortedCopy(ids ...string) []string {
+	out := append([]string(nil), ids...)
+	sort.Strings(out)
+	return out
+}
+
+func sameIDs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// The no-param response is what the issue-detail execution log and the CLI's
+// short-task-ID resolver both read. Adding the coordination params must not
+// have narrowed it: a completed run still comes back.
+func TestListTasksByIssueDefaultsToFullHistory(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+	done := f.task(t, f.childA, "completed")
+	live := f.task(t, f.childA, "running")
+
+	got := taskIDs(runsRequest(t, f.childA, ""))
+	if want := sortedCopy(done, live); !sameIDs(got, want) {
+		t.Fatalf("history runs = %v, want %v (a completed run must survive)", got, want)
+	}
+}
+
+// active=true is the cheap "is an agent on this right now" read. It must drop
+// terminal runs and keep the whole in-flight set — including queued, which is
+// about to touch the same code even though it cannot answer you yet.
+func TestListTasksByIssueActiveDropsTerminalRuns(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+	f.task(t, f.childA, "completed")
+	f.task(t, f.childA, "failed")
+	queued := f.task(t, f.childA, "queued")
+	running := f.task(t, f.childA, "running")
+
+	got := taskIDs(runsRequest(t, f.childA, "active=true"))
+	if want := sortedCopy(queued, running); !sameIDs(got, want) {
+		t.Fatalf("active runs = %v, want %v", got, want)
+	}
+}
+
+// The point of #7768: a child asks the question and learns about its siblings.
+// The parent's own run counts (it is the same coordination family), an
+// unrelated issue's does not, and every row says which issue it belongs to —
+// without that, a caller cannot tell one sibling's run from another's.
+func TestListTasksByIssueFamilyScopeSpansSiblings(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+	onSelf := f.task(t, f.childA, "running")
+	onSibling := f.task(t, f.childB, "dispatched")
+	onParent := f.task(t, f.parentID, "running")
+	f.task(t, f.childB, "completed")
+	f.task(t, f.unrelated, "running")
+
+	runs := runsRequest(t, f.childA, "scope=family&active=true")
+	if want := sortedCopy(onSelf, onSibling, onParent); !sameIDs(taskIDs(runs), want) {
+		t.Fatalf("family runs = %v, want %v (self + sibling + parent, no terminal, no unrelated issue)",
+			taskIDs(runs), want)
+	}
+
+	for _, run := range runs {
+		if run.IssueIdentifier == "" || run.IssueTitle == "" {
+			t.Fatalf("run %s carries no issue identity (%q / %q); a family row cannot be labelled from the task alone",
+				run.ID, run.IssueIdentifier, run.IssueTitle)
+		}
+	}
+}
+
+// Asked from the parent instead of a child, the same flag has to answer the
+// mirror-image question — "who is running on my children?" — rather than
+// returning nothing because the parent has no parent of its own.
+func TestListTasksByIssueFamilyScopeFromParentSeesChildren(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+	onChild := f.task(t, f.childB, "running")
+	onParent := f.task(t, f.parentID, "queued")
+	f.task(t, f.unrelated, "running")
+
+	got := taskIDs(runsRequest(t, f.parentID, "scope=family"))
+	if want := sortedCopy(onChild, onParent); !sameIDs(got, want) {
+		t.Fatalf("family runs from parent = %v, want %v", got, want)
+	}
+}
+
+// An issue with no parent and no children still has to answer, degenerating to
+// its own active runs — otherwise a caller has to know the issue's shape before
+// it can choose a flag.
+func TestListTasksByIssueFamilyScopeOnStandaloneIssue(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+	own := f.task(t, f.unrelated, "running")
+	f.task(t, f.unrelated, "completed")
+	f.task(t, f.childA, "running")
+
+	got := taskIDs(runsRequest(t, f.unrelated, "scope=family"))
+	if want := sortedCopy(own); !sameIDs(got, want) {
+		t.Fatalf("family runs from standalone issue = %v, want %v", got, want)
+	}
+}
+
+// A misspelled scope must fail loudly. Silently falling back to full history
+// would hand an agent every past run when it asked for the live ones, which
+// reads as "nobody else is here" only after the caller has paid for the whole
+// log.
+func TestListTasksByIssueRejectsUnknownScope(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+
+	testutil.Call(t, testHandler.ListTasksByIssue,
+		withURLParam(newRequest(http.MethodGet,
+			"/api/issues/"+f.childA+"/task-runs?scope=sibling", nil), "id", f.childA),
+	).Want(http.StatusBadRequest)
+}

--- a/server/internal/handler/task_runs_scope_test.go
+++ b/server/internal/handler/task_runs_scope_test.go
@@ -46,18 +46,24 @@ func (f familyFixture) task(t *testing.T, issueID, status string) string {
 	})
 }
 
-// runsRequest drives the handler the way the router does: path params carry the
-// issue, the raw query string carries the scope.
-func runsRequest(t *testing.T, issueID, query string) []AgentTaskResponse {
+// runsResponse drives the handler the way the router does: path params carry
+// the issue, the raw query string carries the scope. Headers come back too —
+// the truncation signal rides one.
+func runsResponse(t *testing.T, issueID, query string) *testutil.Response {
 	t.Helper()
 	path := "/api/issues/" + issueID + "/task-runs"
 	if query != "" {
 		path += "?" + query
 	}
-	var out []AgentTaskResponse
-	testutil.Call(t, testHandler.ListTasksByIssue,
+	return testutil.Call(t, testHandler.ListTasksByIssue,
 		withURLParam(newRequest(http.MethodGet, path, nil), "id", issueID),
-	).Want(http.StatusOK).JSON(&out)
+	)
+}
+
+func runsRequest(t *testing.T, issueID, query string) []AgentTaskResponse {
+	t.Helper()
+	var out []AgentTaskResponse
+	runsResponse(t, issueID, query).Want(http.StatusOK).JSON(&out)
 	return out
 }
 
@@ -203,4 +209,99 @@ func TestListTasksByIssueRejectsUnknownScope(t *testing.T) {
 		withURLParam(newRequest(http.MethodGet,
 			"/api/issues/"+f.childA+"/task-runs?scope=sibling", nil), "id", f.childA),
 	).Want(http.StatusBadRequest)
+}
+
+// The whole point of --active is a cheap read. ListIssueTaskUsage returns a row
+// per (task, provider, model) for EVERY task the issue ever ran, so hydrating
+// it here would keep paying the full-history cost the filter exists to remove.
+// Usage is an execution-log concern; a coordination read must not carry it even
+// when the active task happens to have some recorded.
+func TestListTasksByIssueActiveOmitsUsage(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+	running := f.task(t, f.childA, "running")
+	dbfx.Exec(t, `
+		INSERT INTO task_usage (task_id, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, cost_usd_ticks)
+		VALUES ($1, 'anthropic', 'claude-opus-5', 1000, 500, 0, 0, NULL)
+	`, running)
+
+	active := runsRequest(t, f.childA, "active=true")
+	if len(active) != 1 {
+		t.Fatalf("active runs = %d, want 1", len(active))
+	}
+	if len(active[0].Usage) != 0 {
+		t.Fatalf("active read carried usage %+v; the coordination path must not query it", active[0].Usage)
+	}
+
+	// The execution log still gets it — this is a per-path decision, not a
+	// removal of the feature.
+	history := runsRequest(t, f.childA, "")
+	if len(history) != 1 || len(history[0].Usage) != 1 {
+		t.Fatalf("history read lost its usage: %+v", history)
+	}
+}
+
+// A boolean param that only recognises the exact string "true" turns every
+// typo into a silent downgrade: `active=tru` would answer "who is here now?"
+// with the whole execution history under a 200, and the caller reads a pile of
+// finished runs as the live ones. Same reason the unknown-scope check exists.
+func TestListTasksByIssueRejectsInvalidActive(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+	f.task(t, f.childA, "completed")
+
+	for _, bad := range []string{"tru", "TRUE", "1", "yes", ""} {
+		query := "active=" + bad
+		if bad == "" {
+			// The empty value is the one non-rejection in the set: it means the
+			// caller did not ask, so the read stays the full history.
+			runsRequest(t, f.childA, query)
+			continue
+		}
+		runsResponse(t, f.childA, query).Want(http.StatusBadRequest)
+	}
+
+	// false is a real value and must not 400.
+	runsRequest(t, f.childA, "active=false")
+}
+
+// A truncated coordination read and a complete one are indistinguishable in the
+// body, and reading the first as the second produces exactly the wrong
+// conclusion — "no run on that sibling" when the answer was cut off. The cap
+// therefore has to announce itself.
+func TestListTasksByIssueFamilyScopeReportsTruncation(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	f := newFamilyFixture(t)
+
+	// Exactly at the cap: a full page is not a truncated one.
+	for i := 0; i < familyActiveRunCap; i++ {
+		f.task(t, f.childA, "running")
+	}
+	full := runsResponse(t, f.childA, "scope=family").Want(http.StatusOK)
+	if got := full.Header().Get(HeaderActiveRunsTruncated); got != "" {
+		t.Fatalf("truncation header = %q on an exactly-full page, want empty", got)
+	}
+	var atCap []AgentTaskResponse
+	full.JSON(&atCap)
+	if len(atCap) != familyActiveRunCap {
+		t.Fatalf("rows at cap = %d, want %d", len(atCap), familyActiveRunCap)
+	}
+
+	// One past it: the response is capped AND says so.
+	f.task(t, f.childB, "running")
+	over := runsResponse(t, f.childA, "scope=family").Want(http.StatusOK)
+	if got := over.Header().Get(HeaderActiveRunsTruncated); got != "true" {
+		t.Fatalf("truncation header = %q past the cap, want \"true\"", got)
+	}
+	var truncated []AgentTaskResponse
+	over.JSON(&truncated)
+	if len(truncated) != familyActiveRunCap {
+		t.Fatalf("rows past cap = %d, want them trimmed to %d", len(truncated), familyActiveRunCap)
+	}
 }

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -267,6 +267,11 @@ child of that parent — and labels each row with the issue it belongs to, which
 is how you find another agent already working on a sibling sub-issue before you
 open a second PR against the same code.
 
+Rows come back running-first, newest-first within a status, and the family read
+is capped at 50. When the cap truncates the answer the CLI prints a warning on
+stderr — read it. Without that warning a short list means "nobody else is
+there"; with it, the list proves nothing about the runs it did not return.
+
 Both are advisory reads. Nothing here reserves an issue or serialises anything:
 a run you see may finish a second later, and one you don't see may start a
 second later. Coordinate through the issue's comments — the reads tell you whom

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -267,8 +267,12 @@ child of that parent — and labels each row with the issue it belongs to, which
 is how you find another agent already working on a sibling sub-issue before you
 open a second PR against the same code.
 
+The family read returns a compact row — task, issue, agent, status, started —
+not the full execution-log record. If you need a run's detail, follow the task
+id with `multica issue run-messages`.
+
 Rows come back running-first, newest-first within a status, and the family read
-is capped at 50. When the cap truncates the answer the CLI prints a warning on
+is capped at 20. When the cap truncates the answer the CLI prints a warning on
 stderr — read it. Without that warning a short list means "nobody else is
 there"; with it, the list proves nothing about the runs it did not return.
 

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -248,6 +248,30 @@ exact target `(issue, agent)` pair already has a non-terminal task, but it
 deliberately keeps same-agent handoffs to a fresh issue starting runs: cross-issue
 serial chains and triage batches rely on that.
 
+## Who else is running right now
+
+The `## Active sibling runs` block covers only YOUR OWN other in-flight tasks.
+It says nothing about another agent working next to you, and it is a claim-time
+snapshot that does not refresh mid-turn. Ask the server when you need the
+current answer:
+
+```bash
+multica issue runs <issue-id> --active --output json     # in-flight runs on this issue
+multica issue runs <issue-id> --siblings --output json   # ...and across the sub-issue family
+```
+
+`--active` drops the execution history and returns only `queued` / `dispatched`
+/ `running` / `waiting_local_directory` runs. `--siblings` widens the same read
+to the issue's family — its parent (or itself, when it has no parent) plus every
+child of that parent — and labels each row with the issue it belongs to, which
+is how you find another agent already working on a sibling sub-issue before you
+open a second PR against the same code.
+
+Both are advisory reads. Nothing here reserves an issue or serialises anything:
+a run you see may finish a second later, and one you don't see may start a
+second later. Coordinate through the issue's comments — the reads tell you whom
+to coordinate with.
+
 ## Sub-issues: `todo` starts work now, `backlog` parks it
 
 On an agent-assigned issue, create status decides whether the assignee fires

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -159,6 +159,9 @@ away, so no task is left orphaned.
 | Daemon prompts point to the target's comment history and concrete sibling `run-messages` commands | `server/internal/daemon/prompt.go` (`buildActiveSiblingRunsBlock`) |
 | `issue runs --active` / `--siblings` send `active=true` / `scope=family` to the task-runs endpoint | `server/cmd/multica/cmd_issue.go` (`runIssueRuns`) |
 | `scope=family` roots at the issue's parent, or the issue itself when it has none, and returns in-flight runs on that root plus all of its children | `server/internal/handler/daemon.go` (`ListTasksByIssue`), `server/pkg/db/queries/agent.sql` (`ListActiveTasksByIssueFamily`) |
+| Invalid `active` / `scope` values are rejected rather than silently answering with the full history | `server/internal/handler/daemon.go` (`ListTasksByIssue`) |
+| The family cap fetches one row past `familyActiveRunCap` and reports truncation on `X-Active-Runs-Truncated`, which the CLI surfaces on stderr | `server/internal/handler/daemon.go` (`familyActiveRunCap`, `HeaderActiveRunsTruncated`), `server/cmd/multica/cmd_issue.go` (`runIssueRuns`) |
+| The active path skips usage hydration, which is keyed by issue and spans the full history | `server/internal/handler/daemon.go` (`ListTasksByIssue`), `server/pkg/db/queries/task_usage.sql` (`ListIssueTaskUsage`) |
 
 The self-assignment guard is intentionally pair-scoped. It does not treat
 "this agent is busy on some other issue" as a reason to suppress a fresh

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -162,6 +162,7 @@ away, so no task is left orphaned.
 | Invalid `active` / `scope` values are rejected rather than silently answering with the full history | `server/internal/handler/daemon.go` (`ListTasksByIssue`) |
 | The family cap fetches one row past `familyActiveRunCap` and reports truncation on `X-Active-Runs-Truncated`, which the CLI surfaces on stderr | `server/internal/handler/daemon.go` (`familyActiveRunCap`, `HeaderActiveRunsTruncated`), `server/cmd/multica/cmd_issue.go` (`runIssueRuns`) |
 | The active path skips usage hydration, which is keyed by issue and spans the full history | `server/internal/handler/daemon.go` (`ListTasksByIssue`), `server/pkg/db/queries/task_usage.sql` (`ListIssueTaskUsage`) |
+| The family read returns its own compact row rather than the execution-log record, and skips usage and attribution hydration | `server/internal/handler/daemon.go` (`ActiveRunSummary`), `server/pkg/db/queries/agent.sql` (`ListActiveTasksByIssueFamily`) |
 
 The self-assignment guard is intentionally pair-scoped. It does not treat
 "this agent is busy on some other issue" as a reason to suppress a fresh

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -157,6 +157,8 @@ away, so no task is left orphaned.
 | Trusted direct self-assignment suppresses enqueue only when the target `(issue, agent)` already has a non-terminal task | `server/internal/service/issue_trigger.go` (`WillEnqueueRun`), `server/internal/handler/issue_trigger.go` (`shouldSuppressActiveSelfAssignment`) |
 | Claim responses expose a bounded, workspace-scoped snapshot of the same agent's other dispatched/running/waiting issue tasks; queued tasks are excluded | `server/pkg/db/queries/agent.sql` (`ListActiveSiblingIssueTasks`), `server/internal/handler/daemon.go` (`buildClaimedTaskResponse`) |
 | Daemon prompts point to the target's comment history and concrete sibling `run-messages` commands | `server/internal/daemon/prompt.go` (`buildActiveSiblingRunsBlock`) |
+| `issue runs --active` / `--siblings` send `active=true` / `scope=family` to the task-runs endpoint | `server/cmd/multica/cmd_issue.go` (`runIssueRuns`) |
+| `scope=family` roots at the issue's parent, or the issue itself when it has none, and returns in-flight runs on that root plus all of its children | `server/internal/handler/daemon.go` (`ListTasksByIssue`), `server/pkg/db/queries/agent.sql` (`ListActiveTasksByIssueFamily`) |
 
 The self-assignment guard is intentionally pair-scoped. It does not treat
 "this agent is busy on some other issue" as a reason to suppress a fresh

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -271,7 +271,7 @@ func TestWorkingOnIssuesSkillCoversIssueLoopContracts(t *testing.T) {
 		// coordination they exist to prompt.
 		"covers only YOUR OWN other in-flight tasks",
 		"multica issue runs <issue-id> --siblings --output json",
-		"capped at 50",
+		"capped at 20",
 		"Nothing here reserves an issue or serialises anything",
 	}
 	for _, want := range mustContain {

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -261,6 +261,18 @@ func TestWorkingOnIssuesSkillCoversIssueLoopContracts(t *testing.T) {
 		// Owner ruling: metadata is deliberately free-form custom state;
 		// the platform curates no key vocabulary.
 		"the platform curates no vocabulary",
+		// #7768: the claim-time block and the on-demand reads answer different
+		// questions, and conflating them is what left cross-agent overlap
+		// invisible in the first place. All four anchors are load-bearing —
+		// the same-agent scoping is the correction, the command is the
+		// remedy, the cap disclosure is what stops a truncated answer from
+		// reading as an empty one, and the advisory line is a negative safety
+		// boundary: an agent that reads these as a lock will skip the
+		// coordination they exist to prompt.
+		"covers only YOUR OWN other in-flight tasks",
+		"multica issue runs <issue-id> --siblings --output json",
+		"capped at 50",
+		"Nothing here reserves an issue or serialises anything",
 	}
 	for _, want := range mustContain {
 		if !strings.Contains(body, want) {

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -5340,7 +5340,12 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 
 const listActiveTasksByIssueFamily = `-- name: ListActiveTasksByIssueFamily :many
 SELECT
-    atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision,
+    atq.id AS task_id,
+    atq.agent_id,
+    atq.issue_id,
+    atq.status,
+    atq.created_at,
+    atq.started_at,
     w.issue_prefix,
     i.number AS issue_number,
     i.title AS issue_title
@@ -5368,10 +5373,15 @@ type ListActiveTasksByIssueFamilyParams struct {
 }
 
 type ListActiveTasksByIssueFamilyRow struct {
-	AgentTaskQueue AgentTaskQueue `json:"agent_task_queue"`
-	IssuePrefix    string         `json:"issue_prefix"`
-	IssueNumber    int32          `json:"issue_number"`
-	IssueTitle     string         `json:"issue_title"`
+	TaskID      pgtype.UUID        `json:"task_id"`
+	AgentID     pgtype.UUID        `json:"agent_id"`
+	IssueID     pgtype.UUID        `json:"issue_id"`
+	Status      string             `json:"status"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	StartedAt   pgtype.Timestamptz `json:"started_at"`
+	IssuePrefix string             `json:"issue_prefix"`
+	IssueNumber int32              `json:"issue_number"`
+	IssueTitle  string             `json:"issue_title"`
 }
 
 // Cross-issue coordination read for parallel sub-issue work (#7768). Given a
@@ -5387,10 +5397,20 @@ type ListActiveTasksByIssueFamilyRow struct {
 // two apart.
 //
 // Issue identity is joined in because the caller renders runs from several
-// issues in one list and cannot label a row from the task alone. Ordered
-// running-first so the truncation the LIMIT may impose drops the least
-// interesting rows, and bounded because a parent with hundreds of children
-// must not turn one coordination read into an unbounded scan.
+// issues in one list and cannot label a row from the task alone. agent_id is
+// here for the same reason: unlike ListActiveSiblingIssueTasks, whose rows all
+// belong to the claiming agent by construction, this read spans agents — which
+// one is on a sibling is the answer, not a detail.
+//
+// Columns are named rather than embedded. This is the coordination question,
+// not the execution log: result and context are JSONB blobs, and work_dir /
+// trigger_summary / the attribution ids are all execution-log fields that a
+// caller asking "who else is here?" never reads. Selecting them would make
+// Postgres detoast and ship roughly 5x the bytes per row for nothing.
+//
+// Ordered running-first so the truncation the LIMIT may impose drops the least
+// interesting rows, and bounded because a parent with hundreds of children must
+// not turn one coordination read into an unbounded scan.
 func (q *Queries) ListActiveTasksByIssueFamily(ctx context.Context, arg ListActiveTasksByIssueFamilyParams) ([]ListActiveTasksByIssueFamilyRow, error) {
 	rows, err := q.db.Query(ctx, listActiveTasksByIssueFamily, arg.WorkspaceID, arg.RootIssueID, arg.RowLimit)
 	if err != nil {
@@ -5401,60 +5421,12 @@ func (q *Queries) ListActiveTasksByIssueFamily(ctx context.Context, arg ListActi
 	for rows.Next() {
 		var i ListActiveTasksByIssueFamilyRow
 		if err := rows.Scan(
-			&i.AgentTaskQueue.ID,
-			&i.AgentTaskQueue.AgentID,
-			&i.AgentTaskQueue.IssueID,
-			&i.AgentTaskQueue.Status,
-			&i.AgentTaskQueue.Priority,
-			&i.AgentTaskQueue.DispatchedAt,
-			&i.AgentTaskQueue.StartedAt,
-			&i.AgentTaskQueue.CompletedAt,
-			&i.AgentTaskQueue.Result,
-			&i.AgentTaskQueue.Error,
-			&i.AgentTaskQueue.CreatedAt,
-			&i.AgentTaskQueue.Context,
-			&i.AgentTaskQueue.RuntimeID,
-			&i.AgentTaskQueue.SessionID,
-			&i.AgentTaskQueue.WorkDir,
-			&i.AgentTaskQueue.TriggerCommentID,
-			&i.AgentTaskQueue.ChatSessionID,
-			&i.AgentTaskQueue.AutopilotRunID,
-			&i.AgentTaskQueue.Attempt,
-			&i.AgentTaskQueue.MaxAttempts,
-			&i.AgentTaskQueue.ParentTaskID,
-			&i.AgentTaskQueue.FailureReason,
-			&i.AgentTaskQueue.TriggerSummary,
-			&i.AgentTaskQueue.ForceFreshSession,
-			&i.AgentTaskQueue.IsLeaderTask,
-			&i.AgentTaskQueue.WaitReason,
-			&i.AgentTaskQueue.InitiatorUserID,
-			&i.AgentTaskQueue.HandoffNote,
-			&i.AgentTaskQueue.PrepareLeaseExpiresAt,
-			&i.AgentTaskQueue.SquadID,
-			&i.AgentTaskQueue.RuntimeMcpOverlay,
-			&i.AgentTaskQueue.EscalationForTaskID,
-			&i.AgentTaskQueue.FireAt,
-			&i.AgentTaskQueue.OriginatorUserID,
-			&i.AgentTaskQueue.RuntimeConnectedApps,
-			&i.AgentTaskQueue.CoalescedCommentIds,
-			&i.AgentTaskQueue.DeliveredCommentIds,
-			&i.AgentTaskQueue.ChatInputTaskID,
-			&i.AgentTaskQueue.ChatFinalizeDeferredAt,
-			&i.AgentTaskQueue.OriginatorSource,
-			&i.AgentTaskQueue.DelegatedFromTaskID,
-			&i.AgentTaskQueue.RetryOfTaskID,
-			&i.AgentTaskQueue.RerunOfTaskID,
-			&i.AgentTaskQueue.RuleVersionID,
-			&i.AgentTaskQueue.TriggerEvidenceKind,
-			&i.AgentTaskQueue.TriggerEvidenceRefID,
-			&i.AgentTaskQueue.AccountableUserID,
-			&i.AgentTaskQueue.SessionRolloutMissing,
-			&i.AgentTaskQueue.RetiredSessionID,
-			&i.AgentTaskQueue.QuickActionsDisabled,
-			&i.AgentTaskQueue.RegenerateQuickActionsFor,
-			&i.AgentTaskQueue.BranchName,
-			&i.AgentTaskQueue.DurableWorkDir,
-			&i.AgentTaskQueue.ChannelContextRevision,
+			&i.TaskID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.CreatedAt,
+			&i.StartedAt,
 			&i.IssuePrefix,
 			&i.IssueNumber,
 			&i.IssueTitle,

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -5338,6 +5338,137 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 	return items, nil
 }
 
+const listActiveTasksByIssueFamily = `-- name: ListActiveTasksByIssueFamily :many
+SELECT
+    atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision,
+    w.issue_prefix,
+    i.number AS issue_number,
+    i.title AS issue_title
+FROM agent_task_queue atq
+JOIN issue i ON i.id = atq.issue_id
+JOIN workspace w ON w.id = i.workspace_id
+WHERE i.workspace_id = $1
+  AND (i.id = $2::uuid OR i.parent_issue_id = $2::uuid)
+  AND atq.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+ORDER BY
+    CASE atq.status
+        WHEN 'running' THEN 0
+        WHEN 'dispatched' THEN 1
+        WHEN 'waiting_local_directory' THEN 2
+        ELSE 3
+    END,
+    atq.created_at DESC
+LIMIT $3
+`
+
+type ListActiveTasksByIssueFamilyParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	RootIssueID pgtype.UUID `json:"root_issue_id"`
+	RowLimit    int32       `json:"row_limit"`
+}
+
+type ListActiveTasksByIssueFamilyRow struct {
+	AgentTaskQueue AgentTaskQueue `json:"agent_task_queue"`
+	IssuePrefix    string         `json:"issue_prefix"`
+	IssueNumber    int32          `json:"issue_number"`
+	IssueTitle     string         `json:"issue_title"`
+}
+
+// Cross-issue coordination read for parallel sub-issue work (#7768). Given a
+// family root — the target issue's parent, or the target itself when it has
+// none — return every in-flight task on the root and on all of its children,
+// so a run can see who else is already working in the family before it starts
+// overlapping work. Advisory only: nothing here gates, queues, or serialises
+// anything.
+//
+// Same active set as ListActiveTasksByIssue, including 'queued': a queued
+// sibling cannot answer you yet, but it is about to touch the same code, which
+// is exactly what the caller is trying to find out. The status column tells the
+// two apart.
+//
+// Issue identity is joined in because the caller renders runs from several
+// issues in one list and cannot label a row from the task alone. Ordered
+// running-first so the truncation the LIMIT may impose drops the least
+// interesting rows, and bounded because a parent with hundreds of children
+// must not turn one coordination read into an unbounded scan.
+func (q *Queries) ListActiveTasksByIssueFamily(ctx context.Context, arg ListActiveTasksByIssueFamilyParams) ([]ListActiveTasksByIssueFamilyRow, error) {
+	rows, err := q.db.Query(ctx, listActiveTasksByIssueFamily, arg.WorkspaceID, arg.RootIssueID, arg.RowLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListActiveTasksByIssueFamilyRow{}
+	for rows.Next() {
+		var i ListActiveTasksByIssueFamilyRow
+		if err := rows.Scan(
+			&i.AgentTaskQueue.ID,
+			&i.AgentTaskQueue.AgentID,
+			&i.AgentTaskQueue.IssueID,
+			&i.AgentTaskQueue.Status,
+			&i.AgentTaskQueue.Priority,
+			&i.AgentTaskQueue.DispatchedAt,
+			&i.AgentTaskQueue.StartedAt,
+			&i.AgentTaskQueue.CompletedAt,
+			&i.AgentTaskQueue.Result,
+			&i.AgentTaskQueue.Error,
+			&i.AgentTaskQueue.CreatedAt,
+			&i.AgentTaskQueue.Context,
+			&i.AgentTaskQueue.RuntimeID,
+			&i.AgentTaskQueue.SessionID,
+			&i.AgentTaskQueue.WorkDir,
+			&i.AgentTaskQueue.TriggerCommentID,
+			&i.AgentTaskQueue.ChatSessionID,
+			&i.AgentTaskQueue.AutopilotRunID,
+			&i.AgentTaskQueue.Attempt,
+			&i.AgentTaskQueue.MaxAttempts,
+			&i.AgentTaskQueue.ParentTaskID,
+			&i.AgentTaskQueue.FailureReason,
+			&i.AgentTaskQueue.TriggerSummary,
+			&i.AgentTaskQueue.ForceFreshSession,
+			&i.AgentTaskQueue.IsLeaderTask,
+			&i.AgentTaskQueue.WaitReason,
+			&i.AgentTaskQueue.InitiatorUserID,
+			&i.AgentTaskQueue.HandoffNote,
+			&i.AgentTaskQueue.PrepareLeaseExpiresAt,
+			&i.AgentTaskQueue.SquadID,
+			&i.AgentTaskQueue.RuntimeMcpOverlay,
+			&i.AgentTaskQueue.EscalationForTaskID,
+			&i.AgentTaskQueue.FireAt,
+			&i.AgentTaskQueue.OriginatorUserID,
+			&i.AgentTaskQueue.RuntimeConnectedApps,
+			&i.AgentTaskQueue.CoalescedCommentIds,
+			&i.AgentTaskQueue.DeliveredCommentIds,
+			&i.AgentTaskQueue.ChatInputTaskID,
+			&i.AgentTaskQueue.ChatFinalizeDeferredAt,
+			&i.AgentTaskQueue.OriginatorSource,
+			&i.AgentTaskQueue.DelegatedFromTaskID,
+			&i.AgentTaskQueue.RetryOfTaskID,
+			&i.AgentTaskQueue.RerunOfTaskID,
+			&i.AgentTaskQueue.RuleVersionID,
+			&i.AgentTaskQueue.TriggerEvidenceKind,
+			&i.AgentTaskQueue.TriggerEvidenceRefID,
+			&i.AgentTaskQueue.AccountableUserID,
+			&i.AgentTaskQueue.SessionRolloutMissing,
+			&i.AgentTaskQueue.RetiredSessionID,
+			&i.AgentTaskQueue.QuickActionsDisabled,
+			&i.AgentTaskQueue.RegenerateQuickActionsFor,
+			&i.AgentTaskQueue.BranchName,
+			&i.AgentTaskQueue.DurableWorkDir,
+			&i.AgentTaskQueue.ChannelContextRevision,
+			&i.IssuePrefix,
+			&i.IssueNumber,
+			&i.IssueTitle,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAgentTasks = `-- name: ListAgentTasks :many
 SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
 WHERE agent_id = $1

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -2417,6 +2417,45 @@ SELECT * FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
 ORDER BY created_at DESC;
 
+-- name: ListActiveTasksByIssueFamily :many
+-- Cross-issue coordination read for parallel sub-issue work (#7768). Given a
+-- family root — the target issue's parent, or the target itself when it has
+-- none — return every in-flight task on the root and on all of its children,
+-- so a run can see who else is already working in the family before it starts
+-- overlapping work. Advisory only: nothing here gates, queues, or serialises
+-- anything.
+--
+-- Same active set as ListActiveTasksByIssue, including 'queued': a queued
+-- sibling cannot answer you yet, but it is about to touch the same code, which
+-- is exactly what the caller is trying to find out. The status column tells the
+-- two apart.
+--
+-- Issue identity is joined in because the caller renders runs from several
+-- issues in one list and cannot label a row from the task alone. Ordered
+-- running-first so the truncation the LIMIT may impose drops the least
+-- interesting rows, and bounded because a parent with hundreds of children
+-- must not turn one coordination read into an unbounded scan.
+SELECT
+    sqlc.embed(atq),
+    w.issue_prefix,
+    i.number AS issue_number,
+    i.title AS issue_title
+FROM agent_task_queue atq
+JOIN issue i ON i.id = atq.issue_id
+JOIN workspace w ON w.id = i.workspace_id
+WHERE i.workspace_id = @workspace_id
+  AND (i.id = @root_issue_id::uuid OR i.parent_issue_id = @root_issue_id::uuid)
+  AND atq.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+ORDER BY
+    CASE atq.status
+        WHEN 'running' THEN 0
+        WHEN 'dispatched' THEN 1
+        WHEN 'waiting_local_directory' THEN 2
+        ELSE 3
+    END,
+    atq.created_at DESC
+LIMIT @row_limit;
+
 -- name: GetWorkspaceAgentRunCounts :many
 -- Total task runs per agent over the trailing 30 days, used by the Agents
 -- list RUNS column. 30-day window keeps the count meaningful (a long-dormant

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -2431,12 +2431,27 @@ ORDER BY created_at DESC;
 -- two apart.
 --
 -- Issue identity is joined in because the caller renders runs from several
--- issues in one list and cannot label a row from the task alone. Ordered
--- running-first so the truncation the LIMIT may impose drops the least
--- interesting rows, and bounded because a parent with hundreds of children
--- must not turn one coordination read into an unbounded scan.
+-- issues in one list and cannot label a row from the task alone. agent_id is
+-- here for the same reason: unlike ListActiveSiblingIssueTasks, whose rows all
+-- belong to the claiming agent by construction, this read spans agents — which
+-- one is on a sibling is the answer, not a detail.
+--
+-- Columns are named rather than embedded. This is the coordination question,
+-- not the execution log: result and context are JSONB blobs, and work_dir /
+-- trigger_summary / the attribution ids are all execution-log fields that a
+-- caller asking "who else is here?" never reads. Selecting them would make
+-- Postgres detoast and ship roughly 5x the bytes per row for nothing.
+--
+-- Ordered running-first so the truncation the LIMIT may impose drops the least
+-- interesting rows, and bounded because a parent with hundreds of children must
+-- not turn one coordination read into an unbounded scan.
 SELECT
-    sqlc.embed(atq),
+    atq.id AS task_id,
+    atq.agent_id,
+    atq.issue_id,
+    atq.status,
+    atq.created_at,
+    atq.started_at,
     w.issue_prefix,
     i.number AS issue_number,
     i.title AS issue_title


### PR DESCRIPTION
Refs #7768

Not `Closes` — #7768 also asks for claim-time automatic visibility, which this PR deliberately leaves to a follow-up (see below). The upstream issue should stay open to track that half.

## What

An agent could already read one issue's task runs, but only as the full execution history — every past run, hydrated with attribution and token usage — with no way to ask the question coordination actually needs: *who is working right now*. And nothing could answer it across a parent's sub-issues, which is the case #7768 describes: several agents claim sibling children in parallel and each starts overlapping work without knowing the others exist.

Two optional query params on the existing task-runs endpoint, and the flags that drive them:

```bash
multica issue runs <issue-id> --active --output json     # in-flight runs on this issue
multica issue runs <issue-id> --siblings --output json   # ...and across the sub-issue family
```

- `--active` → `?active=true`. Drops the execution history, returns only `queued` / `dispatched` / `running` / `waiting_local_directory` — the same set the issue-detail "agent live" banner already calls active, reusing `ListActiveTasksByIssue` rather than inventing a second definition. It also skips usage hydration, which is keyed by issue and spans the full history.
- `--siblings` → `?scope=family`. Widens the same read across the issue's sub-issue family and returns its own compact row — `task_id`, `issue_id`, `issue_identifier`, `issue_title`, `agent_id`, `status`, `created_at`, `started_at` — rather than the execution-log record.

## Why the existing block doesn't cover this

The claim-time `## Active sibling runs` prompt block reads as if it answers #7768, but `ListActiveSiblingIssueTasks` is scoped by `agent_id` — it lists *your own* other in-flight tasks. A different agent running on a sibling issue is invisible to it, and it is a snapshot taken before the turn started, so it cannot answer "is someone there *now*".

## Family scoping

The family root is the issue's parent, or the issue itself when it has none. One rule covers both directions:

| Asked from | Returns |
|---|---|
| a child | the parent + all its children (itself + siblings) |
| a parent | itself + its children |
| a standalone issue | its own active runs |

So a caller does not need to know an issue's shape before choosing a flag.

**Payload.** The family read has its own response type (`ActiveRunSummary`), not `AgentTaskResponse`. Measured against real data, the execution-log row is ~1645 bytes per run and the caller reads almost none of it: `attribution` alone is 625 bytes and costs an extra query, alongside `result`, `work_dir`, `relative_work_dir`, `trigger_summary` and the coalesced comment ids. The compact row is 367 bytes. The query names its columns instead of embedding the task row, so Postgres stops detoasting the JSONB blobs as well, and the handler drops attribution hydration with the field.

It is deliberately not `ActiveSiblingRunData` either — that is the claim payload's row, and it has no agent field because those runs all belong to the claiming agent by construction. Sharing either type would mean an optional field that only one caller ever sets, which is exactly the shape this removes from `AgentTaskResponse`.

**Ordering and cap contract.** Rows come back running-first, then newest-first within a status, capped at 20.

20 is a response-size budget set to the shape of the normal case — a handful of runs in flight at once — and nothing more. It is explicitly *not* derived from how much work can really be in flight: `agentconfig.MaxMaxConcurrentTasks` lets a single agent run 50 concurrent tasks on its own, this feature exists precisely for the case where several agents work a family at once, and the returned set includes `queued` / `dispatched` / `waiting_local_directory` rows that no execution slot bounds at all — a parent that fans out 200 children can have 200 of them enqueued.

So truncation here is an ordinary outcome, not a pathological one, which is exactly why it must be reported rather than silent — and reporting it is what makes a budget this small safe. The query fetches one row past the cap; the server sets `X-Active-Runs-Truncated` when it comes back (exposed via CORS, like the comment and timeline truncation headers) and the CLI warns on stderr. Documented in the flag help, the skill, and `CLI_AND_DAEMON.md`.

Worst-case response, before and after: 50 × 1645 B ≈ 80 KB ≈ 20k tokens → 20 × 367 B ≈ 7 KB ≈ 1.8k tokens.

Both reads are **advisory**. Nothing here reserves an issue, queues, or serialises anything: a run you see may finish a second later, one you don't see may start a second later. They tell a run *whom to coordinate with*; coordination still happens in comments. That matches the read-only framing #7768 asked for and leaves the "is this a lock?" product question open.

## Compatibility

With neither param the response is byte-identical to what it has always been — full history, newest first. The issue-detail execution log (`listTasksByIssue` in `packages/core/api/client.ts`) and the CLI's short-task-ID resolver (`resolveTaskRunID`) both depend on that, and neither sends a param. `AgentTaskResponse` is untouched — the family read has its own type — so the claim payload and the UI response are unchanged. No migration: the query rides existing indexes (`idx_issue_workspace_parent`, `idx_agent_task_queue_issue_id_keyset`).

Invalid `scope` and invalid `active` are both 400s rather than a silent fallback to full history — answering "is anyone here?" with every past run reads as "nobody" only after the caller has paid for the whole log.

## Deliberately not in this PR

Widening the claim-time `ActiveSiblingRunData` from same-agent to same-family. That changes the prompt every agent run sees, and it depends on the product question the #7768 triage left open — whether the summary is only a hint or a coordination contract. The read-only CLI surface here is useful on its own and commits to nothing. This is why the PR says `Refs`, not `Closes`.

## Verification

Run locally against a real Postgres, all passing:

- `go test ./internal/handler/ -count=1` — full package, 46s. Nine tests in `task_runs_scope_test.go`: default read still returns completed runs; `active=true` drops terminal and keeps queued; `active=true` omits usage while the history read still carries it; invalid `active` values are 400 while `""` and `false` are not; family scope from a child spans self + sibling + parent, excludes an unrelated issue, and carries issue identity on every row; family scope from a parent sees children; family scope on a standalone issue degenerates; unknown scope is a 400; an exactly-full page sets no truncation header while one row past the cap trims and sets it; and the family payload's exact key set, so the lean row cannot quietly merge back into the execution-log shape.
- `go test ./internal/service/ -count=1` — full package, including the working-on-issues contract anchors.
- `go test ./cmd/multica/ -count=1` — full package. Three tests cover the flag → query-param translation (including "no flags means no params"), the family table's columns (task id read from `task_id`, `ISSUE` present, `COMPLETED`/`ERROR` dropped, execution-log columns intact without the flag), and the truncation warning firing on the header and staying silent without it.
- `go test ./cmd/server/ -run TestCORS -count=1` — the truncation-signal guard now covers `X-Active-Runs-Truncated`.
- `go build ./...`, `go vet`, `gofmt` clean.

Two local test failures are pre-existing and reproduce identically on a clean `origin/main` worktree, so they are not attributable to this PR: `TestCleanupSourceContextObjectIntentsBoundsAttemptsNotSuccesses` (`internal/service`, sensitive to leftover rows in a shared local database) and `TestReadinessEndpoints` (`cmd/server`, a local 503 readiness probe).

One note on running the CLI suite locally: `cmd/multica` tests fail inside an agent workdir because the CLI finds `.multica/daemon_task_context.json` and refuses a non-`mat_` token. That is pre-existing and environment-only — `TestRunIssueRunMessagesResolvesShortTaskPrefix` fails the same way untouched. Building the test binary and running it from a directory outside the marker tree passes everything.

Docs updated in the same PR per the built-in-skill rule: `multica-working-on-issues/SKILL.md` gains a "Who else is running right now" section (including the caveat that the prompt block is same-agent only, and the cap disclosure), its source map gains five rows, and `CLI_AND_DAEMON.md` documents both flags and the truncation header. The new agent-facing contract is pinned by four anchors in `builtin_skills_test.go`, including the advisory/no-lock boundary as a negative anchor.


