### PR TITLE
feat(issues): remember previously chosen project when re-creating an issue

### DIFF
--- a/packages/core/issues/stores/draft-store.test.ts
+++ b/packages/core/issues/stores/draft-store.test.ts
@@ -146,12 +146,38 @@ describe("issue draft store — last assignee", () => {
     expect(useIssueDraftStore.getState().isolatedDraftBackup).toBeUndefined();
   });
 
-  it("clearDraft removes the persisted project selection", () => {
+  it("clearDraft yields an empty project when none has ever been remembered", () => {
     const { setShared, clearDraft } = useIssueDraftStore.getState();
 
     setShared({ projectId: "project-1" });
     clearDraft();
 
+    expect(useIssueDraftStore.getState().draft.shared.projectId).toBeUndefined();
+  });
+
+  it("clearDraft prefills the next draft with the remembered project", () => {
+    const { setShared, setLastProject, clearDraft } =
+      useIssueDraftStore.getState();
+
+    // A failed agent task retry re-opens the create form after the original
+    // create already ran clearDraft. The just-used project must survive that
+    // clear so the reopened form starts on the previously chosen project.
+    setShared({ projectId: "project-1" });
+    setLastProject("project-1");
+    clearDraft();
+
+    expect(useIssueDraftStore.getState().draft.shared.projectId).toBe("project-1");
+  });
+
+  it("setLastProject(undefined) lets the user opt back out of a default", () => {
+    const { setLastProject, clearDraft } = useIssueDraftStore.getState();
+
+    setLastProject("project-1");
+    clearDraft();
+    expect(useIssueDraftStore.getState().draft.shared.projectId).toBe("project-1");
+
+    setLastProject(undefined);
+    clearDraft();
     expect(useIssueDraftStore.getState().draft.shared.projectId).toBeUndefined();
   });
 
@@ -381,20 +407,26 @@ describe("issue draft store — logout cleanup", () => {
     setCurrentWorkspace(null, null);
   });
 
-  it("registered reset wipes the last-assignee preference, not just the draft", () => {
-    const { setManual, setLastAssignee } = useIssueDraftStore.getState();
+  it("registered reset wipes the last-assignee and last-project preferences, not just the draft", () => {
+    const { setManual, setShared, setLastAssignee, setLastProject } =
+      useIssueDraftStore.getState();
     setManual({ title: "wip", assigneeType: "member", assigneeId: "alice" });
+    setShared({ projectId: "project-1" });
     setLastAssignee("member", "alice");
+    setLastProject("project-1");
 
     resetAllRegisteredDrafts();
 
     const state = useIssueDraftStore.getState();
     expect(state.lastAssigneeType).toBeUndefined();
     expect(state.lastAssigneeId).toBeUndefined();
-    // clearDraft() would have re-seeded the manual slot from lastAssignee —
-    // the logout reset must not hand the next login a previous user's pick.
+    expect(state.lastProjectId).toBeUndefined();
+    // clearDraft() would have re-seeded the manual slot from lastAssignee and
+    // the shared slot from lastProjectId — the logout reset must not hand the
+    // next login a previous user's picks.
     expect(state.draft.manual.assigneeType).toBeUndefined();
     expect(state.draft.manual.assigneeId).toBeUndefined();
+    expect(state.draft.shared.projectId).toBeUndefined();
   });
 
   it("logout sequence (reset in-memory, then clear storage) leaves no persisted key", async () => {

--- a/packages/core/issues/stores/draft-store.ts
+++ b/packages/core/issues/stores/draft-store.ts
@@ -106,6 +106,10 @@ interface IssueDraftStore {
   // choice instead of always opening with no assignee.
   lastAssigneeType?: IssueAssigneeType;
   lastAssigneeId?: string;
+  // Last project picked at submit time. Persisted across drafts so a re-open
+  // of the create form — notably retrying a failed agent task from the inbox —
+  // starts on the previously chosen project instead of no project.
+  lastProjectId?: string;
   setShared: (patch: Partial<IssueCreateShared>) => void;
   setManual: (patch: Partial<IssueCreateManual>) => void;
   setAgent: (patch: Partial<IssueCreateAgent>) => void;
@@ -114,6 +118,7 @@ interface IssueDraftStore {
   beginIsolatedDraft: () => void;
   endIsolatedDraft: () => void;
   setLastAssignee: (type?: IssueAssigneeType, id?: string) => void;
+  setLastProject: (id?: string) => void;
   hasDraft: () => boolean;
 }
 
@@ -184,6 +189,7 @@ export const useIssueDraftStore = create<IssueDraftStore>()(
       draft: migrateDraft(undefined),
       lastAssigneeType: undefined,
       lastAssigneeId: undefined,
+      lastProjectId: undefined,
       setShared: (patch) =>
         set((s) => ({ draft: { ...s.draft, shared: { ...s.draft.shared, ...patch } } })),
       setManual: (patch) =>
@@ -195,7 +201,7 @@ export const useIssueDraftStore = create<IssueDraftStore>()(
       clearDraft: () =>
         set((s) => ({
           draft: {
-            shared: emptyShared(),
+            shared: { ...emptyShared(), projectId: s.lastProjectId },
             manual: {
               ...emptyManual(),
               assigneeType: s.lastAssigneeType,
@@ -211,7 +217,7 @@ export const useIssueDraftStore = create<IssueDraftStore>()(
           return {
             isolatedDraftBackup: s.draft,
             draft: {
-              shared: emptyShared(),
+              shared: { ...emptyShared(), projectId: s.lastProjectId },
               manual: {
                 ...emptyManual(),
                 assigneeType: s.lastAssigneeType,
@@ -228,6 +234,7 @@ export const useIssueDraftStore = create<IssueDraftStore>()(
           : s),
       setLastAssignee: (type, id) =>
         set({ lastAssigneeType: type, lastAssigneeId: id }),
+      setLastProject: (id) => set({ lastProjectId: id }),
       hasDraft: () => {
         const { manual, agent, shared } = get().draft;
         return !!(
@@ -251,6 +258,7 @@ export const useIssueDraftStore = create<IssueDraftStore>()(
         draft: state.isolatedDraftBackup ?? state.draft,
         lastAssigneeType: state.lastAssigneeType,
         lastAssigneeId: state.lastAssigneeId,
+        lastProjectId: state.lastProjectId,
       }),
       merge: (persistedState, currentState) => {
         const persisted = (persistedState ?? {}) as Partial<IssueDraftStore> & {
@@ -272,14 +280,15 @@ registerDraftCleanup({
   storageKey: "multica_issue_draft",
   workspaceScoped: true,
   // Full reset, NOT clearDraft(): clearDraft deliberately keeps the
-  // last-assignee preference and re-seeds it into the fresh draft's manual
-  // slot — correct between drafts of one user, but on logout it would hand
-  // the previous user's last-picked assignee to the next login on this tab.
+  // last-assignee and last-project preferences and re-seeds them into the fresh
+  // draft — correct between drafts of one user, but on logout it would hand the
+  // previous user's last-picked assignee/project to the next login on this tab.
   resetInMemory: () =>
     useIssueDraftStore.setState({
       draft: migrateDraft(undefined),
       lastAssigneeType: undefined,
       lastAssigneeId: undefined,
+      lastProjectId: undefined,
       isolatedDraftBackup: undefined,
     }),
 });

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -42,6 +42,7 @@ const mockSetAgent = vi.hoisted(() => vi.fn());
 const mockSetActiveMode = vi.hoisted(() => vi.fn());
 const mockClearDraft = vi.hoisted(() => vi.fn());
 const mockSetLastAssignee = vi.hoisted(() => vi.fn());
+const mockSetLastProject = vi.hoisted(() => vi.fn());
 const mockSetKeepOpen = vi.hoisted(() => vi.fn());
 const mockToastCustom = vi.hoisted(() => vi.fn());
 const mockToastDismiss = vi.hoisted(() => vi.fn());
@@ -152,6 +153,7 @@ const mockDraftStore = {
   setActiveMode: mockSetActiveMode,
   clearDraft: mockClearDraft,
   setLastAssignee: mockSetLastAssignee,
+  setLastProject: mockSetLastProject,
   hasDraft: () => false,
 };
 

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -242,6 +242,7 @@ export function ManualCreatePanel({
   const setActiveMode = useIssueDraftStore((s) => s.setActiveMode);
   const clearDraft = useIssueDraftStore((s) => s.clearDraft);
   const setLastAssignee = useIssueDraftStore((s) => s.setLastAssignee);
+  const setLastProject = useIssueDraftStore((s) => s.setLastProject);
   const setLastMode = useCreateModeStore((s) => s.setLastMode);
   const keepOpen = useQuickCreateStore((s) => s.keepOpen);
   const setKeepOpen = useQuickCreateStore((s) => s.setKeepOpen);
@@ -424,12 +425,11 @@ export function ManualCreatePanel({
     setLabelIds([]);
     setPropertyValues({});
     setCustomPropertyPickerId(null);
-    setProjectId(undefined);
     setParentIssueId(undefined);
     setStage(null);
     setChildIssues([]);
-    // Keep the just-used assignee for the next issue in the batch; reset
-    // everything else across the manual + shared slots.
+    // Keep the just-used assignee and project for the next issue in the batch;
+    // reset everything else across the manual + shared slots.
     setManual({
       title: "",
       description: "",
@@ -442,7 +442,6 @@ export function ManualCreatePanel({
     });
     setShared({
       priority: "none",
-      projectId: undefined,
       dueDate: null,
       attachments: [],
     });
@@ -739,6 +738,7 @@ export function ManualCreatePanel({
       // These preferences derive from the SUBMITTED values, not the live
       // draft — an issue was created, so record them regardless of the guard.
       setLastAssignee(assigneeType, assigneeId);
+      setLastProject(projectId);
       setLastMode("manual");
       // Success may only consume the draft it submitted (MUL-5181 P0): any
       // edit after the submit snapshot — typing while the request is in

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -27,6 +27,7 @@ const mockSetShared = vi.hoisted(() => vi.fn());
 const mockSetManual = vi.hoisted(() => vi.fn());
 const mockSetAgent = vi.hoisted(() => vi.fn());
 const mockSetActiveMode = vi.hoisted(() => vi.fn());
+const mockSetLastProject = vi.hoisted(() => vi.fn());
 const mockClearDraft = vi.hoisted(() => vi.fn());
 
 const sourceContextPanelData = {
@@ -91,6 +92,7 @@ const mockIssueDraftStore = {
   setManual: mockSetManual,
   setAgent: mockSetAgent,
   setActiveMode: mockSetActiveMode,
+  setLastProject: mockSetLastProject,
   clearDraft: mockClearDraft,
 };
 

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -194,6 +194,7 @@ export function AgentCreatePanel({
   const setManual = useIssueDraftStore((s) => s.setManual);
   const setAgent = useIssueDraftStore((s) => s.setAgent);
   const setActiveMode = useIssueDraftStore((s) => s.setActiveMode);
+  const setLastProject = useIssueDraftStore((s) => s.setLastProject);
   const clearDraft = useIssueDraftStore((s) => s.clearDraft);
 
   // Resolve a candidate actor against the currently-visible agents / squads.
@@ -450,6 +451,7 @@ export function AgentCreatePanel({
           });
         }
         setLastActor(actor.type, actor.id);
+        setLastProject(projectId ?? undefined);
         setLastMode("agent");
         toast.success(t(($) => $.create_issue.agent.toast_sent), {
           duration: 4000,


### PR DESCRIPTION
Closes #7662

## Problem

When an issue handed to an agent fails, retrying the creation forgets the previously chosen project. The advanced create form and the agent quick-create both seed their project picker from `draft.shared.projectId` in the persisted create-issue draft store. A successful create runs `clearDraft()`, which wiped that slot — so by the time the agent task fails and the user reopens the form from the inbox ("Edit in advanced"), the project selection is gone and has to be picked again every time.

## Fix

Remember the last-used project the same way the store already remembers the last-used assignee:

- Add `lastProjectId` and `setLastProject` to `useIssueDraftStore`, persisted across drafts.
- Record the submitted project on a successful create in both panels (manual `create-issue` and agent `quick-create-issue`).
- Re-seed `shared.projectId` from `lastProjectId` in `clearDraft` and `beginIsolatedDraft`, and reset it on logout cleanup so one user's choice never leaks to the next login on the same tab.
- Keep the chosen project across the manual "Create another" reset, matching how the assignee is already kept.

The inbox "Edit in advanced" retry needs no change: it reads `shared.projectId`, which now carries the remembered project.

## Tests

- Store: added tests that `clearDraft` re-seeds the remembered project, yields an empty project when none was remembered, honors `setLastProject(undefined)` opt-out, and that logout cleanup wipes the preference.
- Extended the two modal test mocks with `setLastProject`.

## Verification

- `pnpm --filter @multica/core exec vitest run issues/stores/draft-store.test.ts drafts/create-draft-store.test.ts` — 21 passed
- `pnpm --filter @multica/views exec vitest run modals/create-issue modals/quick-create-issue` — 76 passed
- `pnpm --filter @multica/core exec tsc --noEmit` and `pnpm --filter @multica/views exec tsc --noEmit` — clean
