### PR TITLE
fix(views): respect popup focus for the right sidebar shortcut

### DIFF
--- a/packages/views/layout/animated-right-sidebar.test.tsx
+++ b/packages/views/layout/animated-right-sidebar.test.tsx
@@ -106,6 +106,70 @@ describe("right sidebar shortcut", () => {
     unmount();
   });
 
+  it.each(["dialog", "menu"])(
+    "leaves Mod+/ to an open %s layer",
+    (role) => {
+      configureShortcutPlatform("macos");
+      const onToggle = vi.fn();
+      const target = document.createElement("div");
+      vi.spyOn(target, "getClientRects").mockReturnValue(
+        [{}] as unknown as DOMRectList,
+      );
+      const { unmount } = renderHook(() =>
+        useRightSidebarShortcut({ current: target }, onToggle),
+      );
+      const layer = document.createElement("div");
+      layer.setAttribute("role", role);
+      document.body.appendChild(layer);
+      const event = new KeyboardEvent("keydown", {
+        key: "/",
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      try {
+        layer.dispatchEvent(event);
+
+        expect(onToggle).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+      } finally {
+        unmount();
+        layer.remove();
+      }
+    },
+  );
+
+  it("leaves Mod+/ to a modal even when focus remains on the page", () => {
+    configureShortcutPlatform("macos");
+    const onToggle = vi.fn();
+    const target = document.createElement("div");
+    vi.spyOn(target, "getClientRects").mockReturnValue(
+      [{}] as unknown as DOMRectList,
+    );
+    const { unmount } = renderHook(() =>
+      useRightSidebarShortcut({ current: target }, onToggle),
+    );
+    const inertPage = document.createElement("div");
+    inertPage.setAttribute("data-base-ui-inert", "");
+    document.body.appendChild(inertPage);
+    const event = new KeyboardEvent("keydown", {
+      key: "/",
+      metaKey: true,
+      cancelable: true,
+    });
+
+    try {
+      document.dispatchEvent(event);
+
+      expect(onToggle).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    } finally {
+      unmount();
+      inertPage.remove();
+    }
+  });
+
   it("leaves the shortcut unclaimed when its detail page is hidden", () => {
     configureShortcutPlatform("macos");
     const onToggle = vi.fn();

--- a/packages/views/layout/animated-right-sidebar.tsx
+++ b/packages/views/layout/animated-right-sidebar.tsx
@@ -12,6 +12,7 @@ import { motion } from "motion/react";
 import type { Layout, PanelSize } from "react-resizable-panels";
 import {
   isEditableShortcutTarget,
+  isPortalLayerShortcutTarget,
   shortcutMatchesEvent,
   useShortcut,
 } from "@multica/core/shortcuts";
@@ -105,6 +106,7 @@ export function useRightSidebarShortcut(
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || event.repeat || isImeComposing(event)) return;
       if (isEditableShortcutTarget(event.target)) return;
+      if (isPortalLayerShortcutTarget(event.target)) return;
       if (!shortcutMatchesEvent(shortcut, event)) return;
 
       const target = targetRef.current;


### PR DESCRIPTION
## What does this PR do?

Keeps `Mod+/` from toggling the background right sidebar while a popup owns the keyboard. The shared detail-page listener currently ignores editable targets and already-handled events, but a keydown from a portaled menu or dialog can still reach it.

The application already has `isPortalLayerShortcutTarget` for this boundary. Reusing it also covers a modal's `data-base-ui-inert` marker when focus has not moved off the page. The listener returns before claiming the event, leaving the popup in control; ordinary visible-page toggling stays unchanged.

Risk is limited to shortcut routing. This uses the existing shared portal policy without changing its selectors, shortcut definitions, layout, or persisted state. Reverting the guard restores the old behavior.

## Related Issue

No existing GitHub issue found for this specific regression. This follows the right-sidebar shortcut introduced in #7445.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/layout/animated-right-sidebar.tsx`: reuse the existing portal-layer guard in `useRightSidebarShortcut`.
- `packages/views/layout/animated-right-sidebar.test.tsx`: add named regressions for menu/dialog targets and a modal with focus left on the underlying page; assert both no toggle and no `preventDefault()`.

## How to Test

1. Open a detail page with a visible right sidebar, then open a menu or dialog and press `Ctrl+/` on Windows/Linux or `Cmd+/` on macOS. Before the fix, the background sidebar can toggle. With this patch it remains unchanged and the page listener leaves the key unclaimed.
2. Close the popup and press the shortcut on the visible page. Normal sidebar toggling must still work.
3. From the repository root with Node 22 and pnpm 10.28.2:

```sh
pnpm --filter @multica/views test layout/animated-right-sidebar.test.tsx
pnpm --filter @multica/views typecheck
pnpm --filter @multica/views exec eslint layout/animated-right-sidebar.tsx layout/animated-right-sidebar.test.tsx
```

The three new regression cases failed on the unchanged upstream implementation: each unexpectedly called `onToggle` once, while the seven existing tests passed.

After the guard was added, all 10 tests passed. Views typecheck, targeted ESLint, and `git diff --check` passed with Node 22.23.2 and pnpm 10.28.2. In the isolated browser fixture, the same `Ctrl+/` on a real Base UI menu item changed the baseline sidebar to closed (1 toggle), but kept it open after the fix (0 toggles); the dialog case showed the same before/after result.

Full `make check-worktree`, full-application E2E, and a packaged Desktop smoke test were not run. The local Docker daemon is unavailable. The attached visual reproductions use the actual shared sidebar/shortcut and Base UI popup components in an isolated browser fixture, not a full product page or an authenticated account.

Official CI passed for head `a4077e9dbec76fb2957cfd0fad73226281812d6b`: [CI run](https://github.com/multica-ai/multica/actions/runs/33627937265). The applicable frontend build/typecheck/lint checks, frontend tests, and both views-test shards passed. The workflow filters checks by changed paths; backend-specific steps were skipped, and this run is not evidence of full-application E2E or packaged Desktop testing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (the scoped checks listed above)
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (isolated real-component reproduction below)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented shortcut or command changed)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Codex traced the existing shortcut and portal policy, extracted only this guard and its regressions onto upstream main at `d4a712abf3880dfbd3daeac5daac1bd4bfb39b6f`, verified the failing cases before the implementation change, and ran the scoped checks. A separate Codex agent reviewed the final diff. Browser evidence uses real upstream components in an explicitly isolated fixture. No separate human manual test or review is claimed.

## Screenshots (optional)

Same real Base UI menu focus and `Ctrl+/`, with the sidebar initially open. This is an isolated reproduction using upstream components, not full-application or packaged Desktop verification.

Before: the background sidebar closes and the toggle count becomes 1.

![Before: popup keypress incorrectly closes the sidebar](https://github.com/user-attachments/assets/f5757f72-4c34-4efe-91b0-43afd54ebb27)

After: the sidebar stays open and the toggle count remains 0.

![After: popup keypress leaves the sidebar unchanged](https://github.com/user-attachments/assets/7013c489-aff2-47a3-ad42-e2ad172f22c4)
