### PR TITLE
feat(views): derived "Waiting on sub-issues" state for in_progress parent issues (#7925)

### DIFF
--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -28,6 +28,7 @@ import { IssueActionsContextMenu } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 import { CustomStatusChip, useIsCustomStatus } from "./custom-status-chip";
+import { issueStatusCategory } from "@multica/core/issues";
 import { useIssueSurfaceActionsOptional } from "../surface/actions-context";
 function formatDate(date: string, locale: string): string {
   return formatDateOnly(date, { month: "short", day: "numeric" }, locale);
@@ -181,7 +182,11 @@ export const BoardCardContent = memo(function BoardCardContent({
           {priorityIconNode}
           <p className="text-caption text-muted-foreground truncate">{issue.identifier}</p>
         </div>
-        <IssueAgentActivityIndicator issueId={issue.id} />
+        <IssueAgentActivityIndicator
+          issueId={issue.id}
+          childProgress={childProgress}
+          statusCategory={issueStatusCategory(issue)}
+        />
       </div>
 
       {/* Row 2: Title */}

--- a/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
@@ -27,7 +27,24 @@ vi.mock("../../agents/components/agent-activity-hover-content", () => ({
 }));
 
 vi.mock("../../i18n", () => ({
-  useT: () => ({ t: () => "Working" }),
+  useT: () => ({
+    t: (selector: (v: Record<string, unknown>) => unknown, vars?: Record<string, unknown>) => {
+      const base = {
+        agent_activity: {
+          status_running: "Working",
+          status_queued: "Queued",
+          status_waiting: "Waiting on sub-issues",
+          waiting_detail: vars ? `${(vars as Record<string, unknown>).done}/${(vars as Record<string, unknown>).total} complete` : "0/1 complete",
+        },
+      };
+      try {
+        const picked = (selector as (v: typeof base) => unknown)(base);
+        return typeof picked === "string" ? picked : String(picked ?? "");
+      } catch {
+        return "Working";
+      }
+    },
+  }),
 }));
 
 // The hover card only portals its content once open, so absence of the body
@@ -140,5 +157,87 @@ describe("IssueAgentActivityIndicator", () => {
     );
 
     expect(container.firstChild).toBeNull();
+  });
+
+  // MUL-7925: derived waiting state (no new query, no status write)
+  it("shows Working when running even with unfinished children", () => {
+    mockState.snapshot = [makeTask({ status: "running" })];
+    const { container } = render(
+      <IssueAgentActivityIndicator
+        issueId="issue-1"
+        statusCategory="in_progress"
+        childProgress={{ done: 0, total: 1 }}
+        hoverCard={false}
+      />,
+    );
+    expect(container.textContent).toContain("Working");
+    expect(container.textContent).not.toContain("Waiting on sub-issues");
+  });
+
+  it("shows Queued when queued even with unfinished children", () => {
+    mockState.snapshot = [makeTask({ status: "queued" })];
+    const { container } = render(
+      <IssueAgentActivityIndicator
+        issueId="issue-1"
+        statusCategory="in_progress"
+        childProgress={{ done: 0, total: 1 }}
+        hoverCard={false}
+      />,
+    );
+    expect(container.textContent).toContain("Queued");
+    expect(container.textContent).not.toContain("Waiting on sub-issues");
+  });
+
+  it("shows Waiting on sub-issues when in_progress with unfinished children and no active task", () => {
+    mockState.snapshot = [];
+    const { container } = render(
+      <IssueAgentActivityIndicator
+        issueId="issue-1"
+        statusCategory="in_progress"
+        childProgress={{ done: 0, total: 1 }}
+        hoverCard={false}
+      />,
+    );
+    expect(container.textContent).toContain("Waiting on sub-issues");
+  });
+
+  it("shows nothing when all children are done even if in_progress and idle", () => {
+    mockState.snapshot = [];
+    const { container } = render(
+      <IssueAgentActivityIndicator
+        issueId="issue-1"
+        statusCategory="in_progress"
+        childProgress={{ done: 1, total: 1 }}
+        hoverCard={false}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows nothing when unfinished children but status is not in_progress", () => {
+    mockState.snapshot = [];
+    const { container } = render(
+      <IssueAgentActivityIndicator
+        issueId="issue-1"
+        statusCategory="todo"
+        childProgress={{ done: 0, total: 1 }}
+        hoverCard={false}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("waiting wraps in a hover card with detail when hoverCard=true", () => {
+    mockState.snapshot = [];
+    render(
+      <IssueAgentActivityIndicator
+        issueId="issue-1"
+        statusCategory="in_progress"
+        childProgress={{ done: 0, total: 1 }}
+      />,
+    );
+    expect(screen.getByTestId("hover-card")).not.toBeNull();
+    expect(screen.getAllByText("Waiting on sub-issues").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("0/1 complete")).not.toBeNull();
   });
 });

--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -16,6 +16,7 @@ import { AgentAvatarStack } from "../../agents/components/agent-avatar-stack";
 import { AgentActivityHoverContent } from "../../agents/components/agent-activity-hover-content";
 import { selectIssueTasks, type IssueTaskGroups } from "../surface/activity";
 import { useT } from "../../i18n";
+import type { IssueStatusCategory } from "@multica/core/types";
 
 const EMPTY_GROUPS: IssueTaskGroups = { running: [], queued: [] };
 
@@ -47,6 +48,11 @@ interface IssueAgentActivityIndicatorProps {
   // Whether hovering opens the activity card. Opt OUT where the card's only
   // incremental information is not worth a popup (Inbox — see below).
   hoverCard?: boolean;
+  // Derived waiting state: an in_progress parent with unfinished children
+  // and no active task shows "Waiting on sub-issues". Reuses already-loaded
+  // childProgress + resolved status category; no extra query (MUL-7925).
+  childProgress?: { done: number; total: number } | null;
+  statusCategory?: IssueStatusCategory | null;
 }
 
 /**
@@ -90,6 +96,8 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
   issueId,
   size = "xs",
   hoverCard = true,
+  childProgress,
+  statusCategory,
 }: IssueAgentActivityIndicatorProps) {
   const { t } = useT("issues");
   const wsId = useWorkspaceId();
@@ -114,10 +122,34 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
     };
   }, [groups]);
 
-  if (agentIds.length === 0) return null;
-  const isRunning = opacity === "full";
+  const hasRunning = groups.running.length > 0;
+  const hasQueued = groups.queued.length > 0;
+  const isWaiting =
+    !hasRunning &&
+    !hasQueued &&
+    statusCategory === "in_progress" &&
+    !!childProgress &&
+    childProgress.total > 0 &&
+    childProgress.done < childProgress.total;
 
-  const badge = (
+  if (agentIds.length === 0 && !isWaiting) return null;
+  const isRunning = hasRunning;
+
+  const badge = isWaiting ? (
+    <span
+      className="text-micro text-muted-foreground"
+      title={
+        childProgress
+          ? t(($) => $.agent_activity.waiting_detail, {
+              done: childProgress.done,
+              total: childProgress.total,
+            })
+          : undefined
+      }
+    >
+      {t(($) => $.agent_activity.status_waiting)}
+    </span>
+  ) : (
     <>
       <AgentAvatarStack
         agentIds={agentIds}
@@ -146,6 +178,39 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
   if (!hoverCard) {
     return (
       <span className="inline-flex shrink-0 items-center gap-1">{badge}</span>
+    );
+  }
+
+  if (isWaiting) {
+    const waitingLabel = t(($) => $.agent_activity.status_waiting);
+    const waitingDetail = childProgress
+      ? t(($) => $.agent_activity.waiting_detail, {
+          done: childProgress.done,
+          total: childProgress.total,
+        })
+      : "";
+    return (
+      <HoverCard>
+        <HoverCardTrigger
+          delay={OPEN_DELAY_MS}
+          closeDelay={CLOSE_DELAY_MS}
+          render={
+            <span className="inline-flex shrink-0 items-center gap-1" />
+          }
+        >
+          {badge}
+        </HoverCardTrigger>
+        <HoverCardContent align="end" className="w-64">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">{waitingLabel}</div>
+            {waitingDetail ? (
+              <div className="text-xs text-muted-foreground">
+                {waitingDetail}
+              </div>
+            ) : null}
+          </div>
+        </HoverCardContent>
+      </HoverCard>
     );
   }
 

--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -62,7 +62,9 @@ interface IssueAgentActivityIndicatorProps {
  *
  *   - has ≥1 running task  → tiny avatar stack + shimmering "Working"
  *   - 0 running, ≥1 queued → half-opacity stack + muted "Queued"
- *   - nothing               → return null (no chrome, no placeholder)
+ *   - 0 active, in_progress parent with unfinished children (done < total)
+ *     → muted "Waiting on sub-issues" (+ hover detail "done/total complete")
+ *   - otherwise             → return null (no chrome, no placeholder)
  *
  * The shimmer reuses chat's `animate-chat-text-shimmer` utility (defined
  * in packages/ui/styles/base.css). Earlier iterations layered a brand
@@ -202,9 +204,9 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
         </HoverCardTrigger>
         <HoverCardContent align="end" className="w-64">
           <div className="space-y-1">
-            <div className="text-sm font-medium">{waitingLabel}</div>
+            <div className="text-body font-medium">{waitingLabel}</div>
             {waitingDetail ? (
-              <div className="text-xs text-muted-foreground">
+              <div className="text-caption text-muted-foreground">
                 {waitingDetail}
               </div>
             ) : null}

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -25,6 +25,7 @@ import { LabelChip } from "../../labels/label-chip";
 import { CustomStatusChip } from "./custom-status-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 import { useIssueSurfaceSelection } from "../surface/selection-context";
+import { issueStatusCategory } from "@multica/core/issues";
 import { useLocale } from "../../i18n";
 
 export interface ChildProgress {
@@ -113,7 +114,11 @@ function ListRowContent({
           <span className="w-16 shrink-0 text-caption text-muted-foreground">
             {issue.identifier}
           </span>
-          <IssueAgentActivityIndicator issueId={issue.id} />
+          <IssueAgentActivityIndicator
+            issueId={issue.id}
+            childProgress={childProgress}
+            statusCategory={issueStatusCategory(issue)}
+          />
 
           <span className="flex min-w-0 flex-1 items-center gap-1.5">
             <span className="truncate">{issue.title}</span>

--- a/packages/views/issues/components/table-inline-title.test.tsx
+++ b/packages/views/issues/components/table-inline-title.test.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 
-import type { Issue } from "@multica/core/types";
+import type { Issue, IssueStatusCategory } from "@multica/core/types";
 
 // InlineTitle renders the self-contained agent-activity badge, which fetches
 // the workspace agent-task snapshot via React Query. Stub it (same pattern as
@@ -15,8 +15,21 @@ import type { Issue } from "@multica/core/types";
 // wired into the cell with the row's issue — otherwise the badge insertion in
 // table-view.tsx could be deleted and every test here would still pass.
 vi.mock("./issue-agent-activity-indicator", () => ({
-  IssueAgentActivityIndicator: ({ issueId }: { issueId: string }) => (
-    <span data-testid="issue-agent-activity" data-issue-id={issueId} />
+  IssueAgentActivityIndicator: ({
+    issueId,
+    childProgress,
+    statusCategory,
+  }: {
+    issueId: string;
+    childProgress?: { done: number; total: number } | null;
+    statusCategory?: string | null;
+  }) => (
+    <span
+      data-testid="issue-agent-activity"
+      data-issue-id={issueId}
+      data-child-progress={childProgress ? `${childProgress.done}/${childProgress.total}` : ""}
+      data-status-category={statusCategory ?? ""}
+    />
   ),
 }));
 
@@ -227,5 +240,59 @@ describe("InlineTitle", () => {
       badge.compareDocumentPosition(titleButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("forwards childProgress and statusCategory to the activity indicator", () => {
+    const row = {
+      kind: "issue" as const,
+      key: "issue:issue-1",
+      issue: {
+        ...makeIssue("Original"),
+        status: "in_progress" as const,
+        status_category: "in_progress" as const,
+      },
+      depth: 0,
+      hasChildren: true,
+      collapsed: false,
+    };
+    render(
+      <InlineTitle
+        {...baseProps}
+        row={row}
+        editing={false}
+        onEditingChange={vi.fn()}
+        childProgress={{ done: 1, total: 3 }}
+        statusCategory={"in_progress" as IssueStatusCategory}
+      />,
+    );
+    const badge = screen.getByTestId("issue-agent-activity");
+    expect(badge.getAttribute("data-child-progress")).toBe("1/3");
+    expect(badge.getAttribute("data-status-category")).toBe("in_progress");
+  });
+
+  it("derives statusCategory from the row issue when not explicitly passed", () => {
+    const row = {
+      kind: "issue" as const,
+      key: "issue:issue-1",
+      issue: {
+        ...makeIssue("Original"),
+        status: "in_progress" as const,
+      },
+      depth: 0,
+      hasChildren: true,
+      collapsed: false,
+    };
+    render(
+      <InlineTitle
+        {...baseProps}
+        row={row}
+        editing={false}
+        onEditingChange={vi.fn()}
+      />,
+    );
+    const badge = screen.getByTestId("issue-agent-activity");
+    // issueStatusCategory(row.issue) fallback inside InlineTitle
+    expect(badge.getAttribute("data-status-category")).toBe("in_progress");
+    expect(badge.getAttribute("data-child-progress")).toBe("");
   });
 });

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -149,6 +149,8 @@ import {
 import type { ChildProgress } from "./list-row";
 import { ListLoadMoreFooter } from "./list-load-more-footer";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+import { issueStatusCategory } from "@multica/core/issues";
+import type { IssueStatusCategory } from "@multica/core/types";
 
 // Enough placeholder rows to cover a typical viewport; the virtualizer only
 // mounts what fits, so overshooting costs nothing.
@@ -633,6 +635,8 @@ export function InlineTitle({
   toggleLabel,
   renameLabel,
   createSubIssueLabel,
+  childProgress,
+  statusCategory,
 }: {
   row: Extract<IssueTableDisplayRow, { kind: "issue" }>;
   /** Rename state is owned by the table (one editor at a time) so it also
@@ -647,6 +651,8 @@ export function InlineTitle({
   toggleLabel: string;
   renameLabel: string;
   createSubIssueLabel: string;
+  childProgress?: ChildProgress | null;
+  statusCategory?: IssueStatusCategory | null;
 }) {
   const [draft, setDraft] = useState(row.issue.title);
   const editingRef = useRef(editing);
@@ -718,7 +724,11 @@ export function InlineTitle({
       <span className="w-16 shrink-0 text-caption text-muted-foreground">
         {row.issue.identifier}
       </span>
-      <IssueAgentActivityIndicator issueId={row.issue.id} />
+      <IssueAgentActivityIndicator
+        issueId={row.issue.id}
+        childProgress={childProgress ?? null}
+        statusCategory={statusCategory ?? issueStatusCategory(row.issue)}
+      />
       {editing ? (
         <Input
           autoFocus
@@ -1146,6 +1156,8 @@ function IssueTableBodyCell({
           toggleLabel={t(($) => $.table.toggle_sub_issues)}
           renameLabel={t(($) => $.table.rename_title)}
           createSubIssueLabel={t(($) => $.actions.create_sub_issue)}
+          childProgress={meta.childProgressMap.get(issue.id) ?? null}
+          statusCategory={issueStatusCategory(issue)}
         />
       );
     case "identifier":

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -573,7 +573,9 @@
     "chip_agents_working_other": "{{count}} agents working",
     "issues_count_one": "{{count}} issue",
     "issues_count_other": "{{count}} issues",
-    "chip_agents_working_unknown": "Agents working: —"
+    "chip_agents_working_unknown": "Agents working: —",
+    "status_waiting": "Waiting on sub-issues",
+    "waiting_detail": "{{done}}/{{total}} complete"
   },
   "filtered_empty": {
     "title": "No issues match these filters",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -551,7 +551,9 @@
     "tasks_count_other": "task {{count}} 件",
     "chip_agents_working_other": "作業中のエージェント {{count}} 件",
     "issues_count_other": "タスク {{count}} 件",
-    "chip_agents_working_unknown": "作業中のエージェント: —"
+    "chip_agents_working_unknown": "作業中のエージェント: —",
+    "status_waiting": "サブタスク待ち",
+    "waiting_detail": "{{done}}/{{total}} 完了"
   },
   "filtered_empty": {
     "title": "フィルター条件に一致するタスクがありません",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -551,7 +551,9 @@
     "tasks_count_other": "task {{count}}개",
     "chip_agents_working_other": "작업 중인 에이전트 {{count}}개",
     "issues_count_other": "태스크 {{count}}개",
-    "chip_agents_working_unknown": "작업 중인 에이전트: —"
+    "chip_agents_working_unknown": "작업 중인 에이전트: —",
+    "status_waiting": "하위 태스크 대기 중",
+    "waiting_detail": "{{done}}/{{total}} 완료"
   },
   "filtered_empty": {
     "title": "필터 조건에 맞는 태스크가 없습니다",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -551,7 +551,9 @@
     "tasks_count_other": "{{count}} 个 task",
     "chip_agents_working_other": "{{count}} 个智能体工作中",
     "issues_count_other": "{{count}} 个任务",
-    "chip_agents_working_unknown": "工作中的智能体：—"
+    "chip_agents_working_unknown": "工作中的智能体：—",
+    "status_waiting": "等待子任务",
+    "waiting_detail": "{{done}}/{{total}} 已完成"
   },
   "filtered_empty": {
     "title": "没有符合筛选条件的任务",


### PR DESCRIPTION
## What does this PR do?

Adds a derived **"Waiting on sub-issues"** presentation state to `IssueAgentActivityIndicator`, shown on board cards, list rows, and table rows for `in_progress` parent issues whose sub-issues are not all done and that have **no** running or queued agent task.

Today every `in_progress` issue looks identical — you cannot tell whether an agent is actually working on it or it is merely parked waiting on its sub-issues. This PR makes that distinction visible without introducing any new persisted status, Kanban column, DB/backend/API change, or extra query/polling: the indicator already subscribes to the shared workspace-wide agent task snapshot, and `childProgress` is already loaded by every call site. The derivation is pure presentation, with active task states always outranking waiting:

1. ≥1 running task → **Working** (unchanged)
2. 0 running, ≥1 queued/dispatched/waiting_local_directory task → **Queued** (unchanged)
3. no active task + `in_progress` category + `childProgress.total > 0` + `done < total` → **Waiting on sub-issues** (new)
4. otherwise → no indicator (unchanged)

## Related Issue

Closes #7925

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/issues/components/issue-agent-activity-indicator.tsx` — extended with optional `childProgress` and `statusCategory` props; derives the waiting branch with the priority above (active states always win). The waiting badge is text-only (`text-micro`, title shows `done/total`); with `hoverCard` enabled it opens a waiting hover card with a `{{done}}/{{total}} complete` detail line. Docstring updated to document the new branch. Hover-card copy moved onto the type scale (`text-body` / `text-caption`) per the #6136 guard.
- `packages/views/issues/components/board-card.tsx`, `packages/views/issues/components/list-row.tsx` — pass the already-loaded `childProgress` and `issueStatusCategory(issue)` to the indicator.
- `packages/views/issues/components/table-view.tsx` — same parity for tables: `InlineTitle` now forwards `childProgressMap.get(issue.id)` and `issueStatusCategory(row.issue)` (no new query; both already exist in the table's data).
- `packages/views/locales/{en,ja,ko,zh-Hans}/issues.json` — added `agent_activity.status_waiting` and `agent_activity.waiting_detail`.
- `packages/views/issues/components/issue-agent-activity-indicator.test.tsx` — 6 new regression cases: running + unfinished → Working, queued + unfinished → Queued, no active + in_progress + unfinished → Waiting, all done → nothing, non-in_progress → nothing, waiting hover card detail.
- `packages/views/issues/components/table-inline-title.test.tsx` — wiring test extended to assert `childProgress` and `statusCategory` are forwarded to the indicator.

Call sites that do not pass the new props (e.g. Inbox, `hoverCard={false}`) render exactly as before — the waiting branch requires `childProgress`, so no existing surface changes behavior.

## How to Test

1. `pnpm --filter @multica/views exec vitest run issues/components/issue-agent-activity-indicator.test.tsx issues/components/table-inline-title.test.tsx` — 18 tests pass (10 indicator incl. the 6 waiting regressions, 8 table wiring incl. the 2 new prop-forwarding cases).
2. `node ./node_modules/typescript/bin/tsc --noEmit -p packages/views/tsconfig.json` — clean.
3. `node ./node_modules/.bin/vitest run app/type-scale.test.ts` in `apps/web` — the previously failing guard is fixed: the two off-scale classes were replaced with `text-body` / `text-caption` (badge itself is `text-micro`).
4. Manually: on a board, put an agent task in queued state on an `in_progress` parent with unfinished sub-issues → **Queued**; cancel it → **Waiting on sub-issues**; complete all sub-issues → badge disappears.

### UI evidence

**Only automated render evidence (jsdom) is available.** Native screenshots could not be produced in this environment: a headless sandbox with no isolated app stack — no Docker, no spare PostgreSQL instance (the local 5432 is a live instance that must not be seeded with test data), no configured env for the web/server apps. The evidence below is therefore a jsdom render snapshot of the indicator (same derivation logic and en locale strings as the component tests), not a screenshot:

Before — no active task, no `childProgress` passed (previous call sites): the component returns `null`; an in_progress parent waiting on sub-issues is indistinguishable from an idle issue.

After — no active task, `statusCategory="in_progress"`, `childProgress={done: 0, total: 1}`:

```html
<div data-testid="hover-card"><div data-testid="hover-card-trigger"><span class="text-micro text-muted-foreground" title="0/1 complete">Waiting on sub-issues</span></div><div data-testid="hover-card-content" data-align="end"><div class="space-y-1"><div class="text-body font-medium">Waiting on sub-issues</div><div class="text-caption text-muted-foreground">0/1 complete</div></div></div></div>
```

(The full before/after HTML snapshot is attached to the tracking thread for this contribution.)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots *(not produced — headless environment without an isolated app stack/database; only automated render evidence (jsdom) available, provided above and attached to the tracker)*
- [ ] I have updated relevant documentation to reflect my changes *(no doc surfaces affected: presentation-only, no new status/column/API)*
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) *(N/A)*
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) *(zh-Hans strings follow existing sub-issue terminology 子任务/任务 in the same file)*
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (worker-opencode coding agent)

**Prompt / approach:**
Implemented from upstream issue #7925's specification: extend the existing `IssueAgentActivityIndicator` (the component that already derives Working/Queued from the shared task snapshot) with the third derived state, reusing already-loaded `childProgress` and the resolved status category. Verification ran locally (focused vitest, `tsc --noEmit`, eslint, `git diff --check`, type-scale guard); the change went through an internal cross-review pass before being opened here.

## Screenshots (optional)

No screenshots attached — native capture was not possible in this environment (headless sandbox, no isolated app stack/database). Only automated render evidence (jsdom) is available; see "UI evidence" above.

