### PR TITLE
fix(wecom): re-read the installation's permission at every stage of a file delivery

### DIFF
--- a/server/internal/integrations/wecom/attachment_revocation_db_test.go
+++ b/server/internal/integrations/wecom/attachment_revocation_db_test.go
@@ -1,0 +1,95 @@
+package wecom
+
+// attachment_revocation_db_test.go — the attachment write path re-reads the
+// installation's permission from the DATABASE, not from a mock, at each stage
+// that is about to put bytes toward the chat. The unit tests beside it
+// (media_upload_test.go) prove the BeforeChunk hook stops the next chunk; this
+// one proves the hook is wired to the real row, so a person revoking the bot
+// mid-upload — an UPDATE on channel_installation — is what stops the file.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestSendAttachment_ARevokeInTheDatabaseMidUploadStopsTheFile(t *testing.T) {
+	pool := twoReplicaDB(t)
+	ctx := context.Background()
+
+	wsID, userID, agentID, instID := mustTestUUID(t), mustTestUUID(t), mustTestUUID(t), mustTestUUID(t)
+	tag := uuidStringPub(instID)[:8]
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("seed: %v\n%s", err, sql)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM channel_installation WHERE id = $1`, instID)
+		_, _ = pool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID)
+		_, _ = pool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, userID)
+		_, _ = pool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+	exec(`INSERT INTO workspace (id, name, slug) VALUES ($1, $2, $3)`, wsID, "revoke "+tag, "revoke-"+tag)
+	exec(`INSERT INTO "user" (id, name, email) VALUES ($1, $2, $3)`, userID, "Revoke "+tag, "revoke-"+tag+"@example.com")
+	exec(`INSERT INTO agent (id, workspace_id, name, runtime_mode) VALUES ($1, $2, $3, 'local')`, agentID, wsID, "revoke-agent-"+tag)
+	exec(`INSERT INTO channel_installation (id, workspace_id, agent_id, channel_type, status, installer_user_id)
+	      VALUES ($1, $2, $3, 'wecom', 'active', $4)`, instID, wsID, agentID, userID)
+
+	// Five chunks at the ladder's middle step of three in flight: the fourth
+	// and fifth have to wait for a slot, and that wait is where the revocation
+	// lands.
+	data := make([]byte, mediaChunkBytes*4+1)
+	objects := &fakeObjectStore{key: "u", data: data}
+	conn := newMediaConn()
+	arrived, release := conn.holdChunks()
+	sender := conn.newSender()
+	reg := newSendersRegistry()
+	reg.set(instID, sender)
+	o := NewOutbound(db.New(pool), reg, slog.Default(), WithAttachments(objects))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := o.sendAttachment(ctx, sender, db.Attachment{
+			ID: mustTestUUID(t), Filename: "big.bin", ContentType: "application/octet-stream",
+			Url: "u", SizeBytes: int64(len(data)),
+		}, attachmentTarget{InstallationID: instID, ChatID: "CHAT_1", ChatType: 1})
+		done <- err
+	}()
+	for i := 0; i < 3; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("chunk %d never reached the wire", i+1)
+		}
+	}
+
+	// The person removes the bot: one row flips in the database. Nothing else
+	// in the process is told.
+	exec(`UPDATE channel_installation SET status = 'revoked' WHERE id = $1`, instID)
+	release()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the delivery never returned")
+	}
+	if !errors.Is(err, errMediaPermissionWithdrawn) {
+		t.Fatalf("delivery reported %v, want errMediaPermissionWithdrawn", err)
+	}
+	if n := len(conn.cmdFrames(cmdUploadMediaChunk)); n != 3 {
+		t.Errorf("%d chunk frames on the wire, want 3: chunks kept going after the row said revoked", n)
+	}
+	if n := len(conn.cmdFrames(cmdUploadMediaFinish)); n != 0 {
+		t.Errorf("%d finish frames on the wire, want 0", n)
+	}
+	if got := mediaSends(t, conn); len(got) != 0 {
+		t.Errorf("sent %d file(s) into a chat whose owner had removed the bot", len(got))
+	}
+}

--- a/server/internal/integrations/wecom/media_upload.go
+++ b/server/internal/integrations/wecom/media_upload.go
@@ -150,6 +150,14 @@ type outboundMedia struct {
 	Filename string
 
 	Data []byte
+
+	// BeforeChunk, when set, is asked before EACH chunk is dispatched. A
+	// non-nil error stops the upload with no further frames. It exists for
+	// the one caller that must stop mid-file: an installation revoked while
+	// the upload is in flight is a person withdrawing the connection, and
+	// chunks sent after that are writes into a chat that said no. The ws
+	// layer only runs the hook — what it checks is the caller's policy.
+	BeforeChunk func(context.Context) error
 }
 
 func (m outboundMedia) validate() error {
@@ -210,7 +218,7 @@ func (s *wsSender) uploadMedia(ctx context.Context, m outboundMedia) (string, er
 	if err != nil {
 		return "", err
 	}
-	if err := s.uploadMediaChunks(ctx, uploadID, chunks); err != nil {
+	if err := s.uploadMediaChunks(ctx, uploadID, chunks, m.BeforeChunk); err != nil {
 		return "", err
 	}
 	return s.uploadMediaFinish(ctx, uploadID)
@@ -246,11 +254,17 @@ func (s *wsSender) uploadMediaInit(ctx context.Context, m outboundMedia, chunks 
 
 // uploadMediaChunks sends every slice, a few at a time. The first failure
 // cancels the rest: there is no partial upload worth finishing.
-func (s *wsSender) uploadMediaChunks(ctx context.Context, uploadID string, chunks [][]byte) error {
+func (s *wsSender) uploadMediaChunks(ctx context.Context, uploadID string, chunks [][]byte, beforeChunk func(context.Context) error) error {
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(mediaChunkParallelism(len(chunks)))
 	for i, chunk := range chunks {
-		g.Go(func() error { return s.uploadMediaChunk(gctx, uploadID, i, chunk) })
+		// Nothing new is offered once a sibling has failed. The goroutine
+		// would refuse it on the same cancelled context anyway; a group
+		// already ending has no use for the slot.
+		if gctx.Err() != nil {
+			break
+		}
+		g.Go(func() error { return s.uploadMediaChunk(gctx, uploadID, i, chunk, beforeChunk) })
 	}
 	return g.Wait()
 }
@@ -260,7 +274,7 @@ func (s *wsSender) uploadMediaChunks(ctx context.Context, uploadID string, chunk
 // chunk_index goes on the wire as a number. The field table in the document
 // calls it a string and the worked example beside it passes a number; WeCom's
 // own SDK sends a number, so that is what the server is known to accept.
-func (s *wsSender) uploadMediaChunk(ctx context.Context, uploadID string, index int, chunk []byte) error {
+func (s *wsSender) uploadMediaChunk(ctx context.Context, uploadID string, index int, chunk []byte, beforeChunk func(context.Context) error) error {
 	body := map[string]any{
 		"upload_id":   uploadID,
 		"chunk_index": index,
@@ -268,6 +282,23 @@ func (s *wsSender) uploadMediaChunk(ctx context.Context, uploadID string, index 
 	}
 	var lastErr error
 	for attempt := 0; attempt < mediaChunkAttempts; attempt++ {
+		// Asked here, immediately before the write, and again before the
+		// retry — because a verdict is only as good as the moment it was
+		// given, and this chunk has two waits between the dispatch loop and
+		// the wire. errgroup.Go blocks while the group is at its limit, so a
+		// yes taken out there can sit behind the slowest chunk ahead of it;
+		// and a lost verdict buys the second offer a whole ackTimeout later.
+		// Both are long enough for someone to take the connection back.
+		//
+		// Refusing from in here is also what cancels the siblings. g.Wait()
+		// from the dispatch loop does not: it waits for the in-flight
+		// goroutines FIRST and cancels afterwards, which is after the thing
+		// it was meant to stop.
+		if beforeChunk != nil {
+			if err := beforeChunk(ctx); err != nil {
+				return err
+			}
+		}
 		_, err := s.request(ctx, cmdUploadMediaChunk, body)
 		if err == nil {
 			return nil

--- a/server/internal/integrations/wecom/media_upload_test.go
+++ b/server/internal/integrations/wecom/media_upload_test.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -507,5 +508,105 @@ func TestOutboundMediaValidate_RejectsUnsendableMedia(t *testing.T) {
 	}
 	if err := (outboundMedia{Kind: mediaTypeFile, Filename: "  "}).validate(); err == nil {
 		t.Error("media with no filename was accepted — the name is the only format hint WeCom gets")
+	}
+}
+
+// errTestWithdrawn is what the permission hook answers once the person has
+// taken the connection back.
+var errTestWithdrawn = errors.New("wecom test: the installation was withdrawn")
+
+// The permission verdict has to be taken by the goroutine that writes, not by
+// the loop that dispatches. errgroup.Go blocks while the group is at its
+// limit, so a verdict taken before the dispatch is a yes that then sits in
+// that wait for as long as the slowest chunk ahead of it — and a withdrawal
+// landing inside the wait still gets its chunk on the wire.
+func TestUploadMediaChunks_AWithdrawalDuringTheSlotWaitStopsTheNextChunk(t *testing.T) {
+	t.Parallel()
+	conn := newMediaConn()
+	arrived, release := conn.holdChunks()
+	sender := conn.newSender()
+
+	var revoked atomic.Bool
+	// Five chunks run three at a time (the ladder's middle step), so the
+	// fourth and fifth are the ones that have to wait for a slot.
+	data := make([]byte, mediaChunkBytes*4+1)
+	done := make(chan error, 1)
+	go func() {
+		_, err := sender.uploadMedia(context.Background(), outboundMedia{
+			Kind: mediaTypeFile, Filename: "big.bin", Data: data,
+			BeforeChunk: func(context.Context) error {
+				if revoked.Load() {
+					return errTestWithdrawn
+				}
+				return nil
+			},
+		})
+		done <- err
+	}()
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("only %d chunks reached the socket, want 3 in flight", i)
+		}
+	}
+	// The group is at its limit and the settle is the window this is about:
+	// long enough for the dispatch loop to have run whatever it runs for the
+	// fourth chunk while the wire holds still.
+	select {
+	case <-arrived:
+		t.Fatal("a fourth chunk went out with three unanswered")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	revoked.Store(true) // the person takes the connection back
+	release()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, errTestWithdrawn) {
+			t.Fatalf("uploadMedia = %v, want the withdrawal", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("uploadMedia never finished")
+	}
+	if n := len(conn.cmdFrames(cmdUploadMediaChunk)); n != 3 {
+		t.Errorf("chunk frames = %d, want 3 — a chunk went on the wire after the withdrawal", n)
+	}
+	if n := len(conn.cmdFrames(cmdUploadMediaFinish)); n != 0 {
+		t.Errorf("finish frames = %d, want 0 — a stopped upload must not be sealed", n)
+	}
+}
+
+// The other wait a stale yes survives, and it is on the far side of the
+// dispatch entirely: a lost verdict buys a second offer one ackTimeout later,
+// and nothing between the two frames asks again.
+func TestUploadMediaChunk_AWithdrawalBeforeTheRetryStopsTheSecondOffer(t *testing.T) {
+	t.Parallel()
+	conn := newMediaConn()
+	conn.dropAcks[cmdUploadMediaChunk] = 1 // the first offer is never answered
+	sender := conn.newSender()
+
+	_, err := sender.uploadMedia(context.Background(), outboundMedia{
+		Kind: mediaTypeFile, Filename: "small.txt", Data: []byte("hello"),
+		// Keyed on the wire: the moment the first frame exists the answer is
+		// no, which puts the withdrawal inside the ackTimeout the retry waits
+		// out — whatever order the checks upstream settle on.
+		BeforeChunk: func(context.Context) error {
+			if len(conn.cmdFrames(cmdUploadMediaChunk)) > 0 {
+				return errTestWithdrawn
+			}
+			return nil
+		},
+	})
+	if !errors.Is(err, errTestWithdrawn) {
+		t.Fatalf("uploadMedia = %v, want the withdrawal", err)
+	}
+	if n := len(conn.cmdFrames(cmdUploadMediaChunk)); n != 1 {
+		t.Errorf("chunk frames = %d, want 1 — the retry went out after the withdrawal", n)
+	}
+	if n := len(conn.cmdFrames(cmdUploadMediaFinish)); n != 0 {
+		t.Errorf("finish frames = %d, want 0", n)
 	}
 }

--- a/server/internal/integrations/wecom/outbound.go
+++ b/server/internal/integrations/wecom/outbound.go
@@ -458,3 +458,68 @@ func (o *Outbound) tryDeliverInbox(ctx context.Context, item map[string]any, rec
 func uuidStringPub(u pgtype.UUID) string {
 	return util.UUIDToString(u)
 }
+
+// installationCheck is what one permission read established. Three outcomes,
+// because collapsing them is how the first version of this gate lost answers:
+// a lookup that failed and a row that says revoked are the same refusal for THIS
+// attempt and opposite facts about every later one.
+type installationCheck int
+
+const (
+	// installationOK — active. Write.
+	installationOK installationCheck = iota
+	// installationGone — revoked, or the row is not there. Final: nobody may
+	// write to it again, and an answer held for it is not owed to anyone.
+	installationGone
+	// installationUnreadable — the read itself failed. Nothing is established.
+	// Refuse this attempt either way; what differs is what the caller owes
+	// afterwards. An answer must NOT be reported finished — it is still the only
+	// copy and still this subscriber's to deliver. An attachment has nowhere to
+	// report to and nothing to lose by waiting: the file stays in object storage
+	// and the user can ask again, so the delivery simply stops.
+	installationUnreadable
+)
+
+// String names the outcomes for the log, so a line saying a delivery stopped
+// also says whether anything is coming back — gone is final, unreadable is this
+// read and no more. Same reason deliveryState carries one (outbound_media.go).
+func (c installationCheck) String() string {
+	switch c {
+	case installationOK:
+		return "ok"
+	case installationGone:
+		return "gone"
+	case installationUnreadable:
+		return "unreadable"
+	default:
+		return "invalid"
+	}
+}
+
+// mayStillWrite reads the installation's permission for one attempt.
+//
+// The three-way split follows the convention the rest of this file already
+// keeps: pgx.ErrNoRows is a fact, every other error is a failed question. The
+// gate that preceded this returned a bool and answered "no" to both, so a
+// database blip on one attempt confirmed a one-shot chat:done as handled and
+// threw the answer away.
+func (o *Outbound) mayStillWrite(ctx context.Context, id pgtype.UUID) installationCheck {
+	if !id.Valid {
+		return installationGone
+	}
+	inst, err := o.q.GetChannelInstallation(ctx, db.GetChannelInstallationParams{
+		ID:          id,
+		ChannelType: channelTypeWecom,
+	})
+	switch {
+	case err == nil:
+	case errors.Is(err, pgx.ErrNoRows):
+		return installationGone
+	default:
+		return installationUnreadable
+	}
+	if inst.Status != string(InstallationActive) {
+		return installationGone
+	}
+	return installationOK
+}

--- a/server/internal/integrations/wecom/outbound_media.go
+++ b/server/internal/integrations/wecom/outbound_media.go
@@ -422,6 +422,10 @@ func (o *Outbound) tellUser(ctx context.Context, to attachmentTarget, text strin
 // sendAttachment carries one file from object storage into the chat, and
 // reports what is known about where it ended up. The error is for the log; the
 // state is what the user is told.
+// errMediaPermissionWithdrawn marks a delivery stopped because the
+// installation was revoked while the file work was in flight.
+var errMediaPermissionWithdrawn = errors.New("wecom: media delivery stopped, permission withdrawn")
+
 func (o *Outbound) sendAttachment(ctx context.Context, sender *wsSender, row db.Attachment, to attachmentTarget) (deliveryState, error) {
 	// The recorded size is checked before a single byte is fetched. An
 	// oversize attachment is refused either way — readObject re-checks what it
@@ -435,6 +439,16 @@ func (o *Outbound) sendAttachment(ctx context.Context, sender *wsSender, row db.
 	if err != nil {
 		return deliveryDefinitelyFailed, err
 	}
+	// Re-asked after the read, between chunks, and after the upload: a
+	// revocation is a person withdrawing the connection, and the object read
+	// or the upload can be minutes long — plenty of room for the withdrawal
+	// to land while the top-of-loop gate's answer goes stale. Each stage that
+	// is about to put bytes toward the chat asks again first; a file already
+	// uploaded but not yet sent is a media_id nobody receives, which is the
+	// cheap side of the asymmetry.
+	if check := o.mayStillWrite(ctx, to.InstallationID); check != installationOK {
+		return deliveryDefinitelyFailed, fmt.Errorf("wecom: installation may no longer be written to (%s): %w", check, errMediaPermissionWithdrawn)
+	}
 	kind := wecomMediaKind(row.ContentType, row.Filename, len(data))
 	name := outboundMediaName(row.Filename, row.ContentType)
 
@@ -442,12 +456,21 @@ func (o *Outbound) sendAttachment(ctx context.Context, sender *wsSender, row db.
 		Kind:     kind,
 		Filename: name,
 		Data:     data,
+		BeforeChunk: func(hctx context.Context) error {
+			if check := o.mayStillWrite(hctx, to.InstallationID); check != installationOK {
+				return fmt.Errorf("wecom: installation may no longer be written to (%s): %w", check, errMediaPermissionWithdrawn)
+			}
+			return nil
+		},
 	})
 	if err != nil {
 		// A failed upload never produced a media_id, so no message was ever
 		// addressed to the chat — including when the failure was the finish
 		// step's own lost ack. The file is definitely not there.
 		return deliveryDefinitelyFailed, fmt.Errorf("upload %s: %w", kind, err)
+	}
+	if check := o.mayStillWrite(ctx, to.InstallationID); check != installationOK {
+		return deliveryDefinitelyFailed, fmt.Errorf("wecom: installation may no longer be written to (%s): %w", check, errMediaPermissionWithdrawn)
 	}
 	// Video is the only kind with fields beyond the media_id, and both are
 	// required. The file's own name is what there is to say about it — the


### PR DESCRIPTION
## What

A file delivery re-reads the installation's permission at every stage that is about to put bytes toward the chat: after the object read, before **each** chunk, and after the upload before the `media_id` is sent.

## Why

A revocation is a person withdrawing the connection, and a file delivery is minutes of work between the top-of-loop gate and the send — the object read, the chunked upload, the finish. A withdrawal landing anywhere in there reached a worker with nothing left to consult, so the file went into a chat whose owner had removed the bot. This is the independent piece from #6606 that you pointed at.

## How

- `uploadMedia` takes an optional `BeforeChunk func(ctx) error`, asked **inside the goroutine that writes**, ahead of every network attempt including retries — so nothing waits between asking and writing. The dispatch loop keeps only a `gctx.Err()` break.
- `sendAttachment` re-reads the row through `mayStillWrite`, which has three outcomes rather than a bool: a row that says revoked is final, a read that failed is this attempt only. Both stop this delivery; the log line says which.
- The `upload_media_finish` frame is deliberately unchecked: it carries no file bytes, and a revocation landing between the last chunk and finish produces a `media_id` the post-upload check then refuses to send.

## Tests

- `TestUploadMediaChunks_AWithdrawalDuringTheSlotWaitStopsTheNextChunk` — five chunks at parallelism three, three held in flight, revoke, release: three chunk frames and no finish.
- `TestUploadMediaChunk_AWithdrawalBeforeTheRetryStopsTheSecondOffer` — one chunk, first verdict dropped, permission withdrawn the moment the first frame exists: one frame on the wire.
- `TestSendAttachment_ARevokeInTheDatabaseMidUploadStopsTheFile` — the real query layer against Postgres: an `UPDATE channel_installation SET status = 'revoked'` while three chunks are held, asserting no finish frame and no send.

Each guard was reverse-verified on its own: with the check hoisted out of the attempt loop the first test passes and the second still fails; with the three re-checks stripped from `sendAttachment` the database test reports the file delivered.

`go test -race ./internal/integrations/wecom ./cmd/server` green against a database migrated through 449.
