### PR TITLE
MUL-6984 refactor(prompt): give each duplicated instruction one owner

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1251,55 +1251,6 @@ func TestBuildPromptCommentTriggeredNoContent(t *testing.T) {
 	}
 }
 
-// TestBuildPromptSquadLeaderNoActionProhibition verifies that when a squad
-// leader is triggered by another agent's comment, the per-turn prompt
-// explicitly forbids posting a comment whose only purpose is to announce
-// no_action or "exiting silently". This is the fix for MUL-2168.
-func TestBuildPromptSquadLeaderNoActionProhibition(t *testing.T) {
-	t.Parallel()
-
-	prompt := BuildPrompt(Task{
-		IssueID:               "issue-1",
-		TriggerCommentID:      "comment-1",
-		TriggerCommentContent: "Progress update: tests passing.",
-		TriggerAuthorType:     "agent",
-		TriggerAuthorName:     "Worker",
-		IsLeaderTask:          true,
-		LeaderRoleResolved:    true,
-		Agent: &AgentData{
-			Name:         "Leader",
-			Instructions: "You lead the team.\n\n## Squad Operating Protocol\n\nYou are the LEADER.",
-		},
-	}, "claude")
-
-	for _, want := range []string{
-		"Squad leader no_action rule",
-		"DO NOT post any comment",
-		"multica squad activity",
-	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("squad leader prompt missing %q\n---\n%s", want, prompt)
-		}
-	}
-
-	// Non-squad-leader agent should NOT get the squad leader rule.
-	nonLeaderPrompt := BuildPrompt(Task{
-		IssueID:               "issue-1",
-		TriggerCommentID:      "comment-1",
-		TriggerCommentContent: "Progress update: tests passing.",
-		TriggerAuthorType:     "agent",
-		TriggerAuthorName:     "Worker",
-		Agent: &AgentData{
-			Name:         "Regular",
-			Instructions: "You are a regular agent.",
-		},
-	}, "claude")
-
-	if strings.Contains(nonLeaderPrompt, "Squad leader no_action rule") {
-		t.Fatalf("non-squad-leader prompt should NOT contain squad leader rule\n---\n%s", nonLeaderPrompt)
-	}
-}
-
 func TestIsWorkspaceNotFoundError(t *testing.T) {
 	t.Parallel()
 
@@ -5638,9 +5589,6 @@ func TestBuildPromptSquadLeaderReplyCommandCarvesOutNoAction(t *testing.T) {
 		},
 	}, "claude")
 
-	if !strings.Contains(prompt, "Squad leader no_action rule") {
-		t.Fatalf("leader prompt missing the no_action rule\n---\n%s", prompt)
-	}
 	if !strings.Contains(prompt, "Unless your outcome is `no_action`, post your reply as a comment") {
 		t.Fatalf("leader prompt missing the carve-out reply imperative\n---\n%s", prompt)
 	}
@@ -5676,9 +5624,6 @@ func TestBuildPromptSquadLeaderMultiThreadCarvesOutNoAction(t *testing.T) {
 		},
 	}
 	prompt := BuildPrompt(leaderTask, "claude")
-	if !strings.Contains(prompt, "Squad leader no_action rule") {
-		t.Fatalf("leader multi-thread prompt missing the no_action rule\n---\n%s", prompt)
-	}
 	scope := strings.Index(prompt, "skip this ENTIRE fan-out block")
 	if scope < 0 {
 		t.Fatalf("leader multi-thread prompt missing the whole-block scope sentence\n---\n%s", prompt)

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1088,17 +1088,27 @@ func TestBuildPromptAutopilotRunOnly(t *testing.T) {
 	t.Parallel()
 
 	prompt := BuildPrompt(Task{
-		AutopilotRunID:       "run-1",
-		AutopilotID:          "autopilot-1",
-		AutopilotTitle:       "Daily dependency check",
-		AutopilotDescription: "Check dependencies and report outdated packages.",
-		AutopilotSource:      "manual",
+		AutopilotRunID:          "run-1",
+		AutopilotID:             "autopilot-1",
+		AutopilotTitle:          "Daily dependency check",
+		AutopilotDescription:    "Check dependencies and report outdated packages.",
+		AutopilotSource:         "manual",
+		AutopilotTriggerPayload: []byte(`{"action":"opened","number":7}`),
 	}, "claude")
 
+	// Every run-scoped autopilot value must appear HERE, and only here. The
+	// runtime brief used to render the same set, which both broke its own
+	// no-per-run-values contract and left two hand-maintained copies to drift
+	// (MUL-6984); execenv.TestAutopilotBriefByteIdenticalAcrossRunScopedFields
+	// pins the brief's side of that split. The payload is rendered whole:
+	// ingress already caps a webhook body at 256 KiB, and truncating at the
+	// only rendering would drop input no CLI can fetch back.
 	for _, want := range []string{
 		"run-only mode",
 		"Autopilot run ID: run-1",
 		"Daily dependency check",
+		"Trigger source: manual",
+		`{"action":"opened","number":7}`,
 		"Check dependencies and report outdated packages.",
 		"multica autopilot get autopilot-1 --output json",
 	} {

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -118,8 +118,17 @@ func writeWorkspacesRootMarkerAtomic(path string, data []byte) error {
 	return nil
 }
 
-// writeContextFiles renders and writes .agent_context/issue_context.md and
-// skills into the appropriate provider-native location.
+// writeContextFiles writes the task's sidecar files: the task-context marker,
+// agent skills in the appropriate provider-native location, and project
+// resources.
+//
+// It deliberately writes no per-task Markdown brief. There used to be an
+// .agent_context/issue_context.md carrying the issue id, trigger comment id,
+// handoff note, quick-create input, and autopilot run data — every one of
+// which the runtime brief and the per-turn user message already carry. No
+// provider read the file (nothing in either surface pointed at it), so it was
+// a third copy that had to be kept in sync with the two that agents actually
+// see, for no reader at all (MUL-6984).
 //
 // Claude:      skills → {workDir}/.claude/skills/{name}/SKILL.md  (native discovery)
 // CodeBuddy:   skills → {workDir}/.codebuddy/skills/{name}/SKILL.md  (native discovery — CodeBuddy is a Claude Code fork but uses its own config directory, not .claude/; see https://www.codebuddy.ai/docs/cli/skills)
@@ -150,27 +159,6 @@ func writeWorkspacesRootMarkerAtomic(path string, data []byte) error {
 func writeContextFiles(workDir, provider string, ctx TaskContextForEnv, manifest *sidecarManifest) error {
 	if err := writeTaskContextMarker(workDir, ctx, manifest); err != nil {
 		return err
-	}
-
-	contextDir := filepath.Join(workDir, ".agent_context")
-	if err := recordMkdirAll(contextDir, 0o755, manifest); err != nil {
-		return fmt.Errorf("create .agent_context dir: %w", err)
-	}
-
-	content := renderIssueContext(provider, ctx)
-	path := filepath.Join(contextDir, "issue_context.md")
-	if err := recordWriteFile(path, []byte(content), 0o644, manifest); err != nil {
-		// A pre-existing path means the user already owns
-		// .agent_context/issue_context.md — either they created it
-		// themselves or it survived from a crashed prior run we can't
-		// safely distinguish from intentional content. Refusing the
-		// write is the correct call: the runtime brief (CLAUDE.md /
-		// AGENTS.md) already carries every fact this file
-		// would, so the agent runs fine without the sidecar copy.
-		// Anything else is a real failure.
-		if !errors.Is(err, errPathPreExists) {
-			return fmt.Errorf("write issue_context.md: %w", err)
-		}
 	}
 
 	if len(ctx.AgentSkills) > 0 {
@@ -1005,79 +993,4 @@ func writeSkillFiles(skillsDir string, skills []SkillContextForEnv, manifest *si
 	}
 
 	return nil
-}
-
-// renderIssueContext builds the markdown content for issue_context.md.
-func renderIssueContext(provider string, ctx TaskContextForEnv) string {
-	if ctx.AutopilotRunID != "" {
-		return renderAutopilotContext(ctx)
-	}
-	if ctx.QuickCreatePrompt != "" {
-		return renderQuickCreateContext(ctx)
-	}
-
-	var b strings.Builder
-
-	b.WriteString("# Task Assignment\n\n")
-	fmt.Fprintf(&b, "**Issue ID:** %s\n\n", ctx.IssueID)
-
-	if ctx.TriggerCommentID != "" {
-		b.WriteString("**Trigger:** Comment Reply\n")
-		b.WriteString("**Triggering comment ID:** `" + ctx.TriggerCommentID + "`\n\n")
-	} else {
-		b.WriteString("**Trigger:** New Assignment\n\n")
-	}
-
-	b.WriteString("## Quick Start\n\n")
-	fmt.Fprintf(&b, "Run `multica issue get %s --output json` to fetch the full issue details.\n\n", ctx.IssueID)
-
-	return b.String()
-}
-
-// renderQuickCreateContext renders issue_context.md for quick-create tasks.
-// This file carries only task data (the user input). Behavioral rules and
-// guardrails live in AGENTS.md (runtime config) and the per-turn prompt to
-// avoid redundancy and conflicting instructions; the skill index lives in the
-// runtime brief like every other kind (MUL-5529).
-func renderQuickCreateContext(ctx TaskContextForEnv) string {
-	var b strings.Builder
-	b.WriteString("# Quick Create\n\n")
-	b.WriteString("**Trigger:** Quick-create modal\n\n")
-	b.WriteString("## User input\n\n")
-	b.WriteString("> ")
-	b.WriteString(ctx.QuickCreatePrompt)
-	b.WriteString("\n\n")
-	return b.String()
-}
-
-func renderAutopilotContext(ctx TaskContextForEnv) string {
-	var b strings.Builder
-
-	b.WriteString("# Autopilot Run\n\n")
-	fmt.Fprintf(&b, "**Autopilot run ID:** %s\n\n", ctx.AutopilotRunID)
-	if ctx.AutopilotID != "" {
-		fmt.Fprintf(&b, "**Autopilot ID:** %s\n\n", ctx.AutopilotID)
-	}
-	if ctx.AutopilotTitle != "" {
-		fmt.Fprintf(&b, "**Title:** %s\n\n", ctx.AutopilotTitle)
-	}
-	if ctx.AutopilotSource != "" {
-		fmt.Fprintf(&b, "**Trigger source:** %s\n\n", ctx.AutopilotSource)
-	}
-	if ctx.AutopilotTriggerPayload != "" {
-		fmt.Fprintf(&b, "## Trigger Payload\n\n```json\n%s\n```\n\n", ctx.AutopilotTriggerPayload)
-	}
-
-	b.WriteString("## Quick Start\n\n")
-	b.WriteString("This is a run-only autopilot task with no assigned issue. Do not run `multica issue get` unless the autopilot instructions explicitly ask you to create or update an issue.\n\n")
-	if ctx.AutopilotID != "" {
-		fmt.Fprintf(&b, "Run `multica autopilot get %s --output json` if you need the full autopilot configuration.\n\n", ctx.AutopilotID)
-	}
-	if strings.TrimSpace(ctx.AutopilotDescription) != "" {
-		b.WriteString("## Autopilot Instructions\n\n")
-		b.WriteString(ctx.AutopilotDescription)
-		b.WriteString("\n\n")
-	}
-
-	return b.String()
 }

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -853,8 +853,9 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	}
 
 	// Roll back the previous dispatch's sidecar writes before refreshing.
-	// On reuse the workdir still holds the prior run's issue_context.md and
-	// skill directories; without clearing them first, writeSkillFiles sees
+	// On reuse the workdir still holds the prior run's skill directories (and,
+	// for a workdir prepared before MUL-6984, its issue_context.md); without
+	// clearing them first, writeSkillFiles sees
 	// its own earlier output occupying the canonical slug and falls back to
 	// a collision-free sibling (issue-review, issue-review-multica,
 	// issue-review-multica-2, …), accumulating a fresh duplicate on every
@@ -872,8 +873,10 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	//      the agent populated (correct on the local_directory teardown path),
 	//      which would otherwise keep the canonical slug occupied and push the
 	//      refresh back to issue-review-multica.
-	//   2. CleanupSidecars rolls back the remaining sidecar files
-	//      (issue_context.md, project resources) and the manifest itself.
+	//   2. CleanupSidecars rolls back the remaining sidecar files (project
+	//      resources today, plus any issue_context.md recorded by a manifest
+	//      an older build wrote — legacy upgrade cleanup, not a live writer)
+	//      and the manifest itself.
 	//
 	// No-op when RootDir is empty (legacy local_directory reuse, which the
 	// daemon skips anyway) or when no prior manifest exists (older build).
@@ -886,7 +889,7 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 		}
 	}
 
-	// Refresh context files (issue_context.md, skills). Reuse tracks a
+	// Refresh context files (skills, project resources). Reuse tracks a
 	// fresh manifest under env.RootDir so a later CleanupSidecars sees
 	// the up-to-date list of writes (an old manifest from a prior run
 	// would otherwise reference files this Reuse no longer creates). For

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -510,17 +510,13 @@ func TestPrepareDirectoryMode(t *testing.T) {
 		t.Fatalf("MulticaConfigRoot mode = %o, want 700", got)
 	}
 
-	// Verify context file contains issue ID and CLI hints.
-	content, err := os.ReadFile(filepath.Join(env.WorkDir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("failed to read issue_context.md: %v", err)
-	}
-	if !strings.Contains(string(content), "a1b2c3d4-e5f6-7890-abcd-ef1234567890") {
-		t.Fatalf("issue_context.md missing the issue id")
-	}
-	// The skill list lives in the runtime brief only (MUL-5529).
-	if strings.Contains(string(content), "code-review") {
-		t.Fatalf("issue_context.md should no longer carry a skill list:\n%s", content)
+	// No Markdown sidecar: the issue id, trigger and handoff facts reach the
+	// agent through the runtime brief and the per-turn message, and the file
+	// that used to repeat them had no reader (MUL-6984). The marker below is
+	// the one sidecar with a consumer — the CLI reads it to recognise a
+	// daemon task when a sandbox strips MULTICA_* from the environment.
+	if _, err := os.Stat(filepath.Join(env.WorkDir, ".agent_context", "issue_context.md")); !os.IsNotExist(err) {
+		t.Fatalf("Prepare wrote a sidecar brief; stat err = %v, want not-exist", err)
 	}
 
 	markerContent, err := os.ReadFile(filepath.Join(env.WorkDir, TaskContextMarkerRelPath))
@@ -830,24 +826,13 @@ func TestWriteContextFiles(t *testing.T) {
 		t.Fatalf("writeContextFiles failed: %v", err)
 	}
 
-	content, err := os.ReadFile(filepath.Join(dir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("failed to read: %v", err)
-	}
-
-	s := string(content)
-	if !strings.Contains(s, "test-issue-id-1234") {
-		t.Errorf("content missing %q", "test-issue-id-1234")
-	}
-
-	// Issue details should NOT be in the context file (agent fetches via CLI).
-	//
-	// Nor the skill list: nothing ever read this copy, and the runtime brief
-	// carries the same names-only index (MUL-5529).
-	for _, absent := range []string{"## Description", "## Workspace Context", "## Agent Skills", "go-conventions"} {
-		if strings.Contains(s, absent) {
-			t.Errorf("content should NOT contain %q", absent)
-		}
+	// writeContextFiles hydrates skills; it writes no Markdown brief of its
+	// own. The sidecar it used to write, .agent_context/issue_context.md, was
+	// a third copy of the issue id / trigger / handoff facts that the runtime
+	// brief and the per-turn message already carry, and no provider ever read
+	// it (MUL-6984).
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "issue_context.md")); !os.IsNotExist(err) {
+		t.Fatalf("writeContextFiles wrote a sidecar brief; stat err = %v, want not-exist", err)
 	}
 
 	// Verify skill directory and files.
@@ -868,68 +853,27 @@ func TestWriteContextFiles(t *testing.T) {
 	}
 }
 
-func TestWriteContextFilesOmitsSkillsWhenEmpty(t *testing.T) {
+// TestWriteContextFilesLeavesNoAgentContextWhenNothingToWrite covers the task
+// with no skills and no project resources. Since the sidecar brief was removed
+// (MUL-6984) that task needs nothing under .agent_context at all, and the
+// directory must not be created speculatively: on a local_directory task this
+// is the USER's own checkout, where an empty managed directory is both noise
+// and something CleanupSidecars then has to reason about removing.
+func TestWriteContextFilesLeavesNoAgentContextWhenNothingToWrite(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	ctx := TaskContextForEnv{
-		IssueID: "minimal-issue-id",
-	}
-
-	if err := writeContextFiles(dir, "", ctx, nil); err != nil {
+	if err := writeContextFiles(dir, "", TaskContextForEnv{IssueID: "minimal-issue-id"}, nil); err != nil {
 		t.Fatalf("writeContextFiles failed: %v", err)
 	}
 
-	content, err := os.ReadFile(filepath.Join(dir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("failed to read: %v", err)
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context")); !os.IsNotExist(err) {
+		t.Fatalf(".agent_context created with nothing to put in it; stat err = %v, want not-exist", err)
 	}
-
-	s := string(content)
-	if !strings.Contains(s, "minimal-issue-id") {
-		t.Error("expected issue ID to be present")
-	}
-	if strings.Contains(s, "## Agent Skills") {
-		t.Error("expected skills section to be omitted when no skills")
-	}
-}
-
-func TestWriteContextFilesAutopilotRunOnly(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-
-	ctx := TaskContextForEnv{
-		AutopilotRunID:       "run-1",
-		AutopilotID:          "autopilot-1",
-		AutopilotTitle:       "Daily dependency check",
-		AutopilotDescription: "Check dependencies and report outdated packages.",
-		AutopilotSource:      "manual",
-	}
-
-	if err := writeContextFiles(dir, "", ctx, nil); err != nil {
-		t.Fatalf("writeContextFiles failed: %v", err)
-	}
-
-	content, err := os.ReadFile(filepath.Join(dir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("failed to read: %v", err)
-	}
-
-	s := string(content)
-	for _, want := range []string{
-		"# Autopilot Run",
-		"run-1",
-		"autopilot-1",
-		"Check dependencies and report outdated packages.",
-		"multica autopilot get autopilot-1 --output json",
-		"no assigned issue",
-	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("autopilot context missing %q\n---\n%s", want, s)
-		}
-	}
-	if strings.Contains(s, "Run `multica issue get") {
-		t.Errorf("autopilot context should not contain issue get workflow\n---\n%s", s)
+	// The marker is a separate contract (the CLI's daemon-task fallback) and
+	// must still be there.
+	if _, err := os.Stat(filepath.Join(dir, TaskContextMarkerRelPath)); err != nil {
+		t.Fatalf("task context marker missing: %v", err)
 	}
 }
 
@@ -977,9 +921,12 @@ func TestWriteContextFilesClaudeNativeSkills(t *testing.T) {
 		t.Error("expected .agent_context/skills/ to NOT exist for Claude provider")
 	}
 
-	// issue_context.md should still be in .agent_context/.
-	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "issue_context.md")); os.IsNotExist(err) {
-		t.Error("expected .agent_context/issue_context.md to exist")
+	// Nothing at all belongs under .agent_context for a native-skills
+	// provider now that the sidecar brief is gone (MUL-6984) — not even the
+	// directory. This runs in the user's own checkout on local_directory
+	// tasks, where an empty managed directory is noise.
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context")); !os.IsNotExist(err) {
+		t.Errorf(".agent_context created for a native-skills provider; stat err = %v, want not-exist", err)
 	}
 }
 
@@ -1041,9 +988,12 @@ func TestWriteContextFilesCodebuddyNativeSkills(t *testing.T) {
 		t.Error("expected .agent_context/skills/ to NOT exist for codebuddy provider")
 	}
 
-	// issue_context.md should still be in .agent_context/.
-	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "issue_context.md")); os.IsNotExist(err) {
-		t.Error("expected .agent_context/issue_context.md to exist")
+	// Nothing at all belongs under .agent_context for a native-skills
+	// provider now that the sidecar brief is gone (MUL-6984) — not even the
+	// directory. This runs in the user's own checkout on local_directory
+	// tasks, where an empty managed directory is noise.
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context")); !os.IsNotExist(err) {
+		t.Errorf(".agent_context created for a native-skills provider; stat err = %v, want not-exist", err)
 	}
 }
 
@@ -1632,9 +1582,12 @@ func TestWriteContextFilesCopilotNativeSkills(t *testing.T) {
 		t.Error("expected .agent_context/skills/ to NOT exist for Copilot provider")
 	}
 
-	// issue_context.md should still be in .agent_context/.
-	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "issue_context.md")); os.IsNotExist(err) {
-		t.Error("expected .agent_context/issue_context.md to exist")
+	// Nothing at all belongs under .agent_context for a native-skills
+	// provider now that the sidecar brief is gone (MUL-6984) — not even the
+	// directory. This runs in the user's own checkout on local_directory
+	// tasks, where an empty managed directory is noise.
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context")); !os.IsNotExist(err) {
+		t.Errorf(".agent_context created for a native-skills provider; stat err = %v, want not-exist", err)
 	}
 }
 
@@ -1701,9 +1654,12 @@ func TestWriteContextFilesOpencodeNativeSkills(t *testing.T) {
 		t.Error("expected .agent_context/skills/ to NOT exist for OpenCode provider")
 	}
 
-	// issue_context.md should still be in .agent_context/.
-	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "issue_context.md")); os.IsNotExist(err) {
-		t.Error("expected .agent_context/issue_context.md to exist")
+	// Nothing at all belongs under .agent_context for a native-skills
+	// provider now that the sidecar brief is gone (MUL-6984) — not even the
+	// directory. This runs in the user's own checkout on local_directory
+	// tasks, where an empty managed directory is noise.
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context")); !os.IsNotExist(err) {
+		t.Errorf(".agent_context created for a native-skills provider; stat err = %v, want not-exist", err)
 	}
 }
 
@@ -2580,7 +2536,9 @@ func TestInjectRuntimeConfigQuickCreateOutputPrefixAgnostic(t *testing.T) {
 	for _, want := range []string{
 		"quick-create task",
 		"Created <identifier-or-id>: <title>",
-		"identifier` from JSON output",
+		// Rules moved into the Workflow section (MUL-6984); the identifier
+		// must still come from the JSON, not from scraped human output.
+		"`identifier` (preferred) or `id` (fallback) from the JSON response",
 		"never assume a workspace issue prefix",
 	} {
 		if !strings.Contains(s, want) {
@@ -2619,9 +2577,7 @@ func TestInjectRuntimeConfigAutopilotRunOnlyNoIssueWorkflow(t *testing.T) {
 
 	for _, want := range []string{
 		"Autopilot in run-only mode",
-		"Autopilot run ID: `run-1`",
-		"Check dependencies and report outdated packages.",
-		"multica autopilot get autopilot-1 --output json",
+		AutopilotIssueCommandsGuard,
 		"Your final assistant output is captured automatically as the autopilot run result",
 	} {
 		if !strings.Contains(s, want) {
@@ -2632,6 +2588,15 @@ func TestInjectRuntimeConfigAutopilotRunOnlyNoIssueWorkflow(t *testing.T) {
 	for _, absent := range []string{
 		"Run `multica issue get",
 		"Final results MUST be delivered via `multica issue comment add`",
+		// Per-run VALUES belong to the per-turn message, which renders them
+		// once (daemon.buildAutopilotPrompt). This file is the prompt-cache
+		// prefix, and its own contract is that no per-run identifier reaches
+		// it (MUL-5377); a second copy of the data here also gave MUL-5696's
+		// drift somewhere to happen (MUL-6984).
+		"run-1",
+		"autopilot-1",
+		"Daily dependency check",
+		"Check dependencies and report outdated packages.",
 	} {
 		if strings.Contains(s, absent) {
 			t.Errorf("autopilot runtime config should not contain %q\n---\n%s", absent, s)
@@ -2726,9 +2691,10 @@ func TestWriteContextFilesHermesSkipsWorkdirSkills(t *testing.T) {
 		t.Errorf("expected no .agent_context/skills/ for Hermes, got err=%v", err)
 	}
 
-	// issue_context.md should still be written under .agent_context/.
-	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "issue_context.md")); err != nil {
-		t.Errorf("expected .agent_context/issue_context.md to exist: %v", err)
+	// And no .agent_context at all: the sidecar brief that used to justify
+	// the directory is gone (MUL-6984), so Hermes leaves the workdir clean.
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context")); !os.IsNotExist(err) {
+		t.Errorf(".agent_context created for Hermes; stat err = %v, want not-exist", err)
 	}
 }
 
@@ -5533,14 +5499,15 @@ func TestInjectRuntimeConfigSquadLeaderCommentTriggeredNoAction(t *testing.T) {
 	}
 	s := string(data)
 
-	// The no_action rule lives on the leader variant of workflow step 4 since
-	// MUL-6417 (the reply-mode block that used to duplicate it is gone): the
-	// delivery imperative itself carries the carve-out, so no later bullet
-	// can contradict it (MUL-5442 #6493 review).
+	// Both delivery imperatives — workflow step 4 and ## Output — must carry
+	// the carve-out, so that no later bullet can contradict the no_action exit
+	// (MUL-5442 #6493 review). They carry the EXCEPTION, not the rule: the
+	// rule itself is stated once, by the Squad Operating Protocol the server
+	// appends to Instructions, and both sites point there (MUL-6984).
 	for _, want := range []string{
 		"unless your outcome is `no_action`",
-		"multica squad activity",
-		"DO NOT post a comment announcing no_action",
+		"see the no_action rule in your Squad Operating Protocol",
+		"which your Squad Operating Protocol states in full",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("squad leader comment-triggered CLAUDE.md missing %q", want)
@@ -5551,10 +5518,15 @@ func TestInjectRuntimeConfigSquadLeaderCommentTriggeredNoAction(t *testing.T) {
 	if strings.Contains(s, "**Post your final results as a comment — this step is mandatory**") {
 		t.Errorf("squad leader CLAUDE.md still carries the unconditional delivery step")
 	}
-
-	// The Output section must use strong prohibition language.
-	if !strings.Contains(s, "you MUST exit without posting any comment") {
-		t.Errorf("Output section missing strong prohibition for squad leader no_action")
+	// And neither site may restate the rule's mechanics — that is what drifted
+	// when four copies of it existed.
+	for _, banned := range []string{
+		"DO NOT post a comment announcing no_action",
+		"you MUST exit without posting any comment",
+	} {
+		if strings.Contains(s, banned) {
+			t.Errorf("squad leader CLAUDE.md restates the protocol-owned no_action rule: %q", banned)
+		}
 	}
 
 	// Non-squad-leader should NOT have the squad leader rule in comment-triggered path.
@@ -6435,11 +6407,14 @@ func TestPrepareLocalWorkDir(t *testing.T) {
 		t.Fatalf("expected envRoot/workdir to NOT exist for local_directory tasks; err=%v", err)
 	}
 
-	// Context files should still land in the user's directory so the
-	// agent can discover them.
-	contextPath := filepath.Join(userDir, ".agent_context", "issue_context.md")
-	if _, err := os.Stat(contextPath); err != nil {
-		t.Fatalf("expected context file in user dir: %v", err)
+	// Sidecars still land in the user's own directory, which is where the
+	// task runs. The marker is the one the CLI actually reads; the Markdown
+	// brief that used to sit beside it had no reader and is gone (MUL-6984).
+	if _, err := os.Stat(filepath.Join(userDir, TaskContextMarkerRelPath)); err != nil {
+		t.Fatalf("expected the task context marker in the user dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(userDir, ".agent_context")); !os.IsNotExist(err) {
+		t.Fatalf("Prepare left .agent_context in the user's own directory; stat err = %v, want not-exist", err)
 	}
 }
 

--- a/server/internal/daemon/execenv/local_worktree_test.go
+++ b/server/internal/daemon/execenv/local_worktree_test.go
@@ -409,7 +409,7 @@ func TestWorktreeModeDeliversBranchWithoutSidecars(t *testing.T) {
 	if env.WorkDir != env.LocalWorktree.Path {
 		t.Errorf("WorkDir = %q, want the worktree root %q", env.WorkDir, env.LocalWorktree.Path)
 	}
-	if _, err := os.Stat(filepath.Join(env.WorkDir, ".agent_context")); err != nil {
+	if _, err := os.Stat(filepath.Join(env.WorkDir, TaskContextMarkerRelPath)); err != nil {
 		t.Fatalf("precondition: Prepare should have written sidecars into the worktree: %v", err)
 	}
 

--- a/server/internal/daemon/execenv/prepare_rollback_test.go
+++ b/server/internal/daemon/execenv/prepare_rollback_test.go
@@ -76,13 +76,15 @@ func TestPrepareRollsBackSidecarsWhenPrepareFailsInPlace(t *testing.T) {
 
 // TestPrepareRollsBackWhenWriteContextFilesFailsAfterMarker covers the earliest
 // failure window there is: writeContextFiles lays the marker down as its very
-// first act, then creates .agent_context, writes skills and writes project
-// resources — any of which can fail with the marker already on disk.
+// first act, then writes skills and project resources — either of which can
+// fail with the marker already on disk.
 //
 // The first version of the MUL-6132 fix armed the rollback only after
 // writeContextFiles returned, so exactly these failures still stranded a marker
 // in the user's repository with nothing else beside it (MUL-6132 review). The
-// induced failure is a plain file where .agent_context must be a directory.
+// induced failure is a plain file where .agent_context must be a directory;
+// the task carries a skill because the default provider's skills tree
+// (.agent_context/skills) is now the only thing that opens that directory.
 func TestPrepareRollsBackWhenWriteContextFilesFailsAfterMarker(t *testing.T) {
 	workspacesRoot := t.TempDir()
 	userDir := t.TempDir()
@@ -101,8 +103,9 @@ func TestPrepareRollsBackWhenWriteContextFilesFailsAfterMarker(t *testing.T) {
 		AgentName:      "Test Agent",
 		LocalWorkDir:   userDir,
 		Task: TaskContextForEnv{
-			IssueID: "33333333-4444-5555-6666-777777777777",
-			AgentID: "77777777-6666-5555-4444-333333333333",
+			IssueID:     "33333333-4444-5555-6666-777777777777",
+			AgentID:     "77777777-6666-5555-4444-333333333333",
+			AgentSkills: []SkillContextForEnv{{Name: "Go Conventions", Content: "Follow Go conventions."}},
 		},
 	}, testLogger())
 	if err == nil {

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -213,6 +213,64 @@ func TestBriefOwnsAutopilotIssueCommandsGuard(t *testing.T) {
 	}
 }
 
+// TestQuickCreateBriefOwnsRunAndOutputRules pins the brief as the single
+// statement of how a quick-create run executes and what it prints (MUL-6984).
+//
+// The same five rules used to be written three times — the brief's Workflow
+// section, the brief's ## Output section, and the per-turn prompt's "Output
+// format" block — with two of the three copies in this very file. The brief is
+// the copy that survives, because its own contract is that these guardrails
+// hold "even if the user message is missing"; the per-turn message now renders
+// only the field VALUES the modal picked.
+func TestQuickCreateBriefOwnsRunAndOutputRules(t *testing.T) {
+	t.Parallel()
+
+	out := buildMetaSkillContent("claude", TaskContextForEnv{
+		QuickCreatePrompt: "create an issue about flaky tests",
+		AgentName:         "Eve", AgentID: "eve-1",
+	})
+
+	for _, want := range []string{
+		// exactly one create, no retry — a retry would duplicate the issue
+		"Run exactly one `multica issue create --output json` invocation",
+		"Do not retry for any reason",
+		// no issue to query, transition, or comment on
+		"Do NOT call `multica issue get`, `multica issue status`, or `multica issue comment add`",
+		// the success line, and the reason it must not be scraped or
+		// prefix-guessed: workspaces set their own issue prefix, so a
+		// successful create must not read as failed
+		"`identifier` (preferred) or `id` (fallback)",
+		"Created <identifier-or-id>: <title>",
+		"never assume a workspace issue prefix such as `MUL-`",
+		// failure path
+		"exit with that error as the only output",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("quick-create brief missing rule %q\n---\n%s", want, out)
+		}
+	}
+
+	// ## Output states where the output goes and how a FILE is delivered; the
+	// rules themselves are stated once, above. A second copy here is what this
+	// change removed.
+	outputIdx := strings.Index(out, "## Output")
+	if outputIdx < 0 {
+		t.Fatalf("quick-create brief has no ## Output section\n---\n%s", out)
+	}
+	outputSection := out[outputIdx:]
+	if !strings.Contains(outputSection, "**Delivering files here:**") {
+		t.Errorf("## Output lost the file-delivery channel\n---\n%s", outputSection)
+	}
+	for _, banned := range []string{
+		"Created <identifier-or-id>: <title>",
+		"Do NOT call `multica issue comment add`",
+	} {
+		if strings.Contains(outputSection, banned) {
+			t.Errorf("## Output restates workflow rule %q\n---\n%s", banned, outputSection)
+		}
+	}
+}
+
 // TestSlimQuickCreateAvailableCommands locks the minimal-variant content
 // for quick-create's Available Commands: `issue create` present, every
 // other Core command absent (the hard guardrails forbid the call).

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -365,7 +365,7 @@ func writeAvailableCommandsQuickCreate(b *strings.Builder) {
 	b.WriteString("**Use `--output json` for structured data.** For anything beyond `issue create`, run `multica --help` or `multica <command> --help`.\n\n")
 	b.WriteString("`--output json` writes JSON to stdout; confirmations and warnings go to stderr. Do not merge them (`2>&1`) into anything that parses the output — that makes a write that SUCCEEDED look like it failed and invites a duplicate retry.\n\n")
 	b.WriteString("### Core\n")
-	b.WriteString("- `multica issue create --title \"...\" [--description \"...\" | --description-file <path> | --description-stdin] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--stage N] [--project <project-id>] [--due-date <YYYY-MM-DD>] [--attachment <path>]` — Create a new issue; `--attachment` may be repeated. For agent-authored long descriptions, prefer `--description-file <path>` over `--description-stdin` (flags after a HEREDOC terminator can be silently swallowed, #4182). Write that file inside your working directory (e.g. `./description.md`), never `/tmp` or shared paths, and treat a failed write as fatal — the CLI rejects a path outside the workdir so a stale file from another run can't leak in (MUL-4252).\n\n")
+	b.WriteString("- `multica issue create --title \"...\" [--description \"...\" | --description-file <path> | --description-stdin] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--stage N] [--project <project-id>] [--due-date <YYYY-MM-DD>] [--attachment <path>]` — Create a new issue; `--attachment` may be repeated. Inline `--description \"...\"` is only for a short single-line body with no code, quotes, backticks or `$()`. Anything multi-line, or carrying code snippets / file paths / quotes / backticks / `$()` — which quick-create descriptions usually are — MUST go to a file, because the shell rewrites or truncates rich text passed inline (MUL-2904). Prefer `--description-file <path>` over `--description-stdin` (flags after a HEREDOC terminator can be silently swallowed, #4182). Write that file inside your working directory (e.g. `./description.md`), never `/tmp` or shared paths, and treat a failed write as fatal — never run `--description-file` against a file whose write did not succeed. The CLI rejects a path outside the workdir so a stale file from another run can't leak in (MUL-4252).\n\n")
 }
 
 // writeIssueBodyFormatting emits the default Markdown hierarchy for issue
@@ -548,11 +548,12 @@ func writeWorkflowChat(b *strings.Builder) {
 // writeWorkflowQuickCreate emits the quick-create workflow's hard
 // guardrails.
 func writeWorkflowQuickCreate(b *strings.Builder) {
-	b.WriteString("**This task was triggered by quick-create.** There is NO existing Multica issue. Follow the field and output rules in the user message you just received; ignore the default assignment-task workflow.\n\n")
-	b.WriteString("Hard guardrails (apply even if the user message is missing):\n")
-	b.WriteString("- Run exactly one `multica issue create` invocation, then exit.\n")
+	b.WriteString("**This task was triggered by quick-create.** There is NO existing Multica issue. The per-turn user message carries this run's field values — what to put in the title, description, assignee, project and parent. It does not restate the rules below; they hold for the run whatever that message says, and they still hold if it never arrived.\n\n")
+	b.WriteString("Hard guardrails:\n")
+	b.WriteString("- Run exactly one `multica issue create --output json` invocation, then exit. Do not retry for any reason, even on a non-zero exit — the issue may already exist, and a second attempt would create a duplicate.\n")
 	b.WriteString("- Do NOT call `multica issue get`, `multica issue status`, or `multica issue comment add` for this task — there is no issue to query, transition, or comment on. The platform writes the user's success/failure inbox notification automatically based on whether `multica issue create` succeeded.\n")
-	b.WriteString("- If the CLI returns an error, exit with that error as the only output. Do not retry.\n\n")
+	b.WriteString("- On success, read the created issue's `identifier` (preferred) or `id` (fallback) from the JSON response, then print exactly one line and exit: `Created <identifier-or-id>: <title>`. No commentary, no follow-up tool calls. Do not scrape human-readable output, and never assume a workspace issue prefix such as `MUL-` — workspaces can set their own.\n")
+	b.WriteString("- On a CLI error or a JSON parse error, exit with that error as the only output. Do not retry.\n\n")
 }
 
 // AutopilotIssueCommandsGuard is the run-only autopilot issue-command boundary,
@@ -563,30 +564,18 @@ func writeWorkflowQuickCreate(b *strings.Builder) {
 const AutopilotIssueCommandsGuard = "Do not run `multica issue get`, `multica issue comment add`, or `multica issue status` for this run unless the autopilot instructions explicitly tell you to create or update an issue"
 
 // writeWorkflowAutopilot emits the autopilot run-only workflow.
-func writeWorkflowAutopilot(b *strings.Builder, ctx TaskContextForEnv) {
+//
+// Rules only. The run's own values — run id, autopilot id, title, trigger
+// source, trigger payload, and the autopilot instructions — are rendered once,
+// by daemon.buildAutopilotPrompt in the per-turn user message. They used to be
+// rendered here as well, which put two hand-maintained copies of the same data
+// in one context window and broke this file's own contract that no per-run
+// value may reach the cache prefix (MUL-5377). MUL-5696 already caught the two
+// copies drifting on the issue-command guard and fixed that one sentence with
+// the shared constant below; MUL-6984 removed the duplicated data itself.
+func writeWorkflowAutopilot(b *strings.Builder) {
 	b.WriteString("**This task was triggered by an Autopilot in run-only mode.** There is no assigned Multica issue for this run.\n\n")
-	fmt.Fprintf(b, "- Autopilot run ID: `%s`\n", ctx.AutopilotRunID)
-	if ctx.AutopilotID != "" {
-		fmt.Fprintf(b, "- Autopilot ID: `%s`\n", ctx.AutopilotID)
-	}
-	if ctx.AutopilotTitle != "" {
-		fmt.Fprintf(b, "- Autopilot title: %s\n", ctx.AutopilotTitle)
-	}
-	if ctx.AutopilotSource != "" {
-		fmt.Fprintf(b, "- Trigger source: %s\n", ctx.AutopilotSource)
-	}
-	if ctx.AutopilotTriggerPayload != "" {
-		fmt.Fprintf(b, "- Trigger payload:\n\n```json\n%s\n```\n", ctx.AutopilotTriggerPayload)
-	}
-	if strings.TrimSpace(ctx.AutopilotDescription) != "" {
-		b.WriteString("\nAutopilot instructions:\n\n")
-		b.WriteString(ctx.AutopilotDescription)
-		b.WriteString("\n\n")
-	}
-	if ctx.AutopilotID != "" {
-		fmt.Fprintf(b, "- Run `multica autopilot get %s --output json` if you need the full autopilot configuration\n", ctx.AutopilotID)
-	}
-	b.WriteString("- Complete the autopilot instructions directly\n")
+	b.WriteString("- The per-turn user message carries this run's autopilot instructions and its identifiers. Complete those instructions directly.\n")
 	b.WriteString("- " + AutopilotIssueCommandsGuard + "\n\n")
 }
 
@@ -694,7 +683,7 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 	b.WriteString("2. Catch up on the comment history — this is mandatory, not optional — in two bounded reads, never one bulk pull: scan every thread cheaply (`--roots-only --summary --compact`), then expand only the threads that matter (`--thread <id> --tail 30 --compact`). Earlier comments often carry context the issue body lacks. Skipping this step is the most common cause of agents acting on stale or incomplete instructions — so always run the scan, even when the trigger looks self-contained. When a comment triggered this run, the per-turn user message names the thread to expand first; the scan is how you decide whether any OTHER thread is also relevant.\n")
 	b.WriteString("3. If any part of what this turn will produce is what the issue itself asks for, set `in_progress` FIRST (skip when the issue is already in an `in_progress`-category status, or when your Agent Identity forbids status writes): the board should show the issue being worked while you work, not only after. The kind of activity — research, design, planning, review — never decides this; only whether the output is part of THIS issue's ask. Then complete the task within your Agent Identity boundaries (`## Instruction Precedence` lists the actions Agent Identity can forbid). If your role is delegation-only, perform the allowed delegation work and stop once that outcome is delivered. Before self-assigning, check the target issue's comment history for an existing claim; when assignment or status only records ownership/progress for work already underway, pass `--no-start` on every such command (the default start behavior is for handing off fresh work).\n")
 	if ctx.IsSquadLeader {
-		b.WriteString("4. **Post your final results as a comment** (unless your outcome is `no_action` — in that case, calling `multica squad activity <issue-id> no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment announcing no_action or saying you are exiting silently. If that call fails, the exception lapses: post exactly one short comment with the outcome instead): post it with `multica issue comment add` using the platform-correct non-inline mode from ## Comment Formatting (never inline `--content`). When the per-turn user message carries a triggering comment, reply in its thread with the `--parent` value it gives you for THIS turn (never one from an earlier turn); when it lists several threads, post one reply per thread. With no triggering comment, post a new top-level comment. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n")
+		b.WriteString("4. **Post your final results as a comment** (unless your outcome is `no_action` — see the no_action rule in your Squad Operating Protocol): post it with `multica issue comment add` using the platform-correct non-inline mode from ## Comment Formatting (never inline `--content`). When the per-turn user message carries a triggering comment, reply in its thread with the `--parent` value it gives you for THIS turn (never one from an earlier turn); when it lists several threads, post one reply per thread. With no triggering comment, post a new top-level comment. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n")
 	} else {
 		b.WriteString("4. **Post your final results as a comment — this step is mandatory**: post it with `multica issue comment add` using the platform-correct non-inline mode from ## Comment Formatting (never inline `--content`). When the per-turn user message carries a triggering comment, reply in its thread with the `--parent` value it gives you for THIS turn (never one from an earlier turn); when it lists several threads, post one reply per thread. With no triggering comment, post a new top-level comment. `## Output` states why this call is the only delivery channel.\n")
 	}
@@ -835,10 +824,7 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 		b.WriteString("This is a run-only autopilot task, so there may be no issue comment to post. Your final assistant output is captured automatically as the autopilot run result. Keep it concise and state the outcome.\n\n")
 		b.WriteString("**Delivering files here:** this surface is text-only — the run result carries no attachments. Describe what you produced; do not link its path.\n")
 	case kindQuickCreate:
-		b.WriteString("This is a quick-create task. There is NO existing issue to comment on. Your final stdout is captured automatically and the platform writes the user's success/failure inbox notification based on whether `multica issue create` succeeded.\n\n")
-		b.WriteString("- Do NOT call `multica issue comment add` — the issue you just created has no conversation context for this run.\n")
-		b.WriteString("- Print exactly one final line: `Created <identifier-or-id>: <title>` after a successful `multica issue create`, using the created issue's `identifier` from JSON output (fall back to its `id`; never assume a workspace issue prefix such as `MUL-`).\n")
-		b.WriteString("- On CLI failure, exit with the CLI error as the only output — the platform turns it into a `quick_create_failed` inbox item for the user.\n\n")
+		b.WriteString("This is a quick-create task. There is NO existing issue to comment on. Your final stdout is captured automatically, and the platform turns it into the user's success or `quick_create_failed` inbox item based on whether `multica issue create` succeeded. What to print in each case is stated once, under `## Workflow`.\n\n")
 		b.WriteString("**Delivering files here:** your stdout is text-only. A file that belongs to the new issue goes on the `multica issue create` call itself via `--attachment <path>`; never put its path in the description or in your stdout line.\n")
 	case kindChat:
 		b.WriteString("This is a chat session. Your reply is delivered directly to the chat window the user is reading.\n\n")
@@ -869,7 +855,7 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 		}
 	default:
 		if ctx.IsSquadLeader {
-			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`** — unless your outcome is `no_action`. When you evaluate a trigger and decide no action is needed, calling `multica squad activity <issue-id> no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment that announces no_action, acknowledges another agent, or says you are exiting silently — such comments are noise. For all other outcomes (`action`, `failed`), a comment is still mandatory. If the `squad activity` call itself fails, the no_action exception does not apply — post exactly one short comment with the outcome so the decision is not lost, and no more than one.\n\n")
+			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`** — unless your outcome is `no_action`, which your Squad Operating Protocol states in full. For every other outcome (`action`, `failed`) a comment is mandatory. The user does NOT see your terminal output or run logs — only comments on the issue.\n\n")
 		} else {
 			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`.** The user does NOT see your terminal output or run logs — only comments on the issue.\n\n")
 		}
@@ -953,7 +939,7 @@ func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 	case kindQuickCreate:
 		writeWorkflowQuickCreate(&b)
 	case kindAutopilotRunOnly:
-		writeWorkflowAutopilot(&b, ctx)
+		writeWorkflowAutopilot(&b)
 	case kindIssue:
 		writeWorkflowIssue(&b, ctx)
 	}

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -949,8 +949,8 @@ func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 	}
 
 	// Every kind, quick-create included. Quick-create used to be skipped here
-	// and carried its own copy in issue_context.md instead; now that both are
-	// the same names-only index, the brief is the one that survives.
+	// and carried its own names-only index in the workdir sidecar instead;
+	// that sidecar is gone (MUL-6984) and the brief is the single index.
 	writeSkills(&b, ctx)
 
 	if kind == kindIssue {

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -1915,6 +1915,74 @@ func firstBriefDiff(want, got string) string {
 		"\n--- variant ---\n" + got[lo:hiG]
 }
 
+// TestAutopilotBriefByteIdenticalAcrossRunScopedFields is the invariant
+// MUL-6984 actually moved, and the one TestBriefByteIdenticalAcrossRunsForEveryKind
+// cannot see: its autopilot row pins run-1 / ap-1 and its variants only mutate
+// the generic resume / initiator / connected-app fields, so reinserting the
+// autopilot title, source, payload or description into the brief would leave
+// it green.
+//
+// Every field below identifies ONE run. The brief lands in messages[0], ahead
+// of the whole conversation, so a per-run value here throws away the prompt
+// cache for the entire history on resume (MUL-5377) — and it also gives a
+// second hand-maintained copy somewhere to drift from the per-turn one, which
+// is how MUL-5696 happened. Two runs of the same autopilot, and two runs of
+// different autopilots, must all produce the same bytes.
+func TestAutopilotBriefByteIdenticalAcrossRunScopedFields(t *testing.T) {
+	t.Parallel()
+
+	base := TaskContextForEnv{AgentID: "a-1", AgentName: "Eve", AutopilotRunID: "run-1", AutopilotID: "ap-1"}
+
+	runs := []struct {
+		name string
+		ctx  TaskContextForEnv
+	}{
+		{"baseline", base},
+		{"second run of the same autopilot", func() TaskContextForEnv {
+			c := base
+			c.AutopilotRunID = "run-2"
+			c.AutopilotTitle = "Nightly dependency sweep"
+			c.AutopilotSource = "schedule"
+			c.AutopilotDescription = "Check dependencies and report outdated packages."
+			c.AutopilotTriggerPayload = `{"schedule":"0 3 * * *"}`
+			return c
+		}()},
+		{"run of a different autopilot", func() TaskContextForEnv {
+			c := base
+			c.AutopilotRunID = "run-3"
+			c.AutopilotID = "ap-2"
+			c.AutopilotTitle = "Triage inbound issues"
+			c.AutopilotSource = "webhook"
+			c.AutopilotDescription = "Read the payload and file one issue per report."
+			c.AutopilotTriggerPayload = `{"action":"opened","issue":{"number":7,"title":"crash on start"}}`
+			return c
+		}()},
+	}
+
+	want := buildMetaSkillContent("claude", runs[0].ctx)
+	for _, r := range runs[1:] {
+		if got := buildMetaSkillContent("claude", r.ctx); got != want {
+			t.Errorf("autopilot brief changed for %q — a per-run value reached the cache prefix\n%s",
+				r.name, firstBriefDiff(want, got))
+		}
+	}
+
+	// Byte-identity alone would also hold if the brief rendered none of these
+	// AND the values never reached the agent at all. Pin the other half here:
+	// the brief must not carry them, and daemon.TestBuildPromptAutopilotRunOnly
+	// pins the per-turn message as the surface that does.
+	for _, banned := range []string{
+		"run-1", "ap-1", "Nightly dependency sweep", "Triage inbound issues",
+		"schedule", "webhook", "Check dependencies", "0 3 * * *", "crash on start",
+	} {
+		for _, r := range runs {
+			if strings.Contains(buildMetaSkillContent("claude", r.ctx), banned) {
+				t.Errorf("autopilot brief (%s) carries the run-scoped value %q; the per-turn message owns it", r.name, banned)
+			}
+		}
+	}
+}
+
 // TestBriefByteIdenticalAcrossRunsForEveryKind extends the MUL-5377 guarantee
 // past issue runs.
 //

--- a/server/internal/daemon/execenv/sidecar_manifest.go
+++ b/server/internal/daemon/execenv/sidecar_manifest.go
@@ -30,11 +30,10 @@ const sidecarManifestFile = ".multica_sidecar_manifest.json"
 //     alternative slug (see allocateCollisionFreeSkillDir) and retries
 //     so the agent still discovers the Multica skill, just under a
 //     different directory name.
-//   - For Multica-only namespaces (.agent_context/issue_context.md,
-//     .multica/project/resources.json) the caller swallows the error
-//     and proceeds — the agent's runtime brief already carries every
-//     fact that would have appeared in those files, so missing-from-
-//     disk is degraded behavior, not failure.
+//   - For the Multica-only namespace (.multica/project/resources.json)
+//     the caller swallows the error and proceeds — the agent's runtime
+//     brief already carries every fact that would have appeared in that
+//     file, so missing-from-disk is degraded behavior, not failure.
 var errPathPreExists = errors.New("execenv: refuse to overwrite pre-existing path")
 
 // sidecarManifest records the filesystem mutations writeContextFiles and

--- a/server/internal/daemon/execenv/skill_visibility_test.go
+++ b/server/internal/daemon/execenv/skill_visibility_test.go
@@ -136,18 +136,6 @@ Hidden body.`,
 			t.Errorf("brief advertised disable-model-invocation skill:\n%s", out)
 		}
 	}
-
-	// issue_context.md and its quick-create / autopilot variants no longer
-	// carry a skill list at all; nothing read that copy.
-	for name, out := range map[string]string{
-		"issue context": renderIssueContext("codex", TaskContextForEnv{IssueID: ctx.IssueID, AgentSkills: ctx.AgentSkills}),
-		"quick create":  renderQuickCreateContext(TaskContextForEnv{QuickCreatePrompt: ctx.QuickCreatePrompt, AgentSkills: ctx.AgentSkills}),
-		"autopilot":     renderAutopilotContext(TaskContextForEnv{AutopilotRunID: ctx.AutopilotRunID, AgentSkills: ctx.AgentSkills}),
-	} {
-		if strings.Contains(out, "## Agent Skills") || strings.Contains(out, "visible-skill") {
-			t.Errorf("%s still renders a skill list:\n%s", name, out)
-		}
-	}
 }
 
 // sanitizeSkillName is not injective — "A B" and "A-B" both reduce to "a-b" —
@@ -260,11 +248,6 @@ Hidden body.`,
 	if strings.Contains(runtimeConfig, "## Skills") {
 		t.Errorf("runtime config should omit Skills section when every skill disables model invocation:\n%s", runtimeConfig)
 	}
-
-	issueContext := renderIssueContext("codex", ctx)
-	if strings.Contains(issueContext, "## Agent Skills") {
-		t.Errorf("issue context should omit Agent Skills section when every skill disables model invocation:\n%s", issueContext)
-	}
 }
 
 func TestWriteContextFilesHydratesDisableModelInvocationSkillButDoesNotAdvertiseIt(t *testing.T) {
@@ -298,12 +281,13 @@ Hidden body.`,
 		t.Fatalf("writeContextFiles failed: %v", err)
 	}
 
-	issueContext, err := os.ReadFile(filepath.Join(dir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("read issue_context.md: %v", err)
-	}
-	if strings.Contains(string(issueContext), "Hidden Skill") {
-		t.Fatalf("issue_context.md advertised hidden skill:\n%s", string(issueContext))
+	// The sidecar brief is gone (MUL-6984): nothing pointed at
+	// .agent_context/issue_context.md, so it was a third copy of facts the
+	// runtime brief and per-turn message already carry. Prepare must not
+	// resurrect it — a workdir-local file no surface names is exactly how a
+	// stale duplicate goes unnoticed.
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "issue_context.md")); !os.IsNotExist(err) {
+		t.Fatalf("writeContextFiles wrote a sidecar brief; stat err = %v, want not-exist", err)
 	}
 
 	hiddenSkill, err := os.ReadFile(filepath.Join(dir, ".agent_context", "skills", "hidden-skill", "SKILL.md"))

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"fmt"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
@@ -700,8 +699,16 @@ func buildAutopilotPrompt(task Task) string {
 	if task.AutopilotSource != "" {
 		fmt.Fprintf(&b, "Trigger source: %s\n", task.AutopilotSource)
 	}
+	// Rendered whole. Ingress already bounds it — handler.maxWebhookBodyBytes
+	// caps a webhook body at 256 KiB — and this is now the payload's ONLY
+	// rendering (it used to be in the runtime brief as well), so truncating
+	// here would drop task input the agent has no way to fetch back: the
+	// full-payload read exists on the server (GET /api/autopilots/{id}/runs/
+	// {runId}) but no CLI command exposes it, and `autopilot runs` lists runs
+	// without payloads. A cap belongs with that command and a threshold picked
+	// from real payload sizes, not as a side effect of de-duplication.
 	if payload := strings.TrimSpace(string(task.AutopilotTriggerPayload)); payload != "" {
-		fmt.Fprintf(&b, "Trigger payload:\n%s\n", capAutopilotTriggerPayload(payload))
+		fmt.Fprintf(&b, "Trigger payload:\n%s\n", payload)
 	}
 	b.WriteString("\nAutopilot instructions:\n")
 	if strings.TrimSpace(task.AutopilotDescription) != "" {
@@ -722,33 +729,6 @@ func buildAutopilotPrompt(task Task) string {
 	// emission point, and a second hand-maintained per-turn copy is exactly
 	// how the two surfaces drifted into conflict before (MUL-5696).
 	return b.String()
-}
-
-// autopilotTriggerPayloadCap bounds the rendered trigger payload. Webhook
-// bodies are written by whatever system fired the trigger, not by anyone in
-// this workspace, so their size is unbounded from Multica's side — a CI or
-// chat-platform event can run to tens of kilobytes of fields no autopilot
-// instruction will ever mention. This is the payload's only rendering, so the
-// cap has to truncate in place and say so: there is no `autopilot runs` flag
-// that fetches one run's payload for an agent to fall back to.
-const autopilotTriggerPayloadCap = 8000
-
-// capAutopilotTriggerPayload truncates payload to autopilotTriggerPayloadCap
-// bytes, cutting on a rune boundary and appending a notice.
-//
-// The notice is not decoration. The payload renders as JSON, and a truncated
-// body is no longer parseable — an agent that reads a clipped object as a
-// whole one draws conclusions from fields that were never there. Saying the
-// text was cut is what makes the remaining prefix safe to read.
-func capAutopilotTriggerPayload(payload string) string {
-	if len(payload) <= autopilotTriggerPayloadCap {
-		return payload
-	}
-	cut := autopilotTriggerPayloadCap
-	for cut > 0 && !utf8.RuneStart(payload[cut]) {
-		cut--
-	}
-	return payload[:cut] + fmt.Sprintf("\n\n[trigger payload truncated at %d of %d bytes — the JSON above is incomplete, do not read it as a whole object]", cut, len(payload))
 }
 
 // squadBriefingMarker is the first heading of the squad-leader briefing the

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
@@ -259,7 +260,6 @@ func buildQuickCreatePrompt(task Task) string {
 	b.WriteString("     CC exception: `multica issue create` has no `--subscriber` flag, and the platform auto-subscribes members whose `[@Name](mention://member/<uuid>)` link appears in the description. When the user wrote \"cc @Y\", strip the verbal \"cc\" wrapper from the User request body and append a final `CC: <mention link(s)>` line to the description so the cc routing still fires.\n\n")
 	b.WriteString("  2. **Context** — include ONLY when the input cited external resources AND you successfully fetched them AND they produced verifiable facts worth recording. Summarize facts only (e.g. \"PR #45 changes auth to JWT\"), not interpretation or unsolicited reference implementations. If you have nothing factual to add, omit the section entirely — never use it as an apology log for resources you could not fetch.\n\n")
 	b.WriteString("  Hard rules: never invent requirements, implementation details, or acceptance criteria the user did not express; never reduce multi-sentence input to a single vague sentence; never echo the title.\n\n")
-	b.WriteString("  Passing the description: a short, single-line body with no code, quotes, backticks, `$()`, or other special characters may go inline via `--description \"...\"`. Anything multi-line, or containing code snippets / file paths / quotes / backticks / `$()` / special characters, or otherwise long — which quick-create descriptions usually are — MUST be written to `./description.md` and passed with `--description-file ./description.md`; passing rich text inline lets the shell rewrite or truncate it (MUL-2904). That file MUST live inside your current working directory (e.g. `./description.md`) — never `/tmp` or any machine-shared path, where a different run may have left a stale file that would silently become this issue's description. If the file write fails for any reason, stop and fix it; never run `--description-file` against a file whose write did not succeed.\n\n")
 
 	// priority
 	if task.QuickCreatePriority != "" {
@@ -329,13 +329,11 @@ func buildQuickCreatePrompt(task Task) string {
 	b.WriteString("- **status**: omit (defaults to `todo`).\n")
 	b.WriteString("- **attachments**: `--attachment` takes LOCAL file paths, never URLs. Image URLs in the user input are already markdown — keep them inline. Files you produced: see `## Output`.\n\n")
 
-	// output format
-	b.WriteString("Output format:\n")
-	b.WriteString("- Run exactly one `multica issue create --output json` invocation. Do not retry for any reason — even on non-zero exit. The issue may already exist; another attempt would create a duplicate.\n")
-	b.WriteString("- Parse the JSON response to read the created issue's `identifier` (preferred) or `id` (fallback). Do not scrape human output and do not assume any workspace issue prefix such as `MUL-`; workspaces can use custom prefixes.\n")
-	b.WriteString("- After success, print exactly one line: `Created <identifier-or-id>: <title>` and exit. No commentary, no follow-up tool calls.\n")
-	b.WriteString("- Do NOT call `multica issue get` or `multica issue comment add` — there is no issue to query or comment on.\n")
-	b.WriteString("- On CLI error or JSON parse error, exit with the error as the only output. The platform writes a failure notification automatically.\n")
+	// How to run the create and what to print is stated once, in the brief's
+	// quick-create Workflow section (execenv.writeWorkflowQuickCreate). Those
+	// rules hold for the whole run and must survive a missing user message, so
+	// the brief is their home; this function renders only the field VALUES the
+	// modal picked, which change every run.
 	return b.String()
 }
 
@@ -433,9 +431,6 @@ func buildCommentPrompt(task Task, provider string) string {
 			}
 			fmt.Fprintf(&b, "Fetch each id you still need directly: `multica issue comment list %s --thread <comment-id> --tail 30 --compact --output json`. `--thread` accepts a reply id, not just a thread root, so you do not need to know which thread the comment lives in. If it is older than those 30 replies, page back with the `Next reply cursor` values (`--before` / `--before-id`) until it appears. Do not finish this turn until every id above is accounted for.\n\n",
 				task.IssueID)
-		}
-		if taskIsSquadLeader(task) {
-			fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise. The comment prohibition is conditional on that call SUCCEEDING: if it exits non-zero, your decision has no trace anywhere, so post exactly ONE short comment stating the outcome and the error instead of exiting silently. That failure comment is this turn's only comment — it does not license a second one.\n\n", task.IssueID)
 		}
 	}
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then decide how to proceed.\n\n", task.IssueID)
@@ -705,8 +700,8 @@ func buildAutopilotPrompt(task Task) string {
 	if task.AutopilotSource != "" {
 		fmt.Fprintf(&b, "Trigger source: %s\n", task.AutopilotSource)
 	}
-	if strings.TrimSpace(string(task.AutopilotTriggerPayload)) != "" {
-		fmt.Fprintf(&b, "Trigger payload:\n%s\n", strings.TrimSpace(string(task.AutopilotTriggerPayload)))
+	if payload := strings.TrimSpace(string(task.AutopilotTriggerPayload)); payload != "" {
+		fmt.Fprintf(&b, "Trigger payload:\n%s\n", capAutopilotTriggerPayload(payload))
 	}
 	b.WriteString("\nAutopilot instructions:\n")
 	if strings.TrimSpace(task.AutopilotDescription) != "" {
@@ -727,6 +722,33 @@ func buildAutopilotPrompt(task Task) string {
 	// emission point, and a second hand-maintained per-turn copy is exactly
 	// how the two surfaces drifted into conflict before (MUL-5696).
 	return b.String()
+}
+
+// autopilotTriggerPayloadCap bounds the rendered trigger payload. Webhook
+// bodies are written by whatever system fired the trigger, not by anyone in
+// this workspace, so their size is unbounded from Multica's side — a CI or
+// chat-platform event can run to tens of kilobytes of fields no autopilot
+// instruction will ever mention. This is the payload's only rendering, so the
+// cap has to truncate in place and say so: there is no `autopilot runs` flag
+// that fetches one run's payload for an agent to fall back to.
+const autopilotTriggerPayloadCap = 8000
+
+// capAutopilotTriggerPayload truncates payload to autopilotTriggerPayloadCap
+// bytes, cutting on a rune boundary and appending a notice.
+//
+// The notice is not decoration. The payload renders as JSON, and a truncated
+// body is no longer parseable — an agent that reads a clipped object as a
+// whole one draws conclusions from fields that were never there. Saying the
+// text was cut is what makes the remaining prefix safe to read.
+func capAutopilotTriggerPayload(payload string) string {
+	if len(payload) <= autopilotTriggerPayloadCap {
+		return payload
+	}
+	cut := autopilotTriggerPayloadCap
+	for cut > 0 && !utf8.RuneStart(payload[cut]) {
+		cut--
+	}
+	return payload[:cut] + fmt.Sprintf("\n\n[trigger payload truncated at %d of %d bytes — the JSON above is incomplete, do not read it as a whole object]", cut, len(payload))
 }
 
 // squadBriefingMarker is the first heading of the squad-leader briefing the

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -35,16 +36,6 @@ func TestBuildQuickCreatePromptRules(t *testing.T) {
 		// context section is conditional and must not be an apology log
 		"include ONLY when the input cited external resources",
 		"never use it as an apology log",
-		// output/reporting must be workspace-prefix agnostic. Workspaces can
-		// use custom issue prefixes, so a successful issue creation should
-		// not look failed merely because the identifier does not match one
-		// fixed prefix.
-		"multica issue create --output json",
-		"JSON response",
-		"identifier",
-		"Do not scrape human output",
-		"do not assume any workspace issue prefix",
-		"Created <identifier-or-id>: <title>",
 		// hard rules
 		"never invent requirements",
 		"never reduce multi-sentence input",
@@ -63,6 +54,92 @@ func TestBuildQuickCreatePromptRules(t *testing.T) {
 
 	if strings.Contains(out, "do NOT pass `--attachment`") {
 		t.Errorf("buildQuickCreatePrompt carries the unconditional --attachment ban that conflicts with the quick-create ## Output delivery channel (MUL-5696)\n--- output ---\n%s", out)
+	}
+
+	// How to run the create, what to print, and how to pass a long
+	// description are RULES: true for every quick-create run, and required
+	// even on a turn whose user message never arrived. They are stated once
+	// in the brief (execenv.TestQuickCreateBriefOwnsRunAndOutputRules and
+	// TestSlimQuickCreateAvailableCommands pin them there). This function
+	// renders the modal's field VALUES; restating the rules alongside them
+	// put two hand-maintained copies in one context window (MUL-6984).
+	for _, moved := range []string{
+		"Output format:",
+		"Run exactly one `multica issue create --output json` invocation",
+		"Created <identifier-or-id>: <title>",
+		"Passing the description:",
+		"never `/tmp` or any machine-shared path",
+	} {
+		if strings.Contains(out, moved) {
+			t.Errorf("buildQuickCreatePrompt restates brief-owned rule %q\n--- output ---\n%s", moved, out)
+		}
+	}
+}
+
+// TestBuildAutopilotPromptCapsTriggerPayload covers the one unbounded value in
+// this prompt. A webhook body is written by whatever system fired the trigger,
+// so nothing in this workspace bounds its size, and the per-turn message is now
+// its only rendering (MUL-6984) — there is no second copy to fall back to and
+// no `autopilot runs` flag that fetches one run's payload. The cap therefore
+// has to truncate in place AND say so: a clipped JSON object read as a whole
+// one is worse than a short one, because the missing fields are invisible.
+func TestBuildAutopilotPromptCapsTriggerPayload(t *testing.T) {
+	t.Parallel()
+
+	oversized := `{"body":"` + strings.Repeat("x", autopilotTriggerPayloadCap*2) + `"}`
+	out := buildAutopilotPrompt(Task{
+		AutopilotRunID:          "run-1",
+		AutopilotID:             "autopilot-1",
+		AutopilotDescription:    "Check dependencies.",
+		AutopilotTriggerPayload: []byte(oversized),
+	})
+
+	if strings.Contains(out, oversized) {
+		t.Fatalf("oversized trigger payload rendered in full (%d bytes)", len(oversized))
+	}
+	if !strings.Contains(out, "trigger payload truncated") {
+		t.Errorf("truncated payload rendered without saying so\n---\n%s", out)
+	}
+	if !strings.Contains(out, "do not read it as a whole object") {
+		t.Errorf("truncation notice does not warn that the JSON is incomplete\n---\n%s", out)
+	}
+	// The instructions are the point of the run and must survive the cap.
+	if !strings.Contains(out, "Check dependencies.") {
+		t.Errorf("autopilot instructions lost alongside the capped payload\n---\n%s", out)
+	}
+
+	// A payload that fits is rendered verbatim — the cap must not touch the
+	// ordinary case, where the payload IS the trigger's meaning.
+	small := `{"action":"opened","number":7}`
+	out = buildAutopilotPrompt(Task{AutopilotRunID: "run-1", AutopilotTriggerPayload: []byte(small)})
+	if !strings.Contains(out, small) {
+		t.Errorf("payload under the cap was not rendered verbatim\n---\n%s", out)
+	}
+	if strings.Contains(out, "trigger payload truncated") {
+		t.Errorf("payload under the cap reported as truncated\n---\n%s", out)
+	}
+}
+
+// TestCapAutopilotTriggerPayloadCutsOnRuneBoundary keeps the truncation from
+// splitting a multi-byte character. A payload is arbitrary UTF-8 — issue
+// titles, chat messages, commit subjects — and a half rune renders as U+FFFD
+// in the middle of the text the agent is meant to read.
+func TestCapAutopilotTriggerPayloadCutsOnRuneBoundary(t *testing.T) {
+	t.Parallel()
+
+	// Three-byte runes so the cap lands mid-character for at least one offset.
+	payload := strings.Repeat("世", autopilotTriggerPayloadCap)
+	got := capAutopilotTriggerPayload(payload)
+	body := got[:strings.Index(got, "\n\n[trigger payload truncated")]
+
+	if !utf8.ValidString(body) {
+		t.Fatalf("truncated payload is not valid UTF-8 (%d bytes)", len(body))
+	}
+	if len(body) > autopilotTriggerPayloadCap {
+		t.Errorf("truncated body = %d bytes, want <= %d", len(body), autopilotTriggerPayloadCap)
+	}
+	if !strings.HasPrefix(payload, body) {
+		t.Error("truncated body is not a prefix of the original payload")
 	}
 }
 
@@ -282,84 +359,59 @@ func TestBuildQuickCreatePromptParentPinning(t *testing.T) {
 	}
 }
 
-// TestBuildPromptSquadLeaderNoActionFailureFallback locks the escape hatch added
-// in MUL-6622 / GH #7487. The comment prohibition is conditional on the
-// `squad activity` call succeeding — the server only rejects a leader comment
-// once the no_action activity exists — so a failed call must not end the turn in
-// silence. The fallback is capped at ONE comment so it cannot collide with the
-// one-comment-per-turn rule.
-func TestBuildPromptSquadLeaderNoActionFailureFallback(t *testing.T) {
-	out := BuildPrompt(Task{
-		IssueID:               "issue-123",
-		TriggerCommentID:      "comment-456",
-		TriggerCommentContent: "LGTM",
-		TriggerAuthorType:     "member",
-		TriggerAuthorName:     "Bohan",
-		IsLeaderTask:          true,
-		LeaderRoleResolved:    true,
-		Agent: &AgentData{
-			Instructions: "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER...",
-		},
-	}, "claude")
+// TestBuildPromptSquadLeaderReplyCarveOutIgnoresTriggerAuthor is the MUL-2168
+// regression, retargeted at the surface that still branches on leadership.
+//
+// The bug was a leader posting "LGTM is a pure acknowledgment — no reply
+// needed. Exiting silently." — noise it produced because the per-turn
+// no_action rule only fired for AGENT-triggered comments, so a member's
+// comment bypassed it. That per-turn copy is gone (MUL-6984): the rule itself
+// now lives once, in the Squad Operating Protocol the server appends to
+// Instructions, and handler.TestSquadOperatingProtocolOwnsNoActionRule pins
+// its wording. What the per-turn message still owns is the reply imperative,
+// which must carry the carve-out so it cannot contradict the protocol — and,
+// as here, it must do so whoever wrote the triggering comment.
+func TestBuildPromptSquadLeaderReplyCarveOutIgnoresTriggerAuthor(t *testing.T) {
+	t.Parallel()
 
-	for _, want := range []string{
-		"conditional on that call SUCCEEDING",
-		"post exactly ONE short comment",
-		"does not license a second one",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("squad leader no_action rule must contain %q, got:\n%s", want, out)
+	for _, authorType := range []string{"member", "agent"} {
+		out := BuildPrompt(Task{
+			IssueID:               "issue-123",
+			TriggerCommentID:      "comment-456",
+			TriggerCommentContent: "LGTM",
+			TriggerAuthorType:     authorType,
+			TriggerAuthorName:     "Bohan",
+			IsLeaderTask:          true,
+			LeaderRoleResolved:    true,
+			Agent: &AgentData{
+				Instructions: "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER...",
+			},
+		}, "claude")
+
+		if !strings.Contains(out, "Unless your outcome is `no_action`, post your reply as a comment") {
+			t.Errorf("%s-triggered leader prompt lost the no_action carve-out\n---\n%s", authorType, out)
+		}
+		// The rule is stated by the protocol in Instructions, never restated
+		// here — a second hand-maintained copy in the same context window is
+		// what drifted before.
+		if strings.Contains(out, "Squad leader no_action rule") {
+			t.Errorf("%s-triggered leader prompt restates the no_action rule\n---\n%s", authorType, out)
 		}
 	}
-}
 
-// TestBuildPromptSquadLeaderNoActionForMemberTrigger verifies that the
-// squad leader no_action prohibition is injected in the per-turn prompt
-// regardless of whether the triggering comment was posted by an agent or
-// a member. This was the root cause of the "LGTM is a pure acknowledgment
-// — no reply needed. Exiting silently." noise comment: the prohibition
-// only fired for agent-triggered comments, so member-triggered ones
-// (like "LGTM") bypassed it.
-func TestBuildPromptSquadLeaderNoActionForMemberTrigger(t *testing.T) {
-	task := Task{
+	// A non-leader gets the unconditional imperative: the carve-out is a
+	// leader-only exception, and offering it to an ordinary agent would licence
+	// a silent exit no `squad activity` call ever records.
+	nonLeader := BuildPrompt(Task{
 		IssueID:               "issue-123",
 		TriggerCommentID:      "comment-456",
 		TriggerCommentContent: "LGTM",
-		TriggerAuthorType:     "member",
-		TriggerAuthorName:     "Bohan",
-		IsLeaderTask:          true,
-		LeaderRoleResolved:    true,
-		Agent: &AgentData{
-			Instructions: "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER...",
-		},
-	}
-	out := BuildPrompt(task, "claude")
-	if !strings.Contains(out, "Squad leader no_action rule") {
-		t.Errorf("buildCommentPrompt must inject squad leader no_action rule for member-triggered comments, got:\n%s", out)
-	}
-	if !strings.Contains(out, "DO NOT post any comment") {
-		t.Errorf("buildCommentPrompt must contain DO NOT post prohibition for member-triggered squad leader, got:\n%s", out)
-	}
-}
-
-// TestBuildPromptSquadLeaderNoActionForAgentTrigger verifies the rule also
-// fires for agent-triggered comments (the original path that already worked).
-func TestBuildPromptSquadLeaderNoActionForAgentTrigger(t *testing.T) {
-	task := Task{
-		IssueID:               "issue-123",
-		TriggerCommentID:      "comment-456",
-		TriggerCommentContent: "Deploy complete.",
 		TriggerAuthorType:     "agent",
-		TriggerAuthorName:     "deploy-boy",
-		IsLeaderTask:          true,
-		LeaderRoleResolved:    true,
-		Agent: &AgentData{
-			Instructions: "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER...",
-		},
-	}
-	out := BuildPrompt(task, "claude")
-	if !strings.Contains(out, "Squad leader no_action rule") {
-		t.Errorf("buildCommentPrompt must inject squad leader no_action rule for agent-triggered comments, got:\n%s", out)
+		TriggerAuthorName:     "Worker",
+		Agent:                 &AgentData{Name: "Regular", Instructions: "You are a regular agent."},
+	}, "claude")
+	if strings.Contains(nonLeader, "Unless your outcome is `no_action`") {
+		t.Errorf("non-leader prompt carries the leader-only carve-out\n---\n%s", nonLeader)
 	}
 }
 
@@ -511,14 +563,8 @@ func TestBuildPromptLegacyServerKeepsBriefingBasedLeaderRole(t *testing.T) {
 		},
 	}, "claude")
 
-	for _, want := range []string{
-		"Squad leader no_action rule",
-		"multica squad activity",
-		"DO NOT post any comment",
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("legacy-server leader prompt lost %q\n---\n%s", want, out)
-		}
+	if !strings.Contains(out, "Unless your outcome is `no_action`, post your reply as a comment") {
+		t.Fatalf("legacy-server leader prompt lost the leader-only reply carve-out\n---\n%s", out)
 	}
 }
 

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"unicode/utf8"
 
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -73,73 +72,6 @@ func TestBuildQuickCreatePromptRules(t *testing.T) {
 		if strings.Contains(out, moved) {
 			t.Errorf("buildQuickCreatePrompt restates brief-owned rule %q\n--- output ---\n%s", moved, out)
 		}
-	}
-}
-
-// TestBuildAutopilotPromptCapsTriggerPayload covers the one unbounded value in
-// this prompt. A webhook body is written by whatever system fired the trigger,
-// so nothing in this workspace bounds its size, and the per-turn message is now
-// its only rendering (MUL-6984) — there is no second copy to fall back to and
-// no `autopilot runs` flag that fetches one run's payload. The cap therefore
-// has to truncate in place AND say so: a clipped JSON object read as a whole
-// one is worse than a short one, because the missing fields are invisible.
-func TestBuildAutopilotPromptCapsTriggerPayload(t *testing.T) {
-	t.Parallel()
-
-	oversized := `{"body":"` + strings.Repeat("x", autopilotTriggerPayloadCap*2) + `"}`
-	out := buildAutopilotPrompt(Task{
-		AutopilotRunID:          "run-1",
-		AutopilotID:             "autopilot-1",
-		AutopilotDescription:    "Check dependencies.",
-		AutopilotTriggerPayload: []byte(oversized),
-	})
-
-	if strings.Contains(out, oversized) {
-		t.Fatalf("oversized trigger payload rendered in full (%d bytes)", len(oversized))
-	}
-	if !strings.Contains(out, "trigger payload truncated") {
-		t.Errorf("truncated payload rendered without saying so\n---\n%s", out)
-	}
-	if !strings.Contains(out, "do not read it as a whole object") {
-		t.Errorf("truncation notice does not warn that the JSON is incomplete\n---\n%s", out)
-	}
-	// The instructions are the point of the run and must survive the cap.
-	if !strings.Contains(out, "Check dependencies.") {
-		t.Errorf("autopilot instructions lost alongside the capped payload\n---\n%s", out)
-	}
-
-	// A payload that fits is rendered verbatim — the cap must not touch the
-	// ordinary case, where the payload IS the trigger's meaning.
-	small := `{"action":"opened","number":7}`
-	out = buildAutopilotPrompt(Task{AutopilotRunID: "run-1", AutopilotTriggerPayload: []byte(small)})
-	if !strings.Contains(out, small) {
-		t.Errorf("payload under the cap was not rendered verbatim\n---\n%s", out)
-	}
-	if strings.Contains(out, "trigger payload truncated") {
-		t.Errorf("payload under the cap reported as truncated\n---\n%s", out)
-	}
-}
-
-// TestCapAutopilotTriggerPayloadCutsOnRuneBoundary keeps the truncation from
-// splitting a multi-byte character. A payload is arbitrary UTF-8 — issue
-// titles, chat messages, commit subjects — and a half rune renders as U+FFFD
-// in the middle of the text the agent is meant to read.
-func TestCapAutopilotTriggerPayloadCutsOnRuneBoundary(t *testing.T) {
-	t.Parallel()
-
-	// Three-byte runes so the cap lands mid-character for at least one offset.
-	payload := strings.Repeat("世", autopilotTriggerPayloadCap)
-	got := capAutopilotTriggerPayload(payload)
-	body := got[:strings.Index(got, "\n\n[trigger payload truncated")]
-
-	if !utf8.ValidString(body) {
-		t.Fatalf("truncated payload is not valid UTF-8 (%d bytes)", len(body))
-	}
-	if len(body) > autopilotTriggerPayloadCap {
-		t.Errorf("truncated body = %d bytes, want <= %d", len(body), autopilotTriggerPayloadCap)
-	}
-	if !strings.HasPrefix(payload, body) {
-		t.Error("truncated body is not a prefix of the original payload")
 	}
 }
 

--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -20,6 +20,17 @@ import (
 // and keep the mention syntax exactly aligned with util.MentionRe — the
 // "Squad Roster" block below renders concrete examples that round-trip
 // through util.ParseMentions, and the protocol text refers to that format.
+//
+// Responsibility 5 is the single statement of the no_action rule (MUL-6984).
+// The runtime brief's workflow step 4 and ## Output, and the per-turn reply
+// imperative, carry only the EXCEPTION to their own instruction and point
+// back here; before that split the rule existed in four copies that had
+// already drifted on the MUL-6622 failure fallback. When the rule changes,
+// it changes here. Do not restate it on another surface, and do not say so
+// inside the text: this const is sent to the model on every leader turn, so
+// a note addressed to maintainers is tokens the leader pays for and cannot
+// act on. multica-squads/references/squad-source-map.md records the same
+// ownership for anyone reading from the skill side.
 const squadOperatingProtocolHeader = `## Squad Operating Protocol
 
 **If you are reading this section, you have been activated as a squad LEADER
@@ -81,11 +92,7 @@ Your responsibilities, in order:
    ` + "`" + `squad activity` + "`" + ` call IS the record; a comment on top of
    it is noise. That prohibition holds only while the call succeeds — if
    it errors, responsibility 3 applies and the turn leaves one short
-   comment instead.
-
-This section is the single statement of the no_action rule. The runtime
-brief and the per-turn message point back here rather than restating it;
-when the rule changes, it changes here.`
+   comment instead.`
 
 // squadParentStatusOwned is responsibility 6 for the case where the issue this
 // leader was woken on is assigned to THIS squad. Only then does the leader own

--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -75,7 +75,17 @@ Your responsibilities, in order:
    activity and decide whether to delegate the next step, escalate to
    the human reporter, or close the loop. If no action is needed
    (e.g. a member posted a progress update that requires no response),
-   record ` + "`" + `no_action` + "`" + ` and exit silently.`
+   record ` + "`" + `no_action` + "`" + ` and exit silently. Exiting silently
+   means posting NO comment at all — not one announcing no_action, not
+   one acknowledging another agent, not one saying you are exiting. The
+   ` + "`" + `squad activity` + "`" + ` call IS the record; a comment on top of
+   it is noise. That prohibition holds only while the call succeeds — if
+   it errors, responsibility 3 applies and the turn leaves one short
+   comment instead.
+
+This section is the single statement of the no_action rule. The runtime
+brief and the per-turn message point back here rather than restating it;
+when the rule changes, it changes here.`
 
 // squadParentStatusOwned is responsibility 6 for the case where the issue this
 // leader was woken on is assigned to THIS squad. Only then does the leader own

--- a/server/internal/handler/squad_briefing_test.go
+++ b/server/internal/handler/squad_briefing_test.go
@@ -143,6 +143,43 @@ func seededHumanMember(t *testing.T) (memberID, userID, userName string) {
 	return
 }
 
+// TestSquadOperatingProtocolOwnsNoActionRule pins the protocol as the single
+// statement of the no_action rule (MUL-6984). It used to be written four
+// times — here, in the per-turn prompt, in the brief's workflow step 4, and in
+// the brief's ## Output — and the four copies had already drifted: only some
+// of them carried the MUL-6622 / GH #7487 escape hatch, which is what keeps a
+// FAILED `squad activity` call from ending the turn in silence. The other
+// three surfaces now point here, so this text has to carry the whole rule:
+// the prohibition, its exact scope, and the failure fallback.
+func TestSquadOperatingProtocolOwnsNoActionRule(t *testing.T) {
+	for _, ownsParentStatus := range []bool{true, false} {
+		protocol := squadOperatingProtocolFor(ownsParentStatus)
+		compact := strings.Join(strings.Fields(protocol), " ")
+
+		for _, want := range []string{
+			// the rule and how it is recorded
+			"multica squad activity <issue-id> <outcome> --reason",
+			"record `no_action` and exit silently",
+			// what "silently" forbids — MUL-2168 was a leader posting
+			// "no reply needed. Exiting silently."
+			"posting NO comment at all",
+			"not one saying you are exiting",
+			// MUL-6622 / #7487: the prohibition lapses when the call fails,
+			// because the server only rejects a leader comment once the
+			// no_action activity exists.
+			"holds only while the call succeeds",
+			"responsibility 3 applies",
+			// one comment, not two — the fallback must not collide with the
+			// one-comment-per-turn rule
+			"never post a second comment",
+		} {
+			if !strings.Contains(compact, want) {
+				t.Errorf("ownsParentStatus=%v: protocol missing %q\n--- protocol ---\n%s", ownsParentStatus, want, protocol)
+			}
+		}
+	}
+}
+
 func TestBuildSquadLeaderBriefing_FullSquad(t *testing.T) {
 	ctx := context.Background()
 	leaderID, leaderName := seededLeaderAgent(t)

--- a/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
+++ b/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
@@ -161,7 +161,18 @@ Contracts:
 - the `no_action` comment prohibition is conditional on this write succeeding
   (comment.go:1851 checks the activity exists), so the injected instructions
   tell leaders to fall back to a comment when the call errors — capped at one
-  comment, and only when the turn has not already commented.
+  comment, and only when the turn has not already commented. That rule is
+  stated in exactly one place: responsibility 5 of the Squad Operating Protocol
+  (`squadOperatingProtocolFor`, `server/internal/handler/squad_briefing.go`),
+  which the server appends to a leader's Instructions. The runtime brief
+  (workflow step 4 and `## Output` in
+  `server/internal/daemon/execenv/runtime_config_sections.go`) and the per-turn
+  reply imperative (`BuildCommentReplyInstructions` /
+  `BuildMultiThreadCommentReplyInstructions`,
+  `server/internal/daemon/execenv/reply_instructions.go`) carry only the
+  `no_action` EXCEPTION to their own imperative and point back at the protocol.
+  They used to restate the rule; the four copies had already drifted on the
+  failure fallback when they were collapsed (MUL-6984).
 
 ## Issue Assignment
 


### PR DESCRIPTION
Follow-up to #7937. Four places where the same data or rule was rendered two or three times into one context window, each resolved by picking the surface that owns it and pointing the others there.

The rule used to pick the owner is the one MUL-5377 already set for issue tasks: **the runtime brief holds what is true of this KIND of task** (stable, and it is the prompt-cache prefix), **the per-turn user message holds what is true of this RUN**, and **the workdir sidecar holds nothing**. The autopilot, quick-create and squad-leader paths had never been cleaned up against it.

## 1. Autopilot run data — brief + per-turn + sidecar → per-turn

Run id, autopilot id, title, trigger source, trigger payload and the instructions themselves were rendered three times. Now once, in `buildAutopilotPrompt`. The brief (`writeWorkflowAutopilot`) keeps the run-only framing and the shared `AutopilotIssueCommandsGuard`, and no longer takes a `ctx`.

This also settles a contract violation: those are per-run values, and the brief's own doc comment promises none reach it. MUL-5696 already caught the two copies drifting on the guard sentence and fixed that one line with a shared constant — the data underneath stayed doubled.

**The trigger payload is rendered whole.** An earlier revision capped it at 8 KB; that is removed. Ingress already bounds a webhook body at 256 KiB (`handler.maxWebhookBodyBytes`), and since de-duplication makes the per-turn message the payload's *only* rendering, truncating there would drop task input with no way back: `GET /api/autopilots/{id}/runs/{runId}` returns the full payload, but no CLI command exposes it and `autopilot runs` lists runs without payloads. A cap belongs with that read-back command and a threshold taken from real payload sizes — not as a side effect of removing duplicates. Rendering once instead of twice is still a strict improvement over today.

## 2. Squad leader `no_action` — four copies → protocol + two pointers

Written in the Squad Operating Protocol, the per-turn prompt, brief workflow step 4, and brief `## Output`. The four had **already drifted**: only some carried the MUL-6622 / #7487 escape hatch that keeps a *failed* `squad activity` call from ending the turn in silence.

The protocol is now the single statement — it is the only document sent exclusively to leaders, and it already held the outcome vocabulary and the failure fallback. The two brief sites and the per-turn reply imperative keep the **exception** to their own imperative ("unless your outcome is `no_action` — see …") and point back. The per-turn ⚠️ block (~600 B on every comment turn) is gone.

## 3. Quick-create rules — three copies → brief

The five run/output rules were in the brief's `## Workflow`, the brief's `## Output`, and the per-turn "Output format" block; the `--description-file` / `/tmp` / MUL-2904 guidance was in the brief's Available Commands and per-turn. The brief owns both now — its own comment says these guardrails must hold "even if the user message is missing" — and the per-turn prompt renders only the field values the modal picked. `## Output` keeps where output goes and how a file is delivered.

## 4. `.agent_context/issue_context.md` — deleted

Nothing read it. The rendered CLAUDE.md never mentions `.agent_context`, no per-turn message points at it, and no provider discovers it; the writer's own comment said *"the runtime brief already carries every fact this file would"*, and it skipped the write outright when the path already existed. Three renderers (`renderIssueContext` / `renderQuickCreateContext` / `renderAutopilotContext`) go with it.

Side effect worth naming: `.agent_context/` is now created only when the default provider needs `.agent_context/skills`, so a `local_directory` task with a native-skills provider leaves no empty managed directory in the user's own checkout.

`.agent_context/skills/` and `.multica/daemon_task_context.json` are unaffected — the marker has a real consumer (the CLI's daemon-task fallback when a sandbox strips `MULTICA_*`).

## Compatibility

Prompt text only. No wire field, CLI flag, DB column or migration, so no server/daemon version coupling.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean on every touched file.
- `go test -p 1 ./internal/daemon/... ./internal/handler/ ./internal/service/` on this branch and on `main`, back to back: **byte-identical results**, same 83 pre-existing failures either way. (`-p 1` matters — those packages share one test database, and running them in parallel makes the failure count jump on whichever tree runs first. The pre-existing failures here are environment-bound: a stale local schema missing `created_by_type`, and daemon profile/HOME path tests.)

Tests followed the text to its new owner rather than being deleted:

- `TestSquadOperatingProtocolOwnsNoActionRule` (new, `internal/handler`) pins the prohibition, its scope, and the failure fallback on the protocol.
- `TestQuickCreateBriefOwnsRunAndOutputRules` (new) pins the five rules on the brief and asserts `## Output` does *not* restate them.
- `TestAutopilotBriefByteIdenticalAcrossRunScopedFields` (new) is the invariant this PR actually moves. `TestBriefByteIdenticalAcrossRunsForEveryKind` could not see it — its autopilot row pins `run-1`/`ap-1` and every variant mutates only the generic resume/initiator/app fields, so putting the title, source, payload or description back in the brief left it green. The new test adds a second and third run varying all of them (including a different autopilot id), asserts the brief is byte-identical, and asserts the brief carries none of those values — byte-identity alone would also hold if they reached no surface at all. Verified against a deliberately reintroduced field, where it fails as intended.
- `TestBuildPromptAutopilotRunOnly` gains the source and payload assertions, pinning the per-turn message as their sole owner.
- `TestBuildPromptSquadLeaderReplyCarveOutIgnoresTriggerAuthor` (new) keeps the MUL-2168 regression — a leader posting "no reply needed. Exiting silently." after a *member's* comment — pointed at the surface that still branches on leadership, and replaces three near-identical per-turn tests.
- Sidecar tests became absence assertions, which is the regression that matters now: `writeContextFiles` must not resurrect a workdir file no surface names.

Deleted: `handoff_context_test.go` (tested only the removed renderer; the per-turn handoff note is covered by `handoff_prompt_test.go`), `TestWriteContextFilesAutopilotRunOnly` (covered by `TestBuildPromptAutopilotRunOnly`), and the three superseded per-turn squad tests.

Also updated `multica-squads/references/squad-source-map.md` to record where the single statement now lives, per the CLAUDE.md rule on built-in skills.



---

**Contract docs corrected after review:** `agent.MinHandoffCLIVersion` (the gate always measured the opening prompt — no provider read the sidecar), the `handoff_note` field docs on both sides of the claim wire, the claim handler's note, `TaskContextForEnv.HandoffNote`, and `errPathPreExists`'s namespace list. The Reuse path keeps its `issue_context.md` mentions, now labelled as cleanup of manifests written by *older builds* rather than of anything this code still writes.
