### PR TITLE
MUL-6996: fix(lark): preserve installation identity

### DIFF
--- a/server/internal/integrations/channel/channel.go
+++ b/server/internal/integrations/channel/channel.go
@@ -91,7 +91,7 @@ type Config struct {
 	// in-tree does today, but Factory implementations should tolerate it
 	// rather than assume Valid). WeCom uses it to key its per-connection
 	// wsSender into a shared registry the OutboundReplier looks up by;
-	// Feishu and Slack don't currently read it.
+	// Feishu uses it for callback authority checks; Slack does not currently read it.
 	ID pgtype.UUID
 
 	// Handler is the shared inbound entry point the engine injects so the

--- a/server/internal/integrations/lark/feishu_channel.go
+++ b/server/internal/integrations/lark/feishu_channel.go
@@ -26,10 +26,9 @@ import (
 // through the Lark HTTP API. One instance is built per channel_installation by
 // the registered Factory; the connector is shared across instances.
 //
-// The Channel holds only the credentials it needs for Connect/Send (decoded
-// from the per-installation config blob). The installation IDENTITY
-// (workspace / agent / installer) is resolved per message by the Router's
-// InstallationResolver, so it is deliberately absent here.
+// The Channel holds connection credentials plus the durable installation row
+// ID. Workspace, agent, and installer identity are resolved per message by the
+// Router's InstallationResolver.
 type feishuChannel struct {
 	inst    Installation
 	conn    EventConnector
@@ -210,9 +209,11 @@ func newFeishuFactory(deps FeishuChannelDeps) channel.Factory {
 		}
 		// cfg.Raw is the per-installation config blob (the channel_installation
 		// .config JSONB): app_id, encrypted app_secret, tenant_key, region, ….
-		// We build a credentials-only Installation from it; the workspace /
-		// agent identity is resolved per message by the Router, not needed here.
+		// We build credentials plus the durable installation row ID from it.
+		// Workspace / agent identity is resolved per message by the Router, not
+		// needed here.
 		inst, err := installationFromRow(db.ChannelInstallation{
+			ID:          cfg.ID,
 			ChannelType: channelTypeFeishu,
 			Config:      cfg.Raw,
 		})

--- a/server/internal/integrations/lark/feishu_channel_test.go
+++ b/server/internal/integrations/lark/feishu_channel_test.go
@@ -193,6 +193,20 @@ func TestFeishuFactory_DecodesConfigCredentials(t *testing.T) {
 	}
 }
 
+func TestFeishuFactory_PreservesInstallationID(t *testing.T) {
+	installationID := uuidFromString(t, "00000000-0000-0000-0000-000000000009")
+	cfg := channel.Config{
+		Type: channel.TypeFeishu,
+		ID:   installationID,
+		Raw:  feishuConfigJSON(t, "cli_app", "lark"),
+	}
+	fc := buildFeishuChannel(t, FeishuChannelDeps{Connector: NewNoopConnector(nil)}, cfg)
+
+	if fc.inst.ID != installationID {
+		t.Fatal("installation ID was not preserved")
+	}
+}
+
 func TestFeishuFactory_MissingConnectorFails(t *testing.T) {
 	_, err := newFeishuFactory(FeishuChannelDeps{})(channel.Config{Type: channel.TypeFeishu, Raw: feishuConfigJSON(t, "cli", "feishu")})
 	if err == nil {


### PR DESCRIPTION
## What does this PR do?

Feishu channels receive the durable channel installation UUID through `channel.Config.ID`, but `newFeishuFactory` rebuilt its temporary `db.ChannelInstallation` from only `cfg.Raw`. That dropped the UUID before `installationFromRow` constructed the connector installation.

Card actions use the connector installation ID as an authority fence against the installation stored with the card. Losing the ID therefore makes valid callbacks look cross-installation and rejects them.

This PR carries `cfg.ID` into the reconstructed row. Workspace, agent, and installer identity continue to be resolved by the existing router path; only the durable row ID is preserved.

## Related Issue

Related to #5528 and #5931. This narrow Feishu installation-identity fix does not close either broader feature request.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Preserve `channel.Config.ID` in the Feishu factory when constructing the connector installation.
- Clarify that Feishu consumes the config ID for callback authority checks.
- Add a factory regression test with a nonzero installation UUID using the existing test helper.

## How to Test

1. Run `go vet ./internal/integrations/channel ./internal/integrations/lark`.
2. Run `go test ./internal/integrations/channel ./internal/integrations/lark -count=1`.
3. Confirm `TestFeishuFactory_PreservesInstallationID` fails without the production line and passes with it.

Local result in Go 1.26.7 Debian, non-root:

- `gofmt`: clean
- changed-package `go vet`: pass
- changed-package `go test`: pass
- `go test ./...` was also attempted in a container. All integration packages passed, while two unrelated daemon process-group tests failed under nested container PID semantics: `TestCombinedOutputKillsDescendantsHoldingOutput` and `TestCreateWorktreeContextCancelsRunningGitProcessTree`. Upstream CI remains the full-suite authority.

## Thinking Path and Risk

The channel engine already provides the database row UUID in `channel.Config.ID`. Other Feishu identity fields intentionally remain resolver-owned. Propagating that existing UUID at the factory boundary is smaller and safer than weakening the callback installation comparison or resolving by App ID.

Risk is limited to Feishu channel construction. Invalid or absent IDs remain invalid and continue to fail closed. No schema, API, credential, callback payload, or authorization rule changes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] This change does not affect UI
- [x] No user-facing documentation changes are required
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** AI coding assistant

**Prompt / approach:** Assisted with tracing the callback authority mismatch, reducing the fix to the factory boundary, adding the regression test, and running repository-aligned verification.