### PR TITLE
feat(opencode): discover OpenAI-compatible provider models

### DIFF
--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -234,6 +234,11 @@ API key と base URL の両方が空の場合、このレイヤーは無効に�
 | `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 出力もツール実行もない状態の静穏上限。`0` で watchdog 全体を無効化 |
 | `MULTICA_AGENT_TOOL_WATCHDOG` | `MULTICA_AGENT_IDLE_WATCHDOG` と同じ | 単一のツール呼び出しが静穏なままでいられる上限。モデルより長い余裕をツールに与えたい場合のみ設定し、`0` はツール実行中に強制停止しません |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode 専用の静穏しきい値 |
+| `MULTICA_OPENCODE_DISCOVERY_BASE_URL` | 空 | `/models` カタログを OpenCode ランタイムへ追加する OpenAI 互換 API ルート（例: `https://gateway.example/v1`） |
+| `MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID` | `openai-compatible` | 検出モデルに付けるプロバイダー接頭辞（例: `gpustack`） |
+| `MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME` | プロバイダー ID | OpenCode の一時プロバイダー設定へ注入する表示名 |
+| `OPENCODE_DISCOVERY_API_KEY` | 空 | 検出エンドポイント用のデーモンローカル bearer token。検出モデルの実行時に OpenCode とその子プロセスが継承します |
+| `MULTICA_OPENCODE_DISCOVERY_API_KEY_ENV` | `OPENCODE_DISCOVERY_API_KEY` | bearer token を保持する別のデーモンローカル環境変数名（任意）。token 自体は生成設定へコピーされません |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `MULTICA_AGENT_IDLE_WATCHDOG` と同じ | Codex のセマンティック静穏しきい値。Codex 自身のタイマーはツール実行中かどうかを判別できないため、独自の短い上限を持たず idle / tool 予算の大きい方に追従します |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | Codex 初回ターンの無進捗上限を明示的に上書き；`0` はデフォルトを維持。実効の初回ターン待機は依然として `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` と全体の実行タイムアウトに制限される——`MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` をこの値より厳密に大きく（余裕を持たせて）設定すること。さもないと待機はその値で打ち切られ、モデルカタログの起動リトライがスキップされる。同値では不十分：セマンティックタイマーが先に起動するため、同値の場合でもリトライが失われることがある |
 | `MULTICA_CODEX_HANDSHAKE_TIMEOUT` | `30s`、`thread/start`・`thread/resume`：`60s` | Codex app-server 起動ハンドシェイクの上限。明示的な値は両方の予算を一括で上書きします |

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -234,6 +234,11 @@ API key와 base URL이 모두 비어 있으면 이 레이어가 꺼지고 업스
 | `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 출력과 도구 실행이 모두 없을 때의 무응답 상한. `0`이면 watchdog 전체가 비활성화됩니다 |
 | `MULTICA_AGENT_TOOL_WATCHDOG` | `MULTICA_AGENT_IDLE_WATCHDOG`와 동일 | 단일 도구 호출이 계속 무응답인 시간 상한. 모델보다 도구에 더 여유를 주고 싶을 때만 따로 설정하며, `0`이면 도구 실행 중에는 강제 종료하지 않습니다 |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode 전용 무응답 기준값 |
+| `MULTICA_OPENCODE_DISCOVERY_BASE_URL` | 비어 있음 | `/models` 카탈로그를 OpenCode 런타임에 추가할 OpenAI 호환 API 루트(예: `https://gateway.example/v1`) |
+| `MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID` | `openai-compatible` | 검색된 모델에 사용할 공급자 접두사(예: `gpustack`) |
+| `MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME` | 공급자 ID | OpenCode 임시 공급자 설정에 주입할 표시 이름 |
+| `OPENCODE_DISCOVERY_API_KEY` | 비어 있음 | 검색 엔드포인트용 데몬 로컬 bearer token. 검색된 모델 실행 시 OpenCode와 하위 프로세스가 상속합니다 |
+| `MULTICA_OPENCODE_DISCOVERY_API_KEY_ENV` | `OPENCODE_DISCOVERY_API_KEY` | bearer token을 보관하는 다른 데몬 로컬 환경 변수 이름(선택 사항). token 자체는 생성된 설정에 복사되지 않습니다 |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `MULTICA_AGENT_IDLE_WATCHDOG`와 동일 | Codex 의미 활동 없음 기준값. Codex 자체 타이머는 도구 실행 중인지 알 수 없으므로 별도의 짧은 상한 대신 idle / tool 예산 중 큰 값을 따릅니다 |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | Codex 첫 턴 무진행 상한의 명시적 재정의; `0` 은 기본값 유지. 실제 첫 턴 대기는 여전히 `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 및 전체 실행 타임아웃으로 제한됨 — `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 을 이 값보다 엄격히 크게(여유를 두고) 설정해야 하며, 그렇지 않으면 대기가 그 값으로 잘리고 모델 카탈로그 시작 재시도가 건너뛰어짐. 값이 같으면 충분하지 않음: 의미 타이머가 먼저 시작되므로 값이 같을 때도 재시도가 손실될 수 있음 |
 | `MULTICA_CODEX_HANDSHAKE_TIMEOUT` | `30s`, `thread/start`·`thread/resume`: `60s` | Codex app-server 시작 handshake 상한. 명시적으로 설정한 값은 두 예산을 모두 일괄 재정의합니다 |

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -234,6 +234,11 @@ The variables below are read on the computer that runs your agents, not in the A
 | `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | Silence ceiling with no output and no tool execution; `0` disables the watchdog entirely |
 | `MULTICA_AGENT_TOOL_WATCHDOG` | same as `MULTICA_AGENT_IDLE_WATCHDOG` | Silence ceiling for a single tool call; set it only to give tools more room than the model gets, `0` never force-stops a tool call |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode-specific silence threshold |
+| `MULTICA_OPENCODE_DISCOVERY_BASE_URL` | empty | OpenAI-compatible API root whose `/models` catalog supplements the OpenCode runtime (for example `https://gateway.example/v1`) |
+| `MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID` | `openai-compatible` | Provider prefix used for discovered models, such as `gpustack` |
+| `MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME` | provider ID | Display name injected into OpenCode's transient provider configuration |
+| `OPENCODE_DISCOVERY_API_KEY` | empty | Daemon-local bearer token for the discovery endpoint; OpenCode and its child processes inherit it when a discovered model runs |
+| `MULTICA_OPENCODE_DISCOVERY_API_KEY_ENV` | `OPENCODE_DISCOVERY_API_KEY` | Optional name of another daemon-local environment variable containing the bearer token; the token itself is never copied into generated configuration |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | same as `MULTICA_AGENT_IDLE_WATCHDOG` | Codex semantic-silence threshold. Codex's own timer cannot see that a tool is running, so it tracks the larger of the idle / tool budgets instead of holding a separate, shorter ceiling |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | Explicit override for the Codex first-turn no-progress ceiling; `0` keeps the default. The effective first-turn wait stays bounded by `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` and the overall execution timeout — set `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` strictly above this value (with some margin), or the wait is truncated to it and the model-catalog startup retry is skipped. Equal values are not enough: the semantic timer is armed first, so at equal durations the retry can still be lost |
 | `MULTICA_CODEX_HANDSHAKE_TIMEOUT` | `30s`; `thread/start`, `thread/resume`: `60s` | Codex app-server startup handshake ceilings. An explicit value overrides both budgets globally |

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -234,6 +234,11 @@ API key 与 base URL 都为空时，这一层关闭，不会发出任何上游�
 | `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 没有输出且没有工具执行时的静默上限；`0` 表示整套 watchdog 关闭 |
 | `MULTICA_AGENT_TOOL_WATCHDOG` | 同 `MULTICA_AGENT_IDLE_WATCHDOG` | 单个工具调用持续静默的上限；只有希望工具比模型有更多余量时才单独设置，`0` 表示工具执行期间永不强制停止 |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode 专用静默阈值 |
+| `MULTICA_OPENCODE_DISCOVERY_BASE_URL` | 空 | 用其 `/models` 目录补充 OpenCode 运行时的 OpenAI 兼容 API 根地址（例如 `https://gateway.example/v1`） |
+| `MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID` | `openai-compatible` | 已发现模型使用的提供商前缀，例如 `gpustack` |
+| `MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME` | 提供商 ID | 注入 OpenCode 临时提供商配置的显示名称 |
+| `OPENCODE_DISCOVERY_API_KEY` | 空 | 发现端点使用的守护进程本地 bearer token；运行已发现模型时 OpenCode 及其子进程会继承它 |
+| `MULTICA_OPENCODE_DISCOVERY_API_KEY_ENV` | `OPENCODE_DISCOVERY_API_KEY` | 可选的其他守护进程本地 bearer token 环境变量名；token 本身不会写入生成的配置 |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | 同 `MULTICA_AGENT_IDLE_WATCHDOG` | Codex 语义静默阈值。Codex 自己的计时器看不到工具是否在执行，因此跟随 idle / tool 预算中较大的那个，而不再单独保留一个更短的上限 |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | 显式覆盖 Codex 首轮无进展上限；`0` 保持默认值。实际首轮等待仍受 `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 和总执行超时限制——需将 `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 设为严格大于此值（并留出余量），否则等待会被截断至该值，且会跳过模型目录启动重试。设为相等还不够：语义计时器先启动，两者相等时仍可能丢失该重试 |
 | `MULTICA_CODEX_HANDSHAKE_TIMEOUT` | `30s`；`thread/start`、`thread/resume`：`60s` | Codex app-server 启动握手上限；显式设置后会统一覆盖两类预算 |

--- a/apps/docs/content/docs/providers.ja.mdx
+++ b/apps/docs/content/docs/providers.ja.mdx
@@ -62,6 +62,19 @@ DeepSeek Harness のモデルカタログはランタイム自身が提供しま
 ツールによってモデル名が異なることがあります。AI コーディングツールを変更すると、以前のモデル値は新しいツールで使えないため、選び直す必要があります。
 </Callout>
 
+### OpenCode 向け OpenAI 互換モデル検出
+
+デーモンは、運用者が設定した 1 つの OpenAI 互換 `/models` エンドポイントから OpenCode のカタログを補完できます。GPUStack、LiteLLM、LM Studio、および models.dev にモデルを公開していないプライベートゲートウェイで利用できます。
+
+```dotenv
+MULTICA_OPENCODE_DISCOVERY_BASE_URL=https://gateway.example/v1
+MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID=gpustack
+MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME=GPUStack
+OPENCODE_DISCOVERY_API_KEY=replace-with-a-local-key
+```
+
+これらをデーモンのローカル環境に設定し、デーモンを再起動します。Multica は `.../models` を取得して返されたモデル ID を通常の `opencode models` カタログへ統合し、タスク開始時には選択されたモデルだけを OpenCode へ注入します。API キーはマシン環境に留まり、生成設定や Multica サーバーデータベースへコピーされません。検出に失敗しても OpenCode の通常カタログは維持されます。
+
 ## セッション再開
 
 表で ✓ が付いたツールは、後続の実行で既存のセッションを続行できます。ただし、元のセッションが残っており、そのセッションへアクセスできるランタイムで作業が実行される必要があります。MiniMax Code 0.1.2 は ACP でセッション読み込み機能を通知しないため、後続の実行では新しい MCode セッションを開始します。

--- a/apps/docs/content/docs/providers.ko.mdx
+++ b/apps/docs/content/docs/providers.ko.mdx
@@ -62,6 +62,19 @@ DeepSeek Harness의 모델 카탈로그는 런타임 자체가 제공합니다(`
 도구마다 모델 이름이 다를 수 있습니다. AI 코딩 도구를 바꾸면 기존 모델 값은 새 도구에서 유효하지 않으므로 다시 선택해야 합니다.
 </Callout>
 
+### OpenCode용 OpenAI 호환 모델 검색
+
+데몬은 운영자가 설정한 하나의 OpenAI 호환 `/models` 엔드포인트에서 OpenCode 카탈로그를 보완할 수 있습니다. GPUStack, LiteLLM, LM Studio 및 models.dev에 모델을 게시하지 않는 비공개 게이트웨이에 사용할 수 있습니다.
+
+```dotenv
+MULTICA_OPENCODE_DISCOVERY_BASE_URL=https://gateway.example/v1
+MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID=gpustack
+MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME=GPUStack
+OPENCODE_DISCOVERY_API_KEY=replace-with-a-local-key
+```
+
+이 변수들을 데몬의 로컬 환경에 설정한 뒤 데몬을 다시 시작하세요. Multica는 `.../models`를 가져와 반환된 모델 ID를 일반 `opencode models` 카탈로그와 병합하고, 태스크 시작 시 선택된 모델만 OpenCode에 주입합니다. API 키는 컴퓨터 환경에만 남으며 생성된 설정이나 Multica 서버 데이터베이스에 복사되지 않습니다. 검색에 실패해도 OpenCode의 일반 카탈로그는 유지됩니다.
+
 ## 세션 복원
 
 표에서 ✓로 표시된 도구는 이후 실행에서 기존 세션을 이어갈 수 있습니다. 원래 세션이 여전히 존재하고 해당 세션에 접근할 수 있는 런타임이 작업을 실행해야 합니다. MiniMax Code 0.1.2는 ACP에서 세션 로드 기능을 알리지 않으므로 이후 실행에서는 새 MCode 세션을 시작합니다.

--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -62,6 +62,19 @@ DeepSeek Harness advertises its model catalog from the runtime itself (`dsh --pr
 Different tools may use different model names. After switching AI coding tools, the previous model value is invalid in the new tool and needs to be selected again.
 </Callout>
 
+### OpenAI-compatible discovery for OpenCode
+
+The daemon can supplement OpenCode's catalog from one operator-configured OpenAI-compatible `/models` endpoint. This is useful for GPUStack, LiteLLM, LM Studio, and private gateways whose models are not published by models.dev:
+
+```dotenv
+MULTICA_OPENCODE_DISCOVERY_BASE_URL=https://gateway.example/v1
+MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID=gpustack
+MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME=GPUStack
+OPENCODE_DISCOVERY_API_KEY=replace-with-a-local-key
+```
+
+Set these variables in the daemon's local environment, then restart the daemon. Multica fetches `.../models`, merges the returned model IDs into the normal `opencode models` catalog, and injects only the selected model into OpenCode when a task starts. The API key stays in the machine environment and is never copied into generated configuration or the Multica server database. Discovery failure preserves OpenCode's normal catalog.
+
 ## Session resumption
 
 All tools marked ✓ support continuing an existing session in a later run. The prerequisites are that the original session still exists and the task is executed by a runtime that can reach it. MiniMax Code 0.1.2 advertises no session-loading capability over ACP, so Multica starts a fresh MCode session for a later run.

--- a/apps/docs/content/docs/providers.zh.mdx
+++ b/apps/docs/content/docs/providers.zh.mdx
@@ -62,6 +62,19 @@ DeepSeek Harness 的模型目录由运行时自身提供（`dsh --profile multic
 不同工具可能使用不同的模型名称。更换 AI 编程工具后，原有的模型值在新工具中无效，需要重新选择。
 </Callout>
 
+### 为 OpenCode 发现 OpenAI 兼容模型
+
+守护进程可以从一个由运维人员配置的 OpenAI 兼容 `/models` 端点补充 OpenCode 模型目录。它适用于 GPUStack、LiteLLM、LM Studio，以及模型未发布到 models.dev 的私有网关：
+
+```dotenv
+MULTICA_OPENCODE_DISCOVERY_BASE_URL=https://gateway.example/v1
+MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID=gpustack
+MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME=GPUStack
+OPENCODE_DISCOVERY_API_KEY=replace-with-a-local-key
+```
+
+在守护进程的本地环境中设置这些变量，然后重启守护进程。Multica 会获取 `.../models`，把返回的模型 ID 合并到正常的 `opencode models` 目录，并在 task 启动时仅向 OpenCode 注入所选模型。API key 始终保留在本机环境中，不会写入生成配置或 Multica 服务端数据库。发现失败时仍保留 OpenCode 的正常目录。
+
 ## 会话恢复
 
 表格中标记 ✓ 的工具支持在后续执行中继续已有会话。前提是原来的会话仍然存在，并且 task 由能够访问它的运行时执行。MiniMax Code 0.1.2 尚未通过 ACP 声明会话加载能力，因此后续执行会新建 MCode 会话。

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"regexp"
@@ -755,6 +757,9 @@ func discoverOpenCodeModels(ctx context.Context, runtimeCmd Command) ([]Model, e
 	if _, err := exec.LookPath(runtimeCmd.Path); err != nil {
 		return []Model{}, nil
 	}
+	providerCtx, providerCancel := context.WithTimeout(ctx, 3*time.Second)
+	discoveredProvider, _ := discoverOpenCodeCompatibleProvider(providerCtx, openCodeDiscoveryHTTPClient, os.Getenv)
+	providerCancel()
 	// Newer opencode (1.15+) syncs its hosted free-model catalog over the
 	// network on `opencode models`, which can take ~6s; the previous 5s cap
 	// timed out and returned an empty list, so the runtime showed online but
@@ -762,6 +767,7 @@ func discoverOpenCodeModels(ctx context.Context, runtimeCmd Command) ([]Model, e
 	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	cmd := runtimeCmd.exec(runCtx, "models", "--verbose")
+	applyOpenCodeDiscoveryEnv(cmd, discoveredProvider)
 	hideAgentWindow(cmd)
 	// Parse whatever the verbose command printed, even on a non-zero exit — a
 	// stale config entry can make `opencode models` exit non-zero while still
@@ -773,6 +779,7 @@ func discoverOpenCodeModels(ctx context.Context, runtimeCmd Command) ([]Model, e
 		// empty list). Retry the plain command, which omits the per-model JSON
 		// but still prints the IDs.
 		cmd = runtimeCmd.exec(runCtx, "models")
+		applyOpenCodeDiscoveryEnv(cmd, discoveredProvider)
 		hideAgentWindow(cmd)
 		out, _ = outputOwned(cmd, runtimeCmd.logger)
 		models = parseOpenCodeModels(string(out))
@@ -781,6 +788,162 @@ func discoverOpenCodeModels(ctx context.Context, runtimeCmd Command) ([]Model, e
 		return []Model{}, nil
 	}
 	return models, nil
+}
+
+type openCodeCompatibleDiscovery struct {
+	ProviderID   string
+	ProviderName string
+	BaseURL      string
+	APIKeyEnv    string
+	Models       []string
+}
+
+var openCodeDiscoveryHTTPClient = &http.Client{
+	// Do not forward an operator's bearer token through endpoint redirects.
+	// The configured URL must identify the authoritative API root directly.
+	CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+}
+
+func openCodeCompatibleProviderFromEnv(getenv func(string) string) (openCodeCompatibleDiscovery, bool) {
+	baseURL := strings.TrimRight(strings.TrimSpace(getenv("MULTICA_OPENCODE_DISCOVERY_BASE_URL")), "/")
+	if baseURL == "" {
+		return openCodeCompatibleDiscovery{}, false
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return openCodeCompatibleDiscovery{}, false
+	}
+	providerID := strings.TrimSpace(getenv("MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID"))
+	if providerID == "" {
+		providerID = "openai-compatible"
+	}
+	if !validOpenCodeProviderID(providerID) {
+		return openCodeCompatibleDiscovery{}, false
+	}
+	providerName := strings.TrimSpace(getenv("MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME"))
+	if providerName == "" {
+		providerName = providerID
+	}
+	apiKeyEnv := strings.TrimSpace(getenv("MULTICA_OPENCODE_DISCOVERY_API_KEY_ENV"))
+	if apiKeyEnv == "" {
+		apiKeyEnv = "OPENCODE_DISCOVERY_API_KEY"
+	}
+	if !validEnvironmentName(apiKeyEnv) {
+		return openCodeCompatibleDiscovery{}, false
+	}
+	return openCodeCompatibleDiscovery{
+		ProviderID: providerID, ProviderName: providerName, BaseURL: baseURL, APIKeyEnv: apiKeyEnv,
+	}, true
+}
+
+func discoverOpenCodeCompatibleProvider(ctx context.Context, client *http.Client, getenv func(string) string) (openCodeCompatibleDiscovery, bool) {
+	discovery, ok := openCodeCompatibleProviderFromEnv(getenv)
+	if !ok {
+		return openCodeCompatibleDiscovery{}, false
+	}
+	apiKey := strings.TrimSpace(getenv(discovery.APIKeyEnv))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discovery.BaseURL+"/models", nil)
+	if err != nil {
+		return openCodeCompatibleDiscovery{}, false
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return openCodeCompatibleDiscovery{}, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return openCodeCompatibleDiscovery{}, false
+	}
+
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	dec := json.NewDecoder(io.LimitReader(resp.Body, 1<<20))
+	if err := dec.Decode(&payload); err != nil {
+		return openCodeCompatibleDiscovery{}, false
+	}
+	ids := make([]string, 0, len(payload.Data))
+	seen := map[string]bool{}
+	for _, item := range payload.Data {
+		id := strings.TrimSpace(item.ID)
+		if id == "" || strings.Contains(id, "#") || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	if len(ids) == 0 {
+		return openCodeCompatibleDiscovery{}, false
+	}
+	discovery.Models = ids
+	return discovery, true
+}
+
+var openCodeProviderIDRe = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`)
+
+func validOpenCodeProviderID(id string) bool { return openCodeProviderIDRe.MatchString(id) }
+
+func validEnvironmentName(name string) bool {
+	if name == "" || !(name[0] == '_' || name[0] >= 'A' && name[0] <= 'Z' || name[0] >= 'a' && name[0] <= 'z') {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		c := name[i]
+		if c != '_' && !(c >= 'A' && c <= 'Z') && !(c >= 'a' && c <= 'z') && !(c >= '0' && c <= '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func applyOpenCodeDiscoveryEnv(cmd *exec.Cmd, discovery openCodeCompatibleDiscovery) {
+	if len(discovery.Models) == 0 {
+		return
+	}
+	discoveredContent, err := openCodeDiscoveryConfigContent(discovery)
+	if err != nil {
+		return
+	}
+	content, err := mergeOpenCodeConfigContents(os.Getenv("OPENCODE_CONFIG_CONTENT"), discoveredContent)
+	if err != nil {
+		return
+	}
+	cmd.Env = replaceEnvValue(os.Environ(), "OPENCODE_CONFIG_CONTENT", content)
+}
+
+func openCodeDiscoveryConfigContent(discovery openCodeCompatibleDiscovery) (string, error) {
+	models := make(map[string]map[string]any, len(discovery.Models))
+	for _, id := range discovery.Models {
+		models[id] = map[string]any{
+			"name": id,
+		}
+	}
+	options := map[string]any{"baseURL": discovery.BaseURL}
+	if discovery.APIKeyEnv != "" {
+		options["apiKey"] = "{env:" + discovery.APIKeyEnv + "}"
+	}
+	content := map[string]any{
+		"provider": map[string]any{
+			discovery.ProviderID: map[string]any{
+				"name":    discovery.ProviderName,
+				"npm":     "@ai-sdk/openai-compatible",
+				"options": options,
+				"models":  models,
+			},
+		},
+	}
+	raw, err := json.Marshal(content)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
 }
 
 // parseOpenCodeModels accepts the `opencode models` text output and

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -2,7 +2,11 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -823,6 +827,159 @@ exit 1
 	}
 	if models[0].ID != "openai/gpt-4o" || models[0].Thinking != nil {
 		t.Fatalf("unexpected fallback model: %+v", models[0])
+	}
+}
+
+func TestDiscoverOpenCodeCompatibleProviderBuildsTransientConfig(t *testing.T) {
+	t.Parallel()
+
+	type capturedRequest struct{ path, auth string }
+	captured := make(chan capturedRequest, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured <- capturedRequest{path: r.URL.Path, auth: r.Header.Get("Authorization")}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"qwen3-coder"},{"id":"deepseek-r1"},{"id":"qwen3-coder"},{"id":"bad#variant"},{"id":""}]}`))
+	}))
+	defer srv.Close()
+
+	env := map[string]string{
+		"MULTICA_OPENCODE_DISCOVERY_BASE_URL":      srv.URL + "/v1/",
+		"MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID":   "gpustack",
+		"MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME": "GPUStack",
+		"MULTICA_OPENCODE_DISCOVERY_API_KEY_ENV":   "GPUSTACK_API_KEY",
+		"GPUSTACK_API_KEY":                         "secret-token",
+	}
+	discovery, ok := discoverOpenCodeCompatibleProvider(context.Background(), srv.Client(), func(key string) string {
+		return env[key]
+	})
+	if !ok {
+		t.Fatal("expected compatible provider discovery")
+	}
+	request := <-captured
+	if request.path != "/v1/models" || request.auth != "Bearer secret-token" {
+		t.Fatalf("request = %+v", request)
+	}
+	if !reflect.DeepEqual(discovery.Models, []string{"deepseek-r1", "qwen3-coder"}) {
+		t.Fatalf("models = %v", discovery.Models)
+	}
+
+	content, err := openCodeDiscoveryConfigContent(discovery)
+	if err != nil {
+		t.Fatalf("openCodeDiscoveryConfigContent: %v", err)
+	}
+	if strings.Contains(content, "secret-token") {
+		t.Fatal("transient OpenCode config must not contain the API key value")
+	}
+	var payload struct {
+		Provider map[string]struct {
+			Name    string `json:"name"`
+			NPM     string `json:"npm"`
+			Options struct {
+				BaseURL string `json:"baseURL"`
+				APIKey  string `json:"apiKey"`
+			} `json:"options"`
+			Models map[string]struct {
+				Name string `json:"name"`
+			} `json:"models"`
+		} `json:"provider"`
+	}
+	if err := json.Unmarshal([]byte(content), &payload); err != nil {
+		t.Fatalf("generated config is invalid JSON: %v", err)
+	}
+	provider := payload.Provider["gpustack"]
+	if provider.Name != "GPUStack" || provider.NPM != "@ai-sdk/openai-compatible" {
+		t.Fatalf("unexpected provider config: %+v", provider)
+	}
+	if provider.Options.BaseURL != srv.URL+"/v1" || provider.Options.APIKey != "{env:GPUSTACK_API_KEY}" {
+		t.Fatalf("unexpected provider options: %+v", provider.Options)
+	}
+	if provider.Models["qwen3-coder"].Name != "qwen3-coder" {
+		t.Fatalf("qwen3-coder config missing: %+v", provider.Models)
+	}
+}
+
+func TestDiscoverOpenCodeModelsSupplementsCLIFromCompatibleEndpoint(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"qwen3-coder"}]}`))
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_OPENCODE_DISCOVERY_BASE_URL", srv.URL+"/v1")
+	t.Setenv("MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID", "gpustack")
+
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "opencode")
+	script := `#!/bin/sh
+echo "openai/gpt-4o"
+case "${OPENCODE_CONFIG_CONTENT-}" in
+  *qwen3-coder*) echo "gpustack/qwen3-coder" ;;
+esac
+`
+	writeTestExecutable(t, fake, []byte(script))
+
+	models, err := discoverOpenCodeModels(context.Background(), Command{Path: fake})
+	if err != nil {
+		t.Fatalf("discoverOpenCodeModels: %v", err)
+	}
+	if got := modelIDs(models); !reflect.DeepEqual(got, []string{"openai/gpt-4o", "gpustack/qwen3-coder"}) {
+		t.Fatalf("models = %v", got)
+	}
+}
+
+func modelIDs(models []Model) []string {
+	ids := make([]string, 0, len(models))
+	for _, model := range models {
+		ids = append(ids, model.ID)
+	}
+	return ids
+}
+
+func TestDiscoverOpenCodeCompatibleProviderRejectsInvalidProviderID(t *testing.T) {
+	t.Parallel()
+
+	discovery, ok := discoverOpenCodeCompatibleProvider(context.Background(), http.DefaultClient, func(key string) string {
+		switch key {
+		case "MULTICA_OPENCODE_DISCOVERY_BASE_URL":
+			return "http://127.0.0.1:1234/v1"
+		case "MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID":
+			return "bad/provider"
+		default:
+			return ""
+		}
+	})
+	if ok || len(discovery.Models) != 0 {
+		t.Fatalf("invalid provider ID must disable discovery, got %+v", discovery)
+	}
+}
+
+func TestApplyOpenCodeDiscoveryEnvInjectsConfigForModelCommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("opencode", "models") //nolint:gosec
+	applyOpenCodeDiscoveryEnv(cmd, openCodeCompatibleDiscovery{
+		ProviderID:   "gpustack",
+		ProviderName: "GPUStack",
+		BaseURL:      "http://127.0.0.1:1234/v1",
+		APIKeyEnv:    "GPUSTACK_API_KEY",
+		Models:       []string{"qwen3-coder"},
+	})
+	env := map[string]string{}
+	for _, entry := range cmd.Env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	content := env["OPENCODE_CONFIG_CONTENT"]
+	if content == "" {
+		t.Fatal("OPENCODE_CONFIG_CONTENT was not injected")
+	}
+	if !strings.Contains(content, `"gpustack"`) || !strings.Contains(content, `"qwen3-coder"`) {
+		t.Fatalf("unexpected injected config: %s", content)
 	}
 }
 

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -142,12 +142,12 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	if opts.Cwd != "" {
 		env = append(env, "PWD="+opts.Cwd)
 	}
-	// Project agent.mcp_config into OpenCode via OPENCODE_CONFIG_CONTENT —
+	// Project agent.mcp_config and an optional daemon-local OpenAI-compatible
+	// provider into OpenCode via OPENCODE_CONFIG_CONTENT —
 	// OpenCode's general inline-config injection mechanism that merges at
 	// "local" scope (after the project-config loop, before remote / managed
-	// configs). MCP is the only field we currently project there; if a
-	// future Multica field needs the same channel it would assemble a
-	// combined OpenCode config slice before the env append.
+	// configs). The assembly helper keeps the provider and MCP slices together
+	// without writing into the task worktree.
 	//
 	// This deliberately leaves <workdir>/opencode.json untouched — the
 	// workdir is reused across turns for the same (agent, issue), and any
@@ -158,11 +158,36 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		cancel()
 		return nil, err
 	}
-	if mcpContent != "" {
-		if _, dup := b.cfg.Env["OPENCODE_CONFIG_CONTENT"]; dup {
-			b.cfg.Logger.Warn("agent.custom_env sets OPENCODE_CONFIG_CONTENT but agent.mcp_config takes precedence and overrides it")
+	providerContent := ""
+	if provider, ok := openCodeCompatibleProviderFromEnv(os.Getenv); ok {
+		prefix := provider.ProviderID + "/"
+		if strings.HasPrefix(opts.Model, prefix) && len(opts.Model) > len(prefix) {
+			provider.Models = []string{strings.TrimPrefix(opts.Model, prefix)}
+			providerContent, err = openCodeDiscoveryConfigContent(provider)
+			if err != nil {
+				cancel()
+				return nil, err
+			}
 		}
-		env = append(env, "OPENCODE_CONFIG_CONTENT="+mcpContent)
+	}
+	if providerContent != "" || mcpContent != "" {
+		userContent := ""
+		// Preserve the existing MCP precedence contract: a daemon-managed MCP
+		// payload replaces user OPENCODE_CONFIG_CONTENT. Provider-only injection
+		// can safely deep-merge because it owns a separate top-level slice.
+		if mcpContent == "" {
+			if configured, ok := b.cfg.Env["OPENCODE_CONFIG_CONTENT"]; ok {
+				userContent = configured
+			} else {
+				userContent = os.Getenv("OPENCODE_CONFIG_CONTENT")
+			}
+		}
+		content, mergeErr := mergeOpenCodeConfigContents(userContent, providerContent, mcpContent)
+		if mergeErr != nil {
+			cancel()
+			return nil, mergeErr
+		}
+		env = replaceEnvValue(env, "OPENCODE_CONFIG_CONTENT", content)
 	}
 	cmd.Env = env
 

--- a/server/pkg/agent/opencode_mcp.go
+++ b/server/pkg/agent/opencode_mcp.go
@@ -64,11 +64,9 @@ type opencodeMCPOAuth struct {
 // OPENCODE_CONFIG_CONTENT is OpenCode's general inline-config injection
 // mechanism — it accepts any subset of OpenCode's schema (model, agent,
 // mode, plugin, mcp, …), not just MCP. This function is scoped to MCP
-// because that's the agent.mcp_config field this PR plumbs through; if a
-// future Multica field needs to project into the same env var (e.g. an
-// agent-level model override), the assemble-and-inject step would move
-// up a layer and merge multiple slices into one OPENCODE_CONFIG_CONTENT
-// value. For now, MCP is the only consumer.
+// because that's the agent.mcp_config field this helper translates. The
+// caller combines its output with other daemon-managed slices, such as an
+// OpenAI-compatible provider catalog, through mergeOpenCodeConfigContents.
 //
 // Why env-var injection vs writing <workdir>/opencode.json: the task workdir
 // is reused across turns for the same (agent, issue), and the agent itself
@@ -107,6 +105,44 @@ func buildOpenCodeMCPConfigContent(raw json.RawMessage) (string, error) {
 		return "", fmt.Errorf("opencode mcp_config: marshal: %w", err)
 	}
 	return string(data), nil
+}
+
+// mergeOpenCodeConfigContents deep-merges partial OpenCode configuration
+// objects in order. Later parts win on scalar conflicts while sibling maps are
+// preserved. This lets daemon-managed provider discovery and MCP settings
+// share OPENCODE_CONFIG_CONTENT without erasing user-owned configuration.
+func mergeOpenCodeConfigContents(parts ...string) (string, error) {
+	merged := map[string]any{}
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		var next map[string]any
+		if err := json.Unmarshal([]byte(part), &next); err != nil {
+			return "", fmt.Errorf("opencode config content: parse: %w", err)
+		}
+		deepMergeOpenCodeConfig(merged, next)
+	}
+	if len(merged) == 0 {
+		return "", nil
+	}
+	data, err := json.Marshal(merged)
+	if err != nil {
+		return "", fmt.Errorf("opencode config content: marshal: %w", err)
+	}
+	return string(data), nil
+}
+
+func deepMergeOpenCodeConfig(dst, src map[string]any) {
+	for key, value := range src {
+		srcMap, srcOK := value.(map[string]any)
+		dstMap, dstOK := dst[key].(map[string]any)
+		if srcOK && dstOK {
+			deepMergeOpenCodeConfig(dstMap, srcMap)
+			continue
+		}
+		dst[key] = value
+	}
 }
 
 // translateMCPConfigForOpenCode converts an agent.mcp_config payload into the

--- a/server/pkg/agent/opencode_mcp_test.go
+++ b/server/pkg/agent/opencode_mcp_test.go
@@ -504,6 +504,59 @@ func TestOpencodeBackendOmitsMCPEnvWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestOpencodeBackendInjectsDiscoveredProviderForSelectedModel(t *testing.T) {
+	t.Setenv("MULTICA_OPENCODE_DISCOVERY_BASE_URL", "https://models.example/v1")
+	t.Setenv("MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID", "gateway")
+	t.Setenv("MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME", "Private Gateway")
+	t.Setenv("MULTICA_OPENCODE_DISCOVERY_API_KEY_ENV", "GATEWAY_API_KEY")
+	t.Setenv("GATEWAY_API_KEY", "local-secret")
+
+	tempDir := t.TempDir()
+	fakePath := filepath.Join(tempDir, "opencode")
+	captureFile := filepath.Join(tempDir, "env-capture.txt")
+	writeTestExecutable(t, fakePath, []byte(fakeOpencodeScriptCapturingEnv()))
+
+	backend, err := New("opencode", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env: map[string]string{
+			"OPENCODE_CAPTURE_FILE":   captureFile,
+			"OPENCODE_CONFIG_CONTENT": `{"permission":{"read":"allow"}}`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Cwd:     t.TempDir(),
+		Timeout: 5 * time.Second,
+		Model:   "gateway/qwen3-coder",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	if result := <-session.Result; result.Status != "completed" {
+		t.Fatalf("status = %q, error = %q; want completed", result.Status, result.Error)
+	}
+
+	content := readCapturedEnv(t, captureFile)["OPENCODE_CONFIG_CONTENT"]
+	if strings.Contains(content, "local-secret") {
+		t.Fatal("provider config leaked the API key value")
+	}
+	for _, want := range []string{`"provider"`, `"gateway"`, `"qwen3-coder"`, `"{env:GATEWAY_API_KEY}"`, `"permission"`} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("OPENCODE_CONFIG_CONTENT missing %s:\n%s", want, content)
+		}
+	}
+}
+
 // TestOpencodeBackendOverridesUserOpenCodeConfigContent asserts the
 // daemon-level mcp_config wins over a user-supplied OPENCODE_CONFIG_CONTENT
 // in agent.custom_env. This is the behaviour Go's os/exec dedup gives us

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,13 @@
     "DESKTOP_RENDERER_PORT",
     "DESKTOP_APP_SUFFIX"
   ],
+  "globalPassThroughEnv": [
+    "MULTICA_OPENCODE_DISCOVERY_BASE_URL",
+    "MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID",
+    "MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME",
+    "MULTICA_OPENCODE_DISCOVERY_API_KEY_ENV",
+    "OPENCODE_DISCOVERY_API_KEY"
+  ],
   "tasks": {
     // `fumadocs-mdx` regenerates `.source/` by removing the directory and
     // writing it again, so two of them in the same package at once is a race:


### PR DESCRIPTION
## Summary

- let an OpenCode runtime supplement its normal catalog from one operator-configured OpenAI-compatible `/models` endpoint
- inject a transient provider definition into OpenCode for discovery and for the selected model at execution time
- keep bearer credentials daemon-local: generated config contains only an environment reference and secrets are never persisted by Multica
- bound discovery to 3 seconds and 1 MiB, reject unsafe endpoint shapes and redirects, deduplicate/sort IDs, and preserve the normal OpenCode catalog on failure
- deep-merge provider configuration without clobbering user configuration or daemon-managed MCP settings
- document the generic setup and a GPUStack example in all four documentation locales

This implements a narrow OpenCode-oriented slice of #7885 without introducing a GPUStack-specific runtime or a server-side secret store.

## Configuration

```dotenv
MULTICA_OPENCODE_DISCOVERY_BASE_URL=https://gateway.example/v1
MULTICA_OPENCODE_DISCOVERY_PROVIDER_ID=gpustack
MULTICA_OPENCODE_DISCOVERY_PROVIDER_NAME=GPUStack
OPENCODE_DISCOVERY_API_KEY=replace-with-a-local-key
```

After the daemon restarts, models returned by `GET .../models` appear as `gpustack/<model-id>` in the existing model picker.

## Verification

- OpenCode-focused Go tests: 131 passed
- docs typecheck: passed
- docs tests: 15 passed
- real OpenCode 1.18.18 smoke test confirmed the generated transient config publishes a discovered model
- full agent suite reached 1,737 passing tests; three Codex semantic-inactivity timing tests also fail unchanged on a clean `upstream/main` worktree