### PR TITLE
MUL-7042: MINT-11: classify active issue workdirs in disk usage

### DIFF
--- a/server/cmd/multica/cmd_daemon_diskusage_status_test.go
+++ b/server/cmd/multica/cmd_daemon_diskusage_status_test.go
@@ -118,6 +118,37 @@ func writeDiskUsageIssueTask(t *testing.T, root, wsID, taskShort, issueID string
 	}
 }
 
+func writeActiveDiskUsageIssueTask(t *testing.T, root, wsID, taskShort, issueID string) {
+	t.Helper()
+	taskDir := filepath.Join(root, wsID, taskShort, "workdir")
+	if err := os.MkdirAll(filepath.Join(taskDir, ".multica"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	provenance, err := json.Marshal(map[string]string{
+		"managed_by":   "multica-daemon-managed-env",
+		"workspace_id": wsID,
+		"agent_id":     "agent-1",
+		"issue_id":     issueID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(filepath.Dir(taskDir), ".managed_env.json"), provenance, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	marker, err := json.Marshal(map[string]string{
+		"managed_by": "multica-daemon-task",
+		"agent_id":   "agent-1",
+		"issue_id":   issueID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, ".multica", "daemon_task_context.json"), marker, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // setupDiskUsageProfile points a profile's CLI config at srv and seeds one
 // issue-kind task dir under that profile's workspaces root.
 func setupDiskUsageProfile(t *testing.T, home, profile, token, serverURL, wsID, taskShort, issueID string) {
@@ -224,6 +255,46 @@ func TestRunDaemonDiskUsageTaskTableResolvesStatus(t *testing.T) {
 	}
 	if !strings.Contains(out, "in_review") {
 		t.Errorf("STATUS column missing the resolved status, got:\n%s", out)
+	}
+}
+
+func TestRunDaemonDiskUsageActiveTaskContextResolvesStatus(t *testing.T) {
+	pinHumanCLIContext(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+	t.Setenv("MULTICA_SERVER_URL", "")
+
+	rec := &gcCheckRecorder{}
+	srv := newGCCheckServer(t, rec)
+	root := filepath.Join(home, "multica_workspaces")
+	writeActiveDiskUsageIssueTask(t, root,
+		"11111111-1111-1111-1111-111111111111", "aaaaaaaa", "issue-active")
+	if err := cli.SaveCLIConfig(cli.CLIConfig{ServerURL: srv.URL, Token: "token-default"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newDiskUsageTestCmd(t)
+	if err := cmd.Flags().Set("output", "json"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureStdout(t, func() error { return runDaemonDiskUsage(cmd, nil) })
+	if err != nil {
+		t.Fatalf("runDaemonDiskUsage: %v", err)
+	}
+
+	var report daemon.DiskUsageReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, out)
+	}
+	if rec.callCount() != 1 {
+		t.Fatalf("gc-check calls = %d, want 1", rec.callCount())
+	}
+	if len(report.Tasks) != 1 {
+		t.Fatalf("tasks = %d, want 1", len(report.Tasks))
+	}
+	if got := report.Tasks[0]; got.Kind != "issue" || got.ParentID != "issue-active" || got.ParentStatus != "in_review" {
+		t.Fatalf("active task = %+v, want issue parent and current status", got)
 	}
 }
 

--- a/server/internal/daemon/diskusage.go
+++ b/server/internal/daemon/diskusage.go
@@ -132,9 +132,8 @@ func ScanDiskUsageRoots(roots []DiskUsageRoot, artifactPatterns []string) (Aggre
 	return agg, nil
 }
 
-// DiskUsageKindUnknown is the kind reported for task directories whose
-// .gc_meta.json is missing or unreadable. Mirrors how the GC orphan path
-// treats them — present on disk, but no parent record we can lock onto.
+// DiskUsageKindUnknown is the kind reported for task directories whose GC and
+// active task-context metadata are missing or unreadable.
 const DiskUsageKindUnknown = "unknown"
 
 // ScanDiskUsage walks workspacesRoot and returns the disk-usage report. The
@@ -313,9 +312,10 @@ func buildTaskUsage(taskDir, wsID, taskShort string, matcher artifactMatcher) Ta
 		Kind:           DiskUsageKindUnknown,
 	}
 
-	metaPresent := false
-	if provenance, err := execenv.ReadManagedEnvProvenance(taskDir); err == nil && provenance != nil {
-		if workspaceID := strings.TrimSpace(provenance.WorkspaceID); workspaceID != "" {
+	var provenance *execenv.ManagedEnvProvenance
+	if p, err := execenv.ReadManagedEnvProvenance(taskDir); err == nil && p != nil {
+		provenance = p
+		if workspaceID := strings.TrimSpace(p.WorkspaceID); workspaceID != "" {
 			usage.WorkspaceID = workspaceID
 			usage.WorkspaceShort = ShortID(workspaceID)
 		}
@@ -326,24 +326,38 @@ func buildTaskUsage(taskDir, wsID, taskShort string, matcher artifactMatcher) Ta
 			usage.WorkspaceShort = ShortID(workspaceID)
 		}
 	}
-	if meta, err := execenv.ReadGCMeta(taskDir); err == nil && meta != nil {
-		metaPresent = true
+	meta, metaErr := execenv.ReadGCMeta(taskDir)
+	if metaErr == nil && meta != nil {
 		if workspaceID := strings.TrimSpace(meta.WorkspaceID); workspaceID != "" {
 			usage.WorkspaceID = workspaceID
 			usage.WorkspaceShort = ShortID(workspaceID)
 		}
-		usage.Kind = string(meta.Kind)
-		usage.ParentID = parentIDForMeta(meta)
+		if parentID := parentIDForMeta(meta); parentID != "" {
+			usage.Kind = string(meta.Kind)
+			usage.ParentID = parentID
+		}
 		if !meta.CompletedAt.IsZero() {
 			usage.AgeSeconds = int64(time.Since(meta.CompletedAt).Seconds())
 		} else if age, ok := gcMetaFileAge(taskDir); ok {
 			usage.AgeSeconds = int64(age.Seconds())
 		}
 	}
+	if os.IsNotExist(metaErr) && provenance != nil && provenance.ManagedBy == execenv.ManagedEnvProvenanceManagedBy {
+		if marker, err := execenv.ReadTaskContextMarker(filepath.Join(taskDir, "workdir")); err == nil && marker.AgentID == provenance.AgentID {
+			switch {
+			case marker.IssueID != "" && marker.IssueID == strings.TrimSpace(provenance.IssueID) && provenance.ChatSessionID == "":
+				usage.Kind = string(execenv.GCKindIssue)
+				usage.ParentID = marker.IssueID
+			case marker.ChatSessionID != "" && marker.ChatSessionID == strings.TrimSpace(provenance.ChatSessionID) && provenance.IssueID == "":
+				usage.Kind = string(execenv.GCKindChat)
+				usage.ParentID = marker.ChatSessionID
+			}
+		}
+	}
 	// With no readable metadata, use taskDir mtime just like orphanByMTime.
 	// Legacy readable metadata without completed_at uses its own file mtime,
 	// matching gcDecisionIssueResult's managed-only fallback.
-	if usage.AgeSeconds <= 0 && !metaPresent {
+	if usage.AgeSeconds <= 0 && metaErr != nil {
 		if info, err := os.Stat(taskDir); err == nil {
 			usage.AgeSeconds = int64(time.Since(info.ModTime()).Seconds())
 		}

--- a/server/internal/daemon/diskusage_test.go
+++ b/server/internal/daemon/diskusage_test.go
@@ -302,6 +302,132 @@ func TestScanDiskUsage_ReadableActiveRootUsesOwnerIdentityWithoutGCMeta(t *testi
 	}
 }
 
+func TestScanDiskUsage_ActiveIssueTaskContextClassification(t *testing.T) {
+	t.Parallel()
+
+	for _, trigger := range []string{"direct", "comment", "delegated-comment"} {
+		t.Run(trigger, func(t *testing.T) {
+			root := t.TempDir()
+			workspaceID := "a05b0e10-ee7a-4603-a72d-a548b2390cb2"
+			issueID := "issue-" + trigger
+			taskDir := filepath.Join(root, workspaceID, trigger)
+			if err := os.MkdirAll(taskDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := execenv.WriteManagedEnvProvenance(taskDir, execenv.ManagedEnvProvenance{
+				WorkspaceID: workspaceID,
+				IssueID:     issueID,
+				AgentID:     "agent-1",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, filepath.Join(taskDir, "workdir", execenv.TaskContextMarkerRelPath), 0)
+			marker, err := json.Marshal(map[string]string{
+				"managed_by": execenv.TaskContextMarkerManagedBy,
+				"agent_id":   "agent-1",
+				"issue_id":   issueID,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(taskDir, "workdir", execenv.TaskContextMarkerRelPath), marker, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			report, err := ScanDiskUsage(root, nil)
+			if err != nil {
+				t.Fatalf("ScanDiskUsage: %v", err)
+			}
+			if len(report.Tasks) != 1 {
+				t.Fatalf("tasks = %d, want 1", len(report.Tasks))
+			}
+			if report.Tasks[0].Kind != string(execenv.GCKindIssue) {
+				t.Errorf("kind = %q, want issue", report.Tasks[0].Kind)
+			}
+			if report.Tasks[0].ParentID != issueID {
+				t.Errorf("parent_id = %q, want %q", report.Tasks[0].ParentID, issueID)
+			}
+
+			if err := ResolveParentStatuses(context.Background(), &report, func(_ context.Context, gotWorkspaceID string, issueIDs []string) (map[string]string, error) {
+				if gotWorkspaceID != workspaceID || len(issueIDs) != 1 || issueIDs[0] != issueID {
+					t.Fatalf("status request = workspace %q, issues %v", gotWorkspaceID, issueIDs)
+				}
+				return map[string]string{issueID: "in_progress"}, nil
+			}); err != nil {
+				t.Fatalf("ResolveParentStatuses: %v", err)
+			}
+			if report.Tasks[0].ParentStatus != "in_progress" {
+				t.Errorf("parent_status = %q, want in_progress", report.Tasks[0].ParentStatus)
+			}
+		})
+	}
+}
+
+func TestScanDiskUsage_InvalidTaskContextStaysUnknown(t *testing.T) {
+	t.Parallel()
+
+	for name, marker := range map[string]string{
+		"incomplete":  `{"managed_by":"multica-daemon-task","agent_id":"agent-1"}`,
+		"corrupt":     `{`,
+		"foreign":     `{"managed_by":"other","issue_id":"issue-1"}`,
+		"wrong agent": `{"managed_by":"multica-daemon-task","agent_id":"agent-2","issue_id":"issue-1"}`,
+		"wrong issue": `{"managed_by":"multica-daemon-task","agent_id":"agent-1","issue_id":"issue-2"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			taskDir := filepath.Join(root, "workspace-1", name)
+			if err := os.MkdirAll(taskDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := execenv.WriteManagedEnvProvenance(taskDir, execenv.ManagedEnvProvenance{
+				WorkspaceID: "workspace-1", IssueID: "issue-1", AgentID: "agent-1",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, filepath.Join(taskDir, "workdir", execenv.TaskContextMarkerRelPath), 0)
+			if err := os.WriteFile(filepath.Join(taskDir, "workdir", execenv.TaskContextMarkerRelPath), []byte(marker), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			report, err := ScanDiskUsage(root, nil)
+			if err != nil {
+				t.Fatalf("ScanDiskUsage: %v", err)
+			}
+			if got := report.Tasks[0]; got.Kind != DiskUsageKindUnknown || got.ParentID != "" {
+				t.Errorf("task = %+v, want unknown with no parent", got)
+			}
+		})
+	}
+
+	t.Run("corrupt gc metadata overrides valid active context", func(t *testing.T) {
+		root := t.TempDir()
+		taskDir := filepath.Join(root, "workspace-1", "corrupt-gc")
+		if err := os.MkdirAll(taskDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := execenv.WriteManagedEnvProvenance(taskDir, execenv.ManagedEnvProvenance{
+			WorkspaceID: "workspace-1", IssueID: "issue-1", AgentID: "agent-1",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(taskDir, "workdir", execenv.TaskContextMarkerRelPath), 0)
+		if err := os.WriteFile(filepath.Join(taskDir, "workdir", execenv.TaskContextMarkerRelPath), []byte(`{"managed_by":"multica-daemon-task","agent_id":"agent-1","issue_id":"issue-1"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(taskDir, ".gc_meta.json"), []byte(`{`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		report, err := ScanDiskUsage(root, nil)
+		if err != nil {
+			t.Fatalf("ScanDiskUsage: %v", err)
+		}
+		if got := report.Tasks[0]; got.Kind != DiskUsageKindUnknown || got.ParentID != "" {
+			t.Errorf("task = %+v, want corrupt GC metadata to stay unknown", got)
+		}
+	})
+}
+
 func TestScanDiskUsage_ManagedCodexSandboxIsExactAndDeduplicated(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -23,11 +23,31 @@ const TaskContextMarkerRelPath = ".multica/daemon_task_context.json"
 // treating TaskContextMarkerRelPath as daemon-owned.
 const TaskContextMarkerManagedBy = "multica-daemon-task"
 
-type taskContextMarkerFile struct {
+type TaskContextMarker struct {
 	ManagedBy     string `json:"managed_by"`
 	AgentID       string `json:"agent_id,omitempty"`
 	IssueID       string `json:"issue_id,omitempty"`
 	ChatSessionID string `json:"chat_session_id,omitempty"`
+}
+
+// ReadTaskContextMarker reads a daemon-owned per-task context marker. Root
+// markers and malformed or foreign files are rejected so callers fail closed.
+func ReadTaskContextMarker(workDir string) (*TaskContextMarker, error) {
+	data, err := os.ReadFile(filepath.Join(workDir, TaskContextMarkerRelPath))
+	if err != nil {
+		return nil, err
+	}
+	var marker TaskContextMarker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return nil, err
+	}
+	marker.IssueID = strings.TrimSpace(marker.IssueID)
+	marker.ChatSessionID = strings.TrimSpace(marker.ChatSessionID)
+	marker.AgentID = strings.TrimSpace(marker.AgentID)
+	if marker.ManagedBy != TaskContextMarkerManagedBy || marker.AgentID == "" || (marker.IssueID == "") == (marker.ChatSessionID == "") {
+		return nil, errors.New("invalid daemon task context marker")
+	}
+	return &marker, nil
 }
 
 // EnsureWorkspacesRootMarker writes a persistent daemon-task marker at
@@ -57,7 +77,7 @@ func EnsureWorkspacesRootMarker(workspacesRoot string) error {
 	}
 	path := filepath.Join(workspacesRoot, TaskContextMarkerRelPath)
 	if existing, err := os.ReadFile(path); err == nil {
-		var marker taskContextMarkerFile
+		var marker TaskContextMarker
 		if json.Unmarshal(existing, &marker) == nil {
 			if marker.ManagedBy == TaskContextMarkerManagedBy {
 				return nil
@@ -72,7 +92,7 @@ func EnsureWorkspacesRootMarker(workspacesRoot string) error {
 		// can safely overwrite; surface it. Callers degrade non-fatally.
 		return fmt.Errorf("read workspaces root marker %s: %w", path, err)
 	}
-	payload := taskContextMarkerFile{ManagedBy: TaskContextMarkerManagedBy}
+	payload := TaskContextMarker{ManagedBy: TaskContextMarkerManagedBy}
 	data, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal workspaces root marker: %w", err)
@@ -200,7 +220,7 @@ func writeTaskContextMarker(workDir string, ctx TaskContextForEnv, manifest *sid
 	// The sidecar manifest removes this marker on normal local_directory
 	// cleanup. If a crash leaves it behind, the CLI intentionally treats it
 	// as daemon context and fails closed instead of using a user PAT.
-	payload := taskContextMarkerFile{
+	payload := TaskContextMarker{
 		ManagedBy:     TaskContextMarkerManagedBy,
 		AgentID:       ctx.AgentID,
 		IssueID:       ctx.IssueID,
@@ -217,7 +237,7 @@ func writeTaskContextMarker(workDir string, ctx TaskContextForEnv, manifest *sid
 			if readErr != nil {
 				return fmt.Errorf("read existing task context marker: %w", readErr)
 			}
-			var marker taskContextMarkerFile
+			var marker TaskContextMarker
 			if json.Unmarshal(existing, &marker) != nil || marker.ManagedBy != TaskContextMarkerManagedBy {
 				return fmt.Errorf("write task context marker: %w", err)
 			}


### PR DESCRIPTION
## What changed
- classify active direct, comment, and delegated-comment issue workdirs from their task-context marker
- require matching daemon-managed provenance before trusting the workdir marker
- preserve GC metadata precedence and leave missing, malformed, foreign, or mismatched manifests as `unknown`
- resolve and expose the current parent issue status for active issue workdirs

## Verification
- `go test ./internal/daemon -run 'TestScanDiskUsage_(ActiveIssueTaskContextClassification|InvalidTaskContextStaysUnknown)$'` — pass
- `go test ./cmd/multica -run 'TestRunDaemonDiskUsageActiveTaskContextResolvesStatus$'` — pass
- `go test ./internal/daemon/execenv -run 'TestPrepareManaged(Issue|Chat)EnvWritesProvenance|TestEnsureWorkspacesRootMarker'` — pass
- affected package suites: daemon package passed; CLI package exposed existing task-marker-sensitive failures when run from a daemon workdir
- `make check` could not start because this fresh checkout has no `.env`

No migration. No disk deletion, daemon lifecycle, or task authorization behavior changed.

Related to MINT-9.