### PR TITLE
fix(runtimes): keep KPI values within their cards on mobile

### DIFF
--- a/packages/views/runtimes/components/shared.tsx
+++ b/packages/views/runtimes/components/shared.tsx
@@ -189,11 +189,14 @@ export function KpiCard({
         ? "text-success"
         : "";
   return (
-    <div className="flex flex-col gap-2 p-5">
+    <div className="flex min-w-0 flex-col gap-2 p-5">
       <div className="text-micro font-medium uppercase tracking-wider text-muted-foreground">
         {label}
       </div>
-      <div className={`text-display font-semibold leading-none tabular-nums ${valueClass}`}>
+      {/* `truncate` keeps an unusually large value clipped inside its own
+          card instead of bleeding into the neighbour once the row is
+          three-across again at `sm` and up. */}
+      <div className={`truncate text-display font-semibold leading-none tabular-nums ${valueClass}`}>
         {value}
       </div>
       {hint != null && (

--- a/packages/views/runtimes/components/usage-section.tsx
+++ b/packages/views/runtimes/components/usage-section.tsx
@@ -224,7 +224,11 @@ export function UsageSection({ runtime }: { runtime: AgentRuntime }) {
           if the user has saved overrides, so those rates remain editable. */}
       <CustomPricingBar usage={filtered} />
 
-      <div className="grid grid-cols-3 divide-x rounded-lg border bg-card">
+      {/* Stacks to a single column on phones — three thirds of a ~390px
+          viewport can't hold a `text-display` KPI value like "960.1M"
+          without it spilling past the card's right edge (MUL issue #7836).
+          At `sm` and up it returns to the divided three-across row. */}
+      <div className="grid grid-cols-1 divide-y rounded-lg border bg-card sm:grid-cols-3 sm:divide-x sm:divide-y-0">
         <KpiCard
           label={t(($) => $.usage.kpi_cost_label, { days })}
           value={


### PR DESCRIPTION
## Problem

On the runtime detail page's usage section, the three KPI cards (`COST`, `CACHE SAVINGS`, `TOKEN`) render in a fixed `grid-cols-3` divided row at every width. At a phone-sized viewport (`390×844`), each card only gets a third of the screen — too narrow for a `text-display` (36px) value such as `960.1M`, which then overflows past the card's right edge (issue #7836).

## Fix

- **`usage-section.tsx`** — the KPI grid now stacks to a single divided column below the `sm` breakpoint and restores the original three-across divided row from `sm` up. This mirrors the responsive-divided-grid pattern already used by the info grid in `runtime-detail.tsx`. Stacked full-width, each card comfortably fits the large value, so no number is shrunk or clipped on mobile.
- **`shared.tsx` (`KpiCard`)** — added `min-w-0` so the card can shrink inside a narrow grid track, and `truncate` on the value so an unusually large number stays clipped inside its own card rather than bleeding into a neighbour once the row is three-across again at `sm`+.

Desktop (`sm` and up) appearance is unchanged. Uses the repo's semantic tokens and the `--text-*` scale throughout.

## Verification

- `pnpm --filter @multica/views exec tsc --noEmit` — passes, no errors.
- `pnpm --filter @multica/views exec vitest run runtimes/components/usage-section` — 6/6 tests pass.

Closes #7836
