### PR TITLE
MUL-6942: fix(views): let long issue identifiers expand instead of overlapping titles

### DIFF
--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -110,7 +110,7 @@ function ListRowContent({
           newTabTitle={issue.identifier}
           className={`flex flex-1 items-center gap-2 min-w-0 ${isDragging ? "pointer-events-none" : ""}`}
         >
-          <span className="w-16 shrink-0 text-caption text-muted-foreground">
+          <span className="min-w-16 shrink-0 text-caption text-muted-foreground">
             {issue.identifier}
           </span>
           <IssueAgentActivityIndicator issueId={issue.id} />

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -715,7 +715,7 @@ export function InlineTitle({
       ) : (
         <span className="w-4 shrink-0" />
       )}
-      <span className="w-16 shrink-0 text-caption text-muted-foreground">
+      <span className="min-w-16 shrink-0 text-caption text-muted-foreground">
         {row.issue.identifier}
       </span>
       <IssueAgentActivityIndicator issueId={row.issue.id} />


### PR DESCRIPTION
## 问题

multica-ai/multica#7891：Table / List 视图中 issue 标识符渲染在固定 64px 宽的盒子（`w-16 shrink-0`）里，项目 key 较长时（如 10 字符 key → 14 字符标识符）文字溢出盒子、叠画在右侧标题上，两者都不可读。

## 修复

两个视图同步修改，`w-16 shrink-0` → `min-w-16 shrink-0`：

- `packages/views/issues/components/list-row.tsx:113`
- `packages/views/issues/components/table-view.tsx:718`

`min-w-16` 保留 4rem 列宽下限（短标识符列对齐不变），长标识符按内容自然撑开；右侧标题 span 本身是 `flex-1 min-w-0 truncate`，自动吸收差值。

## 验证

- `packages/views` 全量单测：413 个文件 / 4937 个用例全部通过
- typecheck 通过；lint 0 errors（27 个 warnings 为存量，与本次改动无关）

Fixes multica-ai/multica#7891