### PR TITLE
feat(issues): flash tab instead of navigating on current-issue mention

### DIFF
--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -36,7 +36,7 @@ import {
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
 import { SIDEBAR_WRAPPER_FILL_CLASS } from "@multica/ui/components/ui/sidebar";
 import { cn } from "@multica/ui/lib/utils";
-import { useTabStore, useActiveGroup, type Tab } from "@/stores/tab-store";
+import { useTabStore, useActiveGroup, useTabFlashSignal, type Tab } from "@/stores/tab-store";
 import { paths } from "@multica/core/paths";
 import {
   useTabPresentation,
@@ -183,6 +183,7 @@ function SortableTabItem({
   isOnly,
   canCloseOthers,
   isNew,
+  flashSeq,
   shouldReduceMotion,
   showSeparator,
 }: {
@@ -196,6 +197,11 @@ function SortableTabItem({
   isOnly: boolean;
   canCloseOthers: boolean;
   isNew: boolean;
+  /**
+   * A monotonic flash sequence for THIS tab, or null when it has no pending
+   * flash. Changing it replays the attention pulse (see `flashActiveTab`).
+   */
+  flashSeq: number | null;
   shouldReduceMotion: boolean;
   /**
    * Hairline on the tab's left edge — hidden next to the active tab, and
@@ -458,6 +464,25 @@ function SortableTabItem({
             onAnimationComplete={() => setShowAddedHighlight(false)}
           />
         )}
+        {flashSeq !== null && (
+          // Attention pulse fired when a link resolves to the surface this tab
+          // already shows (e.g. a mention of the current issue). Keyed on the
+          // sequence so a repeat click on the same tab replays it. Distinct
+          // from the added-tab highlight above: this one fades in and back out
+          // rather than starting lit, since the tab is already on screen.
+          <motion.span
+            key={flashSeq}
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0.5 top-1 bottom-1 rounded-lg bg-primary/15 ring-1 ring-inset ring-primary/30"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: shouldReduceMotion ? [0.4, 0] : [0, 0.7, 0] }}
+            transition={{
+              duration: shouldReduceMotion ? 0.3 : 0.55,
+              times: shouldReduceMotion ? [0, 1] : [0, 0.3, 1],
+              ease: "easeOut",
+            }}
+          />
+        )}
       </motion.div>
     </div>
   );
@@ -558,6 +583,7 @@ export function TabBar() {
   const group = useActiveGroup();
   const moveTab = useTabStore((s) => s.moveTab);
   const activeWorkspaceSlug = useTabStore((s) => s.activeWorkspaceSlug);
+  const flashSignal = useTabFlashSignal();
   const shouldReduceMotion = useReducedMotion() ?? false;
   const tabScrollRef = useRef<HTMLDivElement>(null);
   const previousTabsRef = useRef<TabSnapshot | null>(null);
@@ -679,6 +705,9 @@ export function TabBar() {
                         (candidate) => candidate.id !== tab.id && !candidate.pinned,
                       )}
                       isNew={addedTabIdSet.has(tab.id)}
+                      flashSeq={
+                        flashSignal?.tabId === tab.id ? flashSignal.seq : null
+                      }
                       shouldReduceMotion={shouldReduceMotion}
                       showSeparator={
                         !!previousTab &&

--- a/apps/desktop/src/renderer/src/platform/navigation.test.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.test.tsx
@@ -291,6 +291,20 @@ describe("current location", () => {
   });
 });
 
+describe("flashActiveTab", () => {
+  it("raises a flash signal on the active tab without navigating", () => {
+    const getAdapter = renderProvider();
+    const activeBefore = acmeGroup().activeTabId;
+
+    getAdapter().flashActiveTab!();
+
+    const s = useTabStore.getState();
+    expect(s.flashSignal).toEqual({ tabId: activeBefore, seq: 1 });
+    // No navigation happened.
+    expect(getActiveTab(s)?.url).toBe("/acme/issues");
+  });
+});
+
 describe("routeContentLinkPath (links inside content — MUL-5208)", () => {
   it("opens a same-workspace path in a foreground tab of its own", () => {
     routeContentLinkPath("/acme/issues/MUL-1");

--- a/apps/desktop/src/renderer/src/platform/navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.tsx
@@ -245,6 +245,9 @@ export function DesktopNavigationProvider({
         }
         store.openTab(path, title ?? "", { activate: opts?.activate });
       },
+      flashActiveTab: () => {
+        useTabStore.getState().flashActiveTab();
+      },
       getShareableUrl: (path: string) => `${appUrl}${path}`,
     }),
     [appUrl, location],

--- a/apps/desktop/src/renderer/src/stores/tab-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.test.ts
@@ -491,6 +491,31 @@ describe("reloadActiveTab", () => {
   });
 });
 
+describe("flashActiveTab", () => {
+  it("raises a flash signal for the active tab and bumps seq on each call", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const activeTabId = useTabStore.getState().byWorkspace.acme.activeTabId;
+
+    store.flashActiveTab();
+    expect(useTabStore.getState().flashSignal).toEqual({
+      tabId: activeTabId,
+      seq: 1,
+    });
+
+    store.flashActiveTab();
+    expect(useTabStore.getState().flashSignal).toEqual({
+      tabId: activeTabId,
+      seq: 2,
+    });
+  });
+
+  it("is a no-op with no active workspace", () => {
+    useTabStore.getState().flashActiveTab();
+    expect(useTabStore.getState().flashSignal).toBeNull();
+  });
+});
+
 describe("commitScrollMemento", () => {
   it("stores route-scoped entries on the addressed tab", () => {
     const store = useTabStore.getState();

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -156,6 +156,16 @@ interface TabStore {
   mountGeneration: number;
 
   /**
+   * A one-shot "flash this tab" pulse, or null when nothing is pending. Raised
+   * by `flashActiveTab` when a content link resolves to the surface the active
+   * tab already shows (e.g. a mention of the current issue clicked from inside
+   * that issue): there is nowhere to navigate, so the tab strip briefly
+   * highlights the tab instead. `seq` makes each request distinct so repeated
+   * clicks on the same tab replay the animation. Deliberately NOT persisted.
+   */
+  flashSignal: { tabId: string; seq: number } | null;
+
+  /**
    * Switch to a workspace.
    *   - If the group doesn't exist yet, create it with a single default tab.
    *   - If `openPath` is given, find a tab with that resourceKey and activate
@@ -241,6 +251,12 @@ interface TabStore {
    * Coordinator (it watches this counter) so this action stays pure state.
    */
   reloadActiveTab: () => void;
+  /**
+   * Fire a one-shot flash on the active tab (see `flashSignal`). No-op when no
+   * workspace/tab is active. Each call bumps `seq` so the animation replays
+   * even when the same tab is flashed twice in a row.
+   */
+  flashActiveTab: () => void;
   /**
    * Close the active tab. The always-safe escape from a route-level crash:
    * unlike reloadActiveTab (remounts the same crashing URL), closing
@@ -497,6 +513,7 @@ export const useTabStore = create<TabStore>()(
       activeWorkspaceSlug: null,
       byWorkspace: {},
       mountGeneration: 0,
+      flashSignal: null,
 
       switchWorkspace(slug, openPath) {
         // Defensive no-op if slug is empty/invalid — callers like the
@@ -862,6 +879,13 @@ export const useTabStore = create<TabStore>()(
         set({ mountGeneration: mountGeneration + 1 });
       },
 
+      flashActiveTab() {
+        const active = getActiveTab(get());
+        if (!active) return;
+        const prev = get().flashSignal;
+        set({ flashSignal: { tabId: active.id, seq: (prev?.seq ?? 0) + 1 } });
+      },
+
       closeActiveTab() {
         const { activeWorkspaceSlug, byWorkspace, closeTab } = get();
         if (!activeWorkspaceSlug) return;
@@ -975,7 +999,7 @@ export const useTabStore = create<TabStore>()(
       },
 
       reset() {
-        set({ activeWorkspaceSlug: null, byWorkspace: {}, mountGeneration: 0 });
+        set({ activeWorkspaceSlug: null, byWorkspace: {}, mountGeneration: 0, flashSignal: null });
       },
     }),
     {
@@ -1382,6 +1406,15 @@ export function useActiveTabIdentity(): { slug: string | null; tabId: string | n
 /** The active session's url as a primitive (Coordinator, providers). */
 export function useActiveTabUrl(): string | null {
   return useTabStore((s) => getActiveTab(s)?.url ?? null);
+}
+
+/**
+ * The pending flash pulse (or null). Primitive-stable: the object reference
+ * only changes when `flashActiveTab` fires, so the TabBar re-renders on a
+ * flash and nothing else.
+ */
+export function useTabFlashSignal(): { tabId: string; seq: number } | null {
+  return useTabStore((s) => s.flashSignal);
 }
 
 /**

--- a/packages/views/issues/components/issue-mention-card.test.tsx
+++ b/packages/views/issues/components/issue-mention-card.test.tsx
@@ -152,4 +152,48 @@ describe("IssueMentionCard", () => {
 
     expect(screen.getByTestId("issue-chip")).toHaveAttribute("data-current", "false");
   });
+
+  it("swallows a plain click on the current issue and flashes the active tab instead of navigating", () => {
+    const push = vi.fn();
+    const flashActiveTab = vi.fn();
+    renderCard(makeAdapter({ push, flashActiveTab }), {
+      id: "issue-1",
+      identifier: "MUL-7",
+    });
+
+    fireEvent.click(screen.getByTestId("issue-chip"));
+
+    expect(push).not.toHaveBeenCalled();
+    expect(flashActiveTab).toHaveBeenCalledOnce();
+  });
+
+  it("still opens the current issue in a new tab on a modifier click (desktop)", () => {
+    const push = vi.fn();
+    const openInNewTab = vi.fn();
+    const flashActiveTab = vi.fn();
+    renderCard(makeAdapter({ push, openInNewTab, flashActiveTab }), {
+      id: "issue-1",
+      identifier: "MUL-7",
+    });
+
+    fireEvent.click(screen.getByTestId("issue-chip"), { metaKey: true });
+
+    expect(openInNewTab).toHaveBeenCalledWith("/acme/issues/issue-1", "MUL-7");
+    expect(flashActiveTab).not.toHaveBeenCalled();
+  });
+
+  it("navigates in place for a different issue even while a current issue is set", () => {
+    const push = vi.fn();
+    const flashActiveTab = vi.fn();
+    renderCard(
+      makeAdapter({ push, flashActiveTab }),
+      { id: "issue-2", identifier: "MUL-8" },
+      "issue-1",
+    );
+
+    fireEvent.click(screen.getByTestId("issue-chip"));
+
+    expect(push).toHaveBeenCalledWith("/acme/issues/issue-1");
+    expect(flashActiveTab).not.toHaveBeenCalled();
+  });
 });

--- a/packages/views/issues/components/issue-mention-card.tsx
+++ b/packages/views/issues/components/issue-mention-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AppLink } from "../../navigation";
+import { AppLink, resolveClickIntent, useOptionalNavigation } from "../../navigation";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { IssueChip } from "./issue-chip";
 import { IssueHoverCard } from "./issue-hover-card";
@@ -32,7 +32,10 @@ function CurrentIssueChipContent({ identifier }: { identifier: string }) {
  *
  * AppLink owns the click semantics: plain click navigates in place, modifier
  * and middle clicks open tabs. There is deliberately no per-surface or
- * per-preference override.
+ * per-preference override — with one exception: a plain click on a mention of
+ * the CURRENT issue (the one whose page is rendering this content) navigates
+ * nowhere and flashes the active tab instead, since the destination is the
+ * page already on screen.
  *
  * Hovering opens IssueHoverCard, which shows the detail the chip has no room
  * for. No `delay` is passed, so it opens on Base UI's default dwell. The same
@@ -41,16 +44,31 @@ function CurrentIssueChipContent({ identifier }: { identifier: string }) {
  */
 export function IssueMentionCard({ issueId, fallbackLabel }: IssueMentionCardProps) {
   const p = useWorkspacePaths();
+  const nav = useOptionalNavigation();
   const currentIssue = useCurrentIssueRenderContext();
-  const currentIdentifier =
-    currentIssue && issueId === currentIssue.id
-      ? currentIssue.identifier
-      : null;
+  const isCurrentIssue = !!currentIssue && issueId === currentIssue.id;
+  const currentIdentifier = isCurrentIssue ? currentIssue.identifier : null;
+
+  // A plain click on a mention of the issue the reader is already viewing
+  // would re-navigate to the page it is already on: a no-op that still tears
+  // the detail view down and rebuilds it. Swallow that click and flash the
+  // active tab instead, so the affordance still acknowledges the interaction.
+  // Modifier / middle clicks keep their meaning — opening the same issue in a
+  // NEW tab is a real destination — so only the "push" intent is intercepted.
+  const handleClick = isCurrentIssue
+    ? (e: React.MouseEvent<HTMLAnchorElement>) => {
+        if (resolveClickIntent(e) !== "push") return;
+        e.preventDefault();
+        nav?.flashActiveTab?.();
+      }
+    : undefined;
+
   return (
     <IssueHoverCard issueId={issueId} fallbackLabel={fallbackLabel}>
       <AppLink
         href={p.issueDetail(issueId)}
         newTabTitle={fallbackLabel}
+        onClick={handleClick}
         className="issue-mention align-middle"
       >
         <IssueChip

--- a/packages/views/navigation/types.ts
+++ b/packages/views/navigation/types.ts
@@ -47,6 +47,17 @@ export interface NavigationAdapter {
    */
   canGoBack?: () => boolean;
   /**
+   * Optional: draw attention to the tab the current content is already showing
+   * in, WITHOUT navigating. Used when a link resolves to the surface the user
+   * is already on — e.g. a mention of the current issue from inside that
+   * issue's own detail page: re-navigating there is a no-op that still tears
+   * the page down and back up, so the click is swallowed and this fires a brief
+   * highlight on the active tab instead. Only the desktop shell owns a tab
+   * strip to flash; web leaves it undefined and callers must invoke it via
+   * `flashActiveTab?.()`, treating absence as "nothing to flash".
+   */
+  flashActiveTab?: () => void;
+  /**
    * Optional: step forward through history, the inverse of `back()`. Web wires
    * this to `router.forward`; the desktop shell to the active tab's virtual
    * history. It is optional because not every adapter owns a forward stack: the


### PR DESCRIPTION
## What

When you are on an issue detail page and click a link/mention pointing at the **same** issue (e.g. a `This issue · HOM-9` chip in a comment, or a link in the body that resolves to the current issue), it no longer triggers a route push/reload. Instead the click is swallowed and the active tab briefly flashes to acknowledge the interaction. Links to **other** issues keep their normal navigation, and modifier / middle clicks on the current issue still open it in a new tab.

## Why

Re-navigating to the page already on screen is a no-op that still tears the whole detail view down and rebuilds it — visible flicker for zero benefit. Flashing the tab gives feedback without the churn.

## How

- **Shared contract** (`packages/views/navigation/types.ts`): add optional `NavigationAdapter.flashActiveTab()`. Web leaves it undefined (no tab strip); callers invoke it via `flashActiveTab?.()`.
- **`IssueMentionCard`**: when the resolved target is the current issue (`useCurrentIssueRenderContext`), a plain-`push` click calls `e.preventDefault()` + `flashActiveTab()`. Modifier/middle clicks and other issues are untouched — `resolveClickIntent` gates it.
- **Desktop shell**: `tab-store` gains a one-shot `flashSignal` (`{ tabId, seq }`) and a `flashActiveTab` action (seq bumps per call so repeat clicks replay); the desktop adapter wires it; `TabBar` renders a brief attention pulse keyed on the sequence.

## Tests

- `issue-mention-card.test.tsx`: plain click on current issue flashes + does not push; modifier click still opens a new tab; a different issue still pushes.
- `tab-store.test.ts`: `flashActiveTab` raises the signal and bumps seq; no-op without an active workspace.
- `navigation.test.tsx`: desktop adapter's `flashActiveTab` raises the signal without navigating.

All touched-package tests, `typecheck`, and `eslint` pass locally.

Closes HOM-17.
