### PR TITLE
MUL-7018: remove tests that only restate constants or declarations

### DIFF
--- a/server/cmd/multica/cmd_daemon_probe_test.go
+++ b/server/cmd/multica/cmd_daemon_probe_test.go
@@ -15,12 +15,3 @@ func TestDaemonRuntimeProbeFromAgents(t *testing.T) {
 		t.Fatalf("probe = %#v", probe)
 	}
 }
-
-func TestLoadConfigAllowNoAgentsIsOptIn(t *testing.T) {
-	// The production startup path does not set this override. Keep the probe's
-	// escape hatch explicit rather than weakening the daemon startup invariant.
-	var overrides daemon.Overrides
-	if overrides.AllowNoAgents {
-		t.Fatal("AllowNoAgents must default to false")
-	}
-}

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -2742,26 +2742,6 @@ func TestRunIssueCommentList_DoesNotPrintShowingPreamble(t *testing.T) {
 	}
 }
 
-func TestValidIssueStatuses(t *testing.T) {
-	expected := map[string]bool{
-		"backlog":     true,
-		"todo":        true,
-		"in_progress": true,
-		"in_review":   true,
-		"done":        true,
-		"blocked":     true,
-		"cancelled":   true,
-	}
-	for _, s := range validIssueStatuses {
-		if !expected[s] {
-			t.Errorf("unexpected status in validIssueStatuses: %q", s)
-		}
-	}
-	if len(validIssueStatuses) != len(expected) {
-		t.Errorf("validIssueStatuses has %d entries, expected %d", len(validIssueStatuses), len(expected))
-	}
-}
-
 // TestValidateIssueStatus pins the post-MUL-6243 contract: the CLI validates
 // the SHAPE of a status key, not its membership. A workspace can define custom
 // statuses, so only the server knows the valid set; rejecting an unknown key

--- a/server/internal/daemon/hermes_provider_annotation_test.go
+++ b/server/internal/daemon/hermes_provider_annotation_test.go
@@ -114,26 +114,3 @@ func TestAnnotationCannotChangeMachineDecisions(t *testing.T) {
 		})
 	}
 }
-
-// TestAnnotationAvoidsPersistedRowGuards covers the one reader the test above
-// cannot execute: the SQL text guards in pkg/db/queries/agent.sql, which scan
-// agent_task_queue.error long after the daemon that wrote it is gone. Keep this
-// list in sync with GetLastTaskSession / GetLastChatTaskSession — a hint that
-// matched one of these would quietly exclude healthy sessions from resume.
-func TestAnnotationAvoidsPersistedRowGuards(t *testing.T) {
-	t.Parallel()
-
-	hint := strings.ToLower(hermesProviderUnconfiguredHint)
-	forbidden := []string{
-		"400", "invalid_request_error",
-		"image dimensions exceed max allowed size", "image.source.base64.data",
-		"could not resolve authentication method",
-		"must not be empty", "must be non-empty", "must have non-empty",
-		"non-empty content", "cannot be empty", "should not be empty",
-	}
-	for _, phrase := range forbidden {
-		if strings.Contains(hint, phrase) {
-			t.Errorf("hint contains %q, which a persisted-row resume guard matches on", phrase)
-		}
-	}
-}

--- a/server/internal/events/bus_test.go
+++ b/server/internal/events/bus_test.go
@@ -38,12 +38,6 @@ func TestPublishOnlyMatchingType(t *testing.T) {
 	}
 }
 
-func TestPublishNoSubscribersIsNoop(t *testing.T) {
-	bus := New()
-	// Should not panic
-	bus.Publish(Event{Type: "no:listeners"})
-}
-
 func TestPanicInHandlerDoesNotBreakOthers(t *testing.T) {
 	bus := New()
 	var secondCalled bool

--- a/server/internal/integrations/channel/capability_test.go
+++ b/server/internal/integrations/channel/capability_test.go
@@ -43,25 +43,3 @@ func TestCapability_String(t *testing.T) {
 		})
 	}
 }
-
-// TestCapability_BitsDistinct guards against two constants accidentally
-// sharing a bit after an edit to the iota block.
-func TestCapability_BitsDistinct(t *testing.T) {
-	all := []Capability{
-		CapText, CapRichCard, CapThreadReply, CapQuoteReply,
-		CapAttachment, CapVoice, CapTypingIndicator, CapMessageEdit,
-	}
-	var seen Capability
-	for i, c := range all {
-		if c == 0 {
-			t.Fatalf("capability index %d is zero", i)
-		}
-		if c&(c-1) != 0 {
-			t.Fatalf("capability index %d (%#x) is not a single bit", i, uint64(c))
-		}
-		if seen&c != 0 {
-			t.Fatalf("capability index %d (%#x) overlaps an earlier bit", i, uint64(c))
-		}
-		seen |= c
-	}
-}

--- a/server/internal/integrations/wecom/inbound_media_test.go
+++ b/server/internal/integrations/wecom/inbound_media_test.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"strings"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
@@ -236,17 +235,6 @@ func TestOwnText_MixedWithNothingReadableTakesTheReceipt(t *testing.T) {
 	}
 	if len(conn.frames) != 1 {
 		t.Fatalf("expected one receipt, got %d frames", len(conn.frames))
-	}
-}
-
-// TestUnsupportedReceipt_DoesNotClaimTextOnly: the receipt used to say the
-// bot only handles text. It now routes photos, files, videos and 图文混排, so
-// a person who just watched it answer a screenshot must not then be told it
-// handles text only.
-func TestUnsupportedReceipt_DoesNotClaimTextOnly(t *testing.T) {
-	t.Parallel()
-	if strings.Contains(unsupportedMsgTypeReceipt, "只能处理文字") {
-		t.Errorf("receipt %q still claims text-only while image/file/video/mixed route", unsupportedMsgTypeReceipt)
 	}
 }
 

--- a/server/internal/metrics/labels_test.go
+++ b/server/internal/metrics/labels_test.go
@@ -2,16 +2,6 @@ package metrics
 
 import "testing"
 
-func TestBusinessMetricLabelsRejectHighCardinalityNames(t *testing.T) {
-	for metric, labels := range businessMetricLabels {
-		for _, label := range labels {
-			if _, forbidden := forbiddenMetricLabels[label]; forbidden {
-				t.Fatalf("metric %s uses forbidden label %s", metric, label)
-			}
-		}
-	}
-}
-
 func TestNormalizeRuntimeProviderRecognizesKnownProviders(t *testing.T) {
 	tests := []struct {
 		input string

--- a/server/internal/service/chat_quick_actions_generate_test.go
+++ b/server/internal/service/chat_quick_actions_generate_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-	"unicode"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -268,26 +267,5 @@ func TestRenderChatQuickActionsContextClosesWithTheLanguageRule(t *testing.T) {
 	// it does not scrub the input.
 	if !strings.Contains(out, "已创建工单 EFF-359") || !strings.Contains(out, "- 查看工单详情") {
 		t.Fatalf("conversation and previous labels must survive intact:\n%s", out)
-	}
-}
-
-// Neither prompt may name or contain a language: that is what taught the model
-// Chinese was on the table in the first place.
-func TestChatQuickActionsPromptsNameNoLanguage(t *testing.T) {
-	for name, text := range map[string]string{
-		"system prompt": chatQuickActionsSystemPrompt,
-		"language rule": chatQuickActionsLanguageRule,
-	} {
-		for _, r := range text {
-			if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
-				unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) {
-				t.Fatalf("%s must contain no CJK, found %q", name, r)
-			}
-		}
-		for _, named := range []string{"Chinese", "Japanese", "Korean", "English"} {
-			if strings.Contains(text, named) {
-				t.Fatalf("%s must not name a language, found %q", name, named)
-			}
-		}
 	}
 }

--- a/server/pkg/agent/claude_models_test.go
+++ b/server/pkg/agent/claude_models_test.go
@@ -29,31 +29,6 @@ func loadClaudeListModelsFixture(t *testing.T, version string) []byte {
 	return raw
 }
 
-// TestClaudeListModelsArgs_Pinned locks the discovery argv. Every element is
-// load-bearing and none is obvious from the call site, which is exactly when a
-// pin earns its keep — dropping --verbose or the input format silently turns
-// the probe into a session that never answers.
-func TestClaudeListModelsArgs_Pinned(t *testing.T) {
-	t.Parallel()
-	want := []string{
-		"--print",
-		"--verbose",
-		"--input-format", "stream-json",
-		"--output-format", "stream-json",
-		"--strict-mcp-config",
-	}
-	if !reflect.DeepEqual(claudeListModelsArgs, want) {
-		t.Fatalf("claudeListModelsArgs drifted: got %v, want %v", claudeListModelsArgs, want)
-	}
-	// A model flag here would make discovery report the catalog for one model
-	// instead of the account's, and a prompt would bill a real API call.
-	for _, arg := range claudeListModelsArgs {
-		if arg == "--model" || arg == "-p" {
-			t.Errorf("discovery argv must not pin a model or pass a prompt: %v", claudeListModelsArgs)
-		}
-	}
-}
-
 func TestParseClaudeModelCatalog_RealCLIOutput(t *testing.T) {
 	t.Parallel()
 	infos, err := parseClaudeModelCatalog(loadClaudeListModelsFixture(t, "2.1.258"))

--- a/server/pkg/agent/mcode_test.go
+++ b/server/pkg/agent/mcode_test.go
@@ -289,15 +289,6 @@ func TestMcodeLoadSessionWhenCapabilityAppears(t *testing.T) {
 	}
 }
 
-func TestMcodeBlockedArgsKeepACPTransportStable(t *testing.T) {
-	t.Parallel()
-	for _, arg := range []string{"acp", "login", "--region", "-h", "--help"} {
-		if _, ok := mcodeBlockedArgs[arg]; !ok {
-			t.Errorf("mcodeBlockedArgs missing %q", arg)
-		}
-	}
-}
-
 // A still-running MCode reports session/new failures as a JSON-RPC error, and
 // session/new is the call that launches mcpServers. Only transport-level exit
 // signals may be reported as "MiniMax Code ACP exited" — anything else must

--- a/server/pkg/agent/qwenpaw_test.go
+++ b/server/pkg/agent/qwenpaw_test.go
@@ -221,22 +221,6 @@ func TestQwenpawListModels(t *testing.T) {
 	}
 }
 
-func TestQwenpawBlockedArgs(t *testing.T) {
-	t.Parallel()
-	if _, ok := qwenpawBlockedArgs["acp"]; !ok {
-		t.Fatal("expected acp to be in qwenpawBlockedArgs")
-	}
-	if qwenpawBlockedArgs["acp"] != blockedStandalone {
-		t.Fatalf("expected acp to be blockedStandalone, got %v", qwenpawBlockedArgs["acp"])
-	}
-	if _, ok := qwenpawBlockedArgs["--workspace"]; !ok {
-		t.Fatal("expected --workspace to be in qwenpawBlockedArgs")
-	}
-	if qwenpawBlockedArgs["--workspace"] != blockedWithValue {
-		t.Fatalf("expected --workspace to be blockedWithValue, got %v", qwenpawBlockedArgs["--workspace"])
-	}
-}
-
 func TestQwenpawUsesSessionLoad(t *testing.T) {
 	// Verify that qwenpaw uses session/load (not session/resume) on resume.
 	// QwenPaw's ACP server implements load_session, not session/resume.

--- a/server/pkg/agent/zeroclaw_test.go
+++ b/server/pkg/agent/zeroclaw_test.go
@@ -367,21 +367,6 @@ func TestZeroclawResumeNotFound(t *testing.T) {
 	}
 }
 
-func TestZeroclawBlockedArgs(t *testing.T) {
-	t.Parallel()
-	if _, ok := zeroclawBlockedArgs["acp"]; !ok {
-		t.Fatal("expected acp to be in zeroclawBlockedArgs")
-	}
-	if zeroclawBlockedArgs["acp"] != blockedStandalone {
-		t.Fatalf("expected acp to be blockedStandalone, got %v", zeroclawBlockedArgs["acp"])
-	}
-	for _, flag := range []string{"--help", "-h", "login", "auth", "--login", "--auth"} {
-		if _, ok := zeroclawBlockedArgs[flag]; !ok {
-			t.Fatalf("expected %s to be in zeroclawBlockedArgs", flag)
-		}
-	}
-}
-
 func TestSelectZeroclawPermissionOptionRejectsLegacyChoice(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/publicapi/v1/contract_test.go
+++ b/server/pkg/publicapi/v1/contract_test.go
@@ -1,7 +1,6 @@
 package publicapiv1
 
 import (
-	"net/http"
 	"strings"
 	"testing"
 
@@ -64,54 +63,5 @@ func TestOpenAPICoversCapabilityLedger(t *testing.T) {
 	}
 	if _, exposed := doc.Paths["/hooks/{hook_key}"]; exposed {
 		t.Fatal("Plugin-only person hook leaked into the public contract")
-	}
-}
-
-func TestOperationLedgerPinsSharedScopes(t *testing.T) {
-	want := map[string]string{
-		http.MethodGet + " " + PathIssue:          "issues:read",
-		http.MethodPatch + " " + PathIssue:        "issues:write",
-		http.MethodGet + " " + PathIssueComments:  "comments:read",
-		http.MethodPost + " " + PathIssueComments: "comments:write",
-	}
-	for _, operation := range Operations {
-		if operation.Contract != ContractSharedResource {
-			continue
-		}
-		key := operation.Method + " " + operation.Path
-		if operation.Policy.Scope != want[key] {
-			t.Errorf("%s scope = %q, want %q", key, operation.Policy.Scope, want[key])
-		}
-		if len(operation.Policy.Credentials) != 4 {
-			t.Errorf("%s does not declare both user and Plugin credential families: %v", key, operation.Policy.Credentials)
-		}
-		if operation.Policy.Audit != AuditPlanned {
-			t.Errorf("%s audit status = %q, want %q until an audit sink is implemented", key, operation.Policy.Audit, AuditPlanned)
-		}
-		delete(want, key)
-	}
-	for key := range want {
-		t.Errorf("shared operation missing from ledger: %s", key)
-	}
-}
-
-func TestPluginExtensionsRejectUserCredentialsByContract(t *testing.T) {
-	for _, operation := range Operations {
-		if operation.Contract != ContractPluginExtension {
-			continue
-		}
-		for _, credential := range operation.Policy.Credentials {
-			if credential == CredentialUserOAuth || credential == CredentialPersonalAccess {
-				t.Errorf("%s %s exposes Plugin extension to %s", operation.Method, operation.Path, credential)
-			}
-		}
-	}
-}
-
-func TestOperationLedgerDeclaresAuditLifecycle(t *testing.T) {
-	for _, operation := range Operations {
-		if operation.Policy.Audit == "" {
-			t.Errorf("%s %s has no explicit audit lifecycle", operation.Method, operation.Path)
-		}
 	}
 }


### PR DESCRIPTION
Closes MUL-7018.

## Background

MUL-7018 asked for a sweep of the whole codebase for tests that only verify
constants or source structure, plus any test that obviously cannot fail and
exists only to have been written.

## What was removed

15 Go test functions across 13 files, 239 deletions and no insertions. Each
one reaches no production code path: it compares a package-level constant, map
or slice against a literal copy of that same declaration, so the only way to
make it fail is to edit the test in the same commit as the source. That is a
rename tax, not a safety net.

| Package | Test | Why |
|---|---|---|
| `cmd/multica` | `TestValidIssueStatuses` | Re-declares `validIssueStatuses` and compares the two copies |
| `cmd/multica` | `TestLoadConfigAllowNoAgentsIsOptIn` | Asserts an unset `bool` field is `false` — a language guarantee |
| `internal/integrations/channel` | `TestCapability_BitsDistinct` | Asserts the `iota` block produced distinct single bits |
| `internal/integrations/wecom` | `TestUnsupportedReceipt_DoesNotClaimTextOnly` | Substring check on a string constant |
| `internal/daemon` | `TestAnnotationAvoidsPersistedRowGuards` | Substring check on a string constant |
| `internal/metrics` | `TestBusinessMetricLabelsRejectHighCardinalityNames` | Cross-checks two static maps |
| `internal/service` | `TestChatQuickActionsPromptsNameNoLanguage` | Scans prompt string constants |
| `internal/events` | `TestPublishNoSubscribersIsNoop` | Asserted nothing at all |
| `pkg/agent` | `TestMcodeBlockedArgsKeepACPTransportStable` | Static map key presence |
| `pkg/agent` | `TestQwenpawBlockedArgs` | Static map key/value |
| `pkg/agent` | `TestZeroclawBlockedArgs` | Static map key/value |
| `pkg/agent` | `TestClaudeListModelsArgs_Pinned` | `DeepEqual` against a duplicated literal of `claudeListModelsArgs` |
| `pkg/publicapi/v1` | `TestOperationLedgerPinsSharedScopes` | Iterates the static `Operations` literal and asserts its own declared fields |
| `pkg/publicapi/v1` | `TestPluginExtensionsRejectUserCredentialsByContract` | Same |
| `pkg/publicapi/v1` | `TestOperationLedgerDeclaresAuditLifecycle` | Same |

Three now-unused imports were dropped (`net/http`, `unicode`, `strings`).

## What was deliberately kept

The sweep also surfaced candidates that look similar but have real failure
modes, and those stay:

- **JSON fixture decode tests** (`opencode`, `deveco`, `cursor`, `copilot`,
  `composio`) — they exercise struct tags and decoders against output captured
  from real CLIs. `TestCopilotParseResultFractionalPremiumRequests` is a
  regression test for a float/int decode break.
- **Wire-contract tests** — `TestDashboardFailureWireContractKeepsEmptyReason`
  and `TestExecuteToolRequest_VersionSerialization` catch an `omitempty` or a
  renamed JSON key silently changing the wire form.
- **Test infrastructure** — `TestMain` and the re-executed subprocess helpers
  (`TestCursorShimHelperProcess`, `TestQwenShimHelperProcess`,
  `TestBlockingChildProcess`, `TestLongPathExecutableHelper`) are not tests.
- **Behavioural tests over the same symbols** — `TestCapability_Has`,
  `TestCapability_String`, `TestValidateIssueStatus`,
  `TestDaemonRuntimeProbeFromAgents`,
  `TestNormalizeRuntimeProviderRecognizesKnownProviders`, and
  `TestOpenAPICoversCapabilityLedger`, which validates the operation ledger
  against the embedded OpenAPI document rather than against itself.

The frontend was swept too and nothing was removed. The three TS files that
read repo source text turned out to be substantive: `text-contrast.test.ts`
and `brand-variant-cascade.test.ts` compile the stylesheet and resolve real
cascade specificity, and `package-exports.test.ts` catches dangling
`package.json` export targets and carries its own anti-vacuous guard.

## How this was found

Rather than grepping test names, a scanner walked every Go test function with a
tokenizer and reported the ones whose bodies make no production call at all
(such a test can only assert literals). Two precision bugs were fixed while
building it, both worth knowing about if this is ever repeated:

1. Stripping `//` comments before string literals truncates
   `"https://example.com"` and desynchronizes every quote after it.
2. For `tt.cap.String()` the meaningful identifier is the root of the selector
   chain (`tt`), not the segment beside the paren (`cap`, which collides with a
   builtin name).

The detector went from 157 raw hits to 30 real candidates, each of which was
read before a verdict; 16 remain and are all intentional keeps listed above.

## Testing

- `go vet ./...` clean across the server module.
- `gofmt` clean on every touched file (all four affected files were
  `gofmt`-clean on `main` beforehand, so the reformat is only my own leftover
  blank lines).
- Affected packages pass: `internal/metrics`, `internal/integrations/channel`,
  `internal/events`, `pkg/publicapi/v1`, `cmd/multica`, `pkg/agent`.
- `internal/daemon`, `internal/service`, `internal/integrations/wecom` and
  `channel/engine` fail identically on `main` and on this branch — 181 failing
  test names, `diff` clean — from local test-database schema drift
  (`column "durable_work_dir" does not exist`), not from this change. Verified
  by running both revisions from separate `git worktree` checkouts.

One trap worth recording: running the suite from inside a Multica task workdir
makes `cmd/multica` report 136 failures, because an ancestor `.multica`
directory flips the CLI into agent-context config resolution. From outside the
workdir the same commit reports 0.

## Review focus

Whether any of the 15 removals was load-bearing in a way the code does not
show. The `pkg/publicapi/v1` ledger trio is the judgement call I would look at
first: those checks encode a real policy intent, but they only read the literal
they are declared next to, so today they cannot catch a mistake made in that
same literal. If we want that intent enforced, it belongs where the ledger
meets something independent — the way `TestOpenAPICoversCapabilityLedger`
compares it against the embedded OpenAPI document.
