### PR TITLE
MUL-6983 WEN-94: reply to triggering Lark messages

### DIFF
--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -416,17 +416,16 @@ func outboundChatID(b ChatSessionBinding) ChatID {
 	return ChatID(b.ChannelChatID)
 }
 
-// threadReplyTarget derives the outbound reply target from the chat
-// binding's most-recent inbound trigger. We thread the reply ONLY when
-// that trigger was itself inside a Lark topic (last_lark_thread_id
-// present): normal group / p2p chats keep the unchanged chat-level send
-// path, and only an @-mention that happened inside a thread gets a
-// threaded reply (replying to last_lark_message_id with reply_in_thread).
-// The zero ReplyTarget means "send at the chat level".
+// threadReplyTarget derives the outbound reply target from the binding's
+// most-recent inbound trigger. Every trigger with a message id uses Lark's
+// native reply endpoint; topic messages additionally request an in-thread
+// reply. The zero target is reserved for bindings without a message id.
 func threadReplyTarget(binding ChatSessionBinding) ReplyTarget {
-	if binding.LastThreadID.Valid && binding.LastThreadID.String != "" &&
-		binding.LastMessageID.Valid && binding.LastMessageID.String != "" {
-		return ReplyTarget{MessageID: binding.LastMessageID.String, InThread: true}
+	if binding.LastMessageID.Valid && binding.LastMessageID.String != "" {
+		return ReplyTarget{
+			MessageID: binding.LastMessageID.String,
+			InThread:  binding.LastThreadID.Valid && binding.LastThreadID.String != "",
+		}
 	}
 	return ReplyTarget{}
 }
@@ -451,7 +450,7 @@ func sendWithThreadFallback(log *slog.Logger, op string, target ReplyTarget, sen
 	if err == nil {
 		return nil
 	}
-	if target.IsSet() && isThreadReplyUnsupported(err) {
+	if target.InThread && isThreadReplyUnsupported(err) {
 		log.Warn("lark: thread reply unsupported for target, retrying at chat level",
 			"op", op, "reply_message_id", target.MessageID, "error", err)
 		if fallbackErr := send(ReplyTarget{}); fallbackErr != nil {
@@ -460,7 +459,7 @@ func sendWithThreadFallback(log *slog.Logger, op string, target ReplyTarget, sen
 		return nil
 	}
 	if target.IsSet() {
-		log.Warn("lark: thread reply failed; not falling back (non-classified error)",
+		log.Warn("lark: reply failed; not falling back",
 			"op", op, "reply_message_id", target.MessageID, "error", err)
 	}
 	return fmt.Errorf("%s: %w", op, err)

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -659,22 +659,43 @@ func TestPatcherLegacyBindingFallsBackToKey(t *testing.T) {
 	}
 }
 
-// TestPatcherSendsToChatWhenNoThread verifies that a non-thread trigger
-// (no last_lark_thread_id on the binding) keeps the historical
-// chat-level send: ReplyTarget stays empty so SendTextMessage targets
-// the chat by chat_id. This is the no-behavior-change guarantee for
-// normal group / p2p chats.
-func TestPatcherSendsToChatWhenNoThread(t *testing.T) {
+func TestPatcherRepliesToTriggerWhenNoThread(t *testing.T) {
+	for _, chatType := range []string{"p2p", "group"} {
+		t.Run(chatType, func(t *testing.T) {
+			p, q, api := newTestPatcher(t)
+			q.binding.ChatType = chatType
+			q.binding.LastMessageID = pgtype.Text{String: "om_trigger", Valid: true}
+			taskID := uuidFromString(t, "ee777777-ee77-ee77-ee77-eeeeeeeeeeee")
+
+			p.handleEvent(events.Event{
+				Type:          protocol.EventChatDone,
+				TaskID:        uuidString(taskID),
+				ChatSessionID: uuidString(q.binding.ChatSessionID),
+				Payload:       protocol.ChatDonePayload{Content: "plain reply"},
+			})
+
+			api.mu.Lock()
+			defer api.mu.Unlock()
+			if len(api.textSent) != 1 {
+				t.Fatalf("expected one text send; got %d", len(api.textSent))
+			}
+			got := api.textSent[0].ReplyTarget
+			if got.MessageID != "om_trigger" || got.InThread {
+				t.Errorf("ordinary trigger must use quote reply without topic threading; got %+v", got)
+			}
+		})
+	}
+}
+
+func TestPatcherSendsToChatWhenMessageIDMissing(t *testing.T) {
 	p, q, api := newTestPatcher(t)
-	// binding has a message id but NO thread id → must not thread.
-	q.binding.LastMessageID = pgtype.Text{String: "om_trigger", Valid: true}
-	taskID := uuidFromString(t, "ee777777-ee77-ee77-ee77-eeeeeeeeeeee")
+	q.binding.LastMessageID = pgtype.Text{}
 
 	p.handleEvent(events.Event{
 		Type:          protocol.EventChatDone,
-		TaskID:        uuidString(taskID),
+		TaskID:        uuidString(uuidFromString(t, "ee777777-ee77-ee77-ee77-eeeeeeeeeeee")),
 		ChatSessionID: uuidString(q.binding.ChatSessionID),
-		Payload:       protocol.ChatDonePayload{Content: "plain reply"},
+		Payload:       protocol.ChatDonePayload{Content: "legacy reply"},
 	})
 
 	api.mu.Lock()
@@ -683,8 +704,21 @@ func TestPatcherSendsToChatWhenNoThread(t *testing.T) {
 		t.Fatalf("expected one text send; got %d", len(api.textSent))
 	}
 	if api.textSent[0].ReplyTarget.IsSet() {
-		t.Errorf("non-thread trigger must NOT route through the reply endpoint; got %+v",
-			api.textSent[0].ReplyTarget)
+		t.Errorf("missing message id must use chat-level send; got %+v", api.textSent[0].ReplyTarget)
+	}
+}
+
+func TestQuoteReplyDoesNotUseThreadUnsupportedFallback(t *testing.T) {
+	attempts := 0
+	err := sendWithThreadFallback(newDiscardLogger(), "send", ReplyTarget{MessageID: "om_trigger"}, func(ReplyTarget) error {
+		attempts++
+		return errThreadReplyClassified
+	})
+	if err == nil {
+		t.Fatal("ordinary quote reply failure must be returned")
+	}
+	if attempts != 1 {
+		t.Fatalf("ordinary quote reply must not fall back; got %d attempts", attempts)
 	}
 }
 

--- a/server/internal/integrations/lark/outcome_replier.go
+++ b/server/internal/integrations/lark/outcome_replier.go
@@ -260,15 +260,12 @@ func (r *LarkOutcomeReplier) sendIssueCreated(ctx context.Context, inst Installa
 	})
 }
 
-// inboundReplyTarget threads an outbound reply off the inbound trigger
-// message when that message lived inside a Lark topic (话题). It mirrors
-// threadReplyTarget (used by the event-driven Patcher) but reads the
-// live InboundMessage the replier already holds, so it needs no DB
-// round-trip. An empty thread_id yields the zero ReplyTarget — a
-// chat-level send, i.e. the unchanged behavior for non-thread messages.
+// inboundReplyTarget attaches an outbound reply to the inbound trigger when
+// Lark supplied a message id. InThread only controls whether the reply stays
+// in a topic; ordinary p2p and group messages use quote replies too.
 func inboundReplyTarget(msg InboundMessage) ReplyTarget {
-	if msg.ThreadID != "" && msg.MessageID != "" {
-		return ReplyTarget{MessageID: msg.MessageID, InThread: true}
+	if msg.MessageID != "" {
+		return ReplyTarget{MessageID: msg.MessageID, InThread: msg.ThreadID != ""}
 	}
 	return ReplyTarget{}
 }

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -355,7 +355,7 @@ func TestLarkOutcomeReplierIssueCreatedSendsConfirmation(t *testing.T) {
 
 	inst := Installation{AppID: "cli_x"}
 	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
-	msg := InboundMessage{ChatID: "oc_chat_42", SenderOpenID: "ou_user"}
+	msg := InboundMessage{ChatID: "oc_chat_42", ChatType: ChatTypeP2P, MessageID: "om_issue", SenderOpenID: "ou_user"}
 	rep.Reply(context.Background(), inst, msg, DispatchResult{
 		Outcome:         OutcomeIngested,
 		IssueID:         mustUUID("22222222-2222-2222-2222-222222222222"),
@@ -382,10 +382,43 @@ func TestLarkOutcomeReplierIssueCreatedSendsConfirmation(t *testing.T) {
 	if !strings.Contains(got.Text, "https://multica.test/issues/MUL-42") {
 		t.Errorf("text should embed the deep link back to Multica; got %q", got.Text)
 	}
+	if got.ReplyTarget.MessageID != "om_issue" || got.ReplyTarget.InThread {
+		t.Errorf("p2p /issue confirmation must quote the trigger; got %+v", got.ReplyTarget)
+	}
 	// No interactive card on this path — the confirmation must be
 	// plain text, matching how chat replies render.
 	if len(stub.interactiveOut) != 0 {
 		t.Errorf("issue-created confirmation must not send a card; got %d cards", len(stub.interactiveOut))
+	}
+}
+
+func TestLarkOutcomeReplierGroupNoticeRepliesToTrigger(t *testing.T) {
+	t.Parallel()
+	stub := &stubAPIClientWithRecorder{configured: true}
+	rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+		APIClient:   stub,
+		BindingSvc:  &BindingTokenService{},
+		Credentials: stubCredentialsResolver{secret: "s"},
+		Queries:     stubReplierQueries{},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	msg := InboundMessage{ChatID: "oc_group", ChatType: ChatTypeGroup, MessageID: "om_notice"}
+	rep.Reply(context.Background(), Installation{}, msg, DispatchResult{Outcome: OutcomeAgentArchived})
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.interactiveOut) != 1 {
+		t.Fatalf("expected one notice, got %d", len(stub.interactiveOut))
+	}
+	got := stub.interactiveOut[0].ReplyTarget
+	if got.MessageID != "om_notice" || got.InThread {
+		t.Errorf("ordinary group notice must quote the trigger; got %+v", got)
+	}
+}
+
+func TestInboundReplyTargetFallsBackWithoutMessageID(t *testing.T) {
+	if got := inboundReplyTarget(InboundMessage{ChatID: "oc_group", ThreadID: "omt_topic"}); got.IsSet() {
+		t.Fatalf("missing message id must use chat-level send; got %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- use native Lark replies for task results in ordinary p2p/group chats
- keep topic replies in-thread and restrict chat-level fallback to unsupported topic replies
- make immediate `/issue` and offline/archived notices quote the triggering message

## Tests
- `go test ./internal/integrations/lark -count=1`
- `go test ./internal/integrations/... -count=1`
- `go vet ./internal/integrations/lark`

Full `go test ./... -count=1` reaches and passes the Lark package but fails unrelated CLI tests because the Multica task runtime marker intentionally blocks normal config-token fallback.
