### PR TITLE
MUL-7044: MINT-33: make OpenCode version probes reliable

### DIFF
--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -132,6 +133,9 @@ func TestDetectVersionTimesOutOnHang(t *testing.T) {
 	case err := <-done:
 		if err == nil {
 			t.Fatal("expected an error from a hanging --version probe, got nil")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want controlled context deadline diagnostic", err)
 		}
 		if elapsed := time.Since(start); elapsed > 5*time.Second {
 			t.Fatalf("detection took %v; expected it to be bounded by the timeout", elapsed)

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -1097,11 +1097,11 @@ func cleanupMcpConfigTemp(path string) {
 // wedged by a bun regression (MUL-3812) — would otherwise stall the whole
 // registration loop, the daemon would never flip /health from "starting" to
 // "running", and *every* runtime on the host would appear disconnected. A real
-// `--version` returns well under this bound even on a cold cache or with
-// Windows AV scanning; the timeout exists only to fail a wedged probe fast and
+// `--version` returns under this bound even for source-based launchers starting
+// concurrently on a busy host; the timeout exists only to fail a wedged probe
 // in isolation so the remaining runtimes still register. A var (not const) so
 // tests can shrink it without waiting out the real bound.
-var detectVersionTimeout = 10 * time.Second
+var detectVersionTimeout = 30 * time.Second
 
 func detectCLIVersion(ctx context.Context, runtimeCmd Command) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, detectVersionTimeout)
@@ -1142,6 +1142,14 @@ func detectCLIVersion(ctx context.Context, runtimeCmd Command) (string, error) {
 	data, err := outputOwned(cmd, runtimeCmd.logger)
 	version, recognised := extractVersionLine(string(data))
 	if err != nil {
+		// CommandContext cancellation reaches the owned child process group through
+		// cmd.Cancel. The resulting Wait error is therefore usually the platform's
+		// exit status (for example "signal: killed"), not context.DeadlineExceeded.
+		// Attribute an expired probe to the bound that actually stopped it so daemon
+		// diagnostics distinguish a controlled timeout from an external signal.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", fmt.Errorf("detect version for %s: %w", runtimeCmd, ctxErr)
+		}
 		// recognised, not `version != ""`. The two differ exactly where it
 		// matters: extractVersionLine falls back to the trimmed raw output when
 		// no line carries a semver token, so non-empty means "the CLI printed

--- a/server/pkg/agent/launch_process_unix_test.go
+++ b/server/pkg/agent/launch_process_unix_test.go
@@ -6,9 +6,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -111,6 +114,51 @@ sleep 300
 	for _, pid := range pids {
 		waitProcessGone(t, pid)
 	}
+}
+
+// TestDetectVersionTimeoutOnlyKillsItsProbeGroup guards the daemon safety
+// boundary: timing out one version probe must reap that probe's descendants
+// without signalling an unrelated task in the caller's process group.
+func TestDetectVersionTimeoutOnlyKillsItsProbeGroup(t *testing.T) {
+	tempDir := t.TempDir()
+	pidFile := filepath.Join(tempDir, "probe-child.pid")
+	probePath := filepath.Join(tempDir, "probe")
+	writeTestExecutable(t, probePath, []byte("#!/bin/sh\n"+
+		`( sleep 300 ) </dev/null >/dev/null 2>&1 &
+printf '%s\n' "$!" > "$1"
+wait
+`))
+
+	sibling := exec.Command("sleep", "300")
+	if err := sibling.Start(); err != nil {
+		t.Fatalf("start unrelated process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sibling.Process.Kill()
+		_ = sibling.Wait()
+	})
+
+	orig := detectVersionTimeout
+	detectVersionTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { detectVersionTimeout = orig })
+
+	_, err := detectCLIVersion(context.Background(), NewCommand(probePath, []string{pidFile}))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("detectCLIVersion error = %v, want context deadline exceeded", err)
+	}
+	if err := sibling.Process.Signal(syscall.Signal(0)); err != nil {
+		t.Fatalf("unrelated process %d was signalled by probe cleanup: %v", sibling.Process.Pid, err)
+	}
+
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("read probe child pid: %v", err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parse probe child pid: %v", err)
+	}
+	waitProcessGone(t, childPID)
 }
 
 // TestOutputOwnedMatchesStdlibContract keeps the owned probe helpers drop-in:


### PR DESCRIPTION
## What changed
- extend bounded CLI version discovery from 10s to 30s so source-based OpenCode launchers remain discoverable under concurrent host load
- report deadline-triggered cleanup as `context deadline exceeded` instead of the misleading `signal: killed`
- verify timeout cleanup kills only the probe-owned process group and leaves unrelated processes alive

## Diagnosis
The installed OpenCode command is a Bash launcher for a Bun/TypeScript checkout. Sequential `--version` calls took 2.39-2.65s; eight concurrent calls took 6.75-7.82s, leaving little margin under the previous 10s deadline during active daemon load. Direct invocation completed successfully, so this is resource contention rather than an OpenCode hang. Existing process-group ownership is retained unchanged.

## Verification
- `go test ./pkg/agent -run 'TestDetectVersionTimesOutOnHang|TestDetectCLIVersionWaitsForAWrapperDescendant|TestDetectCLIVersionDoesNotSalvageABannerAsTheVersion|TestDetectVersionTimeoutOnlyKillsItsProbeGroup' -count=1` — pass
- same focused suite with `-race -count=10` — pass
- `go test ./pkg/agent -count=1` — pass
- `go test -race ./pkg/agent -count=1` — pass
- clean-environment `go test ./internal/daemon -count=1` — pass
- `go vet ./pkg/agent ./internal/daemon ./cmd/multica` — pass
- Windows and Darwin `go test -c ./pkg/agent` — pass
- `make check ENV_FILE=.env.worktree` — blocked before checks because this runtime cannot access `/var/run/docker.sock`

No migration or dependency change.

Related to MINT-9.