### PR TITLE
MUL-6975: preserve departed member identity in timelines

### DIFF
--- a/apps/mobile/components/issue/activity-row.tsx
+++ b/apps/mobile/components/issue/activity-row.tsx
@@ -110,6 +110,8 @@ function LeadIcon({
     <ActorAvatar
       type={entry.actor_type as "member" | "agent"}
       id={entry.actor_id}
+      name={entry.actor_name}
+      avatarUrl={entry.actor_avatar_url}
       size={16}
     />
   );
@@ -125,7 +127,8 @@ export function ActivityRow({ entry }: { entry: TimelineEntry }) {
     id: string | null | undefined,
   ): string =>
     getName(type as "member" | "agent" | null | undefined, id);
-  const actorName = resolveName(entry.actor_type, entry.actor_id);
+  const actorName =
+    entry.actor_name || resolveName(entry.actor_type, entry.actor_id);
   const verb = formatActivity(entry, resolveName, catalog.labelOf);
   const showCoalesceBadge =
     (entry.coalesced_count ?? 1) > 1 &&

--- a/apps/mobile/components/issue/comment-card.tsx
+++ b/apps/mobile/components/issue/comment-card.tsx
@@ -220,16 +220,18 @@ function ResolvedThreadBar({
   const authorsLabel = useMemo(() => {
     const MAX_NAMED = 2;
     const seen = new Set<string>();
-    const ordered: { type: string | null; id: string | null }[] = [];
+    const ordered: { type: string | null; id: string | null; name?: string }[] =
+      [];
     for (const e of [entry, ...replies]) {
       const key = `${e.actor_type}:${e.actor_id}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      ordered.push({ type: e.actor_type, id: e.actor_id });
+      ordered.push({ type: e.actor_type, id: e.actor_id, name: e.actor_name });
     }
     const named = ordered
       .slice(0, MAX_NAMED)
       .map((a) =>
+        a.name ||
         getName(a.type as "member" | "agent" | null | undefined, a.id),
       )
       .join(", ");
@@ -407,10 +409,12 @@ function CommentBody({
     issueAttachmentsOptions(wsId, issueId),
   );
 
-  const name = getName(
-    entry.actor_type as "member" | "agent" | null | undefined,
-    entry.actor_id,
-  );
+  const name =
+    entry.actor_name ||
+    getName(
+      entry.actor_type as "member" | "agent" | null | undefined,
+      entry.actor_id,
+    );
   const edited =
     entry.updated_at &&
     entry.created_at &&
@@ -483,6 +487,8 @@ function CommentBody({
         <ActorAvatar
           type={entry.actor_type as "member" | "agent"}
           id={entry.actor_id}
+          name={entry.actor_name}
+          avatarUrl={entry.actor_avatar_url}
           size={24}
           showPresence
         />

--- a/apps/mobile/components/issue/comment-context-menu.tsx
+++ b/apps/mobile/components/issue/comment-context-menu.tsx
@@ -118,10 +118,12 @@ export function useCommentLongPress(
             // Set the reply target — the InlineCommentComposer subscribes
             // to this store, auto-expands, and threads the next submit
             // under entry.id via useCreateComment's `parentId`.
-            const actorName = getName(
-              entry.actor_type as "member" | "agent" | null | undefined,
-              entry.actor_id,
-            );
+            const actorName =
+              entry.actor_name ||
+              getName(
+                entry.actor_type as "member" | "agent" | null | undefined,
+                entry.actor_id,
+              );
             useReplyTargetStore.getState().setTarget({
               commentId: entry.id,
               actorName: actorName || "comment",
@@ -198,6 +200,7 @@ export function useCommentLongPress(
     toggleReaction,
     deleteComment,
     resolveComment,
+    getName,
   ]);
 
   return { onLongPress, isPressed };

--- a/apps/mobile/components/ui/actor-avatar.tsx
+++ b/apps/mobile/components/ui/actor-avatar.tsx
@@ -36,6 +36,9 @@ import { THEME } from "@/lib/theme";
 interface Props {
   type: "member" | "agent" | "system" | "squad" | null | undefined;
   id: string | null | undefined;
+  /** Timeline-provided identity for actors no longer in the live directory. */
+  name?: string;
+  avatarUrl?: string | null;
   size?: number;
   /**
    * Overlay a 3-state presence dot at the bottom-right corner. No-op for
@@ -45,8 +48,23 @@ interface Props {
   showPresence?: boolean;
 }
 
-export function ActorAvatar({ type, id, size = 32, showPresence }: Props) {
-  const avatar = <BareAvatar type={type} id={id} size={size} />;
+export function ActorAvatar({
+  type,
+  id,
+  name,
+  avatarUrl,
+  size = 32,
+  showPresence,
+}: Props) {
+  const avatar = (
+    <BareAvatar
+      type={type}
+      id={id}
+      name={name}
+      avatarUrl={avatarUrl}
+      size={size}
+    />
+  );
 
   if (!showPresence || type !== "agent" || !id) {
     return avatar;
@@ -60,10 +78,14 @@ export function ActorAvatar({ type, id, size = 32, showPresence }: Props) {
 function BareAvatar({
   type,
   id,
+  name,
+  avatarUrl,
   size,
 }: {
   type: Props["type"];
   id: Props["id"];
+  name: Props["name"];
+  avatarUrl: Props["avatarUrl"];
   size: number;
 }) {
   const { getName, getAvatarUrl } = useActorLookup();
@@ -88,7 +110,13 @@ function BareAvatar({
   // Only treat a URL as renderable if it actually looks like one — RN <Image>
   // can crash native-side on malformed sources (empty string, plain "foo",
   // etc.). Cheap regex; falsy / bad input falls through to the icon fallback.
-  const rawUrl = type && type !== "system" ? getAvatarUrl(type, id) : null;
+  const rawUrl = avatarUrl === undefined
+    ? type && type !== "system"
+      ? getAvatarUrl(type, id)
+      : null
+    : avatarUrl;
+  const displayName =
+    name ?? (type === "system" ? "Multica" : getName(type, id));
   const emoji = rawUrl?.startsWith("emoji:")
     ? rawUrl.slice("emoji:".length).trim() || null
     : null;
@@ -104,7 +132,7 @@ function BareAvatar({
         className="items-center justify-center bg-muted"
       >
         <Text
-          accessibilityLabel={type === "system" ? "" : getName(type, id)}
+          accessibilityLabel={type === "system" ? "" : displayName}
           style={{ fontSize: Math.round(size * 0.58), lineHeight: size }}
         >
           {emoji}
@@ -117,6 +145,7 @@ function BareAvatar({
     return (
       <Image
         source={{ uri: url }}
+        accessibilityLabel={displayName}
         style={{ width: size, height: size, borderRadius: radius }}
         className="bg-muted"
       />
@@ -145,7 +174,6 @@ function BareAvatar({
     );
   }
 
-  const name = getName(type, id);
   const isAgent = type === "agent";
   return (
     <View
@@ -161,7 +189,7 @@ function BareAvatar({
           isAgent ? "text-brand" : "text-muted-foreground",
         )}
       >
-        {getInitials(name)}
+        {getInitials(displayName)}
       </Text>
     </View>
   );

--- a/apps/mobile/data/realtime/issue-ws-updaters.test.ts
+++ b/apps/mobile/data/realtime/issue-ws-updaters.test.ts
@@ -115,6 +115,40 @@ describe("mobile issue revision gates", () => {
     });
   });
 
+  it("preserves hydrated actor identity when replacing a comment snapshot", () => {
+    const qc = new QueryClient();
+    const key = issueKeys.timeline(wsId, issueId);
+    qc.setQueryData<TimelineEntry[]>(key, [
+      {
+        type: "comment",
+        id: "comment-1",
+        actor_type: "member",
+        actor_id: "departed-user",
+        actor_name: "Former Member",
+        actor_avatar_url: "https://profiles.example.com/former.png",
+        created_at: "2026-01-01T00:00:00Z",
+        content: "before",
+        revision: 1,
+      },
+    ]);
+
+    replaceCommentTimelineEntry(qc, wsId, issueId, {
+      type: "comment",
+      id: "comment-1",
+      actor_type: "member",
+      actor_id: "departed-user",
+      created_at: "2026-01-01T00:00:00Z",
+      content: "after",
+      revision: 2,
+    });
+
+    expect(qc.getQueryData<TimelineEntry[]>(key)?.[0]).toMatchObject({
+      content: "after",
+      actor_name: "Former Member",
+      actor_avatar_url: "https://profiles.example.com/former.png",
+    });
+  });
+
   it("invalidates after a partial owner event without replacing the full snapshot revision", () => {
     const qc = new QueryClient();
     qc.setQueryData<Issue>(issueKeys.detail(wsId, issueId), {

--- a/apps/mobile/data/realtime/issue-ws-updaters.ts
+++ b/apps/mobile/data/realtime/issue-ws-updaters.ts
@@ -259,7 +259,15 @@ export function replaceCommentTimelineEntry(
     wsId,
     issueId,
     (current) => current.type === "comment" && current.id === entry.id,
-    (current) => acceptsRevision(current.revision, entry.revision) ? entry : current,
+    (current) =>
+      acceptsRevision(current.revision, entry.revision)
+        ? {
+            ...entry,
+            actor_name: entry.actor_name ?? current.actor_name,
+            actor_avatar_url:
+              entry.actor_avatar_url ?? current.actor_avatar_url,
+          }
+        : current,
   );
 }
 

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -557,6 +557,26 @@ describe("TimelineEntriesSchema", () => {
 
     expect(parsed[0]?.source_task_id).toBe("task-1");
   });
+
+  it("preserves server-hydrated historical actor identity", () => {
+    const parsed = TimelineEntriesSchema.parse([
+      {
+        type: "comment",
+        id: "comment-1",
+        actor_type: "member",
+        actor_id: "former-user-1",
+        actor_name: "Former Member",
+        actor_avatar_url: "https://profiles.example.com/former.png",
+        created_at: "2026-01-01T00:00:00Z",
+        content: "Authored before leaving",
+      },
+    ]);
+
+    expect(parsed[0]?.actor_name).toBe("Former Member");
+    expect(parsed[0]?.actor_avatar_url).toBe(
+      "https://profiles.example.com/former.png",
+    );
+  });
 });
 
 describe("AgentTaskListSchema", () => {

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -896,6 +896,8 @@ const TimelineEntrySchema = z.object({
   actor_type: z.string(),
   actor_id: z.string(),
   created_at: z.string(),
+  actor_name: z.string().optional(),
+  actor_avatar_url: z.string().optional(),
   action: z.string().optional(),
   details: z.record(z.string(), z.unknown()).optional(),
   content: z.string().optional(),

--- a/packages/core/types/activity.ts
+++ b/packages/core/types/activity.ts
@@ -13,6 +13,9 @@ export interface TimelineEntry {
   actor_type: string;
   actor_id: string;
   created_at: string;
+  /** Display identity hydrated from the actor's global user row when available. */
+  actor_name?: string;
+  actor_avatar_url?: string;
   // Activity fields
   action?: string;
   details?: Record<string, unknown>;

--- a/packages/core/workspace/hooks.test.tsx
+++ b/packages/core/workspace/hooks.test.tsx
@@ -133,6 +133,7 @@ describe("useActorName", () => {
     expect(third).toBe(first);
     // A stable resolver over an empty directory still resolves gracefully.
     expect(first("member", "user-1")).toBe("Unknown");
+    expect(result.current.hasActor("member", "user-1")).toBeUndefined();
   });
 
   it("resolves names once the directories are loaded", () => {
@@ -158,5 +159,7 @@ describe("useActorName", () => {
     expect(result.current.getActorName("member", "user-1")).toBe("Ada");
     expect(result.current.getActorName("agent", "agent-1")).toBe("Walt");
     expect(result.current.getActorName("squad", "squad-1")).toBe("Core");
+    expect(result.current.hasActor("member", "user-1")).toBe(true);
+    expect(result.current.hasActor("member", "departed-user")).toBe(false);
   });
 });

--- a/packages/core/workspace/hooks.ts
+++ b/packages/core/workspace/hooks.ts
@@ -93,9 +93,12 @@ export function buildActorNameResolver(directories: {
 
 export function useActorName() {
   const wsId = useWorkspaceId();
-  const { data: members = EMPTY_MEMBERS } = useQuery(memberListOptions(wsId));
-  const { data: agents = EMPTY_AGENTS } = useQuery(agentListOptions(wsId));
-  const { data: squads = EMPTY_SQUADS } = useQuery(squadListOptions(wsId));
+  const { data: memberData } = useQuery(memberListOptions(wsId));
+  const { data: agentData } = useQuery(agentListOptions(wsId));
+  const { data: squadData } = useQuery(squadListOptions(wsId));
+  const members = memberData ?? EMPTY_MEMBERS;
+  const agents = agentData ?? EMPTY_AGENTS;
+  const squads = squadData ?? EMPTY_SQUADS;
   // Only for naming a plugin-authored row. Gated on the flag so a workspace
   // without plugins does not fetch a list it can never render an author from.
   const pluginsEnabled = useFeatureEnabled(PLUGINS_V1_FLAG, false);
@@ -124,15 +127,18 @@ export function useActorName() {
     [agents, members, squads, pluginData],
   );
 
-  const getActorInitials = useCallback((type: string, id: string) => {
-    const name = getActorName(type, id);
-    return name
-      .split(" ")
-      .map((w) => w[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
-  }, [getActorName]);
+  const getActorInitials = useCallback(
+    (type: string, id: string, nameOverride?: string) => {
+      const name = nameOverride ?? getActorName(type, id);
+      return name
+        .split(" ")
+        .map((w) => w[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2);
+    },
+    [getActorName],
+  );
 
   const getActorAvatarUrl = useCallback((type: string, id: string): string | null => {
     if (type === "member") return resolvePublicFileUrl(members.find((m) => m.user_id === id)?.avatar_url);
@@ -142,16 +148,30 @@ export function useActorName() {
   }, [agents, members, squads]);
 
   const hasActor = useCallback(
-    (type: string, id: string): boolean => {
-      if (type === "member") return members.some((m) => m.user_id === id);
-      if (type === "agent") return agents.some((a) => a.id === id);
-      if (type === "squad") return squads.some((s) => s.id === id);
+    (type: string, id: string): boolean | undefined => {
+      // undefined means the relevant directory has not produced an
+      // authoritative snapshot yet; it must not be treated as a missing actor.
+      if (type === "member") {
+        return memberData === undefined
+          ? undefined
+          : members.some((m) => m.user_id === id);
+      }
+      if (type === "agent") {
+        return agentData === undefined
+          ? undefined
+          : agents.some((a) => a.id === id);
+      }
+      if (type === "squad") {
+        return squadData === undefined
+          ? undefined
+          : squads.some((s) => s.id === id);
+      }
       if (type === "plugin") {
-        return pluginData?.plugins.some((p) => p.id === id) ?? false;
+        return pluginData?.plugins.some((p) => p.id === id);
       }
       return type === "system";
     },
-    [agents, members, pluginData, squads],
+    [agentData, agents, memberData, members, pluginData, squadData, squads],
   );
 
   return useMemo(

--- a/packages/core/workspace/hooks.ts
+++ b/packages/core/workspace/hooks.ts
@@ -141,6 +141,19 @@ export function useActorName() {
     return null;
   }, [agents, members, squads]);
 
+  const hasActor = useCallback(
+    (type: string, id: string): boolean => {
+      if (type === "member") return members.some((m) => m.user_id === id);
+      if (type === "agent") return agents.some((a) => a.id === id);
+      if (type === "squad") return squads.some((s) => s.id === id);
+      if (type === "plugin") {
+        return pluginData?.plugins.some((p) => p.id === id) ?? false;
+      }
+      return type === "system";
+    },
+    [agents, members, pluginData, squads],
+  );
+
   return useMemo(
     () => ({
       getMemberName,
@@ -149,6 +162,7 @@ export function useActorName() {
       getActorName,
       getActorInitials,
       getActorAvatarUrl,
+      hasActor,
     }),
     [
       getActorAvatarUrl,
@@ -157,6 +171,7 @@ export function useActorName() {
       getAgentName,
       getMemberName,
       getSquadName,
+      hasActor,
     ],
   );
 }

--- a/packages/views/common/actor-avatar-profile-link.test.tsx
+++ b/packages/views/common/actor-avatar-profile-link.test.tsx
@@ -15,7 +15,7 @@ import { NavigationProvider } from "../navigation/context";
 import type { NavigationAdapter } from "../navigation/types";
 import { DeferredPopup } from "./deferred-popup";
 
-const actorDirectory = vi.hoisted(() => ({ known: true }));
+const actorDirectory = vi.hoisted(() => ({ known: true as boolean | undefined }));
 
 vi.mock("@multica/core/workspace/hooks", () => ({
   useActorName: () => ({
@@ -134,6 +134,7 @@ describe("ActorAvatar profile link", () => {
           actorId={MEMBER_ID}
           name="Former Member"
           avatarUrl="https://profiles.example.com/former.png"
+          profileRequiresDirectoryEntry
           enableHoverCard
         />
       </NavigationProvider>,
@@ -141,6 +142,38 @@ describe("ActorAvatar profile link", () => {
 
     expect(screen.getByAltText("Former Member")).toBeInTheDocument();
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("keeps hydrated actor interactions while the directory is loading", () => {
+    actorDirectory.known = undefined;
+    render(
+      <NavigationProvider value={makeAdapter()}>
+        <ActorAvatar
+          actorType="member"
+          actorId={MEMBER_ID}
+          name="Ada Lovelace"
+          profileRequiresDirectoryEntry
+          enableHoverCard
+        />
+      </NavigationProvider>,
+    );
+
+    expect(screen.getByRole("link")).toBeInTheDocument();
+  });
+
+  it("does not change non-timeline avatar interactions when the directory misses", () => {
+    actorDirectory.known = false;
+    render(
+      <NavigationProvider value={makeAdapter()}>
+        <ActorAvatar
+          actorType="member"
+          actorId={MEMBER_ID}
+          name="Ada Lovelace"
+        />
+      </NavigationProvider>,
+    );
+
+    expect(screen.getByRole("link")).toBeInTheDocument();
   });
 
   it("pushes on plain click", () => {

--- a/packages/views/common/actor-avatar-profile-link.test.tsx
+++ b/packages/views/common/actor-avatar-profile-link.test.tsx
@@ -15,11 +15,14 @@ import { NavigationProvider } from "../navigation/context";
 import type { NavigationAdapter } from "../navigation/types";
 import { DeferredPopup } from "./deferred-popup";
 
+const actorDirectory = vi.hoisted(() => ({ known: true }));
+
 vi.mock("@multica/core/workspace/hooks", () => ({
   useActorName: () => ({
     getActorName: () => "Ada Lovelace",
     getActorInitials: () => "AL",
     getActorAvatarUrl: () => null,
+    hasActor: () => actorDirectory.known,
   }),
 }));
 
@@ -118,7 +121,26 @@ function renderCardPicker(adapter: NavigationAdapter) {
 
 describe("ActorAvatar profile link", () => {
   afterEach(() => {
+    actorDirectory.known = true;
     vi.restoreAllMocks();
+  });
+
+  it("renders a departed timeline member as static hydrated identity", () => {
+    actorDirectory.known = false;
+    render(
+      <NavigationProvider value={makeAdapter()}>
+        <ActorAvatar
+          actorType="member"
+          actorId={MEMBER_ID}
+          name="Former Member"
+          avatarUrl="https://profiles.example.com/former.png"
+          enableHoverCard
+        />
+      </NavigationProvider>,
+    );
+
+    expect(screen.getByAltText("Former Member")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 
   it("pushes on plain click", () => {

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -9,6 +9,7 @@ import {
   HoverCardContent,
 } from "@multica/ui/components/ui/hover-card";
 import { useActorName } from "@multica/core/workspace/hooks";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useAgentPresenceDetail } from "@multica/core/agents";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { AgentProfileCard } from "../agents/components/agent-profile-card";
@@ -40,6 +41,9 @@ export type AgentHoverCardVariant = "profile" | "live";
 interface ActorAvatarProps {
   actorType: string;
   actorId: string;
+  /** Timeline-provided identity for actors no longer in the live directory. */
+  name?: string;
+  avatarUrl?: string | null;
   size?: AvatarSize;
   className?: string;
   /**
@@ -77,6 +81,8 @@ const PROFILE_LINK_CONTROL_SELECTOR =
 export function ActorAvatar({
   actorType,
   actorId,
+  name,
+  avatarUrl,
   size,
   className,
   enableHoverCard,
@@ -84,13 +90,26 @@ export function ActorAvatar({
   hoverCardVariant = "profile",
   profileLink,
 }: ActorAvatarProps) {
-  const { getActorName, getActorInitials, getActorAvatarUrl } = useActorName();
+  const { getActorName, getActorAvatarUrl, hasActor } = useActorName();
   const paths = useWorkspacePaths();
+  const resolvedName = name ?? getActorName(actorType, actorId);
+  const resolvedAvatarUrl =
+    avatarUrl === undefined
+      ? getActorAvatarUrl(actorType, actorId)
+      : avatarUrl?.startsWith("/")
+        ? resolvePublicFileUrl(avatarUrl)
+        : avatarUrl;
+  const initials = resolvedName
+    .split(" ")
+    .map((word) => word[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
   const avatar = (
     <ActorAvatarBase
-      name={getActorName(actorType, actorId)}
-      initials={getActorInitials(actorType, actorId)}
-      avatarUrl={getActorAvatarUrl(actorType, actorId)}
+      name={resolvedName}
+      initials={initials}
+      avatarUrl={resolvedAvatarUrl}
       isAgent={actorType === "agent"}
       isSystem={actorType === "system"}
       isSquad={actorType === "squad"}
@@ -112,9 +131,15 @@ export function ActorAvatar({
   ) : (
     avatar
   );
+  // The fallback keeps independently mocked/embedded consumers compatible;
+  // the production hook always supplies hasActor.
+  const profileAvailable = hasActor?.(actorType, actorId) ?? true;
   const shouldLinkToProfile =
-    profileLink ??
-    (actorType === "member" || actorType === "agent" || actorType === "squad");
+    profileAvailable &&
+    (profileLink ??
+      (actorType === "member" ||
+        actorType === "agent" ||
+        actorType === "squad"));
   const profileHref = shouldLinkToProfile
     ? actorType === "member"
       ? paths.memberDetail(actorId)
@@ -130,7 +155,7 @@ export function ActorAvatar({
     dotted
   );
 
-  if (!enableHoverCard) {
+  if (!enableHoverCard || !profileAvailable) {
     return content;
   }
   if (actorType === "agent") {

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -44,6 +44,12 @@ interface ActorAvatarProps {
   /** Timeline-provided identity for actors no longer in the live directory. */
   name?: string;
   avatarUrl?: string | null;
+  /**
+   * Disable profile interactions after the live directory confirms that this
+   * actor no longer has a profile. Timeline surfaces opt in because their
+   * hydrated identity remains displayable after an actor leaves.
+   */
+  profileRequiresDirectoryEntry?: boolean;
   size?: AvatarSize;
   className?: string;
   /**
@@ -83,6 +89,7 @@ export function ActorAvatar({
   actorId,
   name,
   avatarUrl,
+  profileRequiresDirectoryEntry = false,
   size,
   className,
   enableHoverCard,
@@ -90,7 +97,12 @@ export function ActorAvatar({
   hoverCardVariant = "profile",
   profileLink,
 }: ActorAvatarProps) {
-  const { getActorName, getActorAvatarUrl, hasActor } = useActorName();
+  const {
+    getActorName,
+    getActorInitials,
+    getActorAvatarUrl,
+    hasActor,
+  } = useActorName();
   const paths = useWorkspacePaths();
   const resolvedName = name ?? getActorName(actorType, actorId);
   const resolvedAvatarUrl =
@@ -99,16 +111,10 @@ export function ActorAvatar({
       : avatarUrl?.startsWith("/")
         ? resolvePublicFileUrl(avatarUrl)
         : avatarUrl;
-  const initials = resolvedName
-    .split(" ")
-    .map((word) => word[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
   const avatar = (
     <ActorAvatarBase
       name={resolvedName}
-      initials={initials}
+      initials={getActorInitials(actorType, actorId, resolvedName)}
       avatarUrl={resolvedAvatarUrl}
       isAgent={actorType === "agent"}
       isSystem={actorType === "system"}
@@ -131,9 +137,8 @@ export function ActorAvatar({
   ) : (
     avatar
   );
-  // The fallback keeps independently mocked/embedded consumers compatible;
-  // the production hook always supplies hasActor.
-  const profileAvailable = hasActor?.(actorType, actorId) ?? true;
+  const profileAvailable =
+    !profileRequiresDirectoryEntry || hasActor(actorType, actorId) !== false;
   const shouldLinkToProfile =
     profileAvailable &&
     (profileLink ??

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -642,6 +642,7 @@ function CommentRow({
           actorId={entry.actor_id}
           name={entry.actor_name}
           avatarUrl={entry.actor_avatar_url}
+          profileRequiresDirectoryEntry
           size="md"
           enableHoverCard
           showStatusDot
@@ -973,6 +974,7 @@ function CommentCardImpl({
                 actorId={entry.actor_id}
                 name={entry.actor_name}
                 avatarUrl={entry.actor_avatar_url}
+                profileRequiresDirectoryEntry
                 size="md"
                 enableHoverCard
                 showStatusDot

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -637,9 +637,17 @@ function CommentRow({
         highlighted={isHighlighted}
         className="flex items-center gap-2.5 px-4 max-md:px-3 pt-1 pb-1.5"
       >
-        <ActorAvatar actorType={entry.actor_type} actorId={entry.actor_id} size="md" enableHoverCard showStatusDot />
+        <ActorAvatar
+          actorType={entry.actor_type}
+          actorId={entry.actor_id}
+          name={entry.actor_name}
+          avatarUrl={entry.actor_avatar_url}
+          size="md"
+          enableHoverCard
+          showStatusDot
+        />
         <span className="cursor-pointer text-body font-medium">
-          {getActorName(entry.actor_type, entry.actor_id)}
+          {entry.actor_name || getActorName(entry.actor_type, entry.actor_id)}
         </span>
         <Tooltip>
           <TooltipTrigger
@@ -960,9 +968,17 @@ function CommentCardImpl({
               >
                 <ChevronRight className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-90")} />
               </button>
-              <ActorAvatar actorType={entry.actor_type} actorId={entry.actor_id} size="md" enableHoverCard showStatusDot />
+              <ActorAvatar
+                actorType={entry.actor_type}
+                actorId={entry.actor_id}
+                name={entry.actor_name}
+                avatarUrl={entry.actor_avatar_url}
+                size="md"
+                enableHoverCard
+                showStatusDot
+              />
               <span className="shrink-0 cursor-pointer text-body font-medium">
-                {getActorName(entry.actor_type, entry.actor_id)}
+                {entry.actor_name || getActorName(entry.actor_type, entry.actor_id)}
               </span>
               <Tooltip>
                 <TooltipTrigger

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1307,6 +1307,29 @@ describe("IssueDetail (shared)", () => {
     expect(screen.getByText("I can help with this")).toBeInTheDocument();
   });
 
+  it("prefers timeline identity when the actor is absent from the member directory", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      {
+        type: "comment",
+        id: "former-member-comment",
+        actor_type: "member",
+        actor_id: "former-user-1",
+        actor_name: "Former Member",
+        actor_avatar_url: "https://profiles.example.com/former.png",
+        content: "Authored before leaving",
+        parent_id: null,
+        created_at: "2026-01-18T00:00:00Z",
+        updated_at: "2026-01-18T00:00:00Z",
+        comment_type: "comment",
+      },
+    ]);
+
+    renderIssueDetail();
+
+    await screen.findByText("Authored before leaving");
+    expect(screen.getByText("Former Member")).toBeInTheDocument();
+  });
+
   it("reruns the source task from an agent failure comment", async () => {
     mockApiObj.listTimeline.mockResolvedValue([
       ...mockTimeline,

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -633,6 +633,7 @@ function ActivityBlock({
               actorId={entry.actor_id}
               name={entry.actor_name}
               avatarUrl={entry.actor_avatar_url}
+              profileRequiresDirectoryEntry
               size="sm"
             />
           );

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -627,7 +627,15 @@ function ActivityBlock({
         } else if (isDueDateChange) {
           leadIcon = <Calendar className="h-4 w-4 shrink-0 text-muted-foreground" />;
         } else {
-          leadIcon = <ActorAvatar actorType={entry.actor_type} actorId={entry.actor_id} size="sm" />;
+          leadIcon = (
+            <ActorAvatar
+              actorType={entry.actor_type}
+              actorId={entry.actor_id}
+              name={entry.actor_name}
+              avatarUrl={entry.actor_avatar_url}
+              size="sm"
+            />
+          );
         }
 
         return (
@@ -636,7 +644,9 @@ function ActivityBlock({
               {leadIcon}
             </div>
             <div className="flex min-w-0 flex-1 items-center gap-1">
-              <span className="shrink-0 font-medium">{getActorName(entry.actor_type, entry.actor_id)}</span>
+              <span className="shrink-0 font-medium">
+                {entry.actor_name || getActorName(entry.actor_type, entry.actor_id)}
+              </span>
               <span className="truncate">{formatActivity(entry, t, locale, getActorName, resolveStatusLabel)}</span>
               {(entry.coalesced_count ?? 1) > 1 &&
                 entry.action !== "task_completed" &&

--- a/packages/views/issues/components/resolved-thread-bar.tsx
+++ b/packages/views/issues/components/resolved-thread-bar.tsx
@@ -26,18 +26,21 @@ function useAuthorsLabel(entries: TimelineEntry[]): string {
   const { getActorName } = useActorName();
 
   const seen = new Set<string>();
-  const authors: Array<{ type: string; id: string }> = [];
+  const authors: Array<{ type: string; id: string; name?: string }> = [];
   for (const e of entries) {
     const key = `${e.actor_type}:${e.actor_id}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    authors.push({ type: e.actor_type, id: e.actor_id });
+    authors.push({ type: e.actor_type, id: e.actor_id, name: e.actor_name });
   }
 
   if (authors.length <= MAX_NAMED_AUTHORS) {
-    return authors.map((a) => getActorName(a.type, a.id)).join(", ");
+    return authors.map((a) => a.name || getActorName(a.type, a.id)).join(", ");
   }
-  const named = authors.slice(0, MAX_NAMED_AUTHORS).map((a) => getActorName(a.type, a.id)).join(", ");
+  const named = authors
+    .slice(0, MAX_NAMED_AUTHORS)
+    .map((a) => a.name || getActorName(a.type, a.id))
+    .join(", ");
   return t(($) => $.comment.resolve.bar_authors_more, {
     names: named,
     count: authors.length - MAX_NAMED_AUTHORS,

--- a/packages/views/issues/components/thread-minimap.tsx
+++ b/packages/views/issues/components/thread-minimap.tsx
@@ -445,6 +445,7 @@ export function ThreadMinimap({
   const activePreview = preview ? previews[preview.index] : undefined;
   const activeTitle = activeThread && activePreview
     ? activePreview.title ||
+      activeThread.entry.actor_name ||
       getActorName(activeThread.entry.actor_type, activeThread.entry.actor_id)
     : undefined;
 
@@ -466,6 +467,7 @@ export function ThreadMinimap({
         {threads.map((thread, i) => {
           const title =
             previews[i]!.title ||
+            thread.entry.actor_name ||
             getActorName(thread.entry.actor_type, thread.entry.actor_id);
           return (
             <MinimapTick

--- a/packages/views/issues/components/thread-nav-panel.tsx
+++ b/packages/views/issues/components/thread-nav-panel.tsx
@@ -231,6 +231,8 @@ function ThreadRow({
       <ActorAvatar
         actorType={thread.entry.actor_type}
         actorId={thread.entry.actor_id}
+        name={thread.entry.actor_name}
+        avatarUrl={thread.entry.actor_avatar_url}
         size="sm"
         profileLink={false}
         className="mt-0.5 shrink-0"
@@ -348,7 +350,9 @@ export function ThreadNavPanel({
           ? cached.preview
           : commentPreview(thread.entry.content ?? "");
       nextCache.set(thread.id, { content: thread.entry.content, preview });
-      const authorName = getActorName(thread.entry.actor_type, thread.entry.actor_id);
+      const authorName =
+        thread.entry.actor_name ||
+        getActorName(thread.entry.actor_type, thread.entry.actor_id);
       const title = preview.title || authorName;
       return {
         thread,

--- a/packages/views/issues/hooks/use-issue-timeline.test.tsx
+++ b/packages/views/issues/hooks/use-issue-timeline.test.tsx
@@ -342,6 +342,54 @@ describe("useIssueTimeline", () => {
     expect(cacheUpdates.last).toEqual(queryState.data);
   });
 
+  it("preserves hydrated actor identity when applying a comment update", () => {
+    queryState.data = [
+      {
+        type: "comment",
+        id: "c1",
+        actor_type: "member",
+        actor_id: "departed-user",
+        actor_name: "Former Member",
+        actor_avatar_url: "https://profiles.example.com/former.png",
+        content: "before",
+        parent_id: null,
+        created_at: "2026-05-06T01:00:00Z",
+        updated_at: "2026-05-06T01:00:00Z",
+        revision: 1,
+        reactions: [],
+        attachments: [],
+      },
+    ];
+    renderHook(() => useIssueTimeline("issue-1", "user-1"));
+
+    act(() => {
+      wsHandlers.get("comment:updated")!({
+        comment: {
+          id: "c1",
+          issue_id: "issue-1",
+          author_type: "member",
+          author_id: "departed-user",
+          content: "after",
+          parent_id: null,
+          created_at: "2026-05-06T01:00:00Z",
+          updated_at: "2026-05-06T02:00:00Z",
+          revision: 2,
+          type: "comment",
+          reactions: [],
+          attachments: [],
+        },
+      });
+    });
+
+    expect(cacheUpdates.last).toMatchObject([
+      {
+        content: "after",
+        actor_name: "Former Member",
+        actor_avatar_url: "https://profiles.example.com/former.png",
+      },
+    ]);
+  });
+
   it("refetches instead of applying an unversioned event over versioned cache state", () => {
     queryState.data = [{
       type: "comment",
@@ -394,6 +442,8 @@ describe("useIssueTimeline", () => {
         id: "c1",
         actor_type: "member",
         actor_id: "u",
+        actor_name: "Former Member",
+        actor_avatar_url: "https://profiles.example.com/former.png",
         content: "hello",
         parent_id: null,
         created_at: "2026-05-06T01:00:00Z",
@@ -448,11 +498,17 @@ describe("useIssueTimeline", () => {
       resolved_at: string | null;
       resolved_by_type: string | null;
       resolved_by_id: string | null;
+      actor_name?: string;
+      actor_avatar_url?: string;
     }>;
     expect(updated.map((e) => e.id)).toEqual(["c1", "c2"]);
     expect(updated[0]!.resolved_at).toBe("2026-05-06T03:00:00Z");
     expect(updated[0]!.resolved_by_type).toBe("member");
     expect(updated[0]!.resolved_by_id).toBe("u");
+    expect(updated[0]!.actor_name).toBe("Former Member");
+    expect(updated[0]!.actor_avatar_url).toBe(
+      "https://profiles.example.com/former.png",
+    );
     // Sibling entry must not change (identity preserved by .map).
     expect(updated[1]!.resolved_at).toBeNull();
   });

--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -91,7 +91,11 @@ function applyCommentSnapshot(
         return entry;
       }
       return acceptsCommentRevision(entry, comment)
-        ? commentToTimelineEntry(comment)
+        ? {
+            ...commentToTimelineEntry(comment),
+            actor_name: entry.actor_name,
+            actor_avatar_url: entry.actor_avatar_url,
+          }
         : entry;
     }),
   );

--- a/server/cmd/multica/cmd_issue_timeline.go
+++ b/server/cmd/multica/cmd_issue_timeline.go
@@ -227,16 +227,23 @@ func printIssueTimelineTable(entries []map[string]any, actors actorDisplayLookup
 		rows = append(rows, []string{
 			when,
 			kind,
-			timelineActor(strVal(e, "actor_type"), strVal(e, "actor_id"), actors, fullID),
+			timelineActor(
+				strVal(e, "actor_type"),
+				strVal(e, "actor_id"),
+				strVal(e, "actor_name"),
+				actors,
+				fullID,
+			),
 			timelineDetail(e, actors, fullID),
 		})
 	}
 	cli.PrintTable(os.Stdout, headers, rows)
 }
 
-// timelineActor renders an actor as "member:Alice", falling back to a shortened
-// id when the workspace lookup cannot name it (deleted member, foreign id).
-func timelineActor(actorType, actorID string, actors actorDisplayLookup, fullID bool) string {
+// timelineActor renders an actor as "member:Alice". The timeline-provided name
+// wins because it remains available after the member leaves the workspace;
+// live directory lookup and then a shortened id are compatibility fallbacks.
+func timelineActor(actorType, actorID, actorName string, actors actorDisplayLookup, fullID bool) string {
 	switch {
 	case actorType == "" && actorID == "":
 		return ""
@@ -251,6 +258,9 @@ func timelineActor(actorType, actorID string, actors actorDisplayLookup, fullID 
 			return actorID
 		}
 		return truncateID(actorID)
+	}
+	if actorName != "" {
+		return actorType + ":" + actorName
 	}
 	display := actors.actor(actorType, actorID)
 	if !fullID && strings.HasSuffix(display, ":"+actorID) {
@@ -285,8 +295,8 @@ func timelineDetail(entry map[string]any, actors actorDisplayLookup, fullID bool
 	// is absent when that side was unassigned.
 	if hasAnyKey(details, "from_type", "from_id", "to_type", "to_id") {
 		return transitionText(
-			timelineActor(strVal(details, "from_type"), strVal(details, "from_id"), actors, fullID),
-			timelineActor(strVal(details, "to_type"), strVal(details, "to_id"), actors, fullID),
+			timelineActor(strVal(details, "from_type"), strVal(details, "from_id"), "", actors, fullID),
+			timelineActor(strVal(details, "to_type"), strVal(details, "to_id"), "", actors, fullID),
 		)
 	}
 

--- a/server/cmd/multica/cmd_issue_timeline_test.go
+++ b/server/cmd/multica/cmd_issue_timeline_test.go
@@ -237,17 +237,20 @@ func TestTimelineDetail(t *testing.T) {
 func TestTimelineActorSystemWithoutIDRendersType(t *testing.T) {
 	var actors actorDisplayLookup
 
-	if got := timelineActor("system", "", actors, false); got != "system" {
+	if got := timelineActor("system", "", "", actors, false); got != "system" {
 		t.Fatalf("system actor = %q, want %q", got, "system")
 	}
-	if got := timelineActor("", "", actors, false); got != "" {
+	if got := timelineActor("", "", "", actors, false); got != "" {
 		t.Fatalf("empty actor = %q, want empty", got)
 	}
-	if got := timelineActor("member", "abcdefgh1234", actors, false); got != "member:abcdefgh" {
+	if got := timelineActor("member", "abcdefgh1234", "", actors, false); got != "member:abcdefgh" {
 		t.Fatalf("member actor = %q, want member:abcdefgh", got)
 	}
-	if got := timelineActor("member", "abcdefgh1234", actors, true); got != "member:abcdefgh1234" {
+	if got := timelineActor("member", "abcdefgh1234", "", actors, true); got != "member:abcdefgh1234" {
 		t.Fatalf("member actor with --full-id = %q, want the full id", got)
+	}
+	if got := timelineActor("member", "abcdefgh1234", "Former Member", actors, false); got != "member:Former Member" {
+		t.Fatalf("hydrated former member = %q, want member:Former Member", got)
 	}
 }
 

--- a/server/internal/handler/activity.go
+++ b/server/internal/handler/activity.go
@@ -1,12 +1,14 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"sort"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -19,6 +21,11 @@ type TimelineEntry struct {
 	ActorType string `json:"actor_type"`
 	ActorID   string `json:"actor_id"`
 	CreatedAt string `json:"created_at"`
+	// Display-only identity is hydrated from the global user row for member
+	// actors. It remains available after the member leaves this workspace;
+	// actor_type + actor_id stay the durable attribution keys.
+	ActorName      string `json:"actor_name,omitempty"`
+	ActorAvatarURL string `json:"actor_avatar_url,omitempty"`
 
 	// Activity-only fields
 	Action  *string         `json:"action,omitempty"`
@@ -204,11 +211,17 @@ func (h *Handler) ListTimeline(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(HeaderTimelineTruncated, kinds)
 	}
 
+	entries := h.mergeTimeline(r, comments, activities, !wantWrapped)
+	// The current-member directory deliberately excludes departed members, but
+	// timeline attribution must remain readable after they leave. Hydrate only
+	// the member ids already present in this authorised issue response; lookup
+	// failure is display-only and must not make the timeline unavailable.
+	h.hydrateTimelineMemberActors(ctx, entries)
+	if entries == nil {
+		entries = []TimelineEntry{}
+	}
+
 	if wantWrapped {
-		entries := h.mergeTimeline(r, comments, activities, false)
-		if entries == nil {
-			entries = []TimelineEntry{}
-		}
 		resp := timelinePaginatedResponse{
 			Entries:       entries,
 			HasMoreBefore: commentsTruncated || activitiesTruncated,
@@ -228,10 +241,6 @@ func (h *Handler) ListTimeline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entries := h.mergeTimeline(r, comments, activities, true)
-	if entries == nil {
-		entries = []TimelineEntry{}
-	}
 	writeJSON(w, http.StatusOK, entries)
 }
 
@@ -315,6 +324,57 @@ func activityToEntry(a db.ActivityLog) TimelineEntry {
 		Action:    &action,
 		Details:   a.Details,
 		CreatedAt: timestampToString(a.CreatedAt),
+	}
+}
+
+// hydrateTimelineMemberActors adds display identity for member-authored rows
+// without changing the active-member directory's semantics. The ids came from
+// comments/activity rows on an issue loadIssueForUser already authorised, so
+// this creates no arbitrary user lookup surface. The query is bounded by the
+// timeline hard caps and runs once for the whole response, never once per row.
+func (h *Handler) hydrateTimelineMemberActors(ctx context.Context, entries []TimelineEntry) {
+	seen := make(map[string]struct{})
+	ids := make([]pgtype.UUID, 0)
+	for i := range entries {
+		entry := &entries[i]
+		if entry.ActorType != "member" || entry.ActorID == "" {
+			continue
+		}
+		if _, ok := seen[entry.ActorID]; ok {
+			continue
+		}
+		id, err := util.ParseUUID(entry.ActorID)
+		if err != nil {
+			continue
+		}
+		seen[entry.ActorID] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	users, err := h.Queries.GetUsersByIDs(ctx, ids)
+	if err != nil {
+		return
+	}
+	byID := make(map[string]db.GetUsersByIDsRow, len(users))
+	for _, user := range users {
+		byID[uuidToString(user.ID)] = user
+	}
+	for i := range entries {
+		entry := &entries[i]
+		if entry.ActorType != "member" {
+			continue
+		}
+		user, ok := byID[entry.ActorID]
+		if !ok {
+			continue
+		}
+		entry.ActorName = user.Name
+		if user.AvatarUrl.Valid {
+			entry.ActorAvatarURL = h.resolveAvatarURL(user.AvatarUrl.String)
+		}
 	}
 }
 

--- a/server/internal/handler/activity_test.go
+++ b/server/internal/handler/activity_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // fetchTimeline issues a GET /timeline request and returns the decoded entries
@@ -153,6 +155,59 @@ func TestListTimeline_MergesCommentsAndActivities(t *testing.T) {
 	// register the activity listener, so there is no auto issue-created row.
 	if got, want := len(entries), 5; got != want {
 		t.Fatalf("entries = %d, want %d", got, want)
+	}
+}
+
+func TestListTimeline_HydratesDepartedMemberIdentity(t *testing.T) {
+	const (
+		name      = "Former Timeline Member"
+		avatarURL = "https://profiles.example.com/former.png"
+	)
+	userID := dbfx.User(
+		t,
+		name,
+		fmt.Sprintf("former-timeline-%d@example.com", time.Now().UnixNano()),
+		testutil.Cols{"avatar_url": avatarURL},
+	)
+	memberID := dbfx.Member(t, testWorkspaceID, userID, "member")
+	issueID := dbfx.Issue(t, "Departed member timeline identity")
+	commentID := dbfx.Comment(t, issueID, "Authored before leaving", testutil.Cols{
+		"author_id": userID,
+	})
+	activityID := dbfx.Insert(t, "activity_log", testutil.Cols{
+		"workspace_id": testWorkspaceID,
+		"issue_id":     issueID,
+		"actor_type":   "member",
+		"actor_id":     userID,
+		"action":       "description_updated",
+		"details":      testutil.Raw("'{}'::jsonb"),
+	})
+
+	// Membership is current workspace state. Timeline attribution must keep
+	// resolving through the global user row after that state is removed.
+	dbfx.Exec(t, `DELETE FROM member WHERE id = $1`, memberID)
+
+	entries, status := fetchTimeline(t, issueID)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	wantIDs := map[string]bool{commentID: false, activityID: false}
+	for _, entry := range entries {
+		if _, ok := wantIDs[entry.ID]; !ok {
+			continue
+		}
+		wantIDs[entry.ID] = true
+		if entry.ActorName != name {
+			t.Errorf("entry %s actor_name = %q, want %q", entry.ID, entry.ActorName, name)
+		}
+		if entry.ActorAvatarURL != avatarURL {
+			t.Errorf("entry %s actor_avatar_url = %q, want %q", entry.ID, entry.ActorAvatarURL, avatarURL)
+		}
+	}
+	for id, found := range wantIDs {
+		if !found {
+			t.Errorf("timeline entry %s missing", id)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- hydrate optional `actor_name` and `actor_avatar_url` fields for member-authored timeline rows with one best-effort batch lookup
- prefer the hydrated identity across Web, Desktop, Mobile, and CLI while keeping departed members' avatars static and non-navigable
- keep `/members` unchanged for current membership, permissions, and picker semantics

## Safety

- additive response fields only; no migration or persisted-format change
- lookups are limited to actor IDs already present in an authorized issue timeline
- lookup failures fall back to the existing response and display behavior
- no email field is exposed

## Validation

- `go vet ./internal/handler ./cmd/multica`
- `go test ./cmd/multica -run 'TestTimelineActor|TestIssueTimeline' -count=1`
- `go test ./internal/handler -run '^$' -count=1`
- Core typecheck, lint, and focused tests (150 passed)
- Views typecheck, lint, and focused tests (141 passed)
- Mobile typecheck and lint
- `git diff --check`

The new handler integration regression test could not run locally because the existing development database has a pre-existing migration-ledger mismatch: migration 352's relation already exists but the migration is not recorded, so the standard migrator cannot advance to the already-required migration 444. The handler package compiles and vets successfully; CI's migrated database should exercise the test.

Closes MUL-6975
