### PR TITLE
MUL-6942: fix(views): let long issue identifiers expand beyond 4rem

### DIFF
--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -110,7 +110,7 @@ function ListRowContent({
           newTabTitle={issue.identifier}
           className={`flex flex-1 items-center gap-2 min-w-0 ${isDragging ? "pointer-events-none" : ""}`}
         >
-          <span className="w-16 shrink-0 text-caption text-muted-foreground">
+          <span className="min-w-16 shrink-0 text-caption text-muted-foreground">
             {issue.identifier}
           </span>
           <IssueAgentActivityIndicator issueId={issue.id} />

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -715,7 +715,7 @@ export function InlineTitle({
       ) : (
         <span className="w-4 shrink-0" />
       )}
-      <span className="w-16 shrink-0 text-caption text-muted-foreground">
+      <span className="min-w-16 shrink-0 text-caption text-muted-foreground">
         {row.issue.identifier}
       </span>
       <IssueAgentActivityIndicator issueId={row.issue.id} />


### PR DESCRIPTION
## What does this PR do?

Fixes the layout bug reported in #7891: in the **Table** and **List** views, an issue identifier wider than the fixed `w-16` (64px) box overflows and paints on top of the adjacent issue title, making both unreadable. Workspaces with a long project key (e.g. 10 chars → 14-char identifiers, ~95px at `text-caption`) hit this on every row.

The identifier span is `w-16 shrink-0` with no `truncate` or overflow handling, while `w-16` resolves to a hard 64px:

- `packages/views/issues/components/table-view.tsx:718` (`InlineTitle`)
- `packages/views/issues/components/list-row.tsx:113` (`ListRowContent`)

This PR changes that one class in both places, `w-16` → `min-w-16`:

- **Short identifiers** (`MUL-1234` and shorter): the 4rem floor is preserved, so existing column alignment is unchanged.
- **Long identifiers**: the box sizes to its intrinsic content width, and the adjacent title — already `min-w-0 flex-1 truncate` — truncates slightly earlier instead of being overlapped. Table cells keep their `overflow-hidden` boundary and List rows keep their existing scroll behavior, so nothing else changes.

No new layout abstraction, no new constants, no dependency or state changes — the same acceptance pattern as #6182. Before/after screenshots are in #7891.

Closes #7891

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How to Test

1. Check out this branch and confirm `git diff main` touches only the two 1-line class changes above.
2. In a workspace with a long project key (10 characters → 14-character identifiers), open the project **Table** view and **List** view: the identifier no longer overlaps the title.
3. With a short identifier (e.g. `MUL-1234`), confirm the 4rem alignment is unchanged in both views.
4. `pnpm --filter @multica/views typecheck` and `pnpm --filter @multica/views lint` pass; `git diff --check` is clean.

## Verification

- `pnpm --filter @multica/views typecheck`: PASS (`tsc --noEmit`, 0 errors)
- `pnpm --filter @multica/views lint`: PASS (0 errors; 27 warnings pre-existing, none from the modified lines)
- `pnpm --filter @multica/views test` (vitest, full suite): 411/413 files, 4935/4937 tests passed — the 2 failures reproduce identically on unmodified `main` (pre-existing flaky tests, unrelated to this change)
- Focused suites re-verified independently during review: 5 files / 33 tests PASS (`list-view`, `table-inline-title`, `table-view-editing`, `data-table-resize`, `data-table-sticky`)
- Tailwind compatibility checked: Tailwind 4.2.2 compiles `.min-w-16 { min-width: calc(var(--spacing) * 16) }`, and Tailwind 3.4.x maps `minWidth.16` to `theme('spacing')` = 4rem, so the floor behaves identically
- `git diff --check`: PASS
