### PR TITLE
feat(cli): add comparison operators to issue list --property

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -520,13 +520,23 @@ multica issue list --metadata pipeline_status=waiting_review
 multica issue list --metadata pr_number=482 --metadata is_blocked=true
 ```
 
-Use `--property "Name=Value"` (repeatable; one value per flag) to filter by custom property. Names and select option values are case-insensitive and resolve to ids; repeating the same property matches any of its values, different properties must all match. Values are option names or ids (select types), `true`/`false` (checkbox), a member name, email, or id (actor types), or the stored value itself for `text`, `url`, `number`, and `date` (`YYYY-MM-DD`). Only `=` is supported today; the `>=`, `<=` and `!=` spellings are reserved for comparison filters and are rejected. The reserved value `__none__` matches issues where the property is unset:
+Use `--property "Name=Value"` (repeatable; one member per flag) to filter by custom property. Names and select option values are case-insensitive and resolve to ids; repeating the same property matches any of its members, different properties must all match. Values are option names or ids (select types), `true`/`false` (checkbox), a member name, email, or id (actor types), or the stored value itself for `text`, `url`, `number`, and `date` (`YYYY-MM-DD`). The reserved value `__none__` matches issues where the property is unset:
 
 ```bash
 multica issue list --property "Impact=High" --property "Impact=Medium"
 multica issue list --property "Impact=__none__" --status in_review
 multica issue list --property "Score=42" --property "Ship Date=2026-08-28"
 ```
+
+Comparisons go in the same flag. `number` takes `>`, `>=`, `<` and `<=`; `date` takes `>` (after) and `<` (before); `text` and `url` take `~=` (contains, case-insensitive, matched exactly as typed). Quote the flag so the shell does not read `<` and `>` as redirection:
+
+```bash
+multica issue list --property "Score>=3" --property "Impact=High"
+multica issue list --property "Ship Date<2026-09-01" --status todo
+multica issue list --property "Notes~=follow up"
+```
+
+A comparison on a type that cannot honour it is rejected with an error naming the type. So is `!=` (the server has no not-equal filter), and so are `>=` and `<=` on a date: the server only compares dates strictly, and the error names the strict form to use instead. Repeating a property ORs its members, so `"Score>1"` plus `"Score<10"` is not a range. A property whose name contains `=`, `<`, `>`, `!` or `~` has to be given by its UUID.
 
 In JSON output, `properties` is a map from definition id to the stored value: an option id for `select`, a list of option ids for `multi_select`, a `member:<uuid>` reference for the actor types, and the value itself otherwise. Pass `--resolve-properties` to replace that map with the rows `issue property list` prints, one per set property, in catalog order: `property_id`, `name`, `type`, the stored `value`, a human `display`, `display_values` (the per-item names of a `multi_select` or `multi_actor` value) and `archived` when the definition is archived. Archived definitions still resolve, since their values stay on the issue. An option that is no longer in the definition, or a member who has left the workspace, keeps its raw id in `display`. The flag adds at most two requests: the catalog, shared with `--property` and `--sort property:`, and the member list, fetched only when an actor `--property` filter or an actor value on the page needs it and shared between the two. If either request fails the command fails rather than printing ids. In JSON output it combines with `--fields` only when that list keeps `properties`; a `--fields` list without it is rejected rather than resolving a key the same command would delete. The flag has no effect on `--output table`, where it and `--fields` are both ignored and neither is rejected.
 

--- a/apps/docs/content/docs/cli.ja.mdx
+++ b/apps/docs/content/docs/cli.ja.mdx
@@ -224,7 +224,7 @@ CLI の設定ファイルには、あなたとして Multica にアクセスで�
 
 | コマンド | サブコマンド | 用途 | 主なフラグ |
 | --- | --- | --- | --- |
-| `issue` | `list` | タスクを一覧 | `--status`、`--priority`、`--assignee`、`--project`、`--metadata`（繰り返し可）、`--property`（繰り返し可、`"名前=値"`；`__none__` は未設定に一致）、`--limit`、`--offset`、`--sort`（`property:<名前または id>` に対応）、`--full-id`、`--resolve-properties`（JSON のみ；保存された id に加えてプロパティ名・選択肢名・メンバー名を返します） |
+| `issue` | `list` | タスクを一覧 | `--status`、`--priority`、`--assignee`、`--project`、`--metadata`（繰り返し可）、`--property`（繰り返し可、`"名前=値"` または `"Score>=3"`、`"Due<2026-01-01"`、`"Notes~=text"` のような比較；`__none__` は未設定に一致）、`--limit`、`--offset`、`--sort`（`property:<名前または id>` に対応）、`--full-id`、`--resolve-properties`（JSON のみ；保存された id に加えてプロパティ名・選択肢名・メンバー名を返します） |
 | | `get <id>` | 単一のタスクを表示 | `--resolve-properties`（JSON のみ；保存された id に加えてプロパティ名・選択肢名・メンバー名を返します） |
 | | `create` | タスクを作成 | `--title`（必須）、`--description` / `--description-stdin` / `--description-file`、`--status`、`--priority`、`--assignee`、`--parent`、`--stage`、`--project`、`--start-date`、`--due-date`、`--attachment`（繰り返し可） |
 | | `update <id>` | タスクのフィールドを更新 | `create` と同系のフィールドに加え `--position`、`--no-start` |

--- a/apps/docs/content/docs/cli.ko.mdx
+++ b/apps/docs/content/docs/cli.ko.mdx
@@ -224,7 +224,7 @@ CLI 설정 파일에는 사용자를 대신해 Multica에 접근할 수 있는 t
 
 | 명령 | 하위 명령 | 용도 | 주요 flag |
 | --- | --- | --- | --- |
-| `issue` | `list` | 태스크 목록 | `--status`, `--priority`, `--assignee`, `--project`, `--metadata`(반복 가능), `--property`(반복 가능, `"이름=값"`; `__none__`은 미설정과 일치), `--limit`, `--offset`, `--sort`(`property:<이름 또는 id>` 지원), `--full-id`, `--resolve-properties`(JSON 전용; 저장된 id와 함께 속성, 옵션, 멤버 이름을 반환) |
+| `issue` | `list` | 태스크 목록 | `--status`, `--priority`, `--assignee`, `--project`, `--metadata`(반복 가능), `--property`(반복 가능, `"이름=값"` 또는 `"Score>=3"`, `"Due<2026-01-01"`, `"Notes~=text"` 같은 비교; `__none__`은 미설정과 일치), `--limit`, `--offset`, `--sort`(`property:<이름 또는 id>` 지원), `--full-id`, `--resolve-properties`(JSON 전용; 저장된 id와 함께 속성, 옵션, 멤버 이름을 반환) |
 | | `get <id>` | 태스크 하나 확인 | `--resolve-properties`(JSON 전용; 저장된 id와 함께 속성, 옵션, 멤버 이름을 반환) |
 | | `create` | 태스크 생성 | `--title`(필수), `--description` / `--description-stdin` / `--description-file`, `--status`, `--priority`, `--assignee`, `--parent`, `--stage`, `--project`, `--start-date`, `--due-date`, `--attachment`(반복 가능) |
 | | `update <id>` | 태스크 필드 업데이트 | `create`와 같은 종류의 필드에 `--position`, `--no-start` 추가 |

--- a/apps/docs/content/docs/cli.mdx
+++ b/apps/docs/content/docs/cli.mdx
@@ -232,7 +232,7 @@ The tables below cover every current top-level command, grouped the way the CLI 
 
 | Command | Subcommand | Purpose | Key flags |
 | --- | --- | --- | --- |
-| `issue` | `list` | List issues | `--status`, `--priority`, `--assignee`, `--project`, `--metadata` (repeatable), `--property` (repeatable, `"Name=Value"`; `__none__` matches unset), `--limit`, `--offset`, `--sort` (incl. `property:<name-or-id>`), `--full-id`, `--resolve-properties` (JSON only; rows with property, option and member names beside the stored ids) |
+| `issue` | `list` | List issues | `--status`, `--priority`, `--assignee`, `--project`, `--metadata` (repeatable), `--property` (repeatable, `"Name=Value"` or a comparison such as `"Score>=3"`, `"Due<2026-01-01"`, `"Notes~=text"`; `__none__` matches unset), `--limit`, `--offset`, `--sort` (incl. `property:<name-or-id>`), `--full-id`, `--resolve-properties` (JSON only; rows with property, option and member names beside the stored ids) |
 | | `get <id>` | Show a single issue | `--resolve-properties` (JSON only; rows with property, option and member names beside the stored ids) |
 | | `create` | Create an issue | `--title` (required), `--description` / `--description-stdin` / `--description-file`, `--status`, `--priority`, `--assignee`, `--parent`, `--stage`, `--project`, `--start-date`, `--due-date`, `--attachment` (repeatable) |
 | | `update <id>` | Update issue fields | Same fields as `create`, plus `--position`, `--no-start` |

--- a/apps/docs/content/docs/cli.zh.mdx
+++ b/apps/docs/content/docs/cli.zh.mdx
@@ -224,7 +224,7 @@ CLI 配置文件包含可代表你访问 Multica 的令牌。不要提交到仓�
 
 | 命令 | 子命令 | 用途 | 关键 flag |
 | --- | --- | --- | --- |
-| `issue` | `list` | 列出任务 | `--status`、`--priority`、`--assignee`、`--project`、`--metadata`（可重复）、`--property`（可重复，`"名称=值"`；`__none__` 匹配未设置）、`--limit`、`--offset`、`--sort`（支持 `property:<名称或 id>`）、`--full-id`、`--resolve-properties`（仅 JSON；在保存的 id 旁附上属性、选项和成员名称） |
+| `issue` | `list` | 列出任务 | `--status`、`--priority`、`--assignee`、`--project`、`--metadata`（可重复）、`--property`（可重复，`"名称=值"` 或 `"Score>=3"`、`"Due<2026-01-01"`、`"Notes~=text"` 这样的比较；`__none__` 匹配未设置）、`--limit`、`--offset`、`--sort`（支持 `property:<名称或 id>`）、`--full-id`、`--resolve-properties`（仅 JSON；在保存的 id 旁附上属性、选项和成员名称） |
 | | `get <id>` | 查看单个任务 | `--resolve-properties`（仅 JSON；在保存的 id 旁附上属性、选项和成员名称） |
 | | `create` | 创建任务 | `--title`（必填）、`--description` / `--description-stdin` / `--description-file`、`--status`、`--priority`、`--assignee`、`--parent`、`--stage`、`--project`、`--start-date`、`--due-date`、`--attachment`（可重复） |
 | | `update <id>` | 更新任务字段 | 与 `create` 同类字段，另有 `--position`、`--no-start` |

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -171,7 +171,19 @@ var issueCmd = &cobra.Command{
 var issueListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List issues in the workspace",
-	RunE:  runIssueList,
+	Long: "List issues in the workspace.\n\n" +
+		"--property filters by a custom property, one member per flag. \"Name=Value\" is\n" +
+		"equality; the value is an option name or id (select, multi_select), true or\n" +
+		"false (checkbox), a member name, email or id (actor types), or the stored value\n" +
+		"itself (text, url, number, date as YYYY-MM-DD). Comparisons use the same flag:\n" +
+		"  number    \"Score>3\"  \"Score>=3\"  \"Score<3\"  \"Score<=3\"\n" +
+		"  date      \"Ship Date>2026-01-01\" (after)  \"Ship Date<2026-01-01\" (before)\n" +
+		"  text/url  \"Notes~=review\" (contains, case-insensitive; the needle is sent as typed)\n" +
+		"A comparison on any other type is rejected, as is != (the server has no not-equal\n" +
+		"filter) and >= or <= on a date (the error names the strict form to use instead).\n" +
+		"Repeating a property matches ANY of its members, so \"Score>1\" plus \"Score<10\"\n" +
+		"is not a range.",
+	RunE: runIssueList,
 }
 
 var issueGetCmd = &cobra.Command{
@@ -511,7 +523,7 @@ func init() {
 	issueListCmd.Flags().String("assignee-id", "", "Filter by assignee UUID — member, agent, or squad (mutually exclusive with --assignee)")
 	issueListCmd.Flags().String("project", "", "Filter by project ID")
 	issueListCmd.Flags().StringSlice("metadata", nil, "Filter by metadata key=value (repeatable; combined with AND). Value is JSON-parsed: 'true'/'false' → bool, numbers → number, otherwise string. Wrap as '\"42\"' to force a string when the value would otherwise sniff as a number.")
-	issueListCmd.Flags().StringArray("property", nil, `Filter by custom property, written as "Name=Value" (repeatable, one value per flag). Name is a property name (case-insensitive) or its UUID. Value depends on the type: an option name or id for select and multi_select, true or false for checkbox, a member name, email, or id for actor types, and the value itself for text, url, number, and date (YYYY-MM-DD). Use __none__ to match issues where the property is unset; it works for every type, so an option or member actually named __none__ has to be given by id, as does a property whose name contains "=" or ends in <, > or ! (the >=, <=, and != spellings are reserved for comparison filters). Repeating a property matches ANY of its values; different properties must ALL match.`)
+	issueListCmd.Flags().StringArray("property", nil, `Filter by custom property, written as "Name=Value" or as a comparison such as "Score>=3", "Ship Date<2026-01-01" or "Notes~=review" (repeatable, one member per flag; quote it so the shell does not read < and > as redirection). Name is a property name (case-insensitive) or its UUID; a name containing =, <, >, ! or ~ has to be given by UUID. Use __none__ to match issues where the property is unset; it works for every type, so an option or member actually named __none__ has to be given by id. Repeating a property matches ANY of its members; different properties must ALL match. The per-type value forms and comparisons are in the command description above.`)
 	issueListCmd.Flags().Int("limit", 50, "Maximum number of issues to return in one page (the server caps a page at 100; use --offset to page through more)")
 	issueListCmd.Flags().Int("offset", 0, "Number of issues to skip (for pagination)")
 	issueListCmd.Flags().String("sort", "", "Sort column: position (default, manual board order), title, created_at, start_date, due_date, priority, or property:<name-or-id> to sort by a custom property (select properties sort by option order)")

--- a/server/cmd/multica/cmd_issue_property_filter_test.go
+++ b/server/cmd/multica/cmd_issue_property_filter_test.go
@@ -25,6 +25,8 @@ const (
 	testShipDateDefID  = "adadadad-1111-4111-8111-111111111111"
 	testSpecDefID      = "aeaeaeae-1111-4111-8111-111111111111"
 	testFutureDefID    = "afafafaf-1111-4111-8111-111111111111"
+	testScoreGtDefID   = "bcbcbcbc-1111-4111-8111-111111111111"
+	testRiskDefID      = "bdbdbdbd-1111-4111-8111-111111111111"
 )
 
 func propertyFilterTestCatalog() []propertyDTO {
@@ -46,7 +48,11 @@ func propertyFilterTestCatalog() []propertyDTO {
 	spec := propertyDTO{ID: testSpecDefID, Name: "Spec", Type: "url"}
 	// A type this build has never heard of, the way a newer backend would report one.
 	future := propertyDTO{ID: testFutureDefID, Name: "Sentiment", Type: "mood"}
-	return []propertyDTO{impact, blocked, notes, archived, platforms, reviewer, score, shipDate, spec, future}
+	// Names that collide with the comparison spellings: a trailing > is only
+	// reachable by UUID, an interior > still works under =.
+	scoreGt := propertyDTO{ID: testScoreGtDefID, Name: "Score>", Type: "number"}
+	risk := propertyDTO{ID: testRiskDefID, Name: "Risk>Reward", Type: "text"}
+	return []propertyDTO{impact, blocked, notes, archived, platforms, reviewer, score, shipDate, spec, future, scoreGt, risk}
 }
 
 // newPropertyFilterTestServer serves the fixed property catalog and captures
@@ -92,7 +98,10 @@ func listIssuesWithFlags(t *testing.T, flags map[string][]string) error {
 	return err
 }
 
-func decodePropertiesParam(t *testing.T, queries []url.Values) map[string][]string {
+// decodePropertiesParam returns the sent filter with equality members as
+// strings and comparison members as {"op", "value"} maps, the two shapes
+// parsePropertiesFilterParam accepts.
+func decodePropertiesParam(t *testing.T, queries []url.Values) map[string][]any {
 	t.Helper()
 	if len(queries) != 1 {
 		t.Fatalf("expected exactly one /api/issues request, got %d", len(queries))
@@ -101,48 +110,52 @@ func decodePropertiesParam(t *testing.T, queries []url.Values) map[string][]stri
 	if raw == "" {
 		t.Fatalf("no properties query param sent; query = %v", queries[0])
 	}
-	var filter map[string][]string
+	var filter map[string][]any
 	if err := json.Unmarshal([]byte(raw), &filter); err != nil {
 		t.Fatalf("properties param %q is not valid JSON: %v", raw, err)
 	}
 	return filter
 }
 
+func opMember(op, value string) map[string]any {
+	return map[string]any{"op": op, "value": value}
+}
+
 func TestRunIssueListSendsPropertyFilter(t *testing.T) {
 	cases := []struct {
 		name  string
 		flags []string
-		want  map[string][]string
+		want  map[string][]any
 	}{
 		{
 			name:  "select option by name",
 			flags: []string{"Impact=High"},
-			want:  map[string][]string{testImpactDefID: {testImpactHighID}},
+			want:  map[string][]any{testImpactDefID: {testImpactHighID}},
 		},
 		{
 			name:  "case-insensitive property and option names",
 			flags: []string{"impact=high"},
-			want:  map[string][]string{testImpactDefID: {testImpactHighID}},
+			want:  map[string][]any{testImpactDefID: {testImpactHighID}},
 		},
 		{
 			name:  "property and option addressed by UUID",
 			flags: []string{testImpactDefID + "=" + testImpactHighID},
-			want:  map[string][]string{testImpactDefID: {testImpactHighID}},
+			want:  map[string][]any{testImpactDefID: {testImpactHighID}},
 		},
 		{
 			name:  "repeated property flags OR into one definition",
 			flags: []string{"Impact=High", "impact=Medium"},
-			want:  map[string][]string{testImpactDefID: {testImpactHighID, testImpactMediumID}},
+			want:  map[string][]any{testImpactDefID: {testImpactHighID, testImpactMediumID}},
 		},
 		{
 			name:  "duplicate resolved values collapse",
 			flags: []string{"Impact=High", "Impact=high"},
-			want:  map[string][]string{testImpactDefID: {testImpactHighID}},
+			want:  map[string][]any{testImpactDefID: {testImpactHighID}},
 		},
 		{
 			name:  "distinct definitions AND together",
 			flags: []string{"Impact=High", "Blocked=true"},
-			want: map[string][]string{
+			want: map[string][]any{
 				testImpactDefID:  {testImpactHighID},
 				testBlockedDefID: {"true"},
 			},
@@ -150,17 +163,17 @@ func TestRunIssueListSendsPropertyFilter(t *testing.T) {
 		{
 			name:  "unset sentinel passes through for a checkbox",
 			flags: []string{"Blocked=__none__"},
-			want:  map[string][]string{testBlockedDefID: {"__none__"}},
+			want:  map[string][]any{testBlockedDefID: {"__none__"}},
 		},
 		{
 			name:  "unset sentinel passes through for a text property",
 			flags: []string{"Notes=__none__"},
-			want:  map[string][]string{testNotesDefID: {"__none__"}},
+			want:  map[string][]any{testNotesDefID: {"__none__"}},
 		},
 		{
 			name:  "multi_select option by name",
 			flags: []string{"Platforms=iOS"},
-			want:  map[string][]string{testPlatformsDefID: {testPlatformsIOSID}},
+			want:  map[string][]any{testPlatformsDefID: {testPlatformsIOSID}},
 		},
 		{
 			// Stored actor values are canonical lowercase-hyphenated and the
@@ -168,46 +181,174 @@ func TestRunIssueListSendsPropertyFilter(t *testing.T) {
 			// must be re-serialized rather than passed through as typed.
 			name:  "actor member reference canonicalized",
 			flags: []string{"Reviewer=member:ABABABAB-2222-4222-8222-222222222222"},
-			want:  map[string][]string{testReviewerDefID: {"member:abababab-2222-4222-8222-222222222222"}},
+			want:  map[string][]any{testReviewerDefID: {"member:abababab-2222-4222-8222-222222222222"}},
 		},
 		{
 			name:  "text value forwarded verbatim",
 			flags: []string{"Notes=needs a second look"},
-			want:  map[string][]string{testNotesDefID: {"needs a second look"}},
+			want:  map[string][]any{testNotesDefID: {"needs a second look"}},
 		},
 		{
 			// Text is stored exactly as written, so the filter has to pass
 			// through what the user typed.
 			name:  "text value keeps surrounding whitespace",
 			flags: []string{"Notes= padded "},
-			want:  map[string][]string{testNotesDefID: {" padded "}},
+			want:  map[string][]any{testNotesDefID: {" padded "}},
 		},
 		{
 			name:  "number value forwarded",
 			flags: []string{"Score=42"},
-			want:  map[string][]string{testScoreDefID: {"42"}},
+			want:  map[string][]any{testScoreDefID: {"42"}},
 		},
 		{
 			name:  "negative and fractional numbers are accepted",
 			flags: []string{"Score=-1.5"},
-			want:  map[string][]string{testScoreDefID: {"-1.5"}},
+			want:  map[string][]any{testScoreDefID: {"-1.5"}},
 		},
 		{
 			name:  "date value forwarded",
 			flags: []string{"Ship Date=2026-08-28"},
-			want:  map[string][]string{testShipDateDefID: {"2026-08-28"}},
+			want:  map[string][]any{testShipDateDefID: {"2026-08-28"}},
 		},
 		{
 			// A url is stored trimmed, so the filter trims to match it.
 			name:  "url value trimmed to the stored spelling",
 			flags: []string{"Spec= https://example.com/spec "},
-			want:  map[string][]string{testSpecDefID: {"https://example.com/spec"}},
+			want:  map[string][]any{testSpecDefID: {"https://example.com/spec"}},
 		},
 		{
 			// The store cap is 2000 runes, not bytes.
 			name:  "text value at the store length cap is sent",
 			flags: []string{"Notes=" + strings.Repeat("é", 2000)},
-			want:  map[string][]string{testNotesDefID: {strings.Repeat("é", 2000)}},
+			want:  map[string][]any{testNotesDefID: {strings.Repeat("é", 2000)}},
+		},
+		{
+			name:  "equality value keeps comparison characters",
+			flags: []string{"Notes=a<b"},
+			want:  map[string][]any{testNotesDefID: {"a<b"}},
+		},
+		{
+			// "=>" is not a spelling, so the value is the literal ">foo".
+			name:  "equality value starting with > stays literal",
+			flags: []string{"Notes=>foo"},
+			want:  map[string][]any{testNotesDefID: {">foo"}},
+		},
+		{
+			name:  "interior > in a name still resolves under =",
+			flags: []string{"Risk>Reward=high"},
+			want:  map[string][]any{testRiskDefID: {"high"}},
+		},
+		{
+			name:  "number greater than",
+			flags: []string{"Score>3"},
+			want:  map[string][]any{testScoreDefID: {opMember("gt", "3")}},
+		},
+		{
+			name:  "number at least",
+			flags: []string{"Score>=3"},
+			want:  map[string][]any{testScoreDefID: {opMember("gte", "3")}},
+		},
+		{
+			name:  "number less than",
+			flags: []string{"Score<3"},
+			want:  map[string][]any{testScoreDefID: {opMember("lt", "3")}},
+		},
+		{
+			name:  "number at most",
+			flags: []string{"Score<=3"},
+			want:  map[string][]any{testScoreDefID: {opMember("lte", "3")}},
+		},
+		{
+			name:  "negative number after a comparison",
+			flags: []string{"Score>=-1.5"},
+			want:  map[string][]any{testScoreDefID: {opMember("gte", "-1.5")}},
+		},
+		{
+			name:  "whitespace around a comparison is cosmetic",
+			flags: []string{" Score >= 3 "},
+			want:  map[string][]any{testScoreDefID: {opMember("gte", "3")}},
+		},
+		{
+			name:  "date after",
+			flags: []string{"Ship Date>2026-01-01"},
+			want:  map[string][]any{testShipDateDefID: {opMember("after", "2026-01-01")}},
+		},
+		{
+			name:  "date before",
+			flags: []string{"Ship Date<2026-01-01"},
+			want:  map[string][]any{testShipDateDefID: {opMember("before", "2026-01-01")}},
+		},
+		{
+			name:  "text contains",
+			flags: []string{"Notes~=review"},
+			want:  map[string][]any{testNotesDefID: {opMember("contains", "review")}},
+		},
+		{
+			name:  "url contains needs no scheme",
+			flags: []string{"Spec~=example.com"},
+			want:  map[string][]any{testSpecDefID: {opMember("contains", "example.com")}},
+		},
+		{
+			// The needle is matched as typed, so spaces and = are part of it.
+			name:  "contains needle is sent as typed",
+			flags: []string{"Notes~= a=b "},
+			want:  map[string][]any{testNotesDefID: {opMember("contains", " a=b ")}},
+		},
+		{
+			// LIKE escaping is the server's job; escaping here too would
+			// search for a literal backslash.
+			name:  "contains needle is not LIKE-escaped",
+			flags: []string{"Notes~=50%_off"},
+			want:  map[string][]any{testNotesDefID: {opMember("contains", "50%_off")}},
+		},
+		{
+			name:  "contains needle at the server cap is sent",
+			flags: []string{"Notes~=" + strings.Repeat("é", 2000)},
+			want:  map[string][]any{testNotesDefID: {opMember("contains", strings.Repeat("é", 2000))}},
+		},
+		{
+			// The unset sentinel only means unset under =.
+			name:  "contains treats __none__ as a needle",
+			flags: []string{"Notes~=__none__"},
+			want:  map[string][]any{testNotesDefID: {opMember("contains", "__none__")}},
+		},
+		{
+			name:  "comparison with the property addressed by UUID",
+			flags: []string{testScoreDefID + ">=3"},
+			want:  map[string][]any{testScoreDefID: {opMember("gte", "3")}},
+		},
+		{
+			// OR within a definition applies to comparisons too, so this
+			// is "below 1 or above 10", not a range.
+			name:  "repeated comparisons OR into one definition",
+			flags: []string{"Score<1", "Score>10"},
+			want:  map[string][]any{testScoreDefID: {opMember("lt", "1"), opMember("gt", "10")}},
+		},
+		{
+			name:  "equality and comparison on one property are both sent",
+			flags: []string{"Score=3", "Score>3"},
+			want:  map[string][]any{testScoreDefID: {"3", opMember("gt", "3")}},
+		},
+		{
+			name:  "duplicate comparison members collapse",
+			flags: []string{"Score>=3", "Score >= 3"},
+			want:  map[string][]any{testScoreDefID: {opMember("gte", "3")}},
+		},
+		{
+			// A trailing > is a comparison, never part of a name.
+			name:  "Score>=9 compares Score rather than naming Score>",
+			flags: []string{"Score>=9"},
+			want:  map[string][]any{testScoreDefID: {opMember("gte", "9")}},
+		},
+		{
+			name:  "a property named Score> is reachable by UUID",
+			flags: []string{testScoreGtDefID + "=9"},
+			want:  map[string][]any{testScoreGtDefID: {"9"}},
+		},
+		{
+			name:  "a property named Score> takes comparisons by UUID",
+			flags: []string{testScoreGtDefID + ">=9"},
+			want:  map[string][]any{testScoreGtDefID: {opMember("gte", "9")}},
 		},
 	}
 	for _, tc := range cases {
@@ -220,6 +361,41 @@ func TestRunIssueListSendsPropertyFilter(t *testing.T) {
 				t.Fatalf("properties param = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSplitPropertyFilter pins the grammar: the name ends at the first "=",
+// minus a trailing comparison character; without "=", at the first < or >.
+func TestSplitPropertyFilter(t *testing.T) {
+	cases := []struct {
+		pair, name, op, value string
+		ok                    bool
+	}{
+		{"Impact=High", "Impact", "=", "High", true},
+		{"Score>=3", "Score", ">=", "3", true},
+		{"Score<=3", "Score", "<=", "3", true},
+		{"Score!=3", "Score", "!=", "3", true},
+		{"Notes~=a=b", "Notes", "~=", "a=b", true},
+		{"Score>3", "Score", ">", "3", true},
+		{"Ship Date<2026-01-01", "Ship Date", "<", "2026-01-01", true},
+		{" Score >= 3 ", "Score", ">=", " 3 ", true},
+		{"Score > 3", "Score", ">", " 3", true},
+		{"Risk>Reward=high", "Risk>Reward", "=", "high", true},
+		{"Risk>Reward>3", "Risk", ">", "Reward>3", true},
+		{"Notes=a<b", "Notes", "=", "a<b", true},
+		{"Notes==x", "Notes", "=", "=x", true},
+		{"Score=>3", "Score", "=", ">3", true},
+		{">=3", "", ">=", "3", true},
+		{"Score", "", "", "", false},
+		{"Score!3", "", "", "", false},
+		{"Notes~foo", "", "", "", false},
+	}
+	for _, tc := range cases {
+		name, op, value, ok := splitPropertyFilter(tc.pair)
+		if name != tc.name || op != tc.op || value != tc.value || ok != tc.ok {
+			t.Errorf("splitPropertyFilter(%q) = (%q, %q, %q, %v), want (%q, %q, %q, %v)",
+				tc.pair, name, op, value, ok, tc.name, tc.op, tc.value, tc.ok)
+		}
 	}
 }
 
@@ -245,7 +421,34 @@ func TestRunIssueListPropertyFilterErrors(t *testing.T) {
 		{"url must have a host", []string{"Spec=http://"}, "http(s) URL"},
 		{"url over the store length cap", []string{"Spec=https://example.com/" + strings.Repeat("a", 2048)}, "2048 characters or fewer"},
 		{"text over the store length cap", []string{"Notes=" + strings.Repeat("a", 2001)}, "2000 characters or fewer"},
-		{"comparison operators are reserved", []string{"Impact>=Medium"}, "comparison operators"},
+		{"comparison on a select names the type", []string{"Impact>=Medium"}, "select properties only support ="},
+		{"comparison on a checkbox", []string{"Blocked>true"}, "checkbox properties only support ="},
+		{"comparison on an actor", []string{"Reviewer>x"}, "actor properties only support ="},
+		{"comparison on text lists contains", []string{"Notes>3"}, "text properties support ~="},
+		{"contains on a number lists the comparisons", []string{"Score~=3"}, "number properties support >, >=, <, <="},
+		{"contains on a date lists the comparisons", []string{"Ship Date~=2026"}, "date properties support >, <"},
+		{"inclusive date lower bound names the strict form", []string{"Ship Date>=2026-01-01"}, `use "Ship Date>2025-12-31"`},
+		{"inclusive date upper bound names the strict form", []string{"Ship Date<=2026-01-31"}, `use "Ship Date<2026-02-01"`},
+		{"inclusive date bound still validates the date", []string{"Ship Date>=tomorrow"}, "YYYY-MM-DD"},
+		{"inclusive date bound keeps a UUID reference", []string{testShipDateDefID + ">=2026-01-01"}, `use "` + testShipDateDefID + `>2025-12-31"`},
+		{"not-equal on a number", []string{"Score!=3"}, "no not-equal filter"},
+		{"not-equal on a select", []string{"Impact!=High"}, "no not-equal filter"},
+		{"comparison on an unknown type", []string{"Sentiment>1"}, "does not know how to filter"},
+		{"contains on an unknown type", []string{"Sentiment~=happy"}, "does not know how to filter"},
+		{"non-numeric after a comparison", []string{"Score>high"}, "not a valid number"},
+		{"NaN after a comparison", []string{"Score>=NaN"}, "not a finite number"},
+		{"bad date after a comparison", []string{"Ship Date<28/01/2026"}, "YYYY-MM-DD"},
+		{"arrow typo falls through to equality", []string{"Score=>3"}, "not a valid number"},
+		{"empty value after a comparison", []string{"Score>="}, "value after >= cannot be empty"},
+		{"empty needle", []string{"Notes~="}, "value after ~= cannot be empty"},
+		{"whitespace-only needle", []string{"Notes~=   "}, "cannot be empty"},
+		{"needle over the server cap", []string{"Notes~=" + strings.Repeat("a", 2001)}, "2000 characters or fewer"},
+		{"url needle over the url store cap in bytes", []string{"Spec~=" + strings.Repeat("é", 1025)}, "2048 characters or fewer"},
+		{"archived property with a comparison", []string{"Old Impact>=Legacy"}, "archived"},
+		{"empty name before a comparison", []string{">=3"}, "Name=Value"},
+		{"empty name before contains", []string{"~=x"}, "Name=Value"},
+		{"bare ! is not a comparison", []string{"Score!3"}, "Name=Value"},
+		{"interior > in a name needs a UUID for a comparison", []string{"Risk>Reward>3"}, "not found"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/cmd/multica/cmd_issue_resolve_properties_test.go
+++ b/server/cmd/multica/cmd_issue_resolve_properties_test.go
@@ -413,7 +413,7 @@ func TestRunIssueListActorFilterSharesMembersRequest(t *testing.T) {
 	if srv.membersCalls != 1 {
 		t.Errorf("members calls = %d, want one shared by the filter and the resolution", srv.membersCalls)
 	}
-	want := map[string][]string{
+	want := map[string][]any{
 		testReviewerDefID: {"member:" + testMemberAdaID},
 		testOwnersDefID:   {"member:" + testMemberAdaID},
 	}

--- a/server/cmd/multica/cmd_property.go
+++ b/server/cmd/multica/cmd_property.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -959,26 +960,81 @@ const (
 // order by the server, and a passed-but-ignored flag is a footgun in scripts.
 var issueSortablePropertyTypes = []string{"select", "number", "date", "text", "url"}
 
-// buildPropertiesFilterQueryParam converts repeated `--property Name=Value`
-// flags into the JSON object passed as the `properties` query parameter to
-// /api/issues. Each flag carries exactly one value; repeating the same
-// property ORs its values (server semantics: OR within a definition, AND
-// across definitions), keyed by the RESOLVED definition id so name and UUID
-// addressing aggregate into one entry.
-func buildPropertiesFilterQueryParam(ctx context.Context, client *cli.APIClient, directory *memberDirectory, properties []propertyDTO, pairs []string) (string, error) {
-	filter := make(map[string][]string, len(pairs))
-	for _, pair := range pairs {
-		name, rawValue, found := strings.Cut(pair, "=")
-		if !found || strings.TrimSpace(name) == "" {
-			return "", fmt.Errorf(`--property %q must be in "Name=Value" form`, pair)
+// propertyFilterMember is one OR-alternative of a properties filter: a plain
+// value (equality, or the __none__ sentinel) or a server comparison.
+type propertyFilterMember struct {
+	Op    string
+	Value string
+}
+
+func (m propertyFilterMember) MarshalJSON() ([]byte, error) {
+	if m.Op == "" {
+		return json.Marshal(m.Value)
+	}
+	return json.Marshal(map[string]string{"op": m.Op, "value": m.Value})
+}
+
+// propertyFilterOperators maps each --property comparison spelling to the
+// server op per property type, mirroring PROPERTY_FILTER_OPS_BY_TYPE in
+// packages/core/types/property.ts. A known type without entries is
+// equality-only; a type missing here belongs to a newer backend.
+var propertyFilterOperators = map[string]map[string]string{
+	"number":       {">": "gt", ">=": "gte", "<": "lt", "<=": "lte"},
+	"date":         {">": "after", "<": "before"},
+	"text":         {"~=": "contains"},
+	"url":          {"~=": "contains"},
+	"select":       {},
+	"multi_select": {},
+	"checkbox":     {},
+	"actor":        {},
+	"multi_actor":  {},
+}
+
+// propertyFilterSpellings orders the comparison forms for error messages.
+var propertyFilterSpellings = []string{">", ">=", "<", "<=", "~="}
+
+// splitPropertyFilter cuts one --property flag into name, operator and value.
+// With an "=", the name is everything before the first one, minus a trailing
+// <, >, ! or ~ that makes it >=, <=, != or ~=. Without one, the first < or >
+// is a strict comparison. A name that carries those characters in those
+// positions has to be given by UUID.
+func splitPropertyFilter(pair string) (name, op, value string, ok bool) {
+	if name, value, found := strings.Cut(pair, "="); found {
+		name = strings.TrimSpace(name)
+		for _, c := range []string{">", "<", "!", "~"} {
+			if strings.HasSuffix(name, c) {
+				return strings.TrimSpace(strings.TrimSuffix(name, c)), c + "=", value, true
+			}
 		}
-		// Reserved so scripts never come to depend on "Impact>" resolving as a
-		// property name once >=, <=, != mean comparison filters.
-		if n := strings.TrimSpace(name); strings.HasSuffix(n, "<") || strings.HasSuffix(n, ">") || strings.HasSuffix(n, "!") {
-			return "", fmt.Errorf(`--property %q: comparison operators are not supported yet; only "Name=Value" is accepted`, pair)
+		return name, "=", value, true
+	}
+	if i := strings.IndexAny(pair, "<>"); i >= 0 {
+		return strings.TrimSpace(pair[:i]), pair[i : i+1], pair[i+1:], true
+	}
+	return "", "", "", false
+}
+
+// buildPropertiesFilterQueryParam converts repeated `--property` flags into
+// the JSON object passed as the `properties` query parameter to /api/issues.
+// Each flag carries exactly one member, an equality value or a comparison;
+// repeating the same property ORs its members (server semantics: OR within a
+// definition, AND across definitions), keyed by the RESOLVED definition id so
+// name and UUID addressing aggregate into one entry.
+func buildPropertiesFilterQueryParam(ctx context.Context, client *cli.APIClient, directory *memberDirectory, properties []propertyDTO, pairs []string) (string, error) {
+	filter := make(map[string][]propertyFilterMember, len(pairs))
+	for _, pair := range pairs {
+		name, op, rawValue, found := splitPropertyFilter(pair)
+		if !found || name == "" {
+			return "", fmt.Errorf(`--property %q must be in "Name=Value" form, or a comparison such as "Score>=3" (see --help)`, pair)
+		}
+		if op == "!=" {
+			return "", fmt.Errorf("--property %q: != is not supported; the server has no not-equal filter", pair)
 		}
 		if strings.TrimSpace(rawValue) == "" {
-			return "", fmt.Errorf("--property %s: value cannot be empty (use %s to match issues where the property is unset)", name, propertyNoValueSentinel)
+			if op == "=" {
+				return "", fmt.Errorf("--property %s: value cannot be empty (use %s to match issues where the property is unset)", name, propertyNoValueSentinel)
+			}
+			return "", fmt.Errorf("--property %s: value after %s cannot be empty", name, op)
 		}
 		property, err := resolvePropertyRef(properties, name)
 		if err != nil {
@@ -987,19 +1043,17 @@ func buildPropertiesFilterQueryParam(ctx context.Context, client *cli.APIClient,
 		if property.Archived {
 			return "", fmt.Errorf("property %q is archived; archived properties are hidden from filtering (matching the web UI) — restore it with `multica property unarchive` if you need it", property.Name)
 		}
-		value, err := resolvePropertyFilterValue(ctx, client, directory, property, rawValue)
+		var member propertyFilterMember
+		if op == "=" {
+			member.Value, err = resolvePropertyFilterValue(ctx, client, directory, property, rawValue)
+		} else {
+			member, err = resolvePropertyFilterOperator(property, name, op, rawValue)
+		}
 		if err != nil {
 			return "", err
 		}
-		duplicate := false
-		for _, existing := range filter[property.ID] {
-			if existing == value {
-				duplicate = true
-				break
-			}
-		}
-		if !duplicate {
-			filter[property.ID] = append(filter[property.ID], value)
+		if !slices.Contains(filter[property.ID], member) {
+			filter[property.ID] = append(filter[property.ID], member)
 		}
 	}
 	buf, err := json.Marshal(filter)
@@ -1007,6 +1061,92 @@ func buildPropertiesFilterQueryParam(ctx context.Context, client *cli.APIClient,
 		return "", fmt.Errorf("encode properties filter: %w", err)
 	}
 	return string(buf), nil
+}
+
+// resolvePropertyFilterOperator turns a comparison flag into the {op, value}
+// member the server matches with. ref is the name or UUID as typed, so a
+// suggested rewrite stays addressable. The server checks the value shape but
+// not the op against the definition's type, so an op the type cannot honour
+// is rejected here instead of being sent to match nothing. Value rules mirror
+// validatePropertyFilterOperator in internal/handler/property.go.
+func resolvePropertyFilterOperator(property propertyDTO, ref, spelling, raw string) (propertyFilterMember, error) {
+	ops, known := propertyFilterOperators[property.Type]
+	if !known { // a property type only a newer backend knows about
+		return propertyFilterMember{}, fmt.Errorf("--property %s: this CLI does not know how to filter %s properties; update with `multica update`", property.Name, property.Type)
+	}
+	op, ok := ops[spelling]
+	if !ok {
+		if property.Type == "date" && (spelling == ">=" || spelling == "<=") {
+			// The server only compares dates strictly. Values are whole days,
+			// so the inclusive bound is the strict one shifted by a day.
+			day, err := dateFilterValue(property, raw)
+			if err != nil {
+				return propertyFilterMember{}, err
+			}
+			shift := -1
+			if spelling == "<=" {
+				shift = 1
+			}
+			strict := ref + spelling[:1] + day.AddDate(0, 0, shift).Format("2006-01-02")
+			return propertyFilterMember{}, fmt.Errorf("--property %s: %s is not available on a date property (the server only compares dates strictly); use %q", property.Name, spelling, strict)
+		}
+		var supported []string
+		for _, s := range propertyFilterSpellings {
+			if _, ok := ops[s]; ok {
+				supported = append(supported, s)
+			}
+		}
+		if len(supported) == 0 {
+			return propertyFilterMember{}, fmt.Errorf("--property %s: %s is not available on a %s property; %s properties only support =", property.Name, spelling, property.Type, property.Type)
+		}
+		return propertyFilterMember{}, fmt.Errorf("--property %s: %s is not available on a %s property; %s properties support %s", property.Name, spelling, property.Type, property.Type, strings.Join(supported, ", "))
+	}
+	switch op {
+	case "gt", "gte", "lt", "lte":
+		value, err := numberFilterValue(property, raw)
+		return propertyFilterMember{Op: op, Value: value}, err
+	case "before", "after":
+		if _, err := dateFilterValue(property, raw); err != nil {
+			return propertyFilterMember{}, err
+		}
+		return propertyFilterMember{Op: op, Value: strings.TrimSpace(raw)}, nil
+	}
+	// contains: the needle is matched as typed, so it is sent as typed. The
+	// server caps it in runes; a url needle past the url store cap could
+	// never match either.
+	if utf8.RuneCountInString(raw) > maxPropertyTextValueLen {
+		return propertyFilterMember{}, fmt.Errorf("--property %s: value must be %d characters or fewer", property.Name, maxPropertyTextValueLen)
+	}
+	if property.Type == "url" && len(raw) > maxPropertyURLValueLen {
+		return propertyFilterMember{}, fmt.Errorf("--property %s: value must be %d characters or fewer", property.Name, maxPropertyURLValueLen)
+	}
+	return propertyFilterMember{Op: op, Value: raw}, nil
+}
+
+// numberFilterValue validates a number filter value and returns it trimmed.
+func numberFilterValue(property propertyDTO, raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	num, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return "", fmt.Errorf("--property %s: value %q is not a valid number", property.Name, trimmed)
+	}
+	if math.IsNaN(num) || math.IsInf(num, 0) {
+		// NaN and infinity have no JSON spelling, so the server never
+		// builds a numeric match for them and the filter would come
+		// back empty for the wrong reason.
+		return "", fmt.Errorf("--property %s: value %q is not a finite number", property.Name, trimmed)
+	}
+	return trimmed, nil
+}
+
+// dateFilterValue validates a YYYY-MM-DD filter value.
+func dateFilterValue(property propertyDTO, raw string) (time.Time, error) {
+	trimmed := strings.TrimSpace(raw)
+	day, err := time.Parse("2006-01-02", trimmed)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("--property %s: value %q is not a date in YYYY-MM-DD form", property.Name, trimmed)
+	}
+	return day, nil
 }
 
 // resolvePropertyFilterValue turns one human-facing filter value into the
@@ -1036,20 +1176,10 @@ func resolvePropertyFilterValue(ctx context.Context, client *cli.APIClient, dire
 	case "actor", "multi_actor":
 		return resolveActorPropertyRef(ctx, client, directory, trimmed)
 	case "number":
-		num, err := strconv.ParseFloat(trimmed, 64)
-		if err != nil {
-			return "", fmt.Errorf("--property %s: value %q is not a valid number", property.Name, trimmed)
-		}
-		if math.IsNaN(num) || math.IsInf(num, 0) {
-			// NaN and infinity have no JSON spelling, so the server never
-			// builds a numeric match for them and the filter would come
-			// back empty for the wrong reason.
-			return "", fmt.Errorf("--property %s: value %q is not a finite number", property.Name, trimmed)
-		}
-		return trimmed, nil
+		return numberFilterValue(property, raw)
 	case "date":
-		if _, err := time.Parse("2006-01-02", trimmed); err != nil {
-			return "", fmt.Errorf("--property %s: value %q is not a date in YYYY-MM-DD form", property.Name, trimmed)
+		if _, err := dateFilterValue(property, raw); err != nil {
+			return "", err
 		}
 		return trimmed, nil
 	case "url":

--- a/server/internal/service/builtin_skills/multica-platform/references/issues.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/issues.md
@@ -158,18 +158,25 @@ multica issue property unset <issue-id> --name Environment
 ```bash
 multica issue list --property "Impact=High" --property "Impact=Medium" --output json
 multica issue list --property "QA Status=__none__" --status in_review --output json
+multica issue list --property "Effort>=3" --property "Due<2026-10-01" --output json
 multica issue list --sort property:Impact --direction desc --output json
 ```
 
 - `--property` takes one `Name=Value` per flag. Repeating the same property
-  matches ANY of its values; different properties must ALL match. Values are
+  matches ANY of its members; different properties must ALL match. Values are
   option names or ids (select types), `true`/`false` (checkbox), a member
   name/email/id (actor types), or the value itself for text, url, number,
   and date (`YYYY-MM-DD`). The reserved value `__none__` matches
   issues where the property is unset (works for every type; it is not
   index-backed, so use it for targeted audits rather than as a default
-  listing filter). Only `=` is supported today; the `>=`, `<=` and `!=`
-  spellings are reserved for comparison filters and are rejected.
+  listing filter).
+- Comparisons use the same flag: `>`, `>=`, `<`, `<=` on number; `>` (after)
+  and `<` (before) on date; `~=` (contains, case-insensitive) on text and
+  url. Quote the flag so the shell does not read `<` or `>` as redirection.
+  `!=` is rejected (the server has no not-equal filter); `>=` and `<=` on a
+  date are rejected with an error naming the strict form to use. Two
+  comparisons on one property OR, so they do not form a range. Number and
+  date comparisons are not index-backed.
 - `--sort property:<name-or-id>` orders select properties by option order —
   an ordinal scale (Low < Medium < High) sorts by meaning — and number/date/
   text/url by value; issues without the property sort last either way.

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -480,6 +480,13 @@ func TestPlatformSkillCoversPlatformContracts(t *testing.T) {
 				// the routing rule they encoded.
 				"workflow state a human should see and filter by goes in",
 				"goes in the result comment",
+				// #8001: --property comparisons. The op-by-type table is the
+				// only thing between an agent and a silently empty page, and
+				// the two rejections are the cases it would otherwise retry.
+				"Comparisons use the same flag",
+				"`~=` (contains, case-insensitive)",
+				"`!=` is rejected (the server has no not-equal filter)",
+				"so they do not form a range",
 				// #7768: nothing about concurrent runs is pushed into the
 				// prompt any more (MUL-6984), so the skill has to carry the
 				// pull path itself. All three anchors are load-bearing — the
@@ -511,6 +518,9 @@ func TestPlatformSkillCoversPlatformContracts(t *testing.T) {
 				"High-signal keys",
 				"reuse these names so queries stay consistent",
 				"scratchpad for run state",
+				// #8001 replaced the reservation with the operators; a bullet
+				// that says only `=` works would contradict the one below it.
+				"Only `=` is supported today",
 				// Per-turn workflow the runtime brief owns; duplicating it here
 				// is how the two drift apart.
 				"Start from the trigger, not from memory",


### PR DESCRIPTION
## What does this PR do?

`multica issue list --property` now accepts the comparison operators the server has supported since v0.4.38 (#7765). The spellings are the ones #7664 reserved, in the same flag:

| Spelling | number | date | text / url |
| --- | --- | --- | --- |
| `Name>Value` | gt | after | |
| `Name>=Value` | gte | | |
| `Name<Value` | lt | before | |
| `Name<=Value` | lte | | |
| `Name~=Value` | | | contains (case-insensitive substring) |

`Name=Value` still means equality, `__none__` still means unset, and repeating a property still ORs its members. The CLI emits `{"op", "value"}` members for comparisons and plain strings for everything else, so the `properties` query parameter keeps the shape `parsePropertiesFilterParam` already accepts.

The parser follows the reservation exactly. With an `=`, the name is everything before the first one, minus a trailing `<`, `>`, `!` or `~` that makes it `>=`, `<=`, `!=` or `~=`. Without an `=`, the first `<` or `>` is a strict comparison. So `Score>=3` compares `Score`, a property literally named `Score>` is reachable by UUID as before, and a name with an interior `>` (`Risk>Reward=high`) still resolves under `=`.

Loud failures, in the spirit of #7664. The server validates a comparison's value shape but not the op against the definition's type, so a comparison the type cannot honour is rejected client-side with the type named, instead of being sent to match nothing:

```
$ multica issue list --property "Impact>=Medium"
--property Impact: >= is not available on a select property; select properties only support =
$ multica issue list --property "Score~=3"
--property Score: ~= is not available on a number property; number properties support >, >=, <, <=
$ multica issue list --property "Ship Date>=2026-02-15"
--property Ship Date: >= is not available on a date property (the server only compares dates strictly); use "Ship Date>2026-02-14"
$ multica issue list --property "Score!=3"
--property "Score!=3": != is not supported; the server has no not-equal filter
```

`!=` is rejected rather than silently dropped; adding a not-equal op is a server design question (unset semantics, containment SQL) and out of scope here. `>=` and `<=` on a date are rejected because the server only defines strict before/after; since stored dates are whole days the error names the exact strict form to use.

Value rules mirror `validatePropertyFilterOperator`: a finite number for the numeric comparisons (same parse as equality), `YYYY-MM-DD` for before/after, and a needle within the 2000-rune server cap for contains. A url needle is also bounded by the 2048-byte url store cap, since a longer one could never match. Contains needles are sent exactly as typed and are not LIKE-escaped client-side; the server escapes them.

One judgment call to flag: `~=` was not among the characters #7664 reserved, so a property whose name ends in `~` now has to be given by UUID, the same rule that already applied to `<`, `>` and `!`. The flag is a day old and a trailing `~` in a property name is unlikely, but if you would rather keep `~=` out of this flag I can drop contains to a follow-up.

## Related Issue

Closes #7999

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/cmd/multica/cmd_property.go`: `splitPropertyFilter` cuts a flag into name, operator and value; `propertyFilterOperators` is the op-by-type table (mirrors `PROPERTY_FILTER_OPS_BY_TYPE`); `resolvePropertyFilterOperator` validates the op against the type and the value against the server rules; `propertyFilterMember` marshals as a bare string or `{op, value}`. The number and date parsing shared with equality moved into `numberFilterValue` and `dateFilterValue`. Members dedupe by op and value, so `Score>=3` twice collapses and `Score=3` plus `Score>3` both survive.
- `server/cmd/multica/cmd_issue.go`: `issue list` gains a long description with the per-type forms, and the `--property` flag help is shortened to the spellings, the quoting note and the UUID rule.
- `server/cmd/multica/cmd_issue_property_filter_test.go`: each op on its type, the members sent for OR and dedupe, needle transport (spaces, `=`, `%`, `__none__` as a literal, the 2000-rune cap), the `Score>` and `Risk>Reward` precedence cases, and the rejection matrix (every type-mismatch names the type, both inclusive date bounds name the strict form, `!=` on number and select, unknown type, empty name, empty needle, caps, archived with a comparison). A `TestSplitPropertyFilter` table pins the grammar. The existing assertion that a rejected flag never reaches `/api/issues` covers all new error cases.
- `CLI_AND_DAEMON.md`, `apps/docs/content/docs/cli.mdx` and the ja/ko/zh siblings, and `server/internal/service/builtin_skills/multica-platform/references/issues.md` under Custom properties: document the operators, the quoting requirement, the rejections, and that two bounds on one property OR rather than forming a range. `server/internal/service/builtin_skills_test.go` anchors the comparison bullet, the `~=` and `!=` rules and the no-range note, and fails if the old "only `=` is supported" sentence comes back.

No server changes.

## How to Test

1. `cd server && go test ./cmd/multica ./internal/service -count=1` (the operator tables, the never-reaches-the-server assertion, and the skill anchors).
2. Against a v0.4.38+ server, seed a workspace with a number `Score`, a date `Ship Date`, a text `Notes`, a url `Spec`, a select `Impact` and a checkbox `Blocked`, plus a number property literally named `Score>`. I used five issues (Alpha through Epsilon) with values 1, 3, 5, 3.5 and none for `Score`; dates 2026-01-10, 2026-02-15, 2026-03-20, 2026-02-15 and none; notes "needs review", "Review done", "blocked on infra", "ready" and none; and `Score>` set to 9 on Delta only.
3. Run the matrix. Every line below is the output of a CLI built from this branch against a server at `5f0e0f229` (`main` at the time):

```
PASS  Score>3  ->  [Delta Gamma]
PASS  Score>=3  ->  [Beta Delta Gamma]
PASS  Score<3  ->  [Alpha]
PASS  Score<=3  ->  [Alpha Beta]
PASS  Score>=3 Impact=High  ->  [Gamma]
PASS  Score<2 Score>4  ->  [Alpha Gamma]
PASS  Ship Date>2026-02-15  ->  [Gamma]
PASS  Ship Date<2026-02-15  ->  [Alpha]
PASS  Notes~=review  ->  [Alpha Beta]
PASS  Notes~=REVIEW  ->  [Alpha Beta]
PASS  Spec~=example.com  ->  [Alpha Gamma]
PASS  Spec~=EXAMPLE  ->  [Alpha Beta Gamma]
PASS  Notes~=review Notes=__none__  ->  [Alpha Beta Epsilon]
PASS  Score>=9  ->  []
PASS  <uuid of Score>>=9  ->  [Delta]
PASS  <uuid of Score>>>=9  ->  [Delta]
PASS  Impact>=Medium  ->  exit 1: --property Impact: >= is not available on a select property; select properties only support =
PASS  Notes>3  ->  exit 1: --property Notes: > is not available on a text property; text properties support ~=
PASS  Blocked>true  ->  exit 1: --property Blocked: > is not available on a checkbox property; checkbox properties only support =
PASS  Score~=3  ->  exit 1: --property Score: ~= is not available on a number property; number properties support >, >=, <, <=
PASS  Ship Date>=2026-02-15  ->  exit 1: --property Ship Date: >= is not available on a date property (the server only compares dates strictly); use "Ship Date>2026-02-14"
PASS  Ship Date<=2026-02-15  ->  exit 1: --property Ship Date: <= is not available on a date property (the server only compares dates strictly); use "Ship Date<2026-02-16"
PASS  Score!=3  ->  exit 1: --property "Score!=3": != is not supported; the server has no not-equal filter
PASS  Score>abc  ->  exit 1: --property Score: value "abc" is not a valid number
```

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable; the CLI docs under `apps/docs/content/docs/` are updated)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** I wrote a brief describing the gap (the CLI-side rejection, the server contract in `parsePropertiesFilterParam` and `validatePropertyFilterOperator`, and #7664 as the structural precedent) and asked Claude Code to draft a plan. The plan was reviewed by three independent AI reviewers (Antigravity, Codex and a separate Claude session) before any code was written; that round caught a reversed date hint and the interior-`>` regression, both fixed before implementation. The implementation and tests went through the same three-way review, then I ran the live matrix above against a local server and read every line of the diff and docs myself.

