### PR TITLE
fix(codex): force the supported remote compaction path

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -34,9 +34,11 @@ var codexBlockedArgs = map[string]blockedArgMode{
 }
 
 const (
-	codexFastServiceTier     = "priority"
-	codexStandardServiceTier = "default"
-	codexFastModeFeature     = "fast_mode"
+	codexFastServiceTier              = "priority"
+	codexStandardServiceTier          = "default"
+	codexFastModeFeature              = "fast_mode"
+	codexRemoteCompactionV2Feature    = "remote_compaction_v2"
+	minCodexRemoteCompactionV2Version = "0.146.0"
 )
 
 // codexStderrTailBytes bounds the stderr tail captured for inclusion in
@@ -339,12 +341,39 @@ func enforceCodexFastMode(args []string, logger *slog.Logger) []string {
 // prefix unfiltered would let a profile override the tier the agent explicitly
 // selected, inverting the precedence this package promises (GH #7046).
 func stripCodexFastModeConflicts(args []string, logger *slog.Logger) []string {
-	args = filterCodexConfigOverrides(
+	return stripCodexFeatureConflicts(
 		args,
+		codexFastModeFeature,
 		codexManagedFastModeConfigKeyRe,
-		"features.fast_mode",
 		logger,
 	)
+}
+
+// enforceCodexRemoteCompactionV2 keeps daemon-managed Codex tasks off the
+// retired /responses/compact endpoint. A stale user config with this feature
+// disabled is copied into the isolated task home and makes current Codex
+// releases fail every automatic compaction with 404 (GH #8000,
+// openai/codex#42468). The override is process-local: the shared user config is
+// never changed.
+func enforceCodexRemoteCompactionV2(args []string, logger *slog.Logger) []string {
+	return append(
+		stripCodexFeatureConflicts(
+			args,
+			codexRemoteCompactionV2Feature,
+			codexManagedRemoteCompactionV2ConfigKeyRe,
+			logger,
+		),
+		"--enable", codexRemoteCompactionV2Feature,
+	)
+}
+
+func stripCodexFeatureConflicts(
+	args []string,
+	feature string,
+	configKeyRe *regexp.Regexp,
+	logger *slog.Logger,
+) []string {
+	args = filterCodexConfigOverrides(args, configKeyRe, "features."+feature, logger)
 	filtered := make([]string, 0, len(args)+2)
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -360,10 +389,10 @@ func stripCodexFastModeConflicts(args []string, logger *slog.Logger) []string {
 			if !hasInlineValue && i+1 < len(args) {
 				value = args[i+1]
 			}
-			if value == codexFastModeFeature {
+			if value == feature {
 				if logger != nil {
 					logger.Warn("codex: ignored lower-priority feature disable",
-						"feature", codexFastModeFeature)
+						"feature", feature)
 				}
 				if !hasInlineValue {
 					i++
@@ -394,6 +423,9 @@ var codexManagedMcpConfigKeyRe = regexp.MustCompile(`^\s*mcp_servers(?:\s*\.|\s*
 
 var codexManagedFastModeConfigKeyRe = regexp.MustCompile(
 	`^\s*features\s*\.\s*fast_mode\s*(?:=|$)`)
+
+var codexManagedRemoteCompactionV2ConfigKeyRe = regexp.MustCompile(
+	`^\s*features\s*\.\s*remote_compaction_v2\s*(?:=|$)`)
 
 // A daemon-managed shell_environment_policy must also win over profile and
 // custom-arg overrides. Match root and profile policy keys without catching an
@@ -1018,6 +1050,21 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		})
 	}
 	codexArgs := buildCodexArgs(opts, b.cfg.Logger)
+	// remote_compaction_v2 is a Codex-specific compatibility switch, so never
+	// inject it into a custom executable that merely declares protocol_family
+	// codex. Version-gating also keeps the unknown flag away from older Codex
+	// releases that predate the stable v2 implementation.
+	if b.cfg.BuiltinRuntime && codexVersionAtLeast(b.cfg.CodexVersion, minCodexRemoteCompactionV2Version) {
+		runtimeCmd = runtimeCmd.withFilteredPrefix(func(prefix []string) []string {
+			return stripCodexFeatureConflicts(
+				prefix,
+				codexRemoteCompactionV2Feature,
+				codexManagedRemoteCompactionV2ConfigKeyRe,
+				b.cfg.Logger,
+			)
+		})
+		codexArgs = enforceCodexRemoteCompactionV2(codexArgs, b.cfg.Logger)
+	}
 	cmd := runtimeCmd.exec(runCtx, codexArgs...)
 	hideAgentWindow(cmd)
 	// Run codex in its own process group so a cancel-on-stuck cleanup

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -4350,6 +4350,46 @@ func TestBuildCodexArgsFutureServiceTierDoesNotForceFastMode(t *testing.T) {
 	}
 }
 
+func TestEnforceCodexRemoteCompactionV2OverridesStaleConfig(t *testing.T) {
+	t.Parallel()
+
+	args := []string{
+		"app-server", "--listen", "stdio://",
+		"--disable", codexRemoteCompactionV2Feature,
+		"--disable", "memories",
+		"-c", "features.remote_compaction_v2=false",
+		"-c", "features.memories=false",
+	}
+
+	want := []string{
+		"app-server", "--listen", "stdio://",
+		"--disable", "memories",
+		"-c", "features.memories=false",
+		"--enable", codexRemoteCompactionV2Feature,
+	}
+	if got := enforceCodexRemoteCompactionV2(args, slog.Default()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("enforceCodexRemoteCompactionV2 = %v, want %v", got, want)
+	}
+}
+
+func TestCodexRemoteCompactionV2VersionFloor(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		version string
+		want    bool
+	}{
+		{version: "0.145.9", want: false},
+		{version: "0.146.0", want: true},
+		{version: "codex-cli 0.153.0-alpha.5", want: true},
+		{version: "unknown", want: false},
+	} {
+		if got := codexVersionAtLeast(tc.version, minCodexRemoteCompactionV2Version); got != tc.want {
+			t.Errorf("codexVersionAtLeast(%q, %q) = %v, want %v", tc.version, minCodexRemoteCompactionV2Version, got, tc.want)
+		}
+	}
+}
+
 func TestBuildCodexArgsDoesNotLeakMcpToArgv(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- force `remote_compaction_v2` for daemon-managed built-in Codex versions that support it
- remove lower-priority launch-prefix and argument overrides that would re-enable the retired `/responses/compact` path
- leave custom Codex-compatible executables, older Codex versions, and the shared user config untouched
- add focused regression coverage for stale config overrides and the supported version floor

Fixes #8000

Upstream context: openai/codex#42468

## Test plan

- `go test ./pkg/agent -run 'TestEnforceCodexRemoteCompactionV2OverridesStaleConfig|TestCodexRemoteCompactionV2VersionFloor|TestBuildCodexArgsExplicitFastOverridesLowerPriorityDisable' -count=1`\n- `go test ./pkg/agent -count=1`\n- `go vet ./pkg/agent`\n- `go test ./internal/daemon -run '^$' -count=1`\n- `codex app-server --listen stdio:// --enable remote_compaction_v2 --help`