### PR TITLE
feat(agents): support Pi runtime MCP settings

### DIFF
--- a/packages/core/agents/mcp-support.test.ts
+++ b/packages/core/agents/mcp-support.test.ts
@@ -5,14 +5,11 @@ import { providerSupportsMcpConfig } from "./mcp-support";
 describe("providerSupportsMcpConfig", () => {
   it("accepts a provider whose runtime consumes mcp_config", () => {
     expect(providerSupportsMcpConfig("claude")).toBe(true);
+    expect(providerSupportsMcpConfig("pi")).toBe(true);
   });
   it("rejects providers whose runtime ignores mcp_config", () => {
     expect(providerSupportsMcpConfig("antigravity")).toBe(false);
     expect(providerSupportsMcpConfig("copilot")).toBe(false);
-    // Pi ships without MCP by design: upstream's README states "No MCP." and
-    // directs users to extensions instead, so there is no config file Multica
-    // could write that pi would read. Only its omp fork consumes mcp_config.
-    expect(providerSupportsMcpConfig("pi")).toBe(false);
     // ZeroClaw's ACP server never reads `params.mcpServers` — MCP lives in
     // ZeroClaw's own config-dir, so a value saved here could not be honoured.
     expect(providerSupportsMcpConfig("zeroclaw")).toBe(false);

--- a/packages/core/agents/mcp-support.ts
+++ b/packages/core/agents/mcp-support.ts
@@ -26,6 +26,7 @@ const MCP_SUPPORTED_PROVIDERS = new Set([
   "mcode",
   "traecli",
   "dim",
+  "pi",
   "omp",
 ]);
 

--- a/packages/views/agents/components/agent-overview-pane.test.tsx
+++ b/packages/views/agents/components/agent-overview-pane.test.tsx
@@ -190,6 +190,7 @@ describe("AgentOverviewPane MCP tab visibility", () => {
     ["Kiro", "kiro"],
     ["OpenCode", "opencode"],
     ["OpenClaw", "openclaw"],
+    ["Pi", "pi"],
     ["Oh My Pi", "omp"],
   ])("renders the MCP tab when the agent runs on the %s runtime", (_label, provider) => {
     renderPane([makeRuntime(provider)]);

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -8123,6 +8123,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		OpenclawMode:           openclawMode,
 		ClaudeSettingsPath:     env.ClaudeSettingsPath,
 		QwenpawWorkspace:       env.QwenpawWorkspace,
+		PiExtensionPath:        env.PiExtensionPath,
 	}
 	// Some providers do not reliably load the per-task runtime config files we
 	// write into the task workdir:

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -61,7 +61,7 @@ type PrepareParams struct {
 	OpenclawBin  string // resolved openclaw CLI path (only used when Provider == "openclaw"); empty = look up on PATH
 	// McpConfig is the agent's saved `mcp_config` JSON, forwarded to the
 	// provider-specific config preparer when that provider materialises MCP
-	// via a per-task config file. Cursor, OpenClaw, and OMP consume it here;
+	// via a per-task config file. Cursor, OpenClaw, Pi, and OMP consume it here;
 	// other providers wire MCP via ExecOptions.McpConfig in the agent backend.
 	McpConfig json.RawMessage
 	// CursorMcpAuthSource is an explicit opt-in path to a Cursor mcp-auth.json
@@ -314,6 +314,9 @@ type Environment struct {
 	// exports this as CURSOR_DATA_DIR so project-level MCP approvals are
 	// isolated from the user's persistent ~/.cursor/projects state.
 	CursorDataDir string
+	// PiExtensionPath is the daemon-owned Pi extension that connects the
+	// task's MCP servers and registers their tools with Pi.
+	PiExtensionPath string
 	// HermesHome is the path to the per-task HERMES_HOME overlay (set only for
 	// the hermes provider, and only when the agent has skills bound — empty
 	// otherwise, leaving the user's real home in place). It mirrors ~/.hermes/
@@ -607,6 +610,13 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	}
 	if err := prepareOmpMcpConfig(workDir, params.Provider, params.McpConfig, manifest); err != nil {
 		return nil, fmt.Errorf("execenv: prepare omp mcp config: %w", err)
+	}
+	if params.Provider == "pi" {
+		path, err := preparePiMcpExtension(workDir, params.McpConfig, manifest)
+		if err != nil {
+			return nil, fmt.Errorf("execenv: prepare pi mcp extension: %w", err)
+		}
+		env.PiExtensionPath = path
 	}
 
 	// Persist managed-env provenance for non-local resumable envs at Prepare time
@@ -906,6 +916,14 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	if err := prepareOmpMcpConfig(params.WorkDir, params.Provider, params.McpConfig, manifest); err != nil {
 		logger.Warn("execenv: refresh omp mcp config failed; forcing fresh prepare", "error", err)
 		return nil
+	}
+	if params.Provider == "pi" {
+		path, err := preparePiMcpExtension(params.WorkDir, params.McpConfig, manifest)
+		if err != nil {
+			logger.Warn("execenv: refresh pi mcp extension failed; forcing fresh prepare", "error", err)
+			return nil
+		}
+		env.PiExtensionPath = path
 	}
 
 	// Restore CodexHome for Codex provider — the per-task codex-home directory

--- a/server/internal/daemon/execenv/omp_mcp.go
+++ b/server/internal/daemon/execenv/omp_mcp.go
@@ -2,13 +2,19 @@ package execenv
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 )
 
+//go:embed pi_mcp_extension.js
+var piMcpExtension []byte
+
 func prepareOmpMcpConfig(workDir, provider string, raw json.RawMessage, manifest *sidecarManifest) error {
-	if provider != "omp" {
+	if provider != "omp" && provider != "pi" {
 		return nil
 	}
 	trimmed := bytes.TrimSpace(raw)
@@ -30,4 +36,32 @@ func prepareOmpMcpConfig(workDir, provider string, raw json.RawMessage, manifest
 		return err
 	}
 	return nil
+}
+
+func preparePiMcpExtension(workDir string, raw json.RawMessage, manifest *sidecarManifest) (string, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return "", nil
+	}
+	if workDir == "" {
+		return "", errors.New("managed mcp_config requires a working directory")
+	}
+	if !json.Valid(trimmed) {
+		return "", fmt.Errorf("managed mcp_config is not valid JSON")
+	}
+	extensionDir := filepath.Join(workDir, ".pi", "extensions")
+	if err := recordMkdirAll(extensionDir, 0o700, manifest); err != nil {
+		return "", err
+	}
+	path := filepath.Join(extensionDir, "multica-mcp.js")
+	if err := recordWriteFile(path, piMcpExtension, 0o700, manifest); err != nil {
+		if errors.Is(err, errPathPreExists) {
+			return "", errors.New("managed Pi MCP extension would overwrite existing " + path)
+		}
+		return "", err
+	}
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+	return path, nil
 }

--- a/server/internal/daemon/execenv/omp_mcp_test.go
+++ b/server/internal/daemon/execenv/omp_mcp_test.go
@@ -80,3 +80,27 @@ func containsPath(paths []string, want string) bool {
 	}
 	return false
 }
+
+func TestPrepareOmpMcpConfigPiWritesExtension(t *testing.T) {
+	workDir := t.TempDir()
+	manifest := &sidecarManifest{}
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx"}}}`)
+
+	if err := prepareOmpMcpConfig(workDir, "pi", raw, manifest); err != nil {
+		t.Fatalf("prepareOmpMcpConfig: %v", err)
+	}
+	extensionPath, err := preparePiMcpExtension(workDir, raw, manifest)
+	if err != nil {
+		t.Fatalf("preparePiMcpExtension: %v", err)
+	}
+	content, err := os.ReadFile(extensionPath)
+	if err != nil {
+		t.Fatalf("read extension: %v", err)
+	}
+	if !strings.Contains(string(content), "registerTool") || !strings.Contains(string(content), "tools/call") {
+		t.Fatalf("extension does not implement MCP tools: %s", content)
+	}
+	if !containsPath(manifest.Files, extensionPath) {
+		t.Fatalf("manifest = %#v, want extension file", manifest)
+	}
+}

--- a/server/internal/daemon/execenv/pi_mcp_extension.js
+++ b/server/internal/daemon/execenv/pi_mcp_extension.js
@@ -1,0 +1,151 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { spawn } from "node:child_process";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const configPath = join(root, "..", "mcp.json");
+const toolSchema = { type: "object", additionalProperties: true };
+
+function serverEntries(config) {
+  const servers = config?.mcpServers ?? config?.mcp ?? {};
+  return Object.entries(servers).filter(([, server]) => server && typeof server === "object");
+}
+
+function toolName(server, tool) {
+  return `mcp__${server}__${tool}`.replace(/[^a-zA-Z0-9_]/g, "_").slice(0, 128);
+}
+
+function resultText(result) {
+  const content = result?.content ?? [];
+  return content.map((item) => item.type === "text" ? item.text : JSON.stringify(item)).join("\n") || JSON.stringify(result ?? {});
+}
+
+class StdioClient {
+  constructor(server) {
+    this.server = server;
+    this.id = 0;
+    this.pending = new Map();
+    this.buffer = Buffer.alloc(0);
+    const env = { ...process.env, ...(server.env ?? {}) };
+    this.child = spawn(server.command, server.args ?? [], { cwd: server.cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    this.child.stdout.on("data", (chunk) => this.onData(chunk));
+    this.child.on("close", () => this.fail(new Error("MCP server exited")));
+    this.child.on("error", (error) => this.fail(error));
+  }
+
+  fail(error) {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+
+  onData(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    while (true) {
+      const headerEnd = this.buffer.indexOf("\r\n\r\n");
+      const lineEnd = this.buffer.indexOf("\n");
+      if (headerEnd >= 0) {
+        const headers = this.buffer.subarray(0, headerEnd).toString();
+        const match = headers.match(/Content-Length:\s*(\d+)/i);
+        if (!match) break;
+        const length = Number(match[1]);
+        const start = headerEnd + 4;
+        if (this.buffer.length < start + length) break;
+        this.resolve(JSON.parse(this.buffer.subarray(start, start + length).toString()));
+        this.buffer = this.buffer.subarray(start + length);
+      } else if (lineEnd >= 0) {
+        const line = this.buffer.subarray(0, lineEnd).toString().trim();
+        this.buffer = this.buffer.subarray(lineEnd + 1);
+        if (line) this.resolve(JSON.parse(line));
+      } else break;
+    }
+  }
+
+  resolve(message) {
+    if (message.id == null) return;
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    if (message.error) pending.reject(new Error(message.error.message ?? "MCP request failed"));
+    else pending.resolve(message.result);
+  }
+
+  notify(method, params = {}) {
+    const body = JSON.stringify({ jsonrpc: "2.0", method, params });
+    this.child.stdin.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+  }
+
+  request(method, params = {}) {
+    const id = ++this.id;
+    const body = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    this.child.stdin.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+    return new Promise((resolve, reject) => this.pending.set(id, { resolve, reject }));
+  }
+
+  close() { this.child.kill(); }
+}
+
+class HttpClient {
+  constructor(server) { this.server = server; this.sessionId = undefined; }
+  async request(method, params = {}) {
+    const headers = { Accept: "application/json, text/event-stream", "Content-Type": "application/json", ...(this.server.headers ?? {}) };
+    if (this.sessionId) headers["Mcp-Session-Id"] = this.sessionId;
+    const response = await fetch(this.server.url, { method: "POST", headers, body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }) });
+    if (!response.ok) throw new Error(`MCP HTTP ${response.status}`);
+    const sessionId = response.headers.get("mcp-session-id");
+    if (sessionId) this.sessionId = sessionId;
+    const text = await response.text();
+    const data = text.split("\n").filter((line) => line.startsWith("data:")).map((line) => line.slice(5).trim()).pop() ?? text;
+    const result = JSON.parse(data);
+    if (result.error) throw new Error(result.error.message ?? "MCP request failed");
+    return result.result;
+  }
+  close() {}
+}
+
+async function connect(server) {
+  const client = server.command ? new StdioClient(server) : new HttpClient(server);
+  await client.request("initialize", { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "multica-pi", version: "1.0.0" } });
+  if (client.notify) client.notify("notifications/initialized", {});
+  const listed = await client.request("tools/list", {});
+  return { client, tools: listed?.tools ?? [] };
+}
+
+export default function multicaMcpExtension(pi) {
+  const clients = new Map();
+  const registered = new Set();
+
+  const load = async () => {
+    const config = JSON.parse(await readFile(configPath, "utf8"));
+    for (const [serverName, server] of serverEntries(config)) {
+      try {
+        const connection = await connect(server);
+        clients.set(serverName, connection);
+        for (const tool of connection.tools) {
+          const name = toolName(serverName, tool.name);
+          if (registered.has(name)) continue;
+          registered.add(name);
+          pi.registerTool({
+            name,
+            label: `${serverName}: ${tool.name}`,
+            description: tool.description ?? `MCP tool ${tool.name} from ${serverName}`,
+            parameters: tool.inputSchema ?? toolSchema,
+            async execute(_id, params) {
+              const current = clients.get(serverName);
+              if (!current) throw new Error(`MCP server ${serverName} is unavailable`);
+              const result = await current.client.request("tools/call", { name: tool.name, arguments: params });
+              return { content: [{ type: "text", text: resultText(result) }], details: result };
+            },
+          });
+        }
+      } catch (error) {
+        console.error(`[multica-mcp] failed to connect ${serverName}: ${error.message}`);
+      }
+    }
+  };
+
+  pi.on("session_start", load);
+  pi.on("session_shutdown", async () => {
+    for (const connection of clients.values()) connection.client.close();
+  });
+}

--- a/server/internal/daemon/execenv/pi_mcp_test.go
+++ b/server/internal/daemon/execenv/pi_mcp_test.go
@@ -1,0 +1,77 @@
+package execenv
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPreparePiMcpConfigUsesProviderNamespace(t *testing.T) {
+	for _, provider := range []string{"pi", "omp"} {
+		t.Run(provider, func(t *testing.T) {
+			workDir := t.TempDir()
+			manifest := &sidecarManifest{}
+			raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx"}}}`)
+
+			if err := prepareOmpMcpConfig(workDir, provider, raw, manifest); err != nil {
+				t.Fatalf("preparePiMcpConfig: %v", err)
+			}
+			path := filepath.Join(workDir, "."+provider, "mcp.json")
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			if string(data) != string(raw) {
+				t.Fatalf("config = %s, want %s", data, raw)
+			}
+			if !containsPath(manifest.Files, path) || !containsPath(manifest.Dirs, filepath.Dir(path)) {
+				t.Fatalf("manifest = %#v, want config file and directory", manifest)
+			}
+		})
+	}
+}
+
+func TestPreparePiMcpConfigRefusesExistingManagedPath(t *testing.T) {
+	workDir := t.TempDir()
+	path := filepath.Join(workDir, ".pi", "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := []byte(`{"mcpServers":{"user":{"command":"echo"}}}`)
+	if err := os.WriteFile(path, existing, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := prepareOmpMcpConfig(workDir, "pi", json.RawMessage(`{"mcpServers":{"managed":{}}}`), &sidecarManifest{})
+	if err == nil || !strings.Contains(err.Error(), "would overwrite") {
+		t.Fatalf("error = %v, want overwrite error", err)
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(data) != string(existing) {
+		t.Fatalf("existing config changed to %s", data)
+	}
+}
+
+func TestPreparePiMcpConfigCleanupRemovesManagedFiles(t *testing.T) {
+	workDir := t.TempDir()
+	envRoot := t.TempDir()
+	manifest := &sidecarManifest{}
+	if err := prepareOmpMcpConfig(workDir, "omp", json.RawMessage(`{"mcpServers":{"fetch":{}}}`), manifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSidecarManifest(envRoot, manifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := CleanupSidecars(envRoot); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".omp", "mcp.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("managed config still exists, stat error = %v", err)
+	}
+}

--- a/server/internal/daemon/runtime_mcp.go
+++ b/server/internal/daemon/runtime_mcp.go
@@ -301,6 +301,8 @@ func loadRuntimeMcpServerConfigs(provider string) (map[string]any, bool, error) 
 			path = filepath.Join(stateDir, "openclaw.json")
 		}
 		key, format = "mcp.servers", "json"
+	case "pi", "omp":
+		return map[string]any{}, true, nil
 	default:
 		return map[string]any{}, false, nil
 	}
@@ -446,6 +448,8 @@ func listRuntimeLocalMcpServers(provider string) ([]runtimeLocalMcpServerSummary
 		// providers already make and avoids sending full tool-chain state over
 		// the wire.
 		path, key, source, format = filepath.Join(home, ".omp", "agent", "mcp.json"), "mcpServers", "User config", "json"
+	case "pi":
+		path, key, source, format = filepath.Join(home, ".pi", "agent", "mcp.json"), "mcpServers", "User config", "json"
 	default:
 		return []runtimeLocalMcpServerSummary{}, false, nil
 	}

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -93,6 +93,7 @@ type ExecOptions struct {
 	CustomArgs       []string        // per-agent CLI arguments appended after ExtraArgs
 	QwenpawWorkspace string          // per-task QwenPaw workspace directory (passed as --workspace to qwenpaw acp); empty when not applicable
 	McpConfig        json.RawMessage // if non-nil, MCP server config to pass via --mcp-config
+	PiExtensionPath  string          // daemon-owned Pi extension that exposes task MCP servers
 	// ThinkingLevel is the runtime-native reasoning/effort value (e.g.
 	// Claude's "low|medium|high|xhigh|max", Codex's "none|minimal|low|
 	// medium|high|xhigh", OpenCode's model variant names). Empty means

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -594,11 +594,12 @@ func decodePiResult(raw json.RawMessage) string {
 // overridden by user-configured custom_args. Overriding these would
 // break the daemon↔Pi communication protocol.
 var piBlockedArgs = map[string]blockedArgMode{
-	"-p":         blockedStandalone, // non-interactive mode
-	"--print":    blockedStandalone, // alias for -p
-	"--mode":     blockedWithValue,  // "json" event stream protocol
-	"--session":  blockedWithValue,  // daemon manages the session path
-	"--thinking": blockedWithValue,  // owned by agent.thinking_level
+	"-p":          blockedStandalone, // non-interactive mode
+	"--print":     blockedStandalone, // alias for -p
+	"--mode":      blockedWithValue,  // "json" event stream protocol
+	"--session":   blockedWithValue,  // daemon manages the session path
+	"--extension": blockedWithValue,  // daemon manages the task MCP extension
+	"--thinking":  blockedWithValue,  // owned by agent.thinking_level
 }
 
 // piCustomArgModes mirrors Pi 0.83's built-in parser closely enough to
@@ -695,6 +696,9 @@ func buildPiArgs(sessionPath string, opts ExecOptions, logger *slog.Logger) []st
 	}
 	if opts.ThinkingLevel != "" {
 		args = append(args, "--thinking", opts.ThinkingLevel)
+	}
+	if opts.PiExtensionPath != "" {
+		args = append(args, "--extension", opts.PiExtensionPath)
 	}
 	// Note: we intentionally do NOT pass --tools here. Omitting it lets
 	// Pi use its full tool registry, including user-installed extension

--- a/server/pkg/agent/pi_invocation_test.go
+++ b/server/pkg/agent/pi_invocation_test.go
@@ -78,3 +78,32 @@ func TestPiPowerShellCommandArgs_ForwardsMultiLineArgVerbatim(t *testing.T) {
 		t.Errorf("multi-line arg was not forwarded verbatim:\n got  %q\n want %q", got[len(got)-1], multiLine)
 	}
 }
+
+func TestBuildPiArgsIncludesTaskMcpExtension(t *testing.T) {
+	got := buildPiArgs("/tmp/pi-session.jsonl", ExecOptions{
+		PiExtensionPath: "/tmp/task/.pi/extensions/multica-mcp.js",
+	}, slog.Default())
+	want := []string{
+		"-p", "--mode", "json", "--session", "/tmp/pi-session.jsonl",
+		"--extension", "/tmp/task/.pi/extensions/multica-mcp.js",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildPiArgsOwnsTaskMcpExtensionFlag(t *testing.T) {
+	got := buildPiArgs("/tmp/pi-session.jsonl", ExecOptions{
+		PiExtensionPath: "/tmp/task/.pi/extensions/multica-mcp.js",
+		CustomArgs:      []string{"--extension", "/tmp/user-extension.js"},
+	}, slog.Default())
+	for i, arg := range got {
+		if arg == "--extension" {
+			if i+1 >= len(got) || got[i+1] != "/tmp/task/.pi/extensions/multica-mcp.js" {
+				t.Fatalf("task extension was overridden: %#v", got)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing task extension in %#v", got)
+}


### PR DESCRIPTION
## What does this PR do?

Adds real task-scoped MCP support to the Pi runtime through a daemon-generated Pi extension. Pi does not natively read `.pi/mcp.json`, so the extension is loaded explicitly with `--extension`, performs MCP initialization and tool discovery, registers the discovered tools with Pi, and forwards tool calls to the configured stdio or HTTP MCP server.

## Related Issue

Closes #7957

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Add `pi` to the shared MCP-supported provider list and MCP tab visibility coverage.
- Generate task-local `.pi/mcp.json` and `.pi/extensions/multica-mcp.js` sidecars with restrictive permissions and manifest cleanup.
- Pass the task extension to Pi as a daemon-owned `--extension` argument; block custom args from replacing it.
- Implement MCP `initialize`, `tools/list`, and `tools/call` in the extension for stdio and HTTP-style servers, including configured env and headers.
- Refresh the extension on task reuse without changing the existing OMP MCP path.

## How to Test

1. Configure a Pi agent with an MCP server in the agent MCP tab.
2. Run an issue with that agent and verify the task starts Pi with `--extension .pi/extensions/multica-mcp.js`.
3. Verify the extension performs MCP initialization and tool discovery, and that a discovered tool call reaches the configured MCP server.
4. Run `go test ./pkg/agent -run 'TestBuildPiArgsIncludesTaskMcpExtension|TestBuildPiArgsOwnsTaskMcpExtensionFlag' -count=1`.
5. Run `go test ./internal/daemon/execenv -run 'TestPrepareOmpMcpConfig|TestPreparePiMcpExtension' -count=1`, `pnpm exec vitest run packages/core/agents/mcp-support.test.ts`, and `pnpm typecheck`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex CLI

**Prompt / approach:**
Reviewed the upstream Pi behavior and existing OMP MCP path, reproduced the missing runtime-consumption gap, added regression coverage first, then implemented a task-isolated Pi extension that performs the MCP protocol handshake, discovers tools, and routes calls to configured servers.

## Risks

- Pi has intentionally left MCP outside its core, so this extension is maintained against Pi's public `ExtensionAPI` and MCP JSON-RPC interfaces.
- Managed MCP configuration remains task-local and is never placed on the command line; only the extension path is passed to Pi.

## Screenshots (optional)

Not included; the existing MCP tab layout is unchanged.

