### PR TITLE
MUL-6892: retire legacy delegated-failure pending index

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -321,6 +321,7 @@ var concurrentDownIndexCleanups = map[string]string{
 	"375_drop_issue_last_activity_index":                    "idx_issue_workspace_last_activity",
 	"391_drop_agent_task_queue_dispatched_prepare_index":    "idx_agent_task_queue_dispatched_prepare",
 	"437_drop_agent_runtime_last_seen_at_index":             "idx_agent_runtime_last_seen_at",
+	"450_drop_comment_delegated_failure_pending_index":      "idx_comment_delegated_failure_pending",
 }
 
 var preMigrationHooks = func() map[string]preMigrationHook {

--- a/server/cmd/migrate/migrate_delegated_failure_pending_index_retirement_test.go
+++ b/server/cmd/migrate/migrate_delegated_failure_pending_index_retirement_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestDelegatedFailurePendingIndexRetirement(t *testing.T) {
+	adminPool := openTestPool(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	suffix := fmt.Sprintf("%d_%d", time.Now().UnixNano(), rand.Uint32())
+	schema := "migrate_delegated_failure_idx_" + suffix
+	schemaIdent := pgx.Identifier{schema}.Sanitize()
+	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+schemaIdent); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		if _, err := adminPool.Exec(cleanupCtx, "DROP SCHEMA IF EXISTS "+schemaIdent+" CASCADE"); err != nil {
+			t.Logf("drop schema %s: %v", schema, err)
+		}
+	})
+
+	pool := openTestPoolWithSearchPath(t, schema)
+	for _, statement := range []string{
+		`CREATE TABLE schema_migrations (
+			version TEXT PRIMARY KEY,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+		)`,
+		`CREATE TABLE comment (
+			id UUID PRIMARY KEY,
+			created_at TIMESTAMPTZ NOT NULL,
+			author_type TEXT NOT NULL,
+			type TEXT NOT NULL,
+			source_task_id UUID
+		)`,
+	} {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			t.Fatalf("apply fixture statement: %v", err)
+		}
+	}
+
+	options := runOptions{
+		Direction:             "up",
+		SchemaMigrationsTable: schema + ".schema_migrations",
+		AdvisoryLockKey:       int64(rand.Uint64()&0x7fffffffffffffff) | 1,
+		Hooks:                 hooksForDirection("up"),
+	}
+	options.Files = realMigrationFiles(t, []string{
+		"343_comment_delegated_failure_pending_index",
+		"444_comment_recovery_settled_at",
+	}, "up")
+	if err := runMigrations(ctx, pool, options); err != nil {
+		t.Fatalf("apply historical delegated-failure migrations: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO comment (
+			id, created_at, author_type, type, source_task_id, recovery_settled_at
+		)
+		SELECT
+			gen_random_uuid(),
+			now() - make_interval(secs => n),
+			'system',
+			'progress_update',
+			gen_random_uuid(),
+			CASE WHEN n % 10 = 0 THEN NULL ELSE now() END
+		FROM generate_series(1, 5000) AS n
+	`); err != nil {
+		t.Fatalf("seed delegated-failure comments: %v", err)
+	}
+
+	options.Files = realMigrationFiles(t, []string{
+		"445_comment_delegated_failure_unsettled_index",
+	}, "up")
+	if err := runMigrations(ctx, pool, options); err != nil {
+		t.Fatalf("apply replacement delegated-failure index migration: %v", err)
+	}
+	assertIndexValidity(t, pool, schema, "idx_comment_delegated_failure_pending", true)
+	assertIndexValidity(t, pool, schema, "idx_comment_delegated_failure_unsettled", true)
+
+	const version = "450_drop_comment_delegated_failure_pending_index"
+	options.Files = realMigrationFiles(t, []string{version}, "up")
+	if err := runMigrations(ctx, pool, options); err != nil {
+		t.Fatalf("apply delegated-failure index retirement migration: %v", err)
+	}
+	assertIndexExists(t, pool, schema, "idx_comment_delegated_failure_pending", false)
+	assertIndexValidity(t, pool, schema, "idx_comment_delegated_failure_unsettled", true)
+	assertMigrationVersionRecorded(t, ctx, pool, schema, version, true)
+	assertPlanUsesIndex(t, pool, `
+		SELECT id
+		FROM comment
+		WHERE author_type = 'system'
+		  AND type = 'progress_update'
+		  AND source_task_id IS NOT NULL
+		  AND recovery_settled_at IS NULL
+		ORDER BY created_at, id
+		LIMIT 100
+	`, "idx_comment_delegated_failure_unsettled")
+
+	options.Direction = "down"
+	options.Files = realMigrationFiles(t, []string{version}, "down")
+	options.Hooks = hooksForDirection("down")
+	if err := runMigrations(ctx, pool, options); err != nil {
+		t.Fatalf("roll back delegated-failure index retirement migration: %v", err)
+	}
+	assertIndexValidity(t, pool, schema, "idx_comment_delegated_failure_pending", true)
+	assertIndexValidity(t, pool, schema, "idx_comment_delegated_failure_unsettled", true)
+	assertMigrationVersionRecorded(t, ctx, pool, schema, version, false)
+}

--- a/server/migrations/450_drop_comment_delegated_failure_pending_index.down.sql
+++ b/server/migrations/450_drop_comment_delegated_failure_pending_index.down.sql
@@ -1,0 +1,5 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_comment_delegated_failure_pending
+ON comment (created_at, id)
+WHERE author_type = 'system'
+  AND type = 'progress_update'
+  AND source_task_id IS NOT NULL;

--- a/server/migrations/450_drop_comment_delegated_failure_pending_index.up.sql
+++ b/server/migrations/450_drop_comment_delegated_failure_pending_index.up.sql
@@ -1,0 +1,3 @@
+-- Migration 445 replaced this index with the smaller unsettled-only partial
+-- index after the historical recovery backfill completed.
+DROP INDEX CONCURRENTLY IF EXISTS idx_comment_delegated_failure_pending;


### PR DESCRIPTION
## Summary

- drop the legacy delegated-failure pending index concurrently
- keep the smaller unsettled-only replacement index introduced by migration 445
- restore the legacy index concurrently on rollback, with invalid-index retry cleanup
- cover the up/down migration and replacement query plan with an isolated PostgreSQL test

The replacement rollout, historical backfill, and observation window were confirmed complete before this cleanup.

## Validation

- `go test ./cmd/migrate -count=1`
- `go vet ./cmd/migrate`
- `git diff --cached --check`

Closes MUL-6892
