### PR TITLE
MUL-6997: docs(providers): mark Oh-My-Pi as Multica-managed MCP

### DIFF
--- a/apps/docs/content/docs/providers.ja.mdx
+++ b/apps/docs/content/docs/providers.ja.mdx
@@ -37,7 +37,7 @@ Multica は、普段使っている AI コーディングツールの代わり�
 | OpenClaw | `openclaw` | ✓ | ✓ | `skills/` |
 | OpenCode | `opencode` | ✓ | ✓ | `.opencode/skills/` |
 | Pi | `pi` | ✓ | — | `.pi/skills/` |
-| Oh-My-Pi | `omp` | ✓ | — | `.omp/skills/` |
+| Oh-My-Pi | `omp` | ✓ | ✓ | `.omp/skills/` |
 | Qoder CLI | `qodercli` | ✓ | ✓ | `.qoder/skills/` |
 | Qoder CN CLI | `qoderclicn` | ✓ | ✓ | `.qoder/skills/` |
 | Qwen Code | `qwen` | ✓ | ✓ | `.qwen/skills/` |

--- a/apps/docs/content/docs/providers.ko.mdx
+++ b/apps/docs/content/docs/providers.ko.mdx
@@ -37,7 +37,7 @@ Multica는 사용 중인 AI 코딩 도구를 대체하지 않습니다. 런타�
 | OpenClaw | `openclaw` | ✓ | ✓ | `skills/` |
 | OpenCode | `opencode` | ✓ | ✓ | `.opencode/skills/` |
 | Pi | `pi` | ✓ | — | `.pi/skills/` |
-| Oh-My-Pi | `omp` | ✓ | — | `.omp/skills/` |
+| Oh-My-Pi | `omp` | ✓ | ✓ | `.omp/skills/` |
 | Qoder CLI | `qodercli` | ✓ | ✓ | `.qoder/skills/` |
 | Qoder CN CLI | `qoderclicn` | ✓ | ✓ | `.qoder/skills/` |
 | Qwen Code | `qwen` | ✓ | ✓ | `.qwen/skills/` |

--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -37,7 +37,7 @@ Install steps are in [Install AI coding tools](/install-agent-runtime).
 | OpenClaw | `openclaw` | ✓ | ✓ | `skills/` |
 | OpenCode | `opencode` | ✓ | ✓ | `.opencode/skills/` |
 | Pi | `pi` | ✓ | — | `.pi/skills/` |
-| Oh-My-Pi | `omp` | ✓ | — | `.omp/skills/` |
+| Oh-My-Pi | `omp` | ✓ | ✓ | `.omp/skills/` |
 | Qoder CLI | `qodercli` | ✓ | ✓ | `.qoder/skills/` |
 | Qoder CN CLI | `qoderclicn` | ✓ | ✓ | `.qoder/skills/` |
 | Qwen Code | `qwen` | ✓ | ✓ | `.qwen/skills/` |

--- a/apps/docs/content/docs/providers.zh.mdx
+++ b/apps/docs/content/docs/providers.zh.mdx
@@ -37,7 +37,7 @@ Multica 不会替代你使用的 AI 编程工具。运行时会调用电脑上�
 | OpenClaw | `openclaw` | ✓ | ✓ | `skills/` |
 | OpenCode | `opencode` | ✓ | ✓ | `.opencode/skills/` |
 | Pi | `pi` | ✓ | — | `.pi/skills/` |
-| Oh-My-Pi | `omp` | ✓ | — | `.omp/skills/` |
+| Oh-My-Pi | `omp` | ✓ | ✓ | `.omp/skills/` |
 | Qoder CLI | `qodercli` | ✓ | ✓ | `.qoder/skills/` |
 | Qoder CN CLI | `qoderclicn` | ✓ | ✓ | `.qoder/skills/` |
 | Qwen Code | `qwen` | ✓ | ✓ | `.qwen/skills/` |


### PR DESCRIPTION
## Summary

Fixes a stale cell in the AI coding tools comparison table: Oh-My-Pi (`omp`) was still marked `—` in the **Multica-managed MCP** column across all four locales (`en` / `zh` / `ja` / `ko`).

That has been out of date since #7565, which added `omp` to `MCP_SUPPORTED_PROVIDERS` and materialises the managed config as `{workDir}/.omp/mcp.json` through `prepareOmpMcpConfig`. The row was also contradicting the prose further down the same page — the "MCP configuration" section already lists only Antigravity, GitHub Copilot CLI, DevEco Code, and Pi as runtimes that do not read an agent's MCP config.

Docs-only; one table cell per locale, no code paths touched.

## Verification

- Re-checked every row of that column against `MCP_SUPPORTED_PROVIDERS` in `packages/core/agents/mcp-support.ts` (matching the docs' "detected command" values to their provider keys — `cursor-agent`→`cursor`, `kiro-cli`→`kiro`, `qodercli`→`qoder`). `omp` was the only mismatch; every other row already agreed.
- Confirmed the `omp` path end to end: `packages/core/agents/mcp-support.ts` → `agent-overview-pane.tsx` tab visibility → `server/internal/daemon/execenv/omp_mcp.go`.
- Pi's `—` is unchanged and still correct — see #7957.

## Out of scope (noted, not changed)

ZeroClaw appears in the landing page's supported-tools list and in `mcp-support.test.ts`, but has no row in this comparison table at all. Adding it needs its session-resume and skill-injection facts verified, so it is left for a separate change.
