### PR TITLE
fix(selfhost): isolate Compose projects across worktrees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,9 @@ Notes:
 - `POSTGRES_DB` is unique per worktree
 - `POSTGRES_PORT` stays fixed at `5432`
 - backend and frontend ports are derived from the worktree path hash
+- `.env.worktree` includes a deterministic `COMPOSE_PROJECT_NAME` for a
+  self-host Compose stack started directly from that checkout; the local
+  development helpers still pin PostgreSQL to the shared `multica` project
 - `make worktree-env` refuses to overwrite an existing `.env.worktree`
 
 To regenerate a worktree env file:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ export
 MULTICA_ARGS ?= $(ARGS)
 
 COMPOSE := docker compose
+# Local development deliberately shares one PostgreSQL Compose project across
+# the main checkout and worktrees. Worktree env files also carry a distinct
+# project name for self-host Compose stacks, so pin these database helpers to
+# the shared project explicitly.
+LOCAL_COMPOSE := $(COMPOSE) -p multica
 
 define REQUIRE_ENV
 	@if [ ! -f "$(ENV_FILE)" ]; then \
@@ -234,10 +239,10 @@ check: ## Run typecheck, TS tests, Go tests, and Playwright E2E for the current 
 	@ENV_FILE="$(ENV_FILE)" bash scripts/check.sh
 
 db-up: ## Start the shared PostgreSQL container used by main and worktrees
-	@$(COMPOSE) up -d postgres
+	@$(LOCAL_COMPOSE) up -d postgres
 
 db-down: ## Stop the shared PostgreSQL container without removing its Docker volume
-	@$(COMPOSE) down
+	@$(LOCAL_COMPOSE) down
 
 db-drop: ## Permanently drop the current env's local database after confirmation
 	$(REQUIRE_ENV)
@@ -257,7 +262,7 @@ db-reset: ## Drop and recreate the current env's database, then re-run all migra
 	esac
 	@bash scripts/ensure-postgres.sh "$(ENV_FILE)"
 	@echo "==> Dropping and recreating database '$(POSTGRES_DB)'..."
-	@$(COMPOSE) exec -T postgres psql -U $(POSTGRES_USER) -d postgres -v ON_ERROR_STOP=1 \
+	@$(LOCAL_COMPOSE) exec -T postgres psql -U $(POSTGRES_USER) -d postgres -v ON_ERROR_STOP=1 \
 		-c "DROP DATABASE IF EXISTS \"$(POSTGRES_DB)\" WITH (FORCE);" \
 		-c "CREATE DATABASE \"$(POSTGRES_DB)\";"
 	@echo "==> Running migrations..."

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -30,7 +30,7 @@
 # read it back with `docker compose port`, so the health check and the printed
 # URL always match what was actually published.
 
-name: multica
+name: ${COMPOSE_PROJECT_NAME:-multica}
 
 services:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-name: multica
+name: ${COMPOSE_PROJECT_NAME:-multica}
 
 services:
   postgres:

--- a/scripts/drop-database.sh
+++ b/scripts/drop-database.sh
@@ -69,7 +69,10 @@ case "$answer" in
 esac
 
 cd "$root_dir"
-docker compose exec -T postgres \
+# Local development shares one PostgreSQL Compose project across checkouts.
+# Ignore the worktree-specific project name here; it is reserved for direct
+# self-host Compose stacks.
+docker compose -p multica exec -T postgres \
   dropdb \
   --username "$POSTGRES_USER" \
   --maintenance-db postgres \

--- a/scripts/ensure-postgres.sh
+++ b/scripts/ensure-postgres.sh
@@ -68,20 +68,25 @@ is_local() {
 
 if is_local; then
   # ---------- Local: use Docker ----------
+  # Worktree env files carry a unique COMPOSE_PROJECT_NAME so that a direct
+  # self-host Compose stack is isolated. Local development intentionally keeps
+  # one shared PostgreSQL container for all checkouts, so pin these commands to
+  # the documented shared project.
+  local_compose=(docker compose -p multica)
   echo "==> Ensuring shared PostgreSQL container is running on localhost:5432..."
-  docker compose up -d postgres
+  "${local_compose[@]}" up -d postgres
 
   echo "==> Waiting for PostgreSQL to be ready..."
-  until docker compose exec -T postgres pg_isready -U "$POSTGRES_USER" -d postgres > /dev/null 2>&1; do
+  until "${local_compose[@]}" exec -T postgres pg_isready -U "$POSTGRES_USER" -d postgres > /dev/null 2>&1; do
     sleep 1
   done
 
   echo "==> Ensuring database '$POSTGRES_DB' exists..."
-  db_exists="$(docker compose exec -T postgres \
+  db_exists="$("${local_compose[@]}" exec -T postgres \
     psql -U "$POSTGRES_USER" -d postgres -Atqc "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DB'")"
 
   if [ "$db_exists" != "1" ]; then
-    docker compose exec -T postgres \
+    "${local_compose[@]}" exec -T postgres \
       psql -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 \
       -c "CREATE DATABASE \"$POSTGRES_DB\"" \
       > /dev/null

--- a/scripts/init-worktree-env.sh
+++ b/scripts/init-worktree-env.sh
@@ -18,6 +18,7 @@ hash_value="$(printf '%s' "$PWD" | cksum | awk '{print $1}')"
 offset=$((hash_value % 1000))
 
 postgres_db="multica_${slug}_${offset}"
+compose_project_name="multica_${slug}_${offset}"
 postgres_port=5432
 backend_port=$((18080 + offset))
 frontend_port=$((13000 + offset))
@@ -28,6 +29,7 @@ POSTGRES_DB=${postgres_db}
 POSTGRES_USER=multica
 POSTGRES_PASSWORD=multica
 POSTGRES_PORT=${postgres_port}
+COMPOSE_PROJECT_NAME=${compose_project_name}
 DATABASE_URL=postgres://multica:multica@localhost:${postgres_port}/${postgres_db}?sslmode=disable
 
 PORT=${backend_port}
@@ -48,6 +50,7 @@ NEXT_PUBLIC_WS_URL=ws://localhost:${backend_port}/ws
 EOF
 
 echo "Generated $ENV_FILE for worktree '$worktree_name'"
+echo "  Compose project: ${compose_project_name}"
 echo "  Shared Postgres: localhost:${postgres_port}"
 echo "  Database: ${postgres_db}"
 echo "  Backend:  http://localhost:${backend_port}"

--- a/scripts/selfhost-config.test.sh
+++ b/scripts/selfhost-config.test.sh
@@ -43,6 +43,67 @@ sed 's/^FRONTEND_PORT=.*/FRONTEND_PORT=3100/' .env.example >"$tmp_env"
 printf '\nBACKEND_PORT=9100\nSMTP_FROM_EMAIL=multica@example.com\n' >>"$tmp_env"
 printf 'MULTICA_LLM_API_KEY=llm-key-from-env\nMULTICA_LLM_BASE_URL=http://gateway.example/v1\nMULTICA_LLM_DEFAULT_MODEL=model-from-env\nMULTICA_LLM_MAX_RETRIES=3\n' >>"$tmp_env"
 
+# Both Compose entry points must keep the existing single-checkout project name
+# while allowing callers and generated worktree env files to isolate stacks.
+for compose_file in docker-compose.yml docker-compose.selfhost.yml; do
+  default_name="$(
+    env -u COMPOSE_PROJECT_NAME docker compose \
+      --env-file "$tmp_env" \
+      -f "$compose_file" \
+      config | sed -n '1s/^name: //p'
+  )"
+  if [ "$default_name" != "multica" ]; then
+    echo "$compose_file should default to the multica Compose project, got ${default_name:-<none>}"
+    exit 1
+  fi
+
+  override_name="$(
+    env COMPOSE_PROJECT_NAME=multica_config_test docker compose \
+      --env-file "$tmp_env" \
+      -f "$compose_file" \
+      config | sed -n '1s/^name: //p'
+  )"
+  if [ "$override_name" != "multica_config_test" ]; then
+    echo "$compose_file did not honor COMPOSE_PROJECT_NAME, got ${override_name:-<none>}"
+    exit 1
+  fi
+done
+
+worktree_env_same="$tmp_dir/.env.worktree.same"
+worktree_env_other="$tmp_dir/.env.worktree.other"
+WORKTREE_NAME=selfhost-config-test bash scripts/init-worktree-env.sh "$worktree_env_same" >/dev/null
+WORKTREE_NAME=selfhost-config-test bash scripts/init-worktree-env.sh "$worktree_env_other" >/dev/null
+worktree_project_name="$(sed -n 's/^COMPOSE_PROJECT_NAME=//p' "$worktree_env_same")"
+same_generated_project_name="$(sed -n 's/^COMPOSE_PROJECT_NAME=//p' "$worktree_env_other")"
+if [ -z "$worktree_project_name" ] || [ "$worktree_project_name" != "$same_generated_project_name" ]; then
+  echo "worktree env generation must be deterministic"
+  exit 1
+fi
+if ! [[ "$worktree_project_name" =~ ^multica_selfhost_config_test_[0-9]+$ ]]; then
+  echo "worktree env generated an invalid or unexpected Compose project name: $worktree_project_name"
+  exit 1
+fi
+
+FORCE=1 WORKTREE_NAME=selfhost-config-other bash scripts/init-worktree-env.sh "$worktree_env_other" >/dev/null
+other_project_name="$(sed -n 's/^COMPOSE_PROJECT_NAME=//p' "$worktree_env_other")"
+if [ "$worktree_project_name" = "$other_project_name" ]; then
+  echo "different worktree names must not share a Compose project name"
+  exit 1
+fi
+
+generated_name="$(
+  env -u COMPOSE_PROJECT_NAME docker compose \
+    --env-file "$worktree_env_same" \
+    -f docker-compose.yml \
+    config | sed -n '1s/^name: //p'
+)"
+if [ "$generated_name" != "$worktree_project_name" ]; then
+  echo "docker-compose.yml did not use the generated worktree project name"
+  echo "  generated env: $worktree_project_name"
+  echo "  compose name:  ${generated_name:-<none>}"
+  exit 1
+fi
+
 config="$(
   docker compose \
     --env-file "$tmp_env" \

--- a/scripts/worktree-db.test.sh
+++ b/scripts/worktree-db.test.sh
@@ -29,6 +29,9 @@ cat >"$stub_dir/docker" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"$DOCKER_LOG"
+case "$*" in
+  *" pg_isready "*) printf 'accepting connections\n' ;;
+esac
 STUB
 chmod +x "$stub_dir/docker"
 
@@ -36,10 +39,17 @@ local_env="$tmp_dir/local.env"
 cat >"$local_env" <<'EOF'
 POSTGRES_DB=multica_feature_123
 POSTGRES_USER=multica
+COMPOSE_PROJECT_NAME=multica_feature_123_456
 DATABASE_URL=postgres://multica:multica@localhost:5432/multica_feature_123?sslmode=disable
 EOF
 
 output="$tmp_dir/output"
+: >"$docker_log"
+PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/ensure-postgres.sh" "$local_env" >"$output"
+require_contains "$docker_log" "compose -p multica up -d postgres"
+require_contains "$docker_log" "compose -p multica exec -T postgres pg_isready"
+
 : >"$docker_log"
 cancel_status=0
 printf 'n\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
@@ -65,7 +75,7 @@ fi
 printf 'y\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
   bash "$root_dir/scripts/drop-database.sh" "$local_env" >"$output"
 require_contains "$docker_log" \
-  "compose exec -T postgres dropdb --username multica --maintenance-db postgres --if-exists --force -- multica_feature_123"
+  "compose -p multica exec -T postgres dropdb --username multica --maintenance-db postgres --if-exists --force -- multica_feature_123"
 require_contains "$output" "Dropped database 'multica_feature_123'."
 
 remote_env="$tmp_dir/remote.env"
@@ -167,7 +177,7 @@ if [ -e "$worktree" ]; then
   fail "remove-worktree did not remove the worktree after database deletion"
 fi
 require_contains "$docker_log" \
-  "compose exec -T postgres dropdb --username multica --maintenance-db postgres --if-exists --force -- multica_worktree_456"
+  "compose -p multica exec -T postgres dropdb --username multica --maintenance-db postgres --if-exists --force -- multica_worktree_456"
 
 dirty_worktree="$tmp_dir/dirty-worktree"
 git -C "$repo" worktree add -q -b dirty-feature "$dirty_worktree"


### PR DESCRIPTION
## What does this PR do?

The hard-coded top-level Compose project name made self-hosted stacks from different checkouts share the same containers and named volumes. This change makes the project name configurable while preserving `multica` as the default for existing single-checkout setups.

Generated worktree environments now receive a deterministic project name, so a Compose stack started from each checkout gets its own container and volume namespace. The existing local development workflow still shares one PostgreSQL container, with database helpers explicitly pinned to the `multica` project.

## Related Issue

Closes #7967

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- Allow `COMPOSE_PROJECT_NAME` to override the top-level project name in both Compose entry points, with `multica` as the fallback.
- Generate a deterministic per-worktree `COMPOSE_PROJECT_NAME` alongside the existing worktree database and port values.
- Pin local database lifecycle commands to the intentionally shared `multica` Compose project.
- Add regression coverage for the default, explicit override, deterministic generation, and local database helper behavior.
- Document how direct self-host Compose stacks and shared local PostgreSQL use the project name.

## How to Test

1. Run `scripts/selfhost-config.test.sh`.
2. Run `scripts/worktree-db.test.sh`.
3. Run `bash -n scripts/ensure-postgres.sh scripts/drop-database.sh scripts/init-worktree-env.sh scripts/worktree-db.test.sh scripts/selfhost-config.test.sh`.
4. Run `make --no-print-directory -n db-up` and verify it uses `docker compose -p multica`.
5. Generate two worktree env files, start both self-host stacks, and verify that each project has distinct containers and volumes while both backends report healthy and ready.

Existing setups keep the `multica` project name when `COMPOSE_PROJECT_NAME` is unset. The intentional behavior change is limited to generated worktree environments; local database helpers remain on the documented shared project.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Used Codex to inspect the repository conventions and existing contribution patterns, implement the focused Compose/worktree isolation fix, add regression coverage, and validate it with shell/config tests and a two-stack end-to-end run.

## Screenshots (optional)

Not applicable; this change has no UI impact.
