### PR TITLE
test(execenv): make Windows shim stderr assertions locale-independent

### DIFF
--- a/server/internal/daemon/execenv/openclaw_shim_windows_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_windows_test.go
@@ -94,9 +94,10 @@ func systemPath(t *testing.T) string {
 // TestWindowsOpenclawShimMissingNodeSurfacesCmdStderr records what actually
 // happens on Windows when a real npm shim cannot find its interpreter.
 //
-// The first CI run of this job showed cmd.exe's "'node' is not recognized"
-// reaching Go's stderr pipe, which refutes #6061's premise and means this case
-// takes execOpenclawCLI's stderr branch — the shim diagnostic is NOT involved.
+// CI showed cmd.exe's missing-command diagnostic reaching Go's stderr pipe,
+// which refutes #6061's premise and means this case takes execOpenclawCLI's
+// stderr branch — the shim diagnostic is NOT involved. The diagnostic is
+// localized, so assert its command identity and capture, not English wording.
 // Asserting that directly (rather than "either branch is fine") is deliberate:
 // the earlier disjunction let the diagnostic go completely unexercised on
 // Windows while still reporting a pass. If this ever flips, this test fails
@@ -111,12 +112,23 @@ func TestWindowsOpenclawShimMissingNodeSurfacesCmdStderr(t *testing.T) {
 	if err == nil {
 		t.Fatalf("shim must fail without node on PATH, got output %q", out)
 	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() == 0 {
+		t.Fatalf("expected a non-zero shim exit, got %v", err)
+	}
 	msg := err.Error()
 	t.Logf("observed error: %s", msg)
 
-	if !strings.Contains(strings.ToLower(msg), "not recognized") {
-		t.Errorf("expected cmd.exe's own stderr to reach Go's pipe; if this now fails, "+
-			"the platform behaviour changed and the shim diagnostic is carrying this case instead\ngot: %s", msg)
+	_, stderr, hasStderr := strings.Cut(msg, "(stderr: ")
+	stderr = strings.TrimSpace(strings.TrimSuffix(stderr, ")"))
+	if !hasStderr || stderr == "" {
+		t.Errorf("expected cmd.exe's localized stderr to reach Go's pipe\ngot: %s", msg)
+	}
+	if !strings.Contains(strings.ToLower(stderr), "node") {
+		t.Errorf("stderr should identify the missing node command\ngot: %s", msg)
+	}
+	if strings.Contains(msg, "no stderr output;") {
+		t.Errorf("non-empty cmd.exe stderr must not use the silent-shim diagnostic\ngot: %s", msg)
 	}
 	if !strings.Contains(msg, "openclaw config file") {
 		t.Errorf("error should name the failing subcommand\ngot: %s", msg)


### PR DESCRIPTION
## What does this PR do?

Fixes a locale-dependent assertion in the Windows OpenClaw npm-shim regression test. On the tested Windows host, the real missing-Node fixture emits a Chinese `cmd.exe` diagnostic. The daemon correctly captures that stderr, but the test fails because it expects the English words `not recognized`.

The test's purpose is to distinguish captured command stderr from the silent-shim diagnostic. Checking the process result and captured command identity expresses that contract without depending on the OS message language. No production code or runtime behavior changes.

Risk: an overly broad assertion could stop distinguishing the two error paths. The updated test explicitly requires a non-zero process exit, non-empty captured stderr mentioning `node`, the `openclaw config file` context, and no silent-shim fallback. Existing silent-failure and successful-shim tests remain unchanged.

## Related Issue

No existing GitHub issue found for this test-portability defect. This is a follow-up to the Windows shim coverage added in #6084; it does not claim to fix the runtime reports referenced there.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- In `server/internal/daemon/execenv/openclaw_shim_windows_test.go`, replace the English-only assertion with checks for the actual stderr branch and failing command.
- Clarify that the native missing-command diagnostic is localized.
- Preserve the existing fixture, error-context check, and all other Windows shim tests.

## How to Test

From `server/` on Windows with Go 1.26.6:

```powershell
go test ./internal/daemon/execenv -v -run '^TestWindowsOpenclawShimMissingNodeSurfacesCmdStderr$' -count=1 -timeout=5m
go test ./internal/daemon/execenv -v -run '^TestWindowsOpenclawShim' -count=1 -timeout=5m
go vet ./internal/daemon/execenv
```

Observed before the patch: the targeted test ran and failed because the captured native diagnostic was Chinese rather than English. Decoding that diagnostic as CP936 for inspection showed `不是内部或外部命令，也不是可运行的程序` (not an internal or external command, or an executable program). No OS language settings were changed.

After the patch: all 7 Windows shim tests and both path subtests passed, with no skips. `go vet` and `git diff --check` also passed. The tests use temporary fake npm-shim files; the positive case runs Node only on a fixture that prints a constant, not an installed OpenClaw agent.

Full local `make check-worktree` and the full local cross-platform suite were not run: the local Docker daemon is unavailable, and this patch is limited to Windows test assertions.

Official CI passed for head `83aa1e408b87ba19e426bfa9640b68390bde73c9`: [CI run](https://github.com/multica-ai/multica/actions/runs/33627334950). The backend tests, Go vulnerability scan, and Windows execution-environment checks passed. The Windows OpenClaw npm-shim step ran all 7 tests and both path subtests without skips on Go 1.26.7, including the English missing-command diagnostic. The workflow filters checks by changed paths; frontend-specific steps were skipped. No full-application E2E or real-agent smoke test is claimed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (the scoped Windows checks listed above)
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (not applicable; production behavior is unchanged)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable; no product copy changed)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Codex inspected the current upstream test and stderr wrapping, isolated the locale-dependent assertion, reproduced the failure using the real Windows fixture, implemented the test-only change, and ran the checks above. A separate Codex agent reviewed the final diff and scope. This disclosure does not claim a separate human manual test or review.

## Screenshots (optional)

Not applicable: this is a test-only change with no UI effect.
