### PR TITLE
fix(onboarding): resume Mika setup without reprovisioning prompts

### DIFF
--- a/packages/core/onboarding/mika.test.ts
+++ b/packages/core/onboarding/mika.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 import { isMikaAgent, memberNeedsMikaSetup, workspaceNeedsMika } from "./mika";
 
@@ -5,7 +7,11 @@ const mika = { id: "agent-mika", system_key: "mika" };
 const other = { id: "agent-other", system_key: undefined };
 const kicked = {
   agent_id: "agent-mika",
-  last_message: { content: "…", role: "user" as const, created_at: "2026-01-01" },
+  last_message: {
+    content: "…",
+    role: "user" as const,
+    created_at: "2026-01-01",
+  },
 };
 
 describe("workspaceNeedsMika", () => {
@@ -53,7 +59,10 @@ describe("memberNeedsMikaSetup", () => {
 
   it("stays true when the session exists but the kickoff never landed", () => {
     expect(
-      memberNeedsMikaSetup([mika], [{ agent_id: "agent-mika", last_message: null }]),
+      memberNeedsMikaSetup(
+        [mika],
+        [{ agent_id: "agent-mika", last_message: null }],
+      ),
     ).toBe(true);
   });
 
@@ -66,5 +75,23 @@ describe("memberNeedsMikaSetup", () => {
 
   it("is false once the member has a kicked-off Mika conversation", () => {
     expect(memberNeedsMikaSetup([other, mika], [kicked])).toBe(false);
+  });
+
+  it("does not restart onboarding when an empty conversation precedes existing history", () => {
+    const empty = { agent_id: mika.id, last_message: null };
+    expect(memberNeedsMikaSetup([mika], [empty, kicked])).toBe(false);
+    expect(memberNeedsMikaSetup([mika], [kicked, empty])).toBe(false);
+  });
+
+  it("keeps recovery available when all of the member's Mika conversations are empty", () => {
+    expect(
+      memberNeedsMikaSetup(
+        [mika],
+        [
+          { agent_id: mika.id, last_message: null },
+          { agent_id: mika.id, last_message: undefined },
+        ],
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/core/onboarding/mika.ts
+++ b/packages/core/onboarding/mika.ts
@@ -46,11 +46,9 @@ export function memberNeedsMikaSetup(
   const mika = agents.find(isMikaAgent);
   if (!mika) return true;
 
-  // Sessions are per member, so this is the caller's own conversation.
-  const session = sessions.find((s) => s.agent_id === mika.id);
-  if (!session) return true;
-
-  // The opening turn is stored as a real (hidden) message, so an empty
-  // conversation means the kickoff never landed.
-  return !session.last_message;
+  // Sessions are per member and include archived conversations. A newer or
+  // pinned empty conversation must not hide an already-started one.
+  return !sessions.some(
+    (session) => session.agent_id === mika.id && Boolean(session.last_message),
+  );
 }

--- a/packages/core/onboarding/use-bootstrap-mika.ts
+++ b/packages/core/onboarding/use-bootstrap-mika.ts
@@ -38,9 +38,7 @@ export interface BootstrapMikaResult {
  * decided here; the server owns it, which is why this can no longer drift from
  * the product definition the way a client-built payload could.
  */
-export async function bootstrapMika(
-  input: BootstrapMikaInput,
-): Promise<
+export async function bootstrapMika(input: BootstrapMikaInput): Promise<
   BootstrapMikaResult & {
     kickoff: Awaited<ReturnType<typeof api.startMikaOnboarding>>;
   }
@@ -81,6 +79,18 @@ export function useBootstrapMika(workspaceId: string) {
 
   return useMutation({
     mutationFn: (input: BootstrapMikaInput) => bootstrapMika(input),
+    // Agent/session creation can commit before a later step fails. Refresh
+    // those durable results even when the websocket event was missed, so a
+    // retry resumes setup instead of offering to provision Mika again.
+    onSettled: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: workspaceKeys.agents(workspaceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: chatKeys.sessions(workspaceId),
+        }),
+      ]),
     onSuccess: ({ chatSession }) => {
       // No pending task is seeded any more: the opening is written by the
       // server and already persisted by the time this resolves, so there is
@@ -88,12 +98,6 @@ export function useBootstrapMika(workspaceId: string) {
       // list is what makes it appear — and because it is real persisted state,
       // it survives a reload, unlike the pending-task marker it replaces.
       return Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: workspaceKeys.agents(workspaceId),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: chatKeys.sessions(workspaceId),
-        }),
         queryClient.invalidateQueries({
           queryKey: chatKeys.messages(chatSession.id),
         }),

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -28,6 +28,12 @@
     }
   },
   "mika_setup": {
+    "resume_title": "Continue getting started with Mika.",
+    "resume_description": "Continue your first conversation with Mika using its current setup.",
+    "resume_action": "Continue setup",
+    "check_failed": "Couldn't check whether Mika setup is complete.",
+    "retry": "Retry",
+    "runtime_missing": "Mika has no runtime configured. Choose one in the agent settings first.",
     "title": "Your runtime is ready. Start with Mika.",
     "description": "Mika turns your goal into an issue, coordinates the right agent, and helps you add reusable specialists when your workflow needs them.",
     "action": "Start with Mika",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -28,6 +28,12 @@
     }
   },
   "mika_setup": {
+    "resume_title": "Mika の初期設定を続けましょう。",
+    "resume_description": "既存の Mika との会話を開いて、初期設定を完了します。",
+    "resume_action": "設定を続ける",
+    "check_failed": "Mika の設定状況を確認できませんでした。",
+    "retry": "再試行",
+    "runtime_missing": "Mika にランタイムが設定されていません。先にエージェント設定で選択してください。",
     "title": "ランタイムの準備ができました。Mika と始めましょう。",
     "description": "Mika は目標をタスクに落とし込み、適切なエージェントを調整し、ワークフローに必要な再利用可能な specialist の追加を支援します。",
     "action": "Mika と始める",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -28,6 +28,12 @@
     }
   },
   "mika_setup": {
+    "resume_title": "Mika 시작 설정을 계속하세요.",
+    "resume_description": "기존 Mika와의 대화를 열고 시작 설정을 완료하세요.",
+    "resume_action": "설정 계속",
+    "check_failed": "Mika 설정 상태를 확인하지 못했습니다.",
+    "retry": "다시 시도",
+    "runtime_missing": "Mika에 런타임이 설정되지 않았습니다. 먼저 에이전트 설정에서 선택하세요.",
     "title": "런타임이 준비되었습니다. Mika와 시작하세요.",
     "description": "Mika가 목표를 태스크로 구체화하고 적합한 에이전트를 조율하며, 워크플로에 필요할 때 재사용 가능한 specialist 추가를 돕습니다.",
     "action": "Mika와 시작",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -28,6 +28,12 @@
     }
   },
   "mika_setup": {
+    "resume_title": "继续完成 Mika 的上手引导。",
+    "resume_description": "使用现有 Mika 继续你的首次对话。",
+    "resume_action": "继续引导",
+    "check_failed": "暂时无法确认 Mika 的引导状态。",
+    "retry": "重试",
+    "runtime_missing": "Mika 尚未配置运行时，请先在智能体设置中选择。",
     "title": "运行时已准备好，和 Mika 开始。",
     "description": "Mika 会把你的目标转化为任务、协调合适的智能体，并在工作流需要时帮你添加可复用的 specialist。",
     "action": "和 Mika 开始",

--- a/packages/views/runtimes/components/runtimes-page.test.tsx
+++ b/packages/views/runtimes/components/runtimes-page.test.tsx
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { I18nProvider } from "@multica/core/i18n/react";
+import { workspaceKeys } from "@multica/core/workspace/queries";
+import { chatKeys } from "@multica/core/chat/queries";
+import type { Agent } from "@multica/core/types";
+import enCommon from "../../locales/en/common.json";
+import enRuntimes from "../../locales/en/runtimes.json";
+import { RuntimesPage } from "./runtimes-page";
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    listAgents: vi.fn(),
+    listChatSessions: vi.fn(),
+    listRuntimes: vi.fn(),
+    listRuntimeProfiles: vi.fn(),
+    getAgentTaskSnapshot: vi.fn(),
+    createMikaAgent: vi.fn(),
+    startMikaOnboarding: vi.fn(),
+  },
+  push: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@multica/core/api", () => ({ api: mocks.api }));
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "ws-1" }));
+vi.mock("@multica/core/auth", () => {
+  const state = { isLoading: false, user: { id: "member-1" } };
+  return {
+    useAuthStore: Object.assign(
+      (selector: (value: typeof state) => unknown) => selector(state),
+      { getState: () => state },
+    ),
+  };
+});
+vi.mock("@multica/core/paths", () => ({
+  useRequiredWorkspaceSlug: () => "workspace",
+  useWorkspacePaths: () => ({
+    chatSession: (id: string) => `/workspace/chat/${id}`,
+  }),
+}));
+vi.mock("@multica/core/realtime", () => ({ useWSEvent: () => {} }));
+vi.mock("../../navigation", () => ({
+  useNavigation: () => ({ push: mocks.push }),
+  AppLink: (props: ComponentProps<"a">) => <a {...props} />,
+}));
+vi.mock("sonner", () => ({ toast: { error: mocks.error } }));
+vi.mock("./connect-remote-dialog", () => ({ ConnectRemoteDialog: () => null }));
+vi.mock("./cloud-runtime-dialog", () => ({ CloudRuntimeDialog: () => null }));
+vi.mock("./runtime-list", () => ({
+  buildWorkloadIndex: () => new Map(),
+  RuntimeList: () => null,
+}));
+vi.mock("./runtime-machines", () => ({ buildRuntimeMachines: () => [] }));
+vi.mock("./mika-runtime-choice", () => ({
+  MikaRuntimeChoice: () => <div>Runtime choice</div>,
+}));
+
+const mika = {
+  id: "mika-1",
+  system_key: "mika",
+  name: "Mika",
+  runtime_id: "configured-runtime",
+  model: "configured-model",
+} as Agent;
+const session = { id: "session-1", agent_id: mika.id, status: "active" };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.api.listAgents.mockResolvedValue([mika]);
+  mocks.api.listChatSessions.mockResolvedValue([]);
+  mocks.api.listRuntimes.mockResolvedValue([
+    {
+      id: "other-runtime",
+      name: "Other computer",
+      provider: "codex",
+      status: "online",
+    },
+  ]);
+  mocks.api.listRuntimeProfiles.mockResolvedValue([]);
+  mocks.api.getAgentTaskSnapshot.mockResolvedValue([]);
+  mocks.api.createMikaAgent.mockResolvedValue({
+    ...mika,
+    onboarding_session: session,
+  });
+  mocks.api.startMikaOnboarding.mockResolvedValue({
+    started: true,
+    message_id: "opening-1",
+  });
+});
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+  render(
+    <QueryClientProvider client={qc}>
+      <I18nProvider
+        locale="en"
+        resources={{ en: { common: enCommon, runtimes: enRuntimes } }}
+      >
+        <RuntimesPage hasLocalMachine />
+      </I18nProvider>
+    </QueryClientProvider>,
+  );
+  return qc;
+}
+
+// Session-history permutations are covered by core/onboarding/mika.test.ts.
+// This suite covers real query transitions and the recovery action's wiring.
+describe("Mika recovery on the Runtimes page", () => {
+  it.each(["agents", "sessions"] as const)(
+    "does not offer setup when the %s query fails, and can retry",
+    async (failed) => {
+      const request =
+        failed === "agents" ? mocks.api.listAgents : mocks.api.listChatSessions;
+      request.mockRejectedValue(new Error("Network unavailable"));
+      const qc = renderPage();
+      const key =
+        failed === "agents"
+          ? workspaceKeys.agents("ws-1")
+          : chatKeys.sessions("ws-1");
+      await waitFor(() => expect(qc.getQueryState(key)?.status).toBe("error"));
+      expect(
+        screen.queryByRole("button", { name: "Start with Mika" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Continue setup" }),
+      ).not.toBeInTheDocument();
+      request.mockResolvedValue(failed === "agents" ? [mika] : []);
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Retry" }),
+      );
+      expect(
+        await screen.findByRole("button", { name: "Continue setup" }),
+      ).toBeInTheDocument();
+      expect(mocks.api.createMikaAgent).not.toHaveBeenCalled();
+    },
+  );
+
+  it("resumes with the existing agent's runtime without opening a runtime picker", async () => {
+    renderPage();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Continue setup" }),
+    );
+    await waitFor(() =>
+      expect(mocks.push).toHaveBeenCalledWith("/workspace/chat/session-1"),
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mocks.api.createMikaAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime_id: "configured-runtime",
+        model: undefined,
+      }),
+      "workspace",
+    );
+    expect(mocks.api.startMikaOnboarding).toHaveBeenCalledWith(
+      "session-1",
+      { language: "en" },
+      "workspace",
+    );
+  });
+
+  it("keeps recovery available after the opening fails and retries the same server-resolved session", async () => {
+    mocks.api.startMikaOnboarding.mockRejectedValueOnce(
+      new Error("Opening failed"),
+    );
+    renderPage();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Continue setup" }),
+    );
+    await waitFor(() =>
+      expect(mocks.error).toHaveBeenCalledWith("Opening failed"),
+    );
+    expect(mocks.push).not.toHaveBeenCalled();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Continue setup" }),
+    );
+    await waitFor(() =>
+      expect(mocks.push).toHaveBeenCalledWith("/workspace/chat/session-1"),
+    );
+    expect(mocks.api.startMikaOnboarding.mock.calls.map(([id]) => id)).toEqual([
+      "session-1",
+      "session-1",
+    ]);
+  });
+
+  it("refreshes partial provisioning after failure even without an agent-created event", async () => {
+    mocks.api.listAgents.mockResolvedValue([]);
+    mocks.api.createMikaAgent.mockImplementationOnce(async () => {
+      // The agent committed, but opening the member's session failed. The
+      // websocket event may be missed while the client is reconnecting.
+      mocks.api.listAgents.mockResolvedValue([mika]);
+      throw new Error("Could not open the conversation");
+    });
+    renderPage();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Start with Mika" }),
+    );
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Start with Mika",
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.error).toHaveBeenCalledWith(
+        "Could not open the conversation",
+      ),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Continue setup" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mocks.api.startMikaOnboarding).not.toHaveBeenCalled();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Continue setup" }),
+    );
+    await waitFor(() =>
+      expect(mocks.push).toHaveBeenCalledWith("/workspace/chat/session-1"),
+    );
+  });
+
+  it("asks for a runtime only when Mika has not been provisioned", async () => {
+    mocks.api.listAgents.mockResolvedValue([]);
+    renderPage();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Start with Mika" }),
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Runtime choice")).toBeInTheDocument();
+    expect(mocks.api.createMikaAgent).not.toHaveBeenCalled();
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Start with Mika" }),
+    );
+    await waitFor(() =>
+      expect(mocks.api.createMikaAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ runtime_id: "other-runtime" }),
+        "workspace",
+      ),
+    );
+  });
+
+  it("does not silently select another runtime when the existing agent's binding is missing", async () => {
+    mocks.api.listAgents.mockResolvedValue([{ ...mika, runtime_id: "" }]);
+    renderPage();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Continue setup" }),
+    );
+    expect(mocks.error).toHaveBeenCalled();
+    expect(mocks.api.createMikaAgent).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -13,7 +13,11 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { memberNeedsMikaSetup, useBootstrapMika } from "@multica/core/onboarding";
+import {
+  isMikaAgent,
+  memberNeedsMikaSetup,
+  useBootstrapMika,
+} from "@multica/core/onboarding";
 import { MIKA_PLACEHOLDER_EMOJI } from "../../onboarding/components/mika-intro";
 import { useRequiredWorkspaceSlug, useWorkspacePaths } from "@multica/core/paths";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
@@ -22,7 +26,7 @@ import { runtimeProfileListOptions } from "@multica/core/runtimes";
 import { runtimeListOptions, runtimeKeys } from "@multica/core/runtimes/queries";
 import { useWSEvent } from "@multica/core/realtime";
 import { agentListOptions } from "@multica/core/workspace/queries";
-import type { AgentRuntime } from "@multica/core/types";
+import type { Agent, AgentRuntime } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
 import {
   Dialog,
@@ -87,6 +91,7 @@ export function RuntimesPage({
   bootstrapping,
   cloudRuntimeEnabled = false,
 }: RuntimesPageProps = {}) {
+  const { t } = useT("runtimes");
   const isAuthLoading = useAuthStore((state) => state.isLoading);
   const currentUserId = useAuthStore((state) => state.user?.id);
   const wsId = useWorkspaceId();
@@ -100,16 +105,14 @@ export function RuntimesPage({
   const { data: runtimeProfiles = [], isLoading: profilesLoading } = useQuery(
     runtimeProfileListOptions(wsId),
   );
-  const { data: agents = [], isLoading: agentsLoading } = useQuery(
-    agentListOptions(wsId),
-  );
+  const agentsQuery = useQuery(agentListOptions(wsId));
+  const { data: agents = [] } = agentsQuery;
   const { data: snapshot = [] } = useQuery(agentTaskSnapshotOptions(wsId));
   // The Mika entrypoint is per member, not per workspace: the agent alone does
   // not say whether *this* member's conversation was ever opened and kicked
   // off. See memberNeedsMikaSetup.
-  const { data: chatSessions = [], isLoading: chatSessionsLoading } = useQuery(
-    chatSessionsOptions(wsId),
-  );
+  const chatSessionsQuery = useQuery(chatSessionsOptions(wsId));
+  const { data: chatSessions = [] } = chatSessionsQuery;
 
   const handleDaemonEvent = useCallback(() => {
     qc.invalidateQueries({ queryKey: runtimeKeys.all(wsId) });
@@ -179,17 +182,42 @@ export function RuntimesPage({
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto">
           <div className="mx-auto flex w-full max-w-[1440px] flex-col p-4 sm:p-6">
-            {!agentsLoading &&
-              !chatSessionsLoading &&
+            {(agentsQuery.isError || chatSessionsQuery.isError) && (
+              <div
+                role="alert"
+                className="mb-6 flex items-center justify-between gap-4 rounded-xl border p-5"
+              >
+                <p className="text-body text-muted-foreground">
+                  {t(($) => $.mika_setup.check_failed)}
+                </p>
+                <Button
+                  className="shrink-0"
+                  variant="outline"
+                  disabled={
+                    agentsQuery.isFetching || chatSessionsQuery.isFetching
+                  }
+                  onClick={() => {
+                    if (agentsQuery.isError) void agentsQuery.refetch();
+                    if (chatSessionsQuery.isError)
+                      void chatSessionsQuery.refetch();
+                  }}
+                >
+                  {t(($) => $.mika_setup.retry)}
+                </Button>
+              </div>
+            )}
+            {agentsQuery.isSuccess &&
+              chatSessionsQuery.isSuccess &&
               memberNeedsMikaSetup(agents, chatSessions) &&
               runtimes.length > 0 && (
-              <MikaSetupCard
-                workspaceId={wsId}
-                runtimes={runtimes}
-                runtimesLoading={runtimesLoading}
-                currentUserId={currentUserId ?? null}
-              />
-            )}
+                <MikaSetupCard
+                  workspaceId={wsId}
+                  agent={agents.find(isMikaAgent)}
+                  runtimes={runtimes}
+                  runtimesLoading={runtimesLoading}
+                  currentUserId={currentUserId ?? null}
+                />
+              )}
             {(machines.length > 0 || bootstrapping) && (
               <MachineList
                 machines={machines}
@@ -226,16 +254,19 @@ export function RuntimesPage({
  * the box this was reported from), so "the first online one" is arbitrary and
  * could well be a CLI the member never intended to run their Chief of Staff
  * on. Onboarding already makes this an explicit choice; this is the same
- * decision reached from a different entry point, so it asks the same way and
- * reuses the same two controls.
+ * decision reached from a different entry point, so first-time setup reuses
+ * the same two controls. Recovery keeps the existing agent's configuration
+ * and goes straight to completing the member's conversation.
  */
 function MikaSetupCard({
   workspaceId,
+  agent,
   runtimes,
   runtimesLoading,
   currentUserId,
 }: {
   workspaceId: string;
+  agent?: Agent;
   runtimes: AgentRuntime[];
   runtimesLoading?: boolean;
   currentUserId: string | null;
@@ -259,16 +290,25 @@ function MikaSetupCard({
     runtimeId: defaultRuntimeId,
     model: "",
   };
-  const runtimeId = value.runtimeId;
+  // Provisioning needs a choice; recovery must keep the existing binding.
+  // The server resolves the same agent/session under locks on every retry.
+  const runtimeId = agent ? agent.runtime_id : value.runtimeId;
+  const title = agent
+    ? t(($) => $.mika_setup.resume_title)
+    : t(($) => $.mika_setup.title);
 
   const handleStart = async () => {
-    if (!runtimeId || bootstrapMika.isPending) return;
+    if (bootstrapMika.isPending) return;
+    if (!runtimeId) {
+      if (agent) toast.error(t(($) => $.mika_setup.runtime_missing));
+      return;
+    }
     const lang = pickContentLang(i18n.language);
     try {
       const result = await bootstrapMika.mutateAsync({
         workspaceSlug: wsSlug,
         runtimeId,
-        model: value.model || undefined,
+        model: agent ? undefined : value.model || undefined,
         ...getMikaOnboarding(lang),
       });
       setOpen(false);
@@ -285,25 +325,34 @@ function MikaSetupCard({
       <div className="mb-6 flex flex-col gap-4 rounded-xl border bg-card p-5 sm:flex-row sm:items-center">
         <span
           role="img"
-          aria-label={t(($) => $.mika_setup.title)}
+          aria-label={title}
           className="flex size-10 shrink-0 select-none items-center justify-center rounded-full bg-muted text-title-lg leading-none"
         >
           {MIKA_PLACEHOLDER_EMOJI}
         </span>
         <div className="min-w-0 flex-1">
-          <h2 className="text-body font-semibold">
-            {t(($) => $.mika_setup.title)}
-          </h2>
+          <h2 className="text-body font-semibold">{title}</h2>
           <p className="mt-1 text-body leading-relaxed text-muted-foreground">
-            {t(($) => $.mika_setup.description)}
+            {agent
+              ? t(($) => $.mika_setup.resume_description)
+              : t(($) => $.mika_setup.description)}
           </p>
         </div>
-        <Button className="shrink-0" onClick={() => setOpen(true)}>
-          {t(($) => $.mika_setup.action)}
+        <Button
+          className="shrink-0"
+          disabled={bootstrapMika.isPending}
+          onClick={agent ? () => void handleStart() : () => setOpen(true)}
+        >
+          {bootstrapMika.isPending && (
+            <Loader2 aria-hidden className="size-4 animate-spin" />
+          )}
+          {agent
+            ? t(($) => $.mika_setup.resume_action)
+            : t(($) => $.mika_setup.action)}
         </Button>
       </div>
 
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog open={open && !agent} onOpenChange={setOpen}>
         <DialogContent className="sm:max-w-[480px]">
           <DialogHeader>
             <DialogTitle>{t(($) => $.mika_setup.dialog_title)}</DialogTitle>


### PR DESCRIPTION
## What does this PR do?

Make the Runtimes page distinguish an unfinished Mika introduction from first-time provisioning. If Mika already exists, **Continue setup** resumes bootstrap using that agent's runtime and existing configuration, without asking the member to choose a runtime/model again.

The current server already reuses the workspace Mika agent and the member's chat session. The client also intentionally offers recovery when Mika exists but the member has no conversation or only an empty conversation. However, the page presents the first-time setup picker for that recovery path. It also treats failed agent/session queries as empty results, and checks only the first matching session, so an empty chat can mask an established conversation. A bootstrap failure after persisting the agent/session can leave these queries stale.

This patch aligns the client with the existing recovery contract; it does not add a new server provisioning path.

## Related Issue

No separate GitHub issue. Related context: #6520 fixed the opening-message timestamp tie. This addresses client-side query failures, session selection, and resuming an incomplete introduction, which remain independently reproducible.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/onboarding/mika.ts`: suppress setup if any matching Mika session has a last message, including history returned by the existing all-status query.
- `packages/core/onboarding/use-bootstrap-mika.ts`: invalidate agent/session queries on settlement, including a partial failure; keep message invalidation on success.
- `packages/views/runtimes/components/runtimes-page.tsx`: require successful agent/session queries, show a retryable status-check error, and resume an existing Mika using its runtime without a new model override. Preserve the picker for first-time setup and close it when a refresh discovers the persisted agent.
- `packages/views/locales/{en,ja,ko,zh-Hans}/runtimes.json`: add recovery, retry, and missing-runtime copy.
- Regression tests cover query failures, existing-agent recovery, partial bootstrap failure, and empty sessions preceding conversation history.

## How to Test

1. With a workspace Mika already present and the current member having no session or only an empty session, open Runtimes. Before: **Start with Mika** opens the runtime/model picker. After: **Continue setup** calls the existing bootstrap endpoint with Mika's runtime, then opens the returned conversation.
2. Fail either the agent query or the session query. Before: setup may appear because the failed query is treated as empty. After: an error notice offers **Retry**, and retries the failed query before determining setup state.
3. Return an empty Mika session ahead of another Mika session with conversation history. The setup card must remain hidden.
4. Fail bootstrap after the agent or session has been persisted, and omit the corresponding WebSocket update. Both queries must refresh; a subsequent retry must use the existing agent recovery flow.

Local validation:

- `pnpm --filter @multica/core exec vitest run onboarding/mika.test.ts onboarding/use-bootstrap-mika.test.ts`: 17 tests passed.
- `pnpm --filter @multica/views exec vitest run runtimes/components/runtimes-page.test.tsx runtimes/components/mika-runtime-choice.test.tsx locales/parity.test.ts`: 169 tests passed.
- Core and views type checks passed; targeted ESLint and `git diff --check` passed.
- Browser verification rendered the real shared components and desktop styles with synthetic API responses. Clicking **Continue setup** opened the fixture's existing conversation directly, and **Retry** refreshed the failed query.

Validation limits: Windows host with Node 24.20.0 and pnpm 10.28.2. `make check-worktree` was attempted but could not start because `make` is unavailable. Full Go/E2E checks and an installed Electron restart were not run. The screenshots demonstrate the client states and interactions, not a live backend acceptance test.

Risks: no API, database, or server behavior changes. Recovery depends on the existing Mika runtime binding; if it is absent, the UI asks the member to configure it in agent settings rather than choosing an arbitrary runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (targeted checks listed above)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes (not applicable; repair of the existing flow)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex.

**Prompt / approach:** Investigate why Mika setup appears again after an interrupted introduction, preserve the existing server reuse behavior, and prepare a minimal upstream fix. Traced the UI, session helper, bootstrap mutation, and server idempotency; reproduced the client regressions in tests; implemented query guards, history-aware setup detection, and recovery UI; then validated with focused tests and browser screenshots of the actual components using synthetic data.

## Screenshots

Before/after captures are prepared and will be attached before this draft is marked ready. They use the real Multica Runtimes components and desktop styles, synthetic API data, and a small fixture label identifying each state. No account data or production runtime information is included.
