### PR TITLE
MUL-7002: push runtime deletion invalidation to active daemons

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -491,6 +491,9 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		if notifier, ok := opts.DaemonWakeup.(handler.DaemonPendingWorkNotifier); ok {
 			h.DaemonPendingWork = notifier
 		}
+		if notifier, ok := opts.DaemonWakeup.(handler.RuntimeGoneNotifier); ok {
+			h.DaemonRuntimeGone = notifier
+		}
 	}
 	if rdb != nil {
 		h.UpdateStore = handler.NewRedisUpdateStore(rdb)

--- a/server/cmd/server/runtime_gc_test.go
+++ b/server/cmd/server/runtime_gc_test.go
@@ -362,14 +362,19 @@ func TestRuntimeGCBatch_PublishesSystemActorAndDeduplicatesWorkspaceRefresh(t *t
 	}
 	ctx := context.Background()
 	workspaceID := createRuntimeGCFixtureWorkspace(t, ctx, "events")
-	_ = createRuntimeGCFixtureRuntimeForWorkspace(t, ctx, workspaceID, "events-a")
-	_ = createRuntimeGCFixtureRuntimeForWorkspace(t, ctx, workspaceID, "events-b")
+	runtimeA := createRuntimeGCFixtureRuntimeForWorkspace(t, ctx, workspaceID, "events-a")
+	runtimeB := createRuntimeGCFixtureRuntimeForWorkspace(t, ctx, workspaceID, "events-b")
 	publisher := &recordingRuntimeGCPublisher{}
 
 	gcRuntimesWithBudget(ctx, testPool, db.New(testPool), nil, publisher, 5*time.Second)
 
 	var teardownCalls, refreshCalls int
+	gone := make(map[string]int)
 	for _, call := range publisher.calls {
+		if call.kind == "runtime_gone" {
+			gone[call.runtimeID]++
+			continue
+		}
 		if call.workspaceID != workspaceID {
 			continue
 		}
@@ -390,6 +395,9 @@ func TestRuntimeGCBatch_PublishesSystemActorAndDeduplicatesWorkspaceRefresh(t *t
 	}
 	if teardownCalls != 2 || refreshCalls != 1 {
 		t.Fatalf("workspace GC events: teardown=%d refresh=%d, want 2 and 1", teardownCalls, refreshCalls)
+	}
+	if gone[runtimeA] != 1 || gone[runtimeB] != 1 {
+		t.Fatalf("runtime-gone notifications = %v, want one each for %s and %s", gone, runtimeA, runtimeB)
 	}
 }
 
@@ -530,6 +538,7 @@ type runtimeGCPublishCall struct {
 	action                string
 	publishRuntimeRefresh bool
 	cancelledTasks        int
+	runtimeID             string
 }
 
 type recordingRuntimeGCPublisher struct {
@@ -555,6 +564,13 @@ func (p *recordingRuntimeGCPublisher) PublishRuntimeRefresh(workspaceID, actorTy
 		actorType:   actorType,
 		actorID:     actorID,
 		action:      action,
+	})
+}
+
+func (p *recordingRuntimeGCPublisher) NotifyRuntimeGone(runtimeID string) {
+	p.calls = append(p.calls, runtimeGCPublishCall{
+		kind:      "runtime_gone",
+		runtimeID: runtimeID,
 	})
 }
 

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -110,6 +110,7 @@ type runtimeGCTxStarter interface {
 type runtimeGCEventPublisher interface {
 	PublishRuntimeTeardown(context.Context, service.RuntimeTeardownResult, string, string, string, string, bool)
 	PublishRuntimeRefresh(string, string, string, string)
+	NotifyRuntimeGone(string)
 }
 
 type runtimeSweepStageStats struct {
@@ -453,6 +454,7 @@ func gcRuntimesWithBudget(ctx context.Context, txStarter runtimeGCTxStarter, que
 		metrics.RecordRuntimeGCDeleted()
 		gcWorkspaces[result.workspaceID] = true
 		if publisher != nil {
+			publisher.NotifyRuntimeGone(util.UUIDToString(runtimeID))
 			publisher.PublishRuntimeTeardown(gcCtx, result.teardown, result.workspaceID, "system", "", "runtime_gc", false)
 		}
 	}

--- a/server/internal/daemonws/hub.go
+++ b/server/internal/daemonws/hub.go
@@ -336,6 +336,13 @@ func (h *Hub) NotifyPendingWork(runtimeID, kind string) {
 	h.notifyPendingWork(runtimeID, kind, "")
 }
 
+// NotifyRuntimeGone tells daemons watching runtimeID that the server deleted
+// the runtime. The existing heartbeat lookup remains the correctness fallback;
+// this notification only closes the active-connection invalidation gap.
+func (h *Hub) NotifyRuntimeGone(runtimeID string) {
+	h.notifyRuntimeGone(runtimeID, "")
+}
+
 func (h *Hub) notifyTaskAvailable(runtimeID, taskID, eventID string) {
 	if h == nil || runtimeID == "" {
 		return
@@ -379,6 +386,22 @@ func (h *Hub) notifyPendingWork(runtimeID, kind, eventID string) {
 		return
 	}
 	data, err := pendingWorkFrame(runtimeID, kind)
+	if err != nil {
+		return
+	}
+	delivered, deduped := h.notifyFrame(runtimeID, data, eventID)
+	if delivered {
+		M.WakeupDeliveredHit.Add(1)
+	} else if !deduped {
+		M.WakeupDeliveredMiss.Add(1)
+	}
+}
+
+func (h *Hub) notifyRuntimeGone(runtimeID, eventID string) {
+	if h == nil || runtimeID == "" {
+		return
+	}
+	data, err := runtimeGoneFrame(runtimeID)
 	if err != nil {
 		return
 	}
@@ -439,6 +462,19 @@ func (h *Hub) DeliverDaemonRuntime(scopeID string, frame []byte, eventID string)
 		var payload protocol.PendingWorkPayload
 		if err := json.Unmarshal(msg.Payload, &payload); err != nil || payload.RuntimeID == "" {
 			slog.Debug("daemon websocket relay: invalid pending_work payload", "error", err, "scope_id", scopeID, "event_id", eventID)
+			M.WakeupDeliveredMiss.Add(1)
+			return
+		}
+		delivered, deduped := h.notifyFrame(payload.RuntimeID, frame, eventID)
+		if delivered {
+			M.WakeupDeliveredHit.Add(1)
+		} else if !deduped {
+			M.WakeupDeliveredMiss.Add(1)
+		}
+	case protocol.EventDaemonHeartbeatAck:
+		var payload protocol.DaemonHeartbeatAckPayload
+		if err := json.Unmarshal(msg.Payload, &payload); err != nil || payload.RuntimeID == "" || payload.Status != protocol.HeartbeatStatusRuntimeGone || !payload.RuntimeGone {
+			slog.Debug("daemon websocket relay: invalid runtime_gone payload", "error", err, "scope_id", scopeID, "event_id", eventID)
 			M.WakeupDeliveredMiss.Add(1)
 			return
 		}
@@ -571,6 +607,17 @@ func pendingWorkFrame(runtimeID, kind string) ([]byte, error) {
 		Payload: mustMarshalRaw(protocol.PendingWorkPayload{
 			RuntimeID: runtimeID,
 			Kind:      kind,
+		}),
+	})
+}
+
+func runtimeGoneFrame(runtimeID string) ([]byte, error) {
+	return json.Marshal(protocol.Message{
+		Type: protocol.EventDaemonHeartbeatAck,
+		Payload: mustMarshalRaw(protocol.DaemonHeartbeatAckPayload{
+			RuntimeID:   runtimeID,
+			Status:      protocol.HeartbeatStatusRuntimeGone,
+			RuntimeGone: true,
 		}),
 	})
 }

--- a/server/internal/daemonws/hub.go
+++ b/server/internal/daemonws/hub.go
@@ -407,9 +407,9 @@ func (h *Hub) notifyRuntimeGone(runtimeID, eventID string) {
 	}
 	delivered, deduped := h.notifyFrame(runtimeID, data, eventID)
 	if delivered {
-		M.WakeupDeliveredHit.Add(1)
+		M.RuntimeGoneDeliveredHit.Add(1)
 	} else if !deduped {
-		M.WakeupDeliveredMiss.Add(1)
+		M.RuntimeGoneDeliveredMiss.Add(1)
 	}
 }
 
@@ -480,9 +480,9 @@ func (h *Hub) DeliverDaemonRuntime(scopeID string, frame []byte, eventID string)
 		}
 		delivered, deduped := h.notifyFrame(payload.RuntimeID, frame, eventID)
 		if delivered {
-			M.WakeupDeliveredHit.Add(1)
+			M.RuntimeGoneDeliveredHit.Add(1)
 		} else if !deduped {
-			M.WakeupDeliveredMiss.Add(1)
+			M.RuntimeGoneDeliveredMiss.Add(1)
 		}
 	default:
 		M.WakeupDeliveredMiss.Add(1)

--- a/server/internal/daemonws/hub.go
+++ b/server/internal/daemonws/hub.go
@@ -417,12 +417,17 @@ func (h *Hub) DeliverDaemonRuntime(scopeID string, frame []byte, eventID string)
 	if h == nil {
 		return
 	}
-	M.WakeupReceivedTotal.Add(1)
 	var msg protocol.Message
 	if err := json.Unmarshal(frame, &msg); err != nil {
+		M.WakeupReceivedTotal.Add(1)
 		slog.Debug("daemon websocket relay: invalid frame", "error", err, "scope_id", scopeID, "event_id", eventID)
 		M.WakeupDeliveredMiss.Add(1)
 		return
+	}
+	if msg.Type == protocol.EventDaemonHeartbeatAck {
+		M.RuntimeGoneReceivedTotal.Add(1)
+	} else {
+		M.WakeupReceivedTotal.Add(1)
 	}
 	switch msg.Type {
 	case protocol.EventDaemonTaskAvailable:
@@ -475,7 +480,7 @@ func (h *Hub) DeliverDaemonRuntime(scopeID string, frame []byte, eventID string)
 		var payload protocol.DaemonHeartbeatAckPayload
 		if err := json.Unmarshal(msg.Payload, &payload); err != nil || payload.RuntimeID == "" || payload.Status != protocol.HeartbeatStatusRuntimeGone || !payload.RuntimeGone {
 			slog.Debug("daemon websocket relay: invalid runtime_gone payload", "error", err, "scope_id", scopeID, "event_id", eventID)
-			M.WakeupDeliveredMiss.Add(1)
+			M.RuntimeGoneDeliveredMiss.Add(1)
 			return
 		}
 		delivered, deduped := h.notifyFrame(payload.RuntimeID, frame, eventID)

--- a/server/internal/daemonws/metrics.go
+++ b/server/internal/daemonws/metrics.go
@@ -13,21 +13,26 @@ type Metrics struct {
 	WakeupReceivedTotal  atomic.Int64
 	WakeupDeliveredHit   atomic.Int64
 	WakeupDeliveredMiss  atomic.Int64
+
+	RuntimeGoneDeliveredHit  atomic.Int64
+	RuntimeGoneDeliveredMiss atomic.Int64
 }
 
 var M = &Metrics{}
 
 func (m *Metrics) Snapshot() map[string]any {
 	return map[string]any{
-		"connects_total":              m.ConnectsTotal.Load(),
-		"disconnects_total":           m.DisconnectsTotal.Load(),
-		"active_connections":          m.ActiveConnections.Load(),
-		"slow_evictions_total":        m.SlowEvictionsTotal.Load(),
-		"wakeup_published_total":      m.WakeupPublishedTotal.Load(),
-		"wakeup_publish_errors":       m.WakeupPublishErrors.Load(),
-		"wakeup_received_total":       m.WakeupReceivedTotal.Load(),
-		"wakeup_delivered_hit_total":  m.WakeupDeliveredHit.Load(),
-		"wakeup_delivered_miss_total": m.WakeupDeliveredMiss.Load(),
+		"connects_total":                    m.ConnectsTotal.Load(),
+		"disconnects_total":                 m.DisconnectsTotal.Load(),
+		"active_connections":                m.ActiveConnections.Load(),
+		"slow_evictions_total":              m.SlowEvictionsTotal.Load(),
+		"wakeup_published_total":            m.WakeupPublishedTotal.Load(),
+		"wakeup_publish_errors":             m.WakeupPublishErrors.Load(),
+		"wakeup_received_total":             m.WakeupReceivedTotal.Load(),
+		"wakeup_delivered_hit_total":        m.WakeupDeliveredHit.Load(),
+		"wakeup_delivered_miss_total":       m.WakeupDeliveredMiss.Load(),
+		"runtime_gone_delivered_hit_total":  m.RuntimeGoneDeliveredHit.Load(),
+		"runtime_gone_delivered_miss_total": m.RuntimeGoneDeliveredMiss.Load(),
 	}
 }
 
@@ -41,4 +46,6 @@ func (m *Metrics) Reset() {
 	m.WakeupReceivedTotal.Store(0)
 	m.WakeupDeliveredHit.Store(0)
 	m.WakeupDeliveredMiss.Store(0)
+	m.RuntimeGoneDeliveredHit.Store(0)
+	m.RuntimeGoneDeliveredMiss.Store(0)
 }

--- a/server/internal/daemonws/metrics.go
+++ b/server/internal/daemonws/metrics.go
@@ -14,8 +14,11 @@ type Metrics struct {
 	WakeupDeliveredHit   atomic.Int64
 	WakeupDeliveredMiss  atomic.Int64
 
-	RuntimeGoneDeliveredHit  atomic.Int64
-	RuntimeGoneDeliveredMiss atomic.Int64
+	RuntimeGoneDeliveredHit   atomic.Int64
+	RuntimeGoneDeliveredMiss  atomic.Int64
+	RuntimeGonePublishedTotal atomic.Int64
+	RuntimeGonePublishErrors  atomic.Int64
+	RuntimeGoneReceivedTotal  atomic.Int64
 }
 
 var M = &Metrics{}
@@ -33,6 +36,9 @@ func (m *Metrics) Snapshot() map[string]any {
 		"wakeup_delivered_miss_total":       m.WakeupDeliveredMiss.Load(),
 		"runtime_gone_delivered_hit_total":  m.RuntimeGoneDeliveredHit.Load(),
 		"runtime_gone_delivered_miss_total": m.RuntimeGoneDeliveredMiss.Load(),
+		"runtime_gone_published_total":      m.RuntimeGonePublishedTotal.Load(),
+		"runtime_gone_publish_errors":       m.RuntimeGonePublishErrors.Load(),
+		"runtime_gone_received_total":       m.RuntimeGoneReceivedTotal.Load(),
 	}
 }
 
@@ -48,4 +54,7 @@ func (m *Metrics) Reset() {
 	m.WakeupDeliveredMiss.Store(0)
 	m.RuntimeGoneDeliveredHit.Store(0)
 	m.RuntimeGoneDeliveredMiss.Store(0)
+	m.RuntimeGonePublishedTotal.Store(0)
+	m.RuntimeGonePublishErrors.Store(0)
+	m.RuntimeGoneReceivedTotal.Store(0)
 }

--- a/server/internal/daemonws/notifier.go
+++ b/server/internal/daemonws/notifier.go
@@ -144,13 +144,13 @@ func (n *RelayNotifier) NotifyRuntimeGone(runtimeID string) {
 	}
 	frame, err := runtimeGoneFrame(runtimeID)
 	if err != nil {
-		M.WakeupPublishErrors.Add(1)
+		M.RuntimeGonePublishErrors.Add(1)
 		return
 	}
 	if err := n.relay.PublishWithID(realtime.ScopeDaemonRuntime, runtimeID, "", frame, eventID); err != nil {
-		M.WakeupPublishErrors.Add(1)
+		M.RuntimeGonePublishErrors.Add(1)
 		slog.Warn("daemon websocket runtime-gone publish failed", "error", err, "runtime_id", runtimeID)
 		return
 	}
-	M.WakeupPublishedTotal.Add(1)
+	M.RuntimeGonePublishedTotal.Add(1)
 }

--- a/server/internal/daemonws/notifier.go
+++ b/server/internal/daemonws/notifier.go
@@ -128,3 +128,29 @@ func (n *RelayNotifier) NotifyPendingWork(runtimeID, kind string) {
 	}
 	M.WakeupPublishedTotal.Add(1)
 }
+
+// NotifyRuntimeGone invalidates a deleted runtime on the local daemon
+// connection and on any connection held by another API node.
+func (n *RelayNotifier) NotifyRuntimeGone(runtimeID string) {
+	if runtimeID == "" {
+		return
+	}
+	eventID := ulid.Make().String()
+	if n.local != nil {
+		n.local.notifyRuntimeGone(runtimeID, eventID)
+	}
+	if n.relay == nil {
+		return
+	}
+	frame, err := runtimeGoneFrame(runtimeID)
+	if err != nil {
+		M.WakeupPublishErrors.Add(1)
+		return
+	}
+	if err := n.relay.PublishWithID(realtime.ScopeDaemonRuntime, runtimeID, "", frame, eventID); err != nil {
+		M.WakeupPublishErrors.Add(1)
+		slog.Warn("daemon websocket runtime-gone publish failed", "error", err, "runtime_id", runtimeID)
+		return
+	}
+	M.WakeupPublishedTotal.Add(1)
+}

--- a/server/internal/daemonws/runtime_gone_test.go
+++ b/server/internal/daemonws/runtime_gone_test.go
@@ -25,6 +25,26 @@ func TestNotifyRuntimeGone(t *testing.T) {
 	if payload.Status != protocol.HeartbeatStatusRuntimeGone || !payload.RuntimeGone {
 		t.Fatalf("payload = %+v, want runtime_gone acknowledgement", payload)
 	}
+	if M.RuntimeGoneDeliveredHit.Load() != 1 {
+		t.Fatalf("runtime-gone delivered hit metric = %d, want 1", M.RuntimeGoneDeliveredHit.Load())
+	}
+	if M.WakeupDeliveredHit.Load() != 0 || M.WakeupDeliveredMiss.Load() != 0 {
+		t.Fatalf("runtime-gone polluted wakeup delivery metrics: hit=%d miss=%d", M.WakeupDeliveredHit.Load(), M.WakeupDeliveredMiss.Load())
+	}
+}
+
+func TestNotifyRuntimeGoneMissingConnectionDoesNotPolluteWakeupMetrics(t *testing.T) {
+	M.Reset()
+	defer M.Reset()
+
+	NewHub().NotifyRuntimeGone("offline-runtime")
+
+	if M.RuntimeGoneDeliveredHit.Load() != 0 || M.RuntimeGoneDeliveredMiss.Load() != 1 {
+		t.Fatalf("runtime-gone delivery metrics: hit=%d miss=%d, want 0/1", M.RuntimeGoneDeliveredHit.Load(), M.RuntimeGoneDeliveredMiss.Load())
+	}
+	if M.WakeupDeliveredHit.Load() != 0 || M.WakeupDeliveredMiss.Load() != 0 {
+		t.Fatalf("runtime-gone polluted wakeup delivery metrics: hit=%d miss=%d", M.WakeupDeliveredHit.Load(), M.WakeupDeliveredMiss.Load())
+	}
 }
 
 func TestRelayNotifierPublishesAndDeliversRuntimeGone(t *testing.T) {
@@ -54,6 +74,12 @@ func TestRelayNotifierPublishesAndDeliversRuntimeGone(t *testing.T) {
 	case duplicate := <-remoteClient.send:
 		t.Fatalf("expected duplicate relay event to be dropped, got %s", duplicate)
 	case <-time.After(20 * time.Millisecond):
+	}
+	if M.RuntimeGoneDeliveredHit.Load() != 1 || M.RuntimeGoneDeliveredMiss.Load() != 0 {
+		t.Fatalf("runtime-gone delivery metrics after loopback: hit=%d miss=%d, want 1/0", M.RuntimeGoneDeliveredHit.Load(), M.RuntimeGoneDeliveredMiss.Load())
+	}
+	if M.WakeupDeliveredHit.Load() != 0 || M.WakeupDeliveredMiss.Load() != 0 {
+		t.Fatalf("runtime-gone polluted wakeup delivery metrics: hit=%d miss=%d", M.WakeupDeliveredHit.Load(), M.WakeupDeliveredMiss.Load())
 	}
 }
 

--- a/server/internal/daemonws/runtime_gone_test.go
+++ b/server/internal/daemonws/runtime_gone_test.go
@@ -1,0 +1,109 @@
+package daemonws
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/realtime"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+func TestNotifyRuntimeGone(t *testing.T) {
+	M.Reset()
+	defer M.Reset()
+
+	hub := NewHub()
+	client := attachDaemonTestClient(hub, "runtime-1")
+
+	hub.NotifyRuntimeGone("runtime-1")
+
+	payload := readRuntimeGoneFrame(t, client.send)
+	if payload.RuntimeID != "runtime-1" {
+		t.Fatalf("runtime id = %q, want runtime-1", payload.RuntimeID)
+	}
+	if payload.Status != protocol.HeartbeatStatusRuntimeGone || !payload.RuntimeGone {
+		t.Fatalf("payload = %+v, want runtime_gone acknowledgement", payload)
+	}
+}
+
+func TestRelayNotifierPublishesAndDeliversRuntimeGone(t *testing.T) {
+	M.Reset()
+	defer M.Reset()
+
+	relay := &recordingRelayPublisher{}
+	NewRelayNotifier(nil, relay).NotifyRuntimeGone("runtime-1")
+
+	if relay.scopeType != realtime.ScopeDaemonRuntime || relay.scopeID != "runtime-1" {
+		t.Fatalf("relay scope = %q/%q, want daemon-runtime/runtime-1", relay.scopeType, relay.scopeID)
+	}
+	if relay.eventID == "" {
+		t.Fatal("expected event id")
+	}
+
+	remoteHub := NewHub()
+	remoteClient := attachDaemonTestClient(remoteHub, "runtime-1")
+	remoteHub.DeliverDaemonRuntime(relay.scopeID, relay.frame, relay.eventID)
+	payload := readRuntimeGoneFrame(t, remoteClient.send)
+	if payload.RuntimeID != "runtime-1" || payload.Status != protocol.HeartbeatStatusRuntimeGone || !payload.RuntimeGone {
+		t.Fatalf("payload = %+v, want relayed runtime_gone acknowledgement", payload)
+	}
+
+	remoteHub.DeliverDaemonRuntime(relay.scopeID, relay.frame, relay.eventID)
+	select {
+	case duplicate := <-remoteClient.send:
+		t.Fatalf("expected duplicate relay event to be dropped, got %s", duplicate)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestRelayNotifierDedupsRuntimeGoneLoopback(t *testing.T) {
+	M.Reset()
+	defer M.Reset()
+
+	hub := NewHub()
+	client := attachDaemonTestClient(hub, "runtime-1")
+	relay := &localFirstDaemonRelayPublisher{t: t, client: client}
+	NewRelayNotifier(hub, relay).NotifyRuntimeGone("runtime-1")
+
+	if !relay.called || relay.eventID == "" {
+		t.Fatal("expected local delivery followed by relay publish")
+	}
+	if payload := decodeRuntimeGoneFrame(t, relay.localFrame); !payload.RuntimeGone {
+		t.Fatalf("local payload = %+v, want runtime_gone acknowledgement", payload)
+	}
+
+	hub.DeliverDaemonRuntime(relay.scopeID, relay.frame, relay.eventID)
+	select {
+	case duplicate := <-client.send:
+		t.Fatalf("expected Redis loopback to be deduped, got %s", duplicate)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func readRuntimeGoneFrame(t *testing.T, frames <-chan []byte) protocol.DaemonHeartbeatAckPayload {
+	t.Helper()
+	select {
+	case raw := <-frames:
+		return decodeRuntimeGoneFrame(t, raw)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runtime_gone frame")
+		return protocol.DaemonHeartbeatAckPayload{}
+	}
+}
+
+func decodeRuntimeGoneFrame(t *testing.T, raw []byte) protocol.DaemonHeartbeatAckPayload {
+	t.Helper()
+	var msg protocol.Message
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal message: %v", err)
+	}
+	if msg.Type != protocol.EventDaemonHeartbeatAck {
+		t.Fatalf("message type = %q, want %q", msg.Type, protocol.EventDaemonHeartbeatAck)
+	}
+	var payload protocol.DaemonHeartbeatAckPayload
+	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return payload
+}

--- a/server/internal/daemonws/runtime_gone_test.go
+++ b/server/internal/daemonws/runtime_gone_test.go
@@ -2,6 +2,7 @@ package daemonws
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -60,6 +61,12 @@ func TestRelayNotifierPublishesAndDeliversRuntimeGone(t *testing.T) {
 	if relay.eventID == "" {
 		t.Fatal("expected event id")
 	}
+	if M.RuntimeGonePublishedTotal.Load() != 1 || M.RuntimeGonePublishErrors.Load() != 0 {
+		t.Fatalf("runtime-gone publish metrics: published=%d errors=%d, want 1/0", M.RuntimeGonePublishedTotal.Load(), M.RuntimeGonePublishErrors.Load())
+	}
+	if M.WakeupPublishedTotal.Load() != 0 || M.WakeupPublishErrors.Load() != 0 {
+		t.Fatalf("runtime-gone polluted wakeup publish metrics: published=%d errors=%d", M.WakeupPublishedTotal.Load(), M.WakeupPublishErrors.Load())
+	}
 
 	remoteHub := NewHub()
 	remoteClient := attachDaemonTestClient(remoteHub, "runtime-1")
@@ -78,8 +85,49 @@ func TestRelayNotifierPublishesAndDeliversRuntimeGone(t *testing.T) {
 	if M.RuntimeGoneDeliveredHit.Load() != 1 || M.RuntimeGoneDeliveredMiss.Load() != 0 {
 		t.Fatalf("runtime-gone delivery metrics after loopback: hit=%d miss=%d, want 1/0", M.RuntimeGoneDeliveredHit.Load(), M.RuntimeGoneDeliveredMiss.Load())
 	}
+	if M.RuntimeGoneReceivedTotal.Load() != 2 || M.WakeupReceivedTotal.Load() != 0 {
+		t.Fatalf("relay receive metrics: runtime-gone=%d wakeup=%d, want 2/0", M.RuntimeGoneReceivedTotal.Load(), M.WakeupReceivedTotal.Load())
+	}
 	if M.WakeupDeliveredHit.Load() != 0 || M.WakeupDeliveredMiss.Load() != 0 {
 		t.Fatalf("runtime-gone polluted wakeup delivery metrics: hit=%d miss=%d", M.WakeupDeliveredHit.Load(), M.WakeupDeliveredMiss.Load())
+	}
+}
+
+func TestRelayNotifierRuntimeGonePublishErrorDoesNotPolluteWakeupMetrics(t *testing.T) {
+	M.Reset()
+	defer M.Reset()
+
+	NewRelayNotifier(nil, failingRelayPublisher{}).NotifyRuntimeGone("runtime-1")
+
+	if M.RuntimeGonePublishedTotal.Load() != 0 || M.RuntimeGonePublishErrors.Load() != 1 {
+		t.Fatalf("runtime-gone publish metrics: published=%d errors=%d, want 0/1", M.RuntimeGonePublishedTotal.Load(), M.RuntimeGonePublishErrors.Load())
+	}
+	if M.WakeupPublishedTotal.Load() != 0 || M.WakeupPublishErrors.Load() != 0 {
+		t.Fatalf("runtime-gone polluted wakeup publish metrics: published=%d errors=%d", M.WakeupPublishedTotal.Load(), M.WakeupPublishErrors.Load())
+	}
+}
+
+func TestDeliverDaemonRuntimeInvalidRuntimeGoneDoesNotPolluteWakeupMetrics(t *testing.T) {
+	M.Reset()
+	defer M.Reset()
+
+	frame, err := json.Marshal(protocol.Message{
+		Type: protocol.EventDaemonHeartbeatAck,
+		Payload: mustMarshalRaw(protocol.DaemonHeartbeatAckPayload{
+			RuntimeID: "runtime-1",
+			Status:    "invalid",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("marshal invalid runtime-gone frame: %v", err)
+	}
+	NewHub().DeliverDaemonRuntime("runtime-1", frame, "event-1")
+
+	if M.RuntimeGoneReceivedTotal.Load() != 1 || M.RuntimeGoneDeliveredMiss.Load() != 1 {
+		t.Fatalf("invalid runtime-gone metrics: received=%d miss=%d, want 1/1", M.RuntimeGoneReceivedTotal.Load(), M.RuntimeGoneDeliveredMiss.Load())
+	}
+	if M.WakeupReceivedTotal.Load() != 0 || M.WakeupDeliveredMiss.Load() != 0 {
+		t.Fatalf("invalid runtime-gone polluted wakeup metrics: received=%d miss=%d", M.WakeupReceivedTotal.Load(), M.WakeupDeliveredMiss.Load())
 	}
 }
 
@@ -132,4 +180,10 @@ func decodeRuntimeGoneFrame(t *testing.T, raw []byte) protocol.DaemonHeartbeatAc
 		t.Fatalf("unmarshal payload: %v", err)
 	}
 	return payload
+}
+
+type failingRelayPublisher struct{}
+
+func (failingRelayPublisher) PublishWithID(string, string, string, []byte, string) error {
+	return errors.New("injected relay publish failure")
 }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -873,6 +873,7 @@ func (h *Handler) mergeLegacyRuntime(ctx context.Context, newRuntimeID, oldRunti
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit merge: %w", err)
 	}
+	h.NotifyRuntimeGone(uuidToString(oldRuntimeID))
 
 	slog.Info("legacy runtime merged",
 		"legacy_daemon_id", legacyID,

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -173,6 +173,12 @@ type DaemonPendingWorkNotifier interface {
 	NotifyPendingWork(runtimeID, kind string)
 }
 
+// RuntimeGoneNotifier invalidates a runtime that was deleted while its daemon
+// still has an authenticated WebSocket connection.
+type RuntimeGoneNotifier interface {
+	NotifyRuntimeGone(runtimeID string)
+}
+
 type Handler struct {
 	Queries                *db.Queries
 	DB                     dbExecutor
@@ -181,6 +187,7 @@ type Handler struct {
 	DaemonHub              *daemonws.Hub
 	DaemonProfileRefresh   RuntimeProfileRefreshNotifier
 	DaemonWorkspaceRefresh WorkspaceSetRefreshNotifier
+	DaemonRuntimeGone      RuntimeGoneNotifier
 	Bus                    *events.Bus
 	TaskService            *service.TaskService
 	PluginService          *service.PluginService
@@ -410,9 +417,11 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 	}
 	var daemonProfileRefresh RuntimeProfileRefreshNotifier
 	var daemonWorkspaceRefresh WorkspaceSetRefreshNotifier
+	var daemonRuntimeGone RuntimeGoneNotifier
 	if daemonHub != nil {
 		daemonProfileRefresh = daemonHub
 		daemonWorkspaceRefresh = daemonHub
+		daemonRuntimeGone = daemonHub
 	}
 
 	llmClient := llm.New(llm.Config{
@@ -450,6 +459,7 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 		DaemonHub:                    daemonHub,
 		DaemonProfileRefresh:         daemonProfileRefresh,
 		DaemonWorkspaceRefresh:       daemonWorkspaceRefresh,
+		DaemonRuntimeGone:            daemonRuntimeGone,
 		Bus:                          bus,
 		TaskService:                  taskSvc,
 		PluginService:                service.NewPluginService(queries, txStarter),
@@ -718,6 +728,15 @@ func (h *Handler) notifyDaemonWorkspacesChanged(userIDs ...string) {
 		seen[userID] = struct{}{}
 		h.DaemonWorkspaceRefresh.NotifyWorkspacesChanged(userID)
 	}
+}
+
+// NotifyRuntimeGone emits the post-commit runtime invalidation signal. It is
+// exported so the runtime GC can use the same publisher as request handlers.
+func (h *Handler) NotifyRuntimeGone(runtimeID string) {
+	if h == nil || h.DaemonRuntimeGone == nil || runtimeID == "" {
+		return
+	}
+	h.DaemonRuntimeGone.NotifyRuntimeGone(runtimeID)
 }
 
 // publishTask is publish() plus a TaskID hint so the realtime layer can route

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -954,6 +954,7 @@ func (h *Handler) DeleteAgentRuntime(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to delete runtime")
 		return
 	}
+	h.NotifyRuntimeGone(uuidToString(rt.ID))
 
 	slog.Info("runtime deleted",
 		"runtime_id", uuidToString(rt.ID),
@@ -1167,6 +1168,7 @@ func (h *Handler) UnbindAgentsAndDeleteRuntime(w http.ResponseWriter, r *http.Re
 		writeError(w, http.StatusInternalServerError, "failed to commit transaction")
 		return
 	}
+	h.NotifyRuntimeGone(uuidToString(rt.ID))
 
 	h.publishRuntimeTeardown(r.Context(), teardown, wsID, userID)
 

--- a/server/internal/handler/runtime_gone_test.go
+++ b/server/internal/handler/runtime_gone_test.go
@@ -1,0 +1,9 @@
+package handler
+
+type recordingRuntimeGoneNotifier struct {
+	runtimeIDs []string
+}
+
+func (n *recordingRuntimeGoneNotifier) NotifyRuntimeGone(runtimeID string) {
+	n.runtimeIDs = append(n.runtimeIDs, runtimeID)
+}

--- a/server/internal/handler/runtime_gone_test.go
+++ b/server/internal/handler/runtime_gone_test.go
@@ -1,9 +1,0 @@
-package handler
-
-type recordingRuntimeGoneNotifier struct {
-	runtimeIDs []string
-}
-
-func (n *recordingRuntimeGoneNotifier) NotifyRuntimeGone(runtimeID string) {
-	n.runtimeIDs = append(n.runtimeIDs, runtimeID)
-}

--- a/server/internal/handler/runtime_profile.go
+++ b/server/internal/handler/runtime_profile.go
@@ -484,6 +484,9 @@ func (h *Handler) DeleteRuntimeProfile(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to commit transaction")
 		return
 	}
+	for _, runtimeID := range runtimeIDs {
+		h.NotifyRuntimeGone(uuidToString(runtimeID))
+	}
 
 	// Tell connected clients to refetch the runtime list (instances vanished),
 	// and fan out the per-runtime teardown so unbound agents and cancelled

--- a/server/internal/handler/runtime_profile.go
+++ b/server/internal/handler/runtime_profile.go
@@ -462,10 +462,11 @@ func (h *Handler) DeleteRuntimeProfile(w http.ResponseWriter, r *http.Request) {
 
 	// Now the runtime rows have no agent references; remove them, then the
 	// profile itself.
-	if _, err := qtx.DeleteAgentRuntimesByProfile(r.Context(), db.DeleteAgentRuntimesByProfileParams{
+	deletedRuntimes, err := qtx.DeleteAgentRuntimesByProfile(r.Context(), db.DeleteAgentRuntimesByProfileParams{
 		ProfileID:   profileUUID,
 		WorkspaceID: wsUUID,
-	}); err != nil {
+	})
+	if err != nil {
 		slog.Error("DeleteAgentRuntimesByProfile failed", "error", err, "profile_id", uuidToString(profileUUID))
 		writeError(w, http.StatusInternalServerError, "failed to clean up runtime instances")
 		return
@@ -484,8 +485,8 @@ func (h *Handler) DeleteRuntimeProfile(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to commit transaction")
 		return
 	}
-	for _, runtimeID := range runtimeIDs {
-		h.NotifyRuntimeGone(uuidToString(runtimeID))
+	for _, runtime := range deletedRuntimes {
+		h.NotifyRuntimeGone(uuidToString(runtime.ID))
 	}
 
 	// Tell connected clients to refetch the runtime list (instances vanished),

--- a/server/internal/handler/runtime_profile_handler_test.go
+++ b/server/internal/handler/runtime_profile_handler_test.go
@@ -105,7 +105,10 @@ VALUES ($1, $2, 'feishu', 'oc_rp', 'p2p')`, rpChat, rpInstallID); err != nil {
 	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles/"+profileID, nil)
 	req = withURLParams(req, "id", testWorkspaceID, "profileId", profileID)
-	testHandler.DeleteRuntimeProfile(w, req)
+	notifier := &recordingRuntimeGoneNotifier{}
+	h := *testHandler
+	h.DaemonRuntimeGone = notifier
+	h.DeleteRuntimeProfile(w, req)
 
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
@@ -152,6 +155,9 @@ VALUES ($1, $2, 'feishu', 'oc_rp', 'p2p')`, rpChat, rpInstallID); err != nil {
 	if bindingRows != 1 {
 		t.Fatalf("surviving installation's chat-session binding was swept: %d rows", bindingRows)
 	}
+	if len(notifier.runtimeIDs) != 1 || notifier.runtimeIDs[0] != runtimeID {
+		t.Fatalf("runtime-gone notifications = %v, want [%s]", notifier.runtimeIDs, runtimeID)
+	}
 }
 
 // TestDeleteRuntimeProfile_ActiveAgentBlocks confirms the guard still refuses
@@ -170,7 +176,10 @@ func TestDeleteRuntimeProfile_ActiveAgentBlocks(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles/"+profileID, nil)
 	req = withURLParams(req, "id", testWorkspaceID, "profileId", profileID)
-	testHandler.DeleteRuntimeProfile(w, req)
+	notifier := &recordingRuntimeGoneNotifier{}
+	h := *testHandler
+	h.DaemonRuntimeGone = notifier
+	h.DeleteRuntimeProfile(w, req)
 
 	if w.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
@@ -188,6 +197,9 @@ func TestDeleteRuntimeProfile_ActiveAgentBlocks(t *testing.T) {
 	}
 	if rtRows != 1 {
 		t.Fatalf("expected runtime to survive 409, found %d", rtRows)
+	}
+	if len(notifier.runtimeIDs) != 0 {
+		t.Fatalf("rollback/refusal emitted runtime-gone notifications: %v", notifier.runtimeIDs)
 	}
 }
 

--- a/server/internal/handler/runtime_unbind_delete_test.go
+++ b/server/internal/handler/runtime_unbind_delete_test.go
@@ -12,6 +12,14 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
+type recordingRuntimeGoneNotifier struct {
+	runtimeIDs []string
+}
+
+func (n *recordingRuntimeGoneNotifier) NotifyRuntimeGone(runtimeID string) {
+	n.runtimeIDs = append(n.runtimeIDs, runtimeID)
+}
+
 // parseExpectedActiveAgentIDs is the cascade endpoint's input validator.
 // Empty list is a valid plan ("no active agents" — cascade just deletes the
 // runtime); malformed UUIDs must surface as 400 so a bug in the front-end

--- a/server/internal/handler/runtime_unbind_delete_test.go
+++ b/server/internal/handler/runtime_unbind_delete_test.go
@@ -335,7 +335,10 @@ func TestDeleteAgentRuntime_OrphanedProfileAllowsDirectDelete(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
+	notifier := &recordingRuntimeGoneNotifier{}
+	h := *testHandler
+	h.DaemonRuntimeGone = notifier
+	h.DeleteAgentRuntime(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -346,6 +349,9 @@ func TestDeleteAgentRuntime_OrphanedProfileAllowsDirectDelete(t *testing.T) {
 	}
 	if rtRows != 0 {
 		t.Fatalf("expected orphaned custom runtime instance to be deleted, count=%d", rtRows)
+	}
+	if len(notifier.runtimeIDs) != 1 || notifier.runtimeIDs[0] != runtimeID {
+		t.Fatalf("runtime-gone notifications = %v, want [%s]", notifier.runtimeIDs, runtimeID)
 	}
 }
 
@@ -366,7 +372,10 @@ func TestUnbindAgentsAndDeleteRuntime_HappyPath(t *testing.T) {
 	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/unbind-agents-and-delete",
 		map[string]any{"expected_active_agent_ids": []string{agentID}})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UnbindAgentsAndDeleteRuntime(w, req)
+	notifier := &recordingRuntimeGoneNotifier{}
+	h := *testHandler
+	h.DaemonRuntimeGone = notifier
+	h.UnbindAgentsAndDeleteRuntime(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -420,6 +429,9 @@ func TestUnbindAgentsAndDeleteRuntime_HappyPath(t *testing.T) {
 	// archive-and-delete contract.
 	if body.AgentsArchived != 1 {
 		t.Fatalf("agents_archived mirror = %d, want 1", body.AgentsArchived)
+	}
+	if len(notifier.runtimeIDs) != 1 || notifier.runtimeIDs[0] != runtimeID {
+		t.Fatalf("runtime-gone notifications = %v, want [%s]", notifier.runtimeIDs, runtimeID)
 	}
 }
 

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -1125,14 +1125,10 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	// registration does not participate in the workspace delete lock protocol,
 	// so PR1 retains the heartbeat lookup as the correctness fallback for a
 	// registration that races this snapshot.
-	runtimes, err := qtx.ListAgentRuntimes(r.Context(), requester.WorkspaceID)
+	runtimeIDs, err := qtx.ListAgentRuntimeIDsByWorkspace(r.Context(), requester.WorkspaceID)
 	if err != nil {
 		failWorkspaceDelete(w, r, workspaceID, "list runtimes", err)
 		return
-	}
-	runtimeIDs := make([]string, 0, len(runtimes))
-	for _, runtime := range runtimes {
-		runtimeIDs = append(runtimeIDs, uuidToString(runtime.ID))
 	}
 
 	if _, err := qtx.LockChatSessionsByWorkspace(r.Context(), requester.WorkspaceID); err != nil {
@@ -1328,7 +1324,7 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, runtimeID := range runtimeIDs {
-		h.NotifyRuntimeGone(runtimeID)
+		h.NotifyRuntimeGone(uuidToString(runtimeID))
 	}
 	h.deleteS3Objects(r.Context(), append(sourceContextAttachmentURLs, sourceContextIntentURLs...))
 

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -1106,6 +1106,7 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	qtx := h.Queries.WithTx(tx)
 	var sourceContextAttachmentURLs []string
 	var sourceContextIntentURLs []string
+	var runtimeIDs []string
 
 	// SET LOCAL is transaction-scoped, so pgxpool hands this connection back
 	// out with the default (unbounded) lock_timeout after COMMIT / ROLLBACK.
@@ -1120,6 +1121,18 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	if _, err := qtx.LockWorkspaceForDelete(r.Context(), requester.WorkspaceID); err != nil {
 		failWorkspaceDelete(w, r, workspaceID, "lock workspace", err)
 		return
+	}
+	// Snapshot the runtime IDs while the workspace row lock prevents new
+	// runtime registrations. Notify their active daemon connections only after
+	// the workspace teardown commits.
+	runtimes, err := qtx.ListAgentRuntimes(r.Context(), requester.WorkspaceID)
+	if err != nil {
+		failWorkspaceDelete(w, r, workspaceID, "list runtimes", err)
+		return
+	}
+	runtimeIDs = make([]string, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		runtimeIDs = append(runtimeIDs, uuidToString(runtime.ID))
 	}
 
 	if _, err := qtx.LockChatSessionsByWorkspace(r.Context(), requester.WorkspaceID); err != nil {
@@ -1313,6 +1326,9 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("commit workspace delete failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", workspaceID)...)
 		writeError(w, http.StatusInternalServerError, "failed to delete workspace")
 		return
+	}
+	for _, runtimeID := range runtimeIDs {
+		h.NotifyRuntimeGone(runtimeID)
 	}
 	h.deleteS3Objects(r.Context(), append(sourceContextAttachmentURLs, sourceContextIntentURLs...))
 

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -1106,7 +1106,6 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	qtx := h.Queries.WithTx(tx)
 	var sourceContextAttachmentURLs []string
 	var sourceContextIntentURLs []string
-	var runtimeIDs []string
 
 	// SET LOCAL is transaction-scoped, so pgxpool hands this connection back
 	// out with the default (unbounded) lock_timeout after COMMIT / ROLLBACK.
@@ -1122,15 +1121,16 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 		failWorkspaceDelete(w, r, workspaceID, "lock workspace", err)
 		return
 	}
-	// Snapshot the runtime IDs while the workspace row lock prevents new
-	// runtime registrations. Notify their active daemon connections only after
-	// the workspace teardown commits.
+	// Take a best-effort snapshot for post-commit daemon invalidation. Runtime
+	// registration does not participate in the workspace delete lock protocol,
+	// so PR1 retains the heartbeat lookup as the correctness fallback for a
+	// registration that races this snapshot.
 	runtimes, err := qtx.ListAgentRuntimes(r.Context(), requester.WorkspaceID)
 	if err != nil {
 		failWorkspaceDelete(w, r, workspaceID, "list runtimes", err)
 		return
 	}
-	runtimeIDs = make([]string, 0, len(runtimes))
+	runtimeIDs := make([]string, 0, len(runtimes))
 	for _, runtime := range runtimes {
 		runtimeIDs = append(runtimeIDs, uuidToString(runtime.ID))
 	}

--- a/server/internal/handler/workspace_delete_fence_test.go
+++ b/server/internal/handler/workspace_delete_fence_test.go
@@ -349,12 +349,15 @@ func TestMergeLegacyRuntime_KeepsOldRuntimeWhenFenceRefuses(t *testing.T) {
 	}
 	ctx := context.Background()
 	f := newWorkspaceDeletePathFixture(t, "mergefence")
+	notifier := &recordingRuntimeGoneNotifier{}
+	h := *testHandler
+	h.DaemonRuntimeGone = notifier
 
 	// A target runtime id that does not resolve — the same state a merge sees when
 	// the target's workspace was torn down a moment ago.
 	vanishedTarget := parseUUID("00000000-0000-0000-0000-0000000000fe")
 
-	err := testHandler.mergeLegacyRuntime(ctx, vanishedTarget, parseUUID(f.victimRuntime), "legacy-daemon", "delete-test")
+	err := h.mergeLegacyRuntime(ctx, vanishedTarget, parseUUID(f.victimRuntime), "legacy-daemon", "delete-test")
 	if !errors.Is(err, errRuntimeMergeFenced) {
 		t.Fatalf("mergeLegacyRuntime = %v, want errRuntimeMergeFenced", err)
 	}
@@ -374,6 +377,9 @@ func TestMergeLegacyRuntime_KeepsOldRuntimeWhenFenceRefuses(t *testing.T) {
 	if !stillOnOldRuntime {
 		t.Error("the task was re-pointed at the vanished runtime")
 	}
+	if len(notifier.runtimeIDs) != 0 {
+		t.Fatalf("fenced merge emitted runtime-gone notifications: %v", notifier.runtimeIDs)
+	}
 
 	// And the happy path still merges, so the abort is not unconditional.
 	var freshRuntime string
@@ -384,7 +390,7 @@ RETURNING id
 `, f.victimID, testUserID).Scan(&freshRuntime); err != nil {
 		t.Fatalf("create merge target: %v", err)
 	}
-	if err := testHandler.mergeLegacyRuntime(ctx, parseUUID(freshRuntime), parseUUID(f.victimRuntime),
+	if err := h.mergeLegacyRuntime(ctx, parseUUID(freshRuntime), parseUUID(f.victimRuntime),
 		"legacy-daemon", "delete-test"); err != nil {
 		t.Fatalf("merge onto a live runtime: %v", err)
 	}
@@ -393,6 +399,9 @@ RETURNING id
 	}
 	if !rowExists(t, "agent_task_queue", f.taskViaRuntime) {
 		t.Error("a completed merge lost the old runtime's task")
+	}
+	if len(notifier.runtimeIDs) != 1 || notifier.runtimeIDs[0] != f.victimRuntime {
+		t.Fatalf("runtime-gone notifications = %v, want [%s]", notifier.runtimeIDs, f.victimRuntime)
 	}
 }
 

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -315,12 +315,18 @@ VALUES ($1, $2, gen_random_uuid(), gen_random_uuid(), 's3://workspace-delete/sou
 
 	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
 	req = withURLParam(req, "id", wsID)
-	testutil.Call(t, testHandler.DeleteWorkspace, req).Want(http.StatusNoContent)
+	notifier := &recordingRuntimeGoneNotifier{}
+	h := *testHandler
+	h.DaemonRuntimeGone = notifier
+	testutil.Call(t, h.DeleteWorkspace, req).Want(http.StatusNoContent)
 
 	var exists bool
 	dbfx.QueryRow(t, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists)
 	if exists {
 		t.Fatal("workspace still exists after owner DELETE")
+	}
+	if len(notifier.runtimeIDs) != 1 || notifier.runtimeIDs[0] != runtimeID {
+		t.Fatalf("runtime-gone notifications = %v, want [%s]", notifier.runtimeIDs, runtimeID)
 	}
 
 	var pendingCount int

--- a/server/internal/metrics/daemonws.go
+++ b/server/internal/metrics/daemonws.go
@@ -17,6 +17,9 @@ type DaemonWSCollector struct {
 	wakeupPublishErrors  *prometheus.Desc
 	wakeupReceivedTotal  *prometheus.Desc
 	wakeupDeliveredTotal *prometheus.Desc
+	runtimeGonePublished *prometheus.Desc
+	runtimeGoneErrors    *prometheus.Desc
+	runtimeGoneReceived  *prometheus.Desc
 	runtimeGoneDelivered *prometheus.Desc
 }
 
@@ -32,6 +35,9 @@ func NewDaemonWSCollector(m *daemonws.Metrics) *DaemonWSCollector {
 		wakeupPublishErrors:  newDaemonWSDesc("wakeup_publish_errors_total", "Total daemon wakeup Redis publish errors."),
 		wakeupReceivedTotal:  newDaemonWSDesc("wakeup_received_total", "Total daemon wakeups received from the Redis relay."),
 		wakeupDeliveredTotal: prometheus.NewDesc("multica_daemonws_wakeup_delivered_total", "Total daemon wakeup local delivery attempts.", []string{"result"}, nil),
+		runtimeGonePublished: newDaemonWSDesc("runtime_gone_published_total", "Total runtime-gone notifications published to the Redis relay."),
+		runtimeGoneErrors:    newDaemonWSDesc("runtime_gone_publish_errors_total", "Total runtime-gone Redis publish errors."),
+		runtimeGoneReceived:  newDaemonWSDesc("runtime_gone_received_total", "Total runtime-gone notifications received from the Redis relay."),
 		runtimeGoneDelivered: prometheus.NewDesc("multica_daemonws_runtime_gone_delivered_total", "Total runtime-gone local delivery attempts.", []string{"result"}, nil),
 	}
 }
@@ -50,6 +56,9 @@ func (c *DaemonWSCollector) Describe(ch chan<- *prometheus.Desc) {
 		c.wakeupPublishErrors,
 		c.wakeupReceivedTotal,
 		c.wakeupDeliveredTotal,
+		c.runtimeGonePublished,
+		c.runtimeGoneErrors,
+		c.runtimeGoneReceived,
 		c.runtimeGoneDelivered,
 	} {
 		ch <- desc
@@ -70,6 +79,9 @@ func (c *DaemonWSCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.wakeupReceivedTotal, prometheus.CounterValue, float64(m.WakeupReceivedTotal.Load()))
 	ch <- prometheus.MustNewConstMetric(c.wakeupDeliveredTotal, prometheus.CounterValue, float64(m.WakeupDeliveredHit.Load()), "hit")
 	ch <- prometheus.MustNewConstMetric(c.wakeupDeliveredTotal, prometheus.CounterValue, float64(m.WakeupDeliveredMiss.Load()), "miss")
+	ch <- prometheus.MustNewConstMetric(c.runtimeGonePublished, prometheus.CounterValue, float64(m.RuntimeGonePublishedTotal.Load()))
+	ch <- prometheus.MustNewConstMetric(c.runtimeGoneErrors, prometheus.CounterValue, float64(m.RuntimeGonePublishErrors.Load()))
+	ch <- prometheus.MustNewConstMetric(c.runtimeGoneReceived, prometheus.CounterValue, float64(m.RuntimeGoneReceivedTotal.Load()))
 	ch <- prometheus.MustNewConstMetric(c.runtimeGoneDelivered, prometheus.CounterValue, float64(m.RuntimeGoneDeliveredHit.Load()), "hit")
 	ch <- prometheus.MustNewConstMetric(c.runtimeGoneDelivered, prometheus.CounterValue, float64(m.RuntimeGoneDeliveredMiss.Load()), "miss")
 }

--- a/server/internal/metrics/daemonws.go
+++ b/server/internal/metrics/daemonws.go
@@ -17,6 +17,7 @@ type DaemonWSCollector struct {
 	wakeupPublishErrors  *prometheus.Desc
 	wakeupReceivedTotal  *prometheus.Desc
 	wakeupDeliveredTotal *prometheus.Desc
+	runtimeGoneDelivered *prometheus.Desc
 }
 
 func NewDaemonWSCollector(m *daemonws.Metrics) *DaemonWSCollector {
@@ -31,6 +32,7 @@ func NewDaemonWSCollector(m *daemonws.Metrics) *DaemonWSCollector {
 		wakeupPublishErrors:  newDaemonWSDesc("wakeup_publish_errors_total", "Total daemon wakeup Redis publish errors."),
 		wakeupReceivedTotal:  newDaemonWSDesc("wakeup_received_total", "Total daemon wakeups received from the Redis relay."),
 		wakeupDeliveredTotal: prometheus.NewDesc("multica_daemonws_wakeup_delivered_total", "Total daemon wakeup local delivery attempts.", []string{"result"}, nil),
+		runtimeGoneDelivered: prometheus.NewDesc("multica_daemonws_runtime_gone_delivered_total", "Total runtime-gone local delivery attempts.", []string{"result"}, nil),
 	}
 }
 
@@ -48,6 +50,7 @@ func (c *DaemonWSCollector) Describe(ch chan<- *prometheus.Desc) {
 		c.wakeupPublishErrors,
 		c.wakeupReceivedTotal,
 		c.wakeupDeliveredTotal,
+		c.runtimeGoneDelivered,
 	} {
 		ch <- desc
 	}
@@ -67,4 +70,6 @@ func (c *DaemonWSCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.wakeupReceivedTotal, prometheus.CounterValue, float64(m.WakeupReceivedTotal.Load()))
 	ch <- prometheus.MustNewConstMetric(c.wakeupDeliveredTotal, prometheus.CounterValue, float64(m.WakeupDeliveredHit.Load()), "hit")
 	ch <- prometheus.MustNewConstMetric(c.wakeupDeliveredTotal, prometheus.CounterValue, float64(m.WakeupDeliveredMiss.Load()), "miss")
+	ch <- prometheus.MustNewConstMetric(c.runtimeGoneDelivered, prometheus.CounterValue, float64(m.RuntimeGoneDeliveredHit.Load()), "hit")
+	ch <- prometheus.MustNewConstMetric(c.runtimeGoneDelivered, prometheus.CounterValue, float64(m.RuntimeGoneDeliveredMiss.Load()), "miss")
 }

--- a/server/internal/metrics/daemonws_test.go
+++ b/server/internal/metrics/daemonws_test.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/multica-ai/multica/server/internal/daemonws"
+)
+
+func TestDaemonWSCollectorSeparatesRuntimeGoneDelivery(t *testing.T) {
+	m := &daemonws.Metrics{}
+	m.WakeupDeliveredHit.Store(3)
+	m.WakeupDeliveredMiss.Store(4)
+	m.RuntimeGoneDeliveredHit.Store(5)
+	m.RuntimeGoneDeliveredMiss.Store(6)
+
+	err := testutil.CollectAndCompare(NewDaemonWSCollector(m), strings.NewReader(`
+# HELP multica_daemonws_runtime_gone_delivered_total Total runtime-gone local delivery attempts.
+# TYPE multica_daemonws_runtime_gone_delivered_total counter
+multica_daemonws_runtime_gone_delivered_total{result="hit"} 5
+multica_daemonws_runtime_gone_delivered_total{result="miss"} 6
+# HELP multica_daemonws_wakeup_delivered_total Total daemon wakeup local delivery attempts.
+# TYPE multica_daemonws_wakeup_delivered_total counter
+multica_daemonws_wakeup_delivered_total{result="hit"} 3
+multica_daemonws_wakeup_delivered_total{result="miss"} 4
+`),
+		"multica_daemonws_runtime_gone_delivered_total",
+		"multica_daemonws_wakeup_delivered_total",
+	)
+	if err != nil {
+		t.Fatalf("collect daemon websocket delivery metrics: %v", err)
+	}
+}

--- a/server/internal/metrics/daemonws_test.go
+++ b/server/internal/metrics/daemonws_test.go
@@ -15,18 +15,33 @@ func TestDaemonWSCollectorSeparatesRuntimeGoneDelivery(t *testing.T) {
 	m.WakeupDeliveredMiss.Store(4)
 	m.RuntimeGoneDeliveredHit.Store(5)
 	m.RuntimeGoneDeliveredMiss.Store(6)
+	m.RuntimeGonePublishedTotal.Store(7)
+	m.RuntimeGonePublishErrors.Store(8)
+	m.RuntimeGoneReceivedTotal.Store(9)
 
 	err := testutil.CollectAndCompare(NewDaemonWSCollector(m), strings.NewReader(`
 # HELP multica_daemonws_runtime_gone_delivered_total Total runtime-gone local delivery attempts.
 # TYPE multica_daemonws_runtime_gone_delivered_total counter
 multica_daemonws_runtime_gone_delivered_total{result="hit"} 5
 multica_daemonws_runtime_gone_delivered_total{result="miss"} 6
+# HELP multica_daemonws_runtime_gone_publish_errors_total Total runtime-gone Redis publish errors.
+# TYPE multica_daemonws_runtime_gone_publish_errors_total counter
+multica_daemonws_runtime_gone_publish_errors_total 8
+# HELP multica_daemonws_runtime_gone_published_total Total runtime-gone notifications published to the Redis relay.
+# TYPE multica_daemonws_runtime_gone_published_total counter
+multica_daemonws_runtime_gone_published_total 7
+# HELP multica_daemonws_runtime_gone_received_total Total runtime-gone notifications received from the Redis relay.
+# TYPE multica_daemonws_runtime_gone_received_total counter
+multica_daemonws_runtime_gone_received_total 9
 # HELP multica_daemonws_wakeup_delivered_total Total daemon wakeup local delivery attempts.
 # TYPE multica_daemonws_wakeup_delivered_total counter
 multica_daemonws_wakeup_delivered_total{result="hit"} 3
 multica_daemonws_wakeup_delivered_total{result="miss"} 4
 `),
 		"multica_daemonws_runtime_gone_delivered_total",
+		"multica_daemonws_runtime_gone_publish_errors_total",
+		"multica_daemonws_runtime_gone_published_total",
+		"multica_daemonws_runtime_gone_received_total",
 		"multica_daemonws_wakeup_delivered_total",
 	)
 	if err != nil {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -561,6 +561,32 @@ func (q *Queries) IsAgentRuntimeEligibleForGC(ctx context.Context, arg IsAgentRu
 	return eligible, err
 }
 
+const listAgentRuntimeIDsByWorkspace = `-- name: ListAgentRuntimeIDsByWorkspace :many
+SELECT id FROM agent_runtime
+WHERE workspace_id = $1
+ORDER BY id ASC
+`
+
+func (q *Queries) ListAgentRuntimeIDsByWorkspace(ctx context.Context, workspaceID pgtype.UUID) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, listAgentRuntimeIDsByWorkspace, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var id pgtype.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAgentRuntimes = `-- name: ListAgentRuntimes :many
 SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name FROM agent_runtime
 WHERE workspace_id = $1

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -3,6 +3,11 @@ SELECT * FROM agent_runtime
 WHERE workspace_id = $1
 ORDER BY created_at ASC;
 
+-- name: ListAgentRuntimeIDsByWorkspace :many
+SELECT id FROM agent_runtime
+WHERE workspace_id = $1
+ORDER BY id ASC;
+
 -- name: ListVisibleAgentRuntimes :many
 -- A private runtime is another member's machine and must not leak into their
 -- runtime list. The owner can always see their own runtime; everyone else


### PR DESCRIPTION
## Summary

- push a `runtime_gone` heartbeat acknowledgement through the existing daemon WebSocket and Redis relay path
- notify only after committed runtime removal from direct delete, confirmed unbind/delete, profile delete, workspace delete, runtime GC, and legacy runtime merge
- retain the current heartbeat database lookup as the correctness fallback; connection-lease/zero-read work remains in PR2

## Safety

- deletion success does not depend on best-effort notification delivery
- rejected and rolled-back deletion paths do not emit invalidation signals
- existing relay event IDs deduplicate local delivery and Redis loopback

## Testing

- `go test ./internal/daemonws -count=1`
- `go test ./internal/daemon -run 'RuntimeGone' -count=1`
- targeted handler and runtime GC integration tests against a freshly migrated PostgreSQL database
- `go vet ./internal/daemonws ./internal/handler ./cmd/server`
- `go build ./...`

MUL-7002
