### PR TITLE
MUL-6974: warn before overwriting a write-only MCP server entry on edit (#7923)

### DIFF
--- a/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
@@ -274,6 +274,27 @@ describe("McpConfigTab", () => {
     });
   });
 
+  // GH #7923: the write-only replace warning is for entries whose saved
+  // config the caller could NOT read back. Here the real config is handed to
+  // the dialog, so no warning appears and the save button keeps its label.
+  it("edits a readable entry without the write-only replace warning", async () => {
+    const user = userEvent.setup();
+    renderTab({
+      mcp_config: {
+        version: 1,
+        mcpServers: { fetch: { command: "uvx" } },
+      },
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /edit mcp server fetch/i }),
+    );
+    expect(screen.queryByTestId("mcp-write-only-warning")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /save changes/i }),
+    ).toBeInTheDocument();
+  });
+
   it("deletes the last managed server only after confirmation", async () => {
     const user = userEvent.setup();
     const { onSave } = renderTab({

--- a/packages/views/agents/components/tabs/mcp-server-dialog.tsx
+++ b/packages/views/agents/components/tabs/mcp-server-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Loader2, Plus, Trash2 } from "lucide-react";
+import { Loader2, Plus, Trash2, TriangleAlert } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import {
   Dialog,
@@ -244,6 +244,15 @@ export function McpServerDialog({
   // represent, so switching to it cannot rewrite them either.
   const formAvailable = !server || formSupportsServer(server);
 
+  // GH #7923: the workspace library is write-only, so an edit arrives with an
+  // empty config even though a saved entry exists. The form therefore shows
+  // nothing to prefill, and "Save" silently REPLACES the stored configuration.
+  // Say so where the decision is made instead of letting the empty form read
+  // as "the saved state". A caller that could hand us the real config (the
+  // agent's own MCP tab) passes it and never sees this warning.
+  const replacesUnreadableConfig =
+    !!server && Object.keys(server.config).length === 0;
+
   const jsonResult = useMemo(() => parseServerJson(jsonText), [jsonText]);
   const trimmedName = name.trim();
   const nameError =
@@ -350,6 +359,22 @@ export function McpServerDialog({
             </p>
           ) : null}
         </div>
+
+        {replacesUnreadableConfig ? (
+          <div
+            role="alert"
+            data-testid="mcp-write-only-warning"
+            className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2 text-caption"
+          >
+            <TriangleAlert
+              className="mt-0.5 size-3.5 shrink-0 text-warning"
+              aria-hidden="true"
+            />
+            <span>
+              {t(($) => $.tab_body.mcp_config.dialog_write_only_warning)}
+            </span>
+          </div>
+        ) : null}
 
         <Tabs value={mode} onValueChange={handleModeChange}>
           <TabsList className="grid w-full grid-cols-2">
@@ -495,7 +520,9 @@ export function McpServerDialog({
               />
             )}
             {server
-              ? t(($) => $.tab_body.mcp_config.dialog_update_action)
+              ? replacesUnreadableConfig
+                ? t(($) => $.tab_body.mcp_config.dialog_replace_action)
+                : t(($) => $.tab_body.mcp_config.dialog_update_action)
               : t(($) => $.tab_body.mcp_config.dialog_add_action)}
           </Button>
         </DialogFooter>

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -606,6 +606,8 @@
       "dialog_cancel": "Cancel",
       "dialog_add_action": "Add Server",
       "dialog_update_action": "Save Changes",
+      "dialog_replace_action": "Replace Configuration",
+      "dialog_write_only_warning": "The saved configuration can't be read back — the form starts empty, and saving replaces the existing configuration for this server.",
       "delete_dialog_title": "Delete MCP Server?",
       "delete_dialog_description": "{{name}} will no longer be available to this agent. Runtime servers are not affected.",
       "delete_action": "Delete Server",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -487,6 +487,8 @@
       "dialog_cancel": "キャンセル",
       "dialog_add_action": "Server を追加",
       "dialog_update_action": "変更を保存",
+      "dialog_replace_action": "設定を置き換え",
+      "dialog_write_only_warning": "保存済みの設定は読み取れないため、フォームは空の状態で開きます。保存すると既存の設定が丸ごと置き換えられます。",
       "delete_dialog_title": "MCP Server を削除しますか？",
       "delete_dialog_description": "{{name}} はこのエージェントで利用できなくなります。Runtime Server には影響しません。",
       "delete_action": "Server を削除",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -495,6 +495,8 @@
       "dialog_cancel": "취소",
       "dialog_add_action": "Server 추가",
       "dialog_update_action": "변경 저장",
+      "dialog_replace_action": "구성 바꾸기",
+      "dialog_write_only_warning": "저장된 구성을 읽을 수 없어 양식이 비어 있는 상태로 열립니다. 저장하면 기존 구성이 통째로 대체됩니다.",
       "delete_dialog_title": "MCP Server를 삭제할까요?",
       "delete_dialog_description": "{{name}}은 더 이상 이 에이전트에서 사용할 수 없습니다. Runtime Server에는 영향을 주지 않습니다.",
       "delete_action": "Server 삭제",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -594,6 +594,8 @@
       "dialog_cancel": "取消",
       "dialog_add_action": "添加 Server",
       "dialog_update_action": "保存修改",
+      "dialog_replace_action": "替换配置",
+      "dialog_write_only_warning": "无法读取已保存的配置——表单为空白，保存后将整体替换该 Server 的现有配置。",
       "delete_dialog_title": "删除 MCP Server？",
       "delete_dialog_description": "{{name}} 将不再提供给该智能体；运行时中的 Server 不受影响。",
       "delete_action": "删除 Server",

--- a/packages/views/settings/components/mcp-tab.test.tsx
+++ b/packages/views/settings/components/mcp-tab.test.tsx
@@ -126,7 +126,11 @@ describe("McpTab", () => {
     await user.clear(nameInput);
     await user.type(nameInput, "linear-v2");
     await user.type(screen.getByLabelText("Server URL"), "https://linear-v2.example");
-    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+    // GH #7923: the library is write-only, so the edit dialog must say the
+    // form starts empty and name the action for what it is — a wholesale
+    // replacement, not a tweak of hidden values.
+    expect(screen.getByTestId("mcp-write-only-warning")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Replace Configuration" }));
 
     await waitFor(() =>
       expect(mockUpdate).toHaveBeenCalledWith(
@@ -134,6 +138,17 @@ describe("McpTab", () => {
       ),
     );
     expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // GH #7923: adding a server must NOT show the replace warning — there is
+  // nothing stored yet to overwrite, and the add button keeps its own label.
+  it("adds a server without the write-only replace warning", async () => {
+    const user = userEvent.setup();
+    render(<McpTab />, { wrapper: Wrapper });
+
+    await user.click(screen.getByRole("button", { name: /Add server/ }));
+    expect(screen.queryByTestId("mcp-write-only-warning")).toBeNull();
+    expect(screen.getByRole("button", { name: "Add Server" })).toBeInTheDocument();
   });
 
   // The saved entry cannot be read back, but the safe summary still knows the


### PR DESCRIPTION
Fixes #7923

## Problem

Editing an existing server in **Settings → MCP Configuration** opens an empty form: the workspace MCP library is write-only, so the API never returns the stored configuration (name/transport only). Saving then **silently replaces the stored configuration** — the flow looks like a harmless "open the form, fix the name, hit Save", and the original command, args, and env are lost.

## Fix

Keep the write-only design; surface the replacement where the decision is made:

- The edit dialog shows an inline warning (`role="alert"`, warning-tone styling matching the existing `delete-runtime-dialog` notice) when the caller could not hand the dialog a readable config: the saved configuration can't be read back, the form starts empty, and saving replaces the existing configuration for this server.
- In that state the save button reads **"Replace Configuration"** instead of "Save Changes", so the action is named for what it does.
- The judgment is `server && Object.keys(server.config).length === 0` — entries whose config the caller *can* hand over (the agent's own MCP tab) keep the quiet "Save Changes" path, and **Add** never shows the warning.
- New keys under `tab_body.mcp_config` in `en` / `ja` / `ko` / `zh-Hans`.

## Testing

- `packages/views` targeted tests (settings `mcp-tab`, agents `mcp-config-tab`, both i18n parity suites): the existing edit test now asserts the warning appears and submits via "Replace Configuration"; new tests cover "add shows no warning" and "readable config keeps Save Changes".
- Full `packages/views` suite: **413 files / 4939 tests passing** on top of current `main`.
- `tsc --noEmit` and eslint clean on the touched files.
