### PR TITLE
MUL-6972 perf(server): sweep delegated recovery every five minutes

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -647,6 +647,7 @@ func main() {
 	// work, so there is no separate queue TTL to tune: a busy runtime keeps its
 	// backlog, and a departed one retires everything it owned at once.
 	go runRuntimeSweeper(sweepCtx, queries, liveness, taskSvc, bus, runtimeReconnectGrace)
+	go runDelegatedFailureRecoverySweeper(sweepCtx, taskSvc)
 	// Seven-day runtime retention does not share the 30-second liveness tick:
 	// its bounded transactions run independently once per hour, so a slow GC
 	// round cannot delay offline detection or task recovery.

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -28,6 +28,9 @@ const (
 	// latency-sensitive 30-second liveness path. GC remains independently
 	// bounded by runtimeGCTickTimeout once each hourly round begins.
 	runtimeGCSweepInterval = time.Hour
+	// delegatedFailureRecoverySweepInterval keeps the low-probability durable
+	// recovery scan off the latency-sensitive runtime liveness path.
+	delegatedFailureRecoverySweepInterval = 5 * time.Minute
 	// staleThresholdSeconds marks runtimes offline if no heartbeat for this
 	// long. The heartbeat timing derivation lives with the shared service
 	// constant so every task release path uses the same eligibility window.
@@ -154,17 +157,20 @@ func runPeriodicSweep(ctx context.Context, interval time.Duration, sweep func())
 // When liveness is unavailable or errors, we fall back to trusting the DB
 // stale window — that is the original behavior.
 func runRuntimeSweeper(ctx context.Context, queries *db.Queries, liveness handler.LivenessStore, taskSvc *service.TaskService, bus *events.Bus, reconnectGrace time.Duration) {
+	delegatedFailureRecoveryTicks := 0
 	runPeriodicSweep(ctx, sweepInterval, func() {
-		// These stages retain the existing cadence and ordering in PR1 so the
-		// rollout changes no business predicate or recovery semantics. Runtime
-		// GC is the one exception: its seven-day retention work now runs in the
-		// independent hourly loop below and cannot delay this liveness path.
+		// Every stage retains its existing order. The delegated-failure query is
+		// the only one gated to a lower cadence; the others still run every tick.
 		sweepStaleRuntimes(ctx, queries, liveness, taskSvc, bus)
 		sweepOfflineRuntimeTasks(ctx, queries, taskSvc, reconnectGrace)
 		sweepExpiredRuntimeReconnectRetries(ctx, queries, taskSvc, reconnectGrace)
 		sweepStaleTasks(ctx, queries, taskSvc, bus, reconnectGrace)
 		sweepExpiredQueuedTasks(ctx, queries, taskSvc, reconnectGrace)
-		sweepPendingDelegatedFailureRecoveries(ctx, taskSvc)
+		delegatedFailureRecoveryTicks++
+		if delegatedFailureRecoveryTicks >= int(delegatedFailureRecoverySweepInterval/sweepInterval) {
+			sweepPendingDelegatedFailureRecoveries(ctx, taskSvc)
+			delegatedFailureRecoveryTicks = 0
+		}
 		sweepDeferredChatFinalizations(ctx, queries, taskSvc)
 	})
 }

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -157,21 +157,21 @@ func runPeriodicSweep(ctx context.Context, interval time.Duration, sweep func())
 // When liveness is unavailable or errors, we fall back to trusting the DB
 // stale window — that is the original behavior.
 func runRuntimeSweeper(ctx context.Context, queries *db.Queries, liveness handler.LivenessStore, taskSvc *service.TaskService, bus *events.Bus, reconnectGrace time.Duration) {
-	delegatedFailureRecoveryTicks := 0
 	runPeriodicSweep(ctx, sweepInterval, func() {
-		// Every stage retains its existing order. The delegated-failure query is
-		// the only one gated to a lower cadence; the others still run every tick.
+		// These stages retain their existing cadence and ordering. Runtime GC and
+		// delegated-failure recovery run in independent lower-frequency loops.
 		sweepStaleRuntimes(ctx, queries, liveness, taskSvc, bus)
 		sweepOfflineRuntimeTasks(ctx, queries, taskSvc, reconnectGrace)
 		sweepExpiredRuntimeReconnectRetries(ctx, queries, taskSvc, reconnectGrace)
 		sweepStaleTasks(ctx, queries, taskSvc, bus, reconnectGrace)
 		sweepExpiredQueuedTasks(ctx, queries, taskSvc, reconnectGrace)
-		delegatedFailureRecoveryTicks++
-		if delegatedFailureRecoveryTicks >= int(delegatedFailureRecoverySweepInterval/sweepInterval) {
-			sweepPendingDelegatedFailureRecoveries(ctx, taskSvc)
-			delegatedFailureRecoveryTicks = 0
-		}
 		sweepDeferredChatFinalizations(ctx, queries, taskSvc)
+	})
+}
+
+func runDelegatedFailureRecoverySweeper(ctx context.Context, taskSvc *service.TaskService) {
+	runPeriodicSweep(ctx, delegatedFailureRecoverySweepInterval, func() {
+		sweepPendingDelegatedFailureRecoveries(ctx, taskSvc)
 	})
 }
 
@@ -182,9 +182,9 @@ func runRuntimeGCSweeper(ctx context.Context, txStarter runtimeGCTxStarter, quer
 }
 
 // sweepPendingDelegatedFailureRecoveries retries durable coordinator handoffs
-// that were not acquired by an executable task. It runs even when no stale
-// task was found in this tick, which is what repairs a recovery dispatch lost
-// before a server restart.
+// that were not acquired by an executable task. It runs independently of
+// stale-task discovery, which is what repairs a recovery dispatch lost before
+// a server restart.
 func sweepPendingDelegatedFailureRecoveries(ctx context.Context, taskSvc *service.TaskService) (stats runtimeSweepStageStats) {
 	startedAt := time.Now()
 	defer func() {

--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -35,18 +35,6 @@ func TestRuntimeGCRunsOutsideTheLivenessLoop(t *testing.T) {
 	}
 }
 
-func TestDelegatedFailureRecoveryRunsEveryFiveMinutes(t *testing.T) {
-	if delegatedFailureRecoverySweepInterval != 5*time.Minute {
-		t.Fatalf("delegated failure recovery interval = %s, want 5m", delegatedFailureRecoverySweepInterval)
-	}
-	if delegatedFailureRecoverySweepInterval%sweepInterval != 0 {
-		t.Fatalf("delegated failure recovery interval %s is not a multiple of runtime sweep interval %s", delegatedFailureRecoverySweepInterval, sweepInterval)
-	}
-	if ticks := delegatedFailureRecoverySweepInterval / sweepInterval; ticks != 10 {
-		t.Fatalf("delegated failure recovery cadence = every %d runtime ticks, want 10", ticks)
-	}
-}
-
 // TestRuntimeGCDailyCandidateCapacity prevents an interval or batch-size change
 // from silently reducing the hourly GC worker below its agreed daily capacity.
 func TestRuntimeGCDailyCandidateCapacity(t *testing.T) {

--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -35,6 +35,18 @@ func TestRuntimeGCRunsOutsideTheLivenessLoop(t *testing.T) {
 	}
 }
 
+func TestDelegatedFailureRecoveryRunsEveryFiveMinutes(t *testing.T) {
+	if delegatedFailureRecoverySweepInterval != 5*time.Minute {
+		t.Fatalf("delegated failure recovery interval = %s, want 5m", delegatedFailureRecoverySweepInterval)
+	}
+	if delegatedFailureRecoverySweepInterval%sweepInterval != 0 {
+		t.Fatalf("delegated failure recovery interval %s is not a multiple of runtime sweep interval %s", delegatedFailureRecoverySweepInterval, sweepInterval)
+	}
+	if ticks := delegatedFailureRecoverySweepInterval / sweepInterval; ticks != 10 {
+		t.Fatalf("delegated failure recovery cadence = every %d runtime ticks, want 10", ticks)
+	}
+}
+
 // TestRuntimeGCDailyCandidateCapacity prevents an interval or batch-size change
 // from silently reducing the hourly GC worker below its agreed daily capacity.
 func TestRuntimeGCDailyCandidateCapacity(t *testing.T) {


### PR DESCRIPTION
## Summary

- move delegated-failure recovery out of the 30-second runtime liveness loop
- run it in an independent five-minute loop bound to the existing sweeper shutdown context
- leave every other sweeper stage and all recovery behavior unchanged

## Testing

- `go test -race ./cmd/server -run '^TestPeriodicSweepStopsWithItsContext$' -count=1`
- `go vet ./cmd/server`
- `go test ./cmd/server -run '^$' -count=1`
- `git diff --check`

The full `go test ./cmd/server -count=1` suite is blocked by the reused local test database being behind current migrations (including missing `conversation_starters` and `recovery_settled_at` columns); the existing lifecycle test and package compilation pass.

Closes MUL-6972
