### PR TITLE
feat(cli): target a workspace by exact identifier with --workspace

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -268,7 +268,10 @@ func newAPIClient(cmd *cobra.Command) (*cli.APIClient, error) {
 	}
 
 	serverURL := resolveServerURL(cmd)
-	workspaceID := resolveWorkspaceID(cmd)
+	workspaceID, err := resolveTargetWorkspaceID(cmd)
+	if err != nil {
+		return nil, err
+	}
 	if serverURL == "" {
 		return nil, fmt.Errorf("server URL not set: use --server-url flag, MULTICA_SERVER_URL env, or 'multica config set server_url <url>'")
 	}
@@ -491,6 +494,47 @@ func resolveWorkspaceID(cmd *cobra.Command) string {
 	profile := resolveProfile(cmd)
 	cfg, _ := cli.LoadCLIConfigForProfile(profile)
 	return cfg.WorkspaceID
+}
+
+// resolveTargetWorkspaceID resolves the workspace a command should act on.
+//
+// The --workspace flag (accepting a full UUID, slug, or short UUID prefix)
+// takes highest precedence so scripts can pin a workspace by exact identifier,
+// independent of the mutable current-workspace pointer persisted in
+// config.json. That pointer is global process-shared state — any concurrent
+// `multica workspace switch` (or another script) can shift it mid-run and
+// silently retarget an unrelated command at the wrong workspace (GitHub
+// #7654). A UUID is forwarded as-is; a slug or prefix is resolved against the
+// caller's accessible workspace list, which also serves as the access /
+// existence check and yields a clear "not found" error for an unknown value.
+//
+// When --workspace is absent the existing resolution chain applies unchanged
+// (--workspace-id flag, MULTICA_WORKSPACE_ID env, profile default), preserving
+// today's behavior. Inside a daemon-managed agent task the workspace is bound
+// by the task token and the server ignores any client-supplied workspace, so
+// the flag is deliberately not honored there — resolution stays with the
+// daemon-provided env, exactly as resolveWorkspaceID already enforces.
+func resolveTargetWorkspaceID(cmd *cobra.Command) (string, error) {
+	if !inDaemonManagedExecutionContext() && cmd.Flags().Changed("workspace") {
+		target := strings.TrimSpace(cmd.Flag("workspace").Value.String())
+		if target == "" {
+			return "", fmt.Errorf("--workspace cannot be empty; pass a workspace id, slug, or id prefix")
+		}
+		// A full UUID is self-identifying: forward it without an extra
+		// /api/workspaces round trip, mirroring resolveWorkspaceArg. The
+		// downstream endpoint enforces access.
+		if uuidRegexp.MatchString(target) {
+			return target, nil
+		}
+		ctx, cancel := cli.APIContext(context.Background())
+		defer cancel()
+		ws, err := resolveWorkspaceRef(ctx, cmd, target)
+		if err != nil {
+			return "", err
+		}
+		return ws.ID, nil
+	}
+	return resolveWorkspaceID(cmd), nil
 }
 
 // requireWorkspaceID resolves the workspace ID and returns an error with

--- a/server/cmd/multica/cmd_workspace.go
+++ b/server/cmd/multica/cmd_workspace.go
@@ -91,8 +91,13 @@ var workspaceSwitchCmd = &cobra.Command{
 		"prefix (≥4 hex chars) as shown in 'workspace list'. Subsequent " +
 		"commands without --workspace-id or MULTICA_WORKSPACE_ID will target " +
 		"this workspace.\n\n" +
-		"Resolution priority (highest to lowest): --workspace-id flag, " +
-		"MULTICA_WORKSPACE_ID env, profile default (set by this command).\n\n" +
+		"Resolution priority (highest to lowest): --workspace flag, " +
+		"--workspace-id flag, MULTICA_WORKSPACE_ID env, profile default (set by " +
+		"this command).\n\n" +
+		"The profile default is shared, mutable state: a concurrent 'switch' " +
+		"can retarget it mid-run. For deterministic scripts, pass the global " +
+		"--workspace <id|slug|prefix> flag on each command instead of relying " +
+		"on the default.\n\n" +
 		"For low-level use, 'multica config set workspace_id <id>' writes the " +
 		"same setting without verification.",
 	Args: exactArgs(1),

--- a/server/cmd/multica/cmd_workspace_flag_test.go
+++ b/server/cmd/multica/cmd_workspace_flag_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+// workspaceFlagTestCmd builds a command carrying the same persistent flags the
+// real root command exposes, so resolution helpers see --workspace,
+// --workspace-id, --server-url, and --profile just as they do at runtime.
+func workspaceFlagTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("server-url", "", "")
+	cmd.Flags().String("workspace", "", "")
+	cmd.Flags().String("workspace-id", "", "")
+	cmd.Flags().String("profile", "", "")
+	return cmd
+}
+
+// clearDaemonContextEnv strips every signal that would make the CLI treat the
+// process as a daemon-managed agent task, so --workspace resolution runs the
+// human/script path under test.
+func clearDaemonContextEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "")
+	t.Setenv(cli.TaskConfigRootEnv, "")
+}
+
+const (
+	bureauWorkspaceID = "11111111-1111-1111-1111-111111111111"
+	digLabWorkspaceID = "22222222-2222-2222-2222-222222222222"
+)
+
+// workspaceListServer serves GET /api/workspaces with a fixed two-workspace
+// roster (bureau + dig-lab) so slug resolution has something to match against.
+func workspaceListServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/workspaces" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": bureauWorkspaceID, "name": "Bureau", "slug": "bureau"},
+			{"id": digLabWorkspaceID, "name": "Dig Lab", "slug": "dig-lab"},
+		})
+	}))
+}
+
+func TestResolveTargetWorkspaceID_FlagUUIDOverridesConfigPointer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearDaemonContextEnv(t)
+	t.Setenv("MULTICA_WORKSPACE_ID", "")
+	// The mutable current-workspace pointer targets dig-lab.
+	if err := cli.SaveCLIConfig(cli.CLIConfig{WorkspaceID: digLabWorkspaceID}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cmd := workspaceFlagTestCmd()
+	if err := cmd.Flags().Set("workspace", bureauWorkspaceID); err != nil {
+		t.Fatalf("set --workspace: %v", err)
+	}
+
+	got, err := resolveTargetWorkspaceID(cmd)
+	if err != nil {
+		t.Fatalf("resolveTargetWorkspaceID: %v", err)
+	}
+	if got != bureauWorkspaceID {
+		t.Fatalf("resolveTargetWorkspaceID() = %q, want %q (flag must override config pointer)", got, bureauWorkspaceID)
+	}
+}
+
+func TestResolveTargetWorkspaceID_AbsentFlagFallsBackToConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearDaemonContextEnv(t)
+	t.Setenv("MULTICA_WORKSPACE_ID", "")
+	if err := cli.SaveCLIConfig(cli.CLIConfig{WorkspaceID: digLabWorkspaceID}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	got, err := resolveTargetWorkspaceID(workspaceFlagTestCmd())
+	if err != nil {
+		t.Fatalf("resolveTargetWorkspaceID: %v", err)
+	}
+	if got != digLabWorkspaceID {
+		t.Fatalf("resolveTargetWorkspaceID() = %q, want %q (config fallback)", got, digLabWorkspaceID)
+	}
+}
+
+func TestResolveTargetWorkspaceID_FlagSlugResolvesToUUID(t *testing.T) {
+	srv := workspaceListServer(t)
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	clearDaemonContextEnv(t)
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "")
+	// Config points at dig-lab; the flag names bureau by slug.
+	if err := cli.SaveCLIConfig(cli.CLIConfig{WorkspaceID: digLabWorkspaceID}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cmd := workspaceFlagTestCmd()
+	if err := cmd.Flags().Set("workspace", "bureau"); err != nil {
+		t.Fatalf("set --workspace: %v", err)
+	}
+
+	got, err := resolveTargetWorkspaceID(cmd)
+	if err != nil {
+		t.Fatalf("resolveTargetWorkspaceID: %v", err)
+	}
+	if got != bureauWorkspaceID {
+		t.Fatalf("resolveTargetWorkspaceID() = %q, want %q (slug must resolve to canonical UUID)", got, bureauWorkspaceID)
+	}
+}
+
+func TestResolveTargetWorkspaceID_UnknownWorkspaceErrors(t *testing.T) {
+	srv := workspaceListServer(t)
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	clearDaemonContextEnv(t)
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "")
+
+	cmd := workspaceFlagTestCmd()
+	if err := cmd.Flags().Set("workspace", "ghost"); err != nil {
+		t.Fatalf("set --workspace: %v", err)
+	}
+
+	_, err := resolveTargetWorkspaceID(cmd)
+	if err == nil {
+		t.Fatal("resolveTargetWorkspaceID(): expected error for unknown workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("resolveTargetWorkspaceID() error = %q, want a clear not-found message mentioning the input", err.Error())
+	}
+}
+
+func TestResolveTargetWorkspaceID_IgnoredInDaemonContext(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// Daemon-managed context: workspace is bound by the task token / env, and
+	// the flag must not re-target it (nor read user config).
+	t.Setenv("MULTICA_AGENT_ID", "agent-123")
+	t.Setenv("MULTICA_TASK_ID", "task-456")
+	t.Setenv("MULTICA_DAEMON_PORT", "")
+	t.Setenv(cli.TaskConfigRootEnv, "")
+	t.Setenv("MULTICA_WORKSPACE_ID", digLabWorkspaceID)
+
+	cmd := workspaceFlagTestCmd()
+	if err := cmd.Flags().Set("workspace", "bureau"); err != nil {
+		t.Fatalf("set --workspace: %v", err)
+	}
+
+	got, err := resolveTargetWorkspaceID(cmd)
+	if err != nil {
+		t.Fatalf("resolveTargetWorkspaceID: %v", err)
+	}
+	if got != digLabWorkspaceID {
+		t.Fatalf("resolveTargetWorkspaceID() = %q, want %q (daemon env, flag ignored)", got, digLabWorkspaceID)
+	}
+}
+
+func TestNewAPIClient_WorkspaceFlagSetsClientWorkspaceID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearDaemonContextEnv(t)
+	t.Setenv("MULTICA_SERVER_URL", "https://api.example.test")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "")
+	if err := cli.SaveCLIConfig(cli.CLIConfig{WorkspaceID: digLabWorkspaceID}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cmd := workspaceFlagTestCmd()
+	if err := cmd.Flags().Set("workspace", bureauWorkspaceID); err != nil {
+		t.Fatalf("set --workspace: %v", err)
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		t.Fatalf("newAPIClient: %v", err)
+	}
+	if client.WorkspaceID != bureauWorkspaceID {
+		t.Fatalf("client.WorkspaceID = %q, want %q", client.WorkspaceID, bureauWorkspaceID)
+	}
+}

--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -41,6 +41,7 @@ func init() {
 
 	rootCmd.PersistentFlags().String("server-url", "", "Multica server URL (env: MULTICA_SERVER_URL)")
 	rootCmd.PersistentFlags().String("workspace-id", "", "Workspace ID (env: MULTICA_WORKSPACE_ID)")
+	rootCmd.PersistentFlags().String("workspace", "", "Target a workspace by exact id, slug, or id prefix for this command, ignoring the current-workspace default (deterministic for scripts)")
 	rootCmd.PersistentFlags().String("profile", "", "Configuration profile name (e.g. dev) — isolates config, daemon state, and workspaces")
 	rootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "Print full error details on failure (env: MULTICA_DEBUG)")
 


### PR DESCRIPTION
## Problem

The "current workspace" is global mutable state persisted in `config.json`, shared by every process. Any concurrent `multica workspace switch` — or another script running in parallel — can shift it mid-run, so a command that relies on the default silently acts on the wrong workspace.

As reported in #7654, this makes destructive operations unsafe in scripts:

```
multica workspace switch bureau && multica issue list        # shows BUR-*
multica issue update BUR-12 --status done
# → {"identifier": "DIG-12"}   ← a DIFFERENT issue in another workspace, exit 0, no error
```

The switch from call A is lost by call B: `update` resolves against whatever the global pointer happens to be, not the identifier the caller named.

## Change

Add a global `--workspace` flag that accepts a full UUID, a slug, or a short UUID prefix (the same identifiers `workspace list` shows):

```
multica issue update BUR-12 --status done --workspace bureau
```

- Resolution precedence (highest to lowest): `--workspace`, `--workspace-id`, `MULTICA_WORKSPACE_ID`, profile default. When `--workspace` is absent, resolution is unchanged, so existing behavior is fully backward compatible.
- Resolved once at the `newAPIClient` choke point, so every resource command (`issue`, `project`, `label`, `agent`, …) threads it through without per-command wiring.
- A UUID is forwarded as-is (no extra round trip); a slug or prefix is resolved against the caller's accessible workspaces, which doubles as the access/existence check and yields a clear not-found error for an unknown value.
- Independent of the mutable current-workspace pointer, so parallel scripts are deterministic.
- Inside a daemon-managed agent task the workspace is bound by the task token and the server ignores any client-supplied workspace, so the flag is deliberately not honored there — resolution stays with the daemon-provided env.

The `workspace switch` help text now points scripts at `--workspace` instead of the shared default.

## Tests

`server/cmd/multica/cmd_workspace_flag_test.go` covers:

- `--workspace <uuid>` overrides the config current-workspace pointer.
- `--workspace <slug>` resolves to the canonical UUID.
- An unknown workspace errors clearly.
- An absent flag falls back to the configured default.
- The flag is ignored inside a daemon-managed task context.

## Verification

```
cd server
gofmt -l cmd/multica/...        # clean
go build ./...                  # ok
go test ./cmd/multica/ -count=1 # ok
```

Closes #7654