### PR TITLE
MUL-7029 fix(daemon): stop rejecting preparation fields from an older parent

### DIFF
--- a/server/internal/daemon/execenv/isolation.go
+++ b/server/internal/daemon/execenv/isolation.go
@@ -236,11 +236,26 @@ func marshalPreparationRequest(request preparationRequest) ([]byte, error) {
 	return json.Marshal(payload)
 }
 
+// decodePreparationRequest reads the parent's payload. Unknown fields are
+// IGNORED, not rejected: parent and helper are the same program but not
+// necessarily the same build. The parent is the daemon process that is
+// running; the helper is whatever binary sits at that executable path when the
+// task starts, and every upgrade path replaces the file under a live daemon —
+// Desktop swaps the bundled/managed CLI and defers the restart while the daemon
+// is busy, `brew upgrade` and a manual replacement are picked up by
+// trySelfReload only on its next idle tick. Until the daemon re-execs, an
+// older parent talks to a newer helper.
+//
+// DisallowUnknownFields turned that ordinary window into a hard failure of
+// every task on the host: removing TaskContextForEnv.HandoffNote (#7626) left
+// old daemons still sending an untagged, non-omitempty `"HandoffNote": ""`,
+// and the new helper answered `json: unknown field "HandoffNote"` (MUL-7029).
+// Field drift in a struct nobody versions is expected here, so the request is
+// decoded on the same best-effort terms as the response the parent reads back:
+// a param the other side does not know about is dropped, not fatal.
 func decodePreparationRequest(in io.Reader) (preparationRequest, error) {
 	var request preparationRequest
-	decoder := json.NewDecoder(in)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&request); err != nil {
+	if err := json.NewDecoder(in).Decode(&request); err != nil {
 		return preparationRequest{}, err
 	}
 	return request, nil

--- a/server/internal/daemon/execenv/isolation_test.go
+++ b/server/internal/daemon/execenv/isolation_test.go
@@ -137,6 +137,63 @@ func TestPreparationHelperRoundTripsProjectResources(t *testing.T) {
 	}
 }
 
+// TestPreparationHelperAcceptsFieldsFromAnOlderParent pins the version-skew
+// half of the helper protocol. The parent is the running daemon process and
+// the helper is the binary currently at its executable path, so an upgrade
+// that replaces that file under a live daemon has an older parent feeding a
+// newer helper until the daemon re-execs. Rejecting the fields the newer build
+// dropped failed every task on the host for the whole window: removing
+// TaskContextForEnv.HandoffNote (#7626) left installed daemons sending an
+// untagged, non-omitempty `"HandoffNote": ""` and the helper answered
+// `json: unknown field "HandoffNote"` (MUL-7029).
+func TestPreparationHelperAcceptsFieldsFromAnOlderParent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	workDir := filepath.Join(t.TempDir(), "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("seed workdir: %v", err)
+	}
+
+	payload, err := marshalPreparationRequest(preparationRequest{
+		Action: preparationActionReuse,
+		Reuse: &ReuseParams{
+			WorkDir:  workDir,
+			Provider: "claude",
+			Task:     TaskContextForEnv{IssueID: "issue-helper-old-parent"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal preparation request: %v", err)
+	}
+	// Re-add the fields an older build put on the wire: one the removed
+	// handoff note actually occupied, and one on the params struct itself.
+	var wire map[string]any
+	if err := json.Unmarshal(payload, &wire); err != nil {
+		t.Fatalf("open payload: %v", err)
+	}
+	reuse := wire["reuse"].(map[string]any)
+	reuse["Task"].(map[string]any)["HandoffNote"] = "scope this run to the parser"
+	reuse["RetiredParamFromAnOlderBuild"] = true
+	oldParentPayload, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("reseal payload: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := RunPreparationHelper(bytes.NewReader(oldParentPayload), &out, logger); err != nil {
+		t.Fatalf("RunPreparationHelper on an older parent's payload: %v", err)
+	}
+	var response preparationResponse
+	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+		t.Fatalf("decode preparation response: %v", err)
+	}
+	if response.Error != "" {
+		t.Fatalf("helper reported error %q, want the reuse to succeed", response.Error)
+	}
+	if response.Environment == nil || response.Environment.WorkDir != workDir {
+		t.Fatalf("environment = %#v, want workdir %q", response.Environment, workDir)
+	}
+}
+
 func TestPreparationRequestPreservesOpenclawGatewayForHelper(t *testing.T) {
 	t.Parallel()
 	want := OpenclawGatewayPin{


### PR DESCRIPTION
## What broke

Every task on an upgraded host failed before the agent started:

```
reuse execution environment: execenv: preparation helper failed: exit status 1:
decode preparation request: json: unknown field "HandoffNote"
```

## Why

The daemon does not prepare a task in its own process. `PrepareIsolated` /
`ReuseIsolated` spawn `<os.Executable()> __multica_execenv_prepare` and pass the
params as JSON over stdin. Parent and helper are the same *program*, but not
necessarily the same *build*: the parent is the daemon process that is running,
the helper is whatever binary sits at that path when the task starts, and every
upgrade path replaces the file under a live daemon.

* Desktop swaps the bundled/managed CLI and, on a version mismatch while the
  daemon is busy, **defers** the restart (`ensureRunningDaemonVersionMatches`).
* `brew upgrade` / a manual replacement is picked up by `trySelfReload`, which
  only fires on an idle tick every 10 minutes.

So an older parent feeding a newer helper is an ordinary, expected window.
`decodePreparationRequest` ran `DisallowUnknownFields`, which turned that window
into a hard failure of every task on the host.

#7626 was enough to trigger it. It removed `TaskContextForEnv.HandoffNote`,
which was untagged and had no `omitempty` — so installed daemons kept putting
`"HandoffNote": ""` on the wire unconditionally, and the upgraded helper refused
the whole request. Nothing about the *note* was involved; an empty one failed
exactly the same way.

## The change

Decode the request on the same best-effort terms as the response the parent
already reads back: a param the other side does not know about is dropped, not
fatal. Strictness bought nothing here — parent and helper are both this package
and the wire shape is pinned by this file's own tests — while costing a full
outage of the host for the length of every upgrade window.

Because the rejection lives on the *receiving* side, landing this fixes the
class going forward: from this release on, a helper tolerates the fields any
older daemon still sends.

## Verified

* New `TestPreparationHelperAcceptsFieldsFromAnOlderParent` drives
  `RunPreparationHelper` with an old-parent payload (`Task.HandoffNote` plus a
  retired top-level param). It fails on `main` with the exact reported error and
  passes with the change.
* `go test ./internal/daemon/execenv/ -run 'TestPreparation|TestPrepareIsolated|TestLockEnvRoot|TestRehydrate'` — pass.
* Full `./internal/daemon/execenv` and `./internal/daemon` runs show only
  pre-existing failures on this host (Hermes store-path and daemon-ID tests that
  read the real `~/.multica` profile); they fail identically on a clean `main`.

## Not covered

The opposite skew — a **newer** parent against an **older** helper, e.g. a
binary downgrade — still hits `DisallowUnknownFields` inside the old binary.
That cannot be fixed from here; it needs the daemon restarted onto the matching
build, which the existing reload paths already do.
