### PR TITLE
fix(server): keep the parent workdir on codex_semantic_inactivity retries (GH #7998)

### DIFF
--- a/server/cmd/server/rerun_session_test.go
+++ b/server/cmd/server/rerun_session_test.go
@@ -552,6 +552,13 @@ func TestGetLastTaskSessionExcludesCodexSemanticInactivity(t *testing.T) {
 	}
 }
 
+// TestCreateRetryTaskFreshensCodexSemanticInactivity pins the full retry
+// contract for Codex semantic inactivity timeouts: the poisoned provider
+// session is discarded and a fresh session is forced, but the parent's
+// work_dir is retained — a resume-unsafe provider session does not imply a
+// resume-unsafe workdir (GH #7998). When the stale workdir itself is
+// unusable, the daemon's reuse validation still falls back to a fresh
+// Prepare.
 func TestCreateRetryTaskFreshensCodexSemanticInactivity(t *testing.T) {
 	if testPool == nil {
 		t.Skip("no database connection")
@@ -584,8 +591,8 @@ func TestCreateRetryTaskFreshensCodexSemanticInactivity(t *testing.T) {
 	if child.SessionID.Valid {
 		t.Fatalf("expected retry child to drop poisoned session_id, got %q", child.SessionID.String)
 	}
-	if child.WorkDir.Valid {
-		t.Fatalf("expected retry child to drop poisoned work_dir, got %q", child.WorkDir.String)
+	if !child.WorkDir.Valid || child.WorkDir.String != "/tmp/codex-stuck" {
+		t.Fatalf("expected retry child to inherit parent work_dir, got %+v", child.WorkDir)
 	}
 	if !child.ForceFreshSession {
 		t.Fatal("expected retry child to force a fresh session")

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2619,6 +2619,23 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 				)
 				resp.PriorSessionResumeUnavailable = true
 			}
+		} else if task.RetryOfTaskID.Valid && task.ForceFreshSession {
+			// Auto-retry child with a forced fresh session (codex_semantic_inactivity
+			// is the only reason CreateRetryTask sets the flag): the poisoned
+			// provider session must NOT be resumed, but the child inherits the
+			// parent's work_dir (GH #7998) — offer it so the daemon's reuse
+			// validation (shouldReusePriorWorkdir) can continue in the same
+			// filesystem/worktree while starting a fresh provider session. A
+			// resume-unsafe provider session says nothing about the filesystem;
+			// when the stale workdir fails reuse validation the daemon falls back
+			// to a fresh Prepare (best-effort, same contract as the rerun path).
+			// PriorSessionID stays empty: a forced-fresh auto-retry never resumes a
+			// session through this path. Auto-retries without the flag (e.g. plain
+			// timeout) still take the GetLastTaskSession branch below, which picks
+			// the freshest resume-safe row rather than this child's own pointer.
+			if task.WorkDir.Valid {
+				resp.PriorWorkDir = task.WorkDir.String
+			}
 		} else if !task.ForceFreshSession {
 			// Non-rerun follow-up on the same issue: resume the most recent
 			// (agent, issue) session so the agent keeps the issue's conversation

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2730,6 +2730,11 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			}
 		}
 		projectCtx.applyTo(&resp)
+		// Auto-retry children keep their filesystem even when the provider
+		// session must start fresh (codex_semantic_inactivity).
+		if task.RetryOfTaskID.Valid && task.ForceFreshSession && task.WorkDir.Valid {
+			resp.PriorWorkDir = task.WorkDir.String
+		}
 		if !task.ForceFreshSession && !task.ChannelContextRevision.Valid {
 			// Resume chat sessions only when the stored pointer was produced
 			// by the same runtime as the claiming task. When the chat_session

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3170,6 +3170,50 @@ func TestClaimTask_AutoRetryOffersParentWorkdirForFreshSession(t *testing.T) {
 	}
 }
 
+func TestClaimTask_ChatAutoRetryOffersParentWorkdirForFreshSession(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+	sessionID := dbfx.ChatSession(t, agentID, testutil.Cols{
+		"title":      "chat auto-retry workdir reuse fixture",
+		"session_id": "chat-pointer-session",
+		"work_dir":   "/tmp/chat-pointer-workdir",
+		"runtime_id": runtimeID,
+	})
+	dbfx.Insert(t, "chat_message", testutil.Cols{
+		"chat_session_id": sessionID,
+		"role":            "user",
+		"content":         "retry this chat turn",
+	})
+	parentID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id":      runtimeID,
+		"chat_session_id": sessionID,
+		"status":          "failed",
+		"failure_reason":  "codex_semantic_inactivity",
+		"session_id":      "poison-chat-session",
+		"work_dir":        "/tmp/auto-retry-chat-parent-workdir",
+	})
+	child, err := db.New(testPool).CreateRetryTask(ctx, db.CreateRetryTaskParams{ID: parseUUID(parentID)})
+	if err != nil {
+		t.Fatalf("CreateRetryTask: %v", err)
+	}
+	if uuidToString(child.ChatSessionID) != sessionID || child.WorkDir.String != "/tmp/auto-retry-chat-parent-workdir" || child.SessionID.Valid || !child.ForceFreshSession {
+		t.Fatalf("fixture child violates the chat GH #7998 row contract: chat_session=%q workdir=%q session=%v force_fresh=%v",
+			uuidToString(child.ChatSessionID), child.WorkDir.String, child.SessionID, child.ForceFreshSession)
+	}
+
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorWorkDir != "/tmp/auto-retry-chat-parent-workdir" {
+		t.Fatalf("PriorWorkDir = %q, want /tmp/auto-retry-chat-parent-workdir (inherited workdir must reach the daemon claim)", task.PriorWorkDir)
+	}
+	if task.PriorSessionID != "" {
+		t.Fatalf("PriorSessionID = %q, want empty (poisoned session is never resumed)", task.PriorSessionID)
+	}
+}
+
 func TestClaimTask_ChatPriorSessionRuntimeGuard(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3120,6 +3120,56 @@ func TestClaimTask_ManualRetryReusesWorkdir(t *testing.T) {
 	})
 }
 
+// TestClaimTask_AutoRetryOffersParentWorkdirForFreshSession is the GH #7998
+// claim-layer contract: an automatic retry child that CreateRetryTask cloned
+// from a codex_semantic_inactivity parent inherits the parent's work_dir, and
+// the claim handler must hand that pointer to the daemon as PriorWorkDir while
+// leaving PriorSessionID empty — the poisoned provider session is never
+// resumed (force_fresh_session stays true). Reuse stays best-effort: the
+// daemon's shouldReusePriorWorkdir validation may still decline and fall back
+// to a fresh Prepare. Contrast with the manual-rerun contract in
+// TestClaimTask_ManualRetryReusesWorkdir.
+func TestClaimTask_AutoRetryOffersParentWorkdirForFreshSession(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	issueID := dbfx.Issue(t, "auto-retry workdir reuse fixture", testutil.Cols{
+		"status": "in_progress",
+		"number": 81301,
+	})
+	parentID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id":     runtimeID,
+		"issue_id":       issueID,
+		"status":         "failed",
+		"failure_reason": "codex_semantic_inactivity",
+		"session_id":     "poison-session",
+		"work_dir":       "/tmp/auto-retry-parent-workdir",
+	})
+	// Production path, not a hand-built row: CreateRetryTask writes the child's
+	// retry_of_task_id lineage and inherits the parent work_dir (GH #7998), and
+	// NULL fire_at inserts an immediately-claimable 'queued' child.
+	child, err := db.New(testPool).CreateRetryTask(ctx, db.CreateRetryTaskParams{ID: parseUUID(parentID)})
+	if err != nil {
+		t.Fatalf("CreateRetryTask: %v", err)
+	}
+	if child.WorkDir.String != "/tmp/auto-retry-parent-workdir" || child.SessionID.Valid || !child.ForceFreshSession {
+		t.Fatalf("fixture child violates the GH #7998 row contract: workdir=%q session=%v force_fresh=%v",
+			child.WorkDir.String, child.SessionID, child.ForceFreshSession)
+	}
+
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorWorkDir != "/tmp/auto-retry-parent-workdir" {
+		t.Fatalf("PriorWorkDir = %q, want /tmp/auto-retry-parent-workdir (inherited workdir must reach the daemon claim)", task.PriorWorkDir)
+	}
+	if task.PriorSessionID != "" {
+		t.Fatalf("PriorSessionID = %q, want empty (poisoned session is never resumed)", task.PriorSessionID)
+	}
+}
+
 func TestClaimTask_ChatPriorSessionRuntimeGuard(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2994,7 +2994,7 @@ SELECT
     CASE WHEN p.chat_session_id IS NOT NULL THEN GREATEST(p.priority, 3) ELSE p.priority END,
     p.trigger_comment_id, p.coalesced_comment_ids, p.trigger_summary, p.context,
     CASE WHEN p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity' THEN NULL ELSE p.session_id END,
-    CASE WHEN p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity' THEN NULL ELSE p.work_dir END,
+    p.work_dir,
     p.attempt + 1, COALESCE($3::int, p.max_attempts), p.id,
     p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity',
     p.is_leader_task,
@@ -3051,7 +3051,11 @@ type CreateRetryTaskParams struct {
 // agent's resume context (session_id/work_dir) so the child can continue
 // the conversation when the backend supports it. Resume-unsafe failures are
 // retried as fresh sessions so the child does not inherit a stuck agent
-// conversation. Keep the CASE WHEN predicates in sync with
+// conversation. codex_semantic_inactivity discards only the session_id, not
+// the work_dir: a resume-unsafe provider session says nothing about the
+// filesystem, so the child keeps the parent's workdir and the daemon's reuse
+// validation falls back to a fresh Prepare when that workdir is unusable
+// (GH #7998). Keep the CASE WHEN predicates in sync with
 // resumeUnsafeFailureReason and the resume lookup blacklists. attempt is
 // incremented; max_attempts, trigger_comment_id, coalesced_comment_ids,
 // is_leader_task, and squad_id are inherited so the retried task receives the

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -502,7 +502,11 @@ WHERE id = $1 AND issue_id IS NULL
 -- agent's resume context (session_id/work_dir) so the child can continue
 -- the conversation when the backend supports it. Resume-unsafe failures are
 -- retried as fresh sessions so the child does not inherit a stuck agent
--- conversation. Keep the CASE WHEN predicates in sync with
+-- conversation. codex_semantic_inactivity discards only the session_id, not
+-- the work_dir: a resume-unsafe provider session says nothing about the
+-- filesystem, so the child keeps the parent's workdir and the daemon's reuse
+-- validation falls back to a fresh Prepare when that workdir is unusable
+-- (GH #7998). Keep the CASE WHEN predicates in sync with
 -- resumeUnsafeFailureReason and the resume lookup blacklists. attempt is
 -- incremented; max_attempts, trigger_comment_id, coalesced_comment_ids,
 -- is_leader_task, and squad_id are inherited so the retried task receives the
@@ -568,7 +572,7 @@ SELECT
     CASE WHEN p.chat_session_id IS NOT NULL THEN GREATEST(p.priority, 3) ELSE p.priority END,
     p.trigger_comment_id, p.coalesced_comment_ids, p.trigger_summary, p.context,
     CASE WHEN p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity' THEN NULL ELSE p.session_id END,
-    CASE WHEN p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity' THEN NULL ELSE p.work_dir END,
+    p.work_dir,
     p.attempt + 1, COALESCE(sqlc.narg(max_attempts)::int, p.max_attempts), p.id,
     p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity',
     p.is_leader_task,


### PR DESCRIPTION
## What does this PR do?

When a task fails with `codex_semantic_inactivity`, `CreateRetryTask` discarded the parent's provider session **and** its `work_dir` together, then forced a fresh session. The problem: that failure reason tells us the provider *session* is unsafe to resume — it says nothing about the filesystem state. A resume-unsafe session does not imply a resume-unsafe workdir, so this PR stops throwing away the user's already-progressed worktree state along with the poisoned session.

The fix keeps the existing retry semantics intact: the poisoned `session_id` is still dropped and `force_fresh_session` stays `true`, but the retry child now **inherits the parent's `work_dir`**. The claim handler is extended so an automatic retry (a `retry_of_task_id` child with `force_fresh_session`) forwards that `work_dir` to the daemon as `PriorWorkDir` with an empty `PriorSessionID` for both issue and chat tasks, so the daemon reuses the existing filesystem and starts a fresh provider session — no workdir is thrown away, and no poisoned session is resumed. When the workdir is stale or unusable, the daemon's existing reuse validation (`shouldReusePriorWorkdir` → `execenv.Reuse`) declines and falls back to a fresh `Prepare` — no new filesystem-existence check or retry logic is added.

## Related Issue

Closes https://github.com/multica-ai/multica/issues/7998

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/pkg/db/queries/agent.sql` — `CreateRetryTask`: for `codex_semantic_inactivity`, keep nulling `session_id` and forcing a fresh session, but remove the `CASE` that also nulled `work_dir` so the retry child inherits `p.work_dir`. No other failure-reason path is touched. Query doc comment updated to state the new contract.
- `server/pkg/db/generated/agent.sql.go` — regenerated via `sqlc generate` (v1.31.1); diff is confined to the SQL change above (embedded query text + doc comment).
- `server/internal/handler/daemon.go` — claim handler: issue and chat automatic-retry routes now forward the child's own `task.WorkDir` as `resp.PriorWorkDir` when `retry_of_task_id` is set and `force_fresh_session=true`, while leaving `PriorSessionID` empty. The existing `shouldReusePriorWorkdir` provenance validation and the fresh-`Prepare` fallback — and `execenv.Reuse`'s "empty means a fresh thread" rule on the empty session — are reused unchanged; manual-rerun and follow-up resume semantics are untouched.
- `server/cmd/server/rerun_session_test.go` — `TestCreateRetryTaskFreshensCodexSemanticInactivity` now asserts the full DB contract: `session_id` dropped, `work_dir` inherited (`/tmp/codex-stuck`), `force_fresh_session` true, attempt 2.
- `server/internal/handler/daemon_test.go` — issue and chat claim-layer regressions use a `codex_semantic_inactivity` parent → real `CreateRetryTask` → actual claim and assert `PriorWorkDir == parent.WorkDir` with `PriorSessionID == ""` (fresh provider session over the preserved worktree).

## How to Test

1. `cd server && make sqlc` — regenerate; confirm only `agent.sql.go` changes (LF/CRLF churn from a local Windows regeneration is not part of the diff).
2. `go vet ./...` — passes.
3. `go build ./cmd/server` — passes.
4. `go test -count=1 ./cmd/server/ -run 'TestCreateRetryTask' -v` — requires a live PostgreSQL (schema migrated to latest); both `TestCreateRetryTaskFreshensCodexSemanticInactivity` and `TestCreateRetryTaskKeepsOrdinaryTimeoutSession` pass.
5. `go test ./internal/handler -run 'TestClaimTask_(AutoRetryOffersParentWorkdirForFreshSession|ChatAutoRetryOffersParentWorkdirForFreshSession)' -count=1` — requires a live PostgreSQL; the issue and chat claim-layer regressions both pass. These cover an automatic retry parent that failed with `codex_semantic_inactivity`, a real `CreateRetryTask` child, and the final claim response (`PriorWorkDir == parent.WorkDir`, `PriorSessionID == ""`). In a live run, watch the daemon reuse the existing worktree (`shouldReusePriorWorkdir` passes so `execenv.Reuse` mounts the same workdir) while starting a fresh provider session. To sanity-check the fallback, delete the recorded workdir and repeat — the daemon declines reuse and prepares a fresh environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (multi-agent: worker-opencode implementation, Worker-codex independent cross-check, cheap-models pre-flight/review)

**Prompt / approach:**
Implementation spec (upstream #7998) was executed as a minimal production change: drop the `work_dir` CASE in `CreateRetryTask` (keep `session_id` NULL + `force_fresh_session`), then extend the claim handler's issue and chat automatic-retry routes to forward the child's preserved `work_dir` as `PriorWorkDir` with an empty `PriorSessionID`, so the daemon reuses the worktree and starts a fresh provider session. `sqlc` regenerated the binding; the existing DB-level regression test was flipped to pin the new contract and issue/chat claim-layer regressions prove the workdir flows into the daemon on automatic retries. Two independent agents cross-checked the diff, SQL semantics, generated output, test results and the daemon reuse-path trace; maintainer re-review was requested after that cross-check.
