### PR TITLE
MUL-7038: fix(repocache): restore resolved base commit before isolated checkout

### DIFF
--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -1110,6 +1110,13 @@ func createIsolatedCheckoutContext(ctx context.Context, barePath, repoURL, check
 		}
 	}
 
+	// Enforce the resolved-base-commit invariant before the detached checkout:
+	// the fresh clone's object store must contain the commit that was resolved
+	// from the shared cache before the clone started (multica-ai/multica#8011).
+	if err := ensureBaseCommitInCheckoutContext(ctx, barePath, checkoutPath, baseRef, baseCommit); err != nil {
+		return "", err
+	}
+
 	if out, err := runGitCombinedOutputContext(ctx, "-C", checkoutPath, "checkout", "--detach", baseCommit); err != nil {
 		return "", fmt.Errorf("git checkout --detach: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -1129,6 +1136,41 @@ func createIsolatedCheckoutContext(ctx context.Context, barePath, repoURL, check
 	}
 	cleanup = false
 	return actualBranch, nil
+}
+
+// ensureBaseCommitInCheckoutContext verifies that a fresh isolated checkout's object
+// store contains the commit resolved from the shared bare cache before the
+// clone started, and performs a bounded local recovery when it does not.
+//
+// The healthy path is a single `rev-parse --verify`: a `git clone --local`
+// from a full cache hard-links the whole object store, so the commit is there
+// and nothing else happens. When the cache is shallow, Git ignores --local
+// and clones over the pack protocol instead; such a clone transfers only the
+// objects reachable from the heads it fetches (refs/heads/*), so a freshly
+// fetched tip that arrived through the remote-tracking refspec
+// (refs/remotes/origin/*) can be missing even though it resolved in the
+// cache a moment earlier (multica-ai/multica#8011).
+//
+// Recovery fetches exactly baseRef from the local bare cache — never the
+// network origin, never a wider refspec, no cache mutation — into FETCH_HEAD
+// only. Object transfer alone is sufficient because the caller checks out
+// baseCommit by SHA. If the local cache cannot serve the commit either, fail
+// loudly instead of falling back: a shallow cache's stale refs/heads/* head
+// must never be checked out in place of the resolved base commit.
+func ensureBaseCommitInCheckoutContext(ctx context.Context, barePath, checkoutPath, baseRef, baseCommit string) error {
+	if gitRefExistsContext(ctx, checkoutPath, baseCommit+"^{commit}") {
+		return nil
+	}
+	out, err := runGitCombinedOutputContext(ctx, "-C", checkoutPath, "fetch", "--no-tags", barePath, baseRef)
+	if err != nil {
+		return fmt.Errorf("isolated checkout is missing resolved base commit %s (shallow cache at %s): recovery fetch of %s failed: %s: %w",
+			baseCommit, barePath, baseRef, strings.TrimSpace(string(out)), err)
+	}
+	if !gitRefExistsContext(ctx, checkoutPath, baseCommit+"^{commit}") {
+		return fmt.Errorf("isolated checkout is still missing resolved base commit %s after recovery fetch of %s from cache %s; refusing to check out a stale commit instead",
+			baseCommit, baseRef, barePath)
+	}
+	return nil
 }
 
 func resolveCommit(repoPath, ref string) (string, error) {

--- a/server/internal/daemon/repocache/shallow_cache_test.go
+++ b/server/internal/daemon/repocache/shallow_cache_test.go
@@ -1,0 +1,153 @@
+package repocache
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCreateIsolatedCheckoutFromShallowCacheResolvesFetchedTip reproduces
+// multica-ai/multica#8011: an isolated checkout created from a shallow shared
+// cache loses the commit CreateWorktree just resolved as its base.
+//
+// The shared cache below has the reported topology: it is shallow, its stale
+// refs/heads/master still points at commit A, and the freshly fetched tip B is
+// reachable only through refs/remotes/origin/master. `git clone --local` from
+// a shallow source is silently downgraded to a transport-based clone, which
+// transfers only the objects reachable from the heads it fetches
+// (refs/heads/*) — so B is absent from the fresh checkout and the subsequent
+// `git checkout --detach B` fails (reported as "reference is not a tree";
+// "unable to read tree" on newer Git).
+func TestCreateIsolatedCheckoutFromShallowCacheResolvesFetchedTip(t *testing.T) {
+	t.Parallel()
+
+	// A bare origin plus a working clone: commit A, then advance origin/master
+	// with commit B after the shallow cache snapshot was taken.
+	originDir := filepath.Join(t.TempDir(), "origin.git")
+	workDir := filepath.Join(t.TempDir(), "work")
+	seed := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git setup %v failed: %s: %v", args, out, err)
+		}
+	}
+	seed("init", workDir)
+	// `* -text` pins byte-exact working-tree content regardless of the local
+	// core.autocrlf, so the assertions below hold on every platform.
+	if err := os.WriteFile(filepath.Join(workDir, ".gitattributes"), []byte("* -text\n"), 0o644); err != nil {
+		t.Fatalf("write .gitattributes: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "a.txt"), []byte("contents of a.txt\n"), 0o644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	seed("-C", workDir, "add", ".gitattributes", "a.txt")
+	seed("-C", workDir, "commit", "-m", "commit A")
+	seed("-C", workDir, "branch", "-M", "master")
+	// The bare origin is a plain-path full clone — only the cache seed below
+	// needs a shallow fetch. `--depth` is honored only over the pack protocol
+	// (a plain path takes the local hardlink shortcut and drops the depth
+	// silently), so that one clone has to go through file:// with an
+	// all-forward-slash URL.
+	originURL := "file://" + filepath.ToSlash(originDir)
+	if !strings.HasPrefix(filepath.ToSlash(originDir), "/") {
+		originURL = "file:///" + filepath.ToSlash(originDir)
+	}
+	seed("clone", "--bare", "--", workDir, originDir)
+
+	// The workspace registers the repository by a canonical remote URL instead
+	// of the local origin path: a file:// URL carrying a Windows drive letter
+	// would give bareDirName a "C:" path segment, which no filesystem accepts
+	// as a directory name. The canonical URL is never contacted — every fetch
+	// in this test flows through the daemon-owned cache or the local paths.
+	repoURL := "https://shallow-test.local/origin.git"
+
+	// Seed the shared bare cache as a depth-1 shallow clone, then convert it to
+	// the modern remote-tracking layout — the two steps Cache.Sync performs on
+	// a cold miss.
+	cache := New(t.TempDir(), testLogger())
+	barePath := filepath.Join(cache.root, "ws-1", bareDirName(repoURL))
+	if err := os.MkdirAll(filepath.Dir(barePath), 0o755); err != nil {
+		t.Fatalf("create workspace cache dir: %v", err)
+	}
+	seed("clone", "--bare", "--depth=1", "--", originURL, barePath)
+	if err := ensureRemoteTrackingLayout(barePath); err != nil {
+		t.Fatalf("ensure refspec: %v", err)
+	}
+
+	// Advance origin/master with commit B and fetch it through the same
+	// cache-fetch path CreateWorktree uses.
+	commitA := gitHead(t, workDir)
+	if err := os.WriteFile(filepath.Join(workDir, "b.txt"), []byte("contents of b.txt\n"), 0o644); err != nil {
+		t.Fatalf("write b.txt: %v", err)
+	}
+	runGitAuthored(t, workDir, "add", "b.txt")
+	runGitAuthored(t, workDir, "commit", "-m", "commit B")
+	commitB := gitHead(t, workDir)
+	runGitAuthored(t, workDir, "push", originDir, "master:master")
+	if err := cache.Fetch(barePath); err != nil {
+		t.Fatalf("cache fetch: %v", err)
+	}
+
+	// Mandatory preconditions: the assertions below must exercise the exact
+	// #8011 topology, not an accidental generic checkout setup.
+	if shallow, err := runGitOutput("-C", barePath, "rev-parse", "--is-shallow-repository"); err != nil || strings.TrimSpace(string(shallow)) != "true" {
+		t.Fatalf("precondition: shared cache must be shallow, got %q err=%v", shallow, err)
+	}
+	if got := gitRefCommit(t, barePath, "refs/heads/master"); got != commitA {
+		t.Fatalf("precondition: refs/heads/master = %s, want stale head %s", got, commitA)
+	}
+	if got := gitRefCommit(t, barePath, "refs/remotes/origin/master"); got != commitB {
+		t.Fatalf("precondition: refs/remotes/origin/master = %s, want fetched tip %s", got, commitB)
+	}
+	if commitA == commitB {
+		t.Fatal("precondition: stale head and fetched tip must be distinct commits")
+	}
+	if err := runGit("-C", barePath, "rev-parse", "--verify", commitB+"^{commit}"); err != nil {
+		t.Fatalf("precondition: fetched tip %s must resolve in the bare cache: %v", commitB, err)
+	}
+
+	// The production path used by Linux/Windows Codex isolated checkouts.
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID:         "ws-1",
+		RepoURL:             repoURL,
+		WorkDir:             t.TempDir(),
+		AgentName:           "Linux Codex",
+		TaskID:              "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		IsolatedGitMetadata: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+
+	// The resolved base commit must have survived the clone.
+	if got := gitHead(t, result.Path); got != commitB {
+		t.Fatalf("isolated checkout HEAD = %s, want fetched tip %s", got, commitB)
+	}
+	content, err := os.ReadFile(filepath.Join(result.Path, "b.txt"))
+	if err != nil {
+		t.Fatalf("read b.txt from isolated checkout: %v", err)
+	}
+	if got, want := string(content), "contents of b.txt\n"; got != want {
+		t.Fatalf("b.txt = %q, want %q", got, want)
+	}
+
+	// The recovery pulls the object from the local cache without rewriting the
+	// shared cache's stale head.
+	if got := gitRefCommit(t, barePath, "refs/heads/master"); got != commitA {
+		t.Fatalf("shared cache refs/heads/master was rewritten by the recovery: got %s, want %s", got, commitA)
+	}
+	origin, err := runGitOutput("-C", result.Path, "remote", "get-url", "origin")
+	if err != nil {
+		t.Fatalf("get origin URL: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(origin)), repoURL; got != want {
+		t.Fatalf("origin URL = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

`Cache.CreateWorktree` with `IsolatedGitMetadata: true` can silently lose the commit it just resolved as its base when the shared bare cache is shallow. With a shallow source, Git ignores `git clone --local` and clones over the pack protocol instead; such a clone transfers only the objects reachable from the heads it fetches (`refs/heads/*`), so a tip that arrived through the cache's remote-tracking refspec (`refs/remotes/origin/*`) is absent from the fresh checkout even though it resolved in the cache moments earlier. The subsequent `git checkout --detach <sha>` then fails with `fatal: reference is not a tree` / `unable to read tree` (multica-ai/multica#8011).

This change makes isolated checkout creation enforce the resolved-base-commit invariant: after the clone and before the detached checkout, the checkout's object store must actually contain the resolved base commit; if it does not, fetch exactly the resolved ref from the local bare cache and re-verify. Recovery is bounded to the requested base ref, and the failure mode refuses to substitute the stale head.

**Non-goals** (intentionally out of scope for this PR):

- No cache policy change — how the shared cache originally became shallow is not investigated or changed here
- No full unshallow — caches are not unshallowed as part of this fix
- No refspec widening — the isolated checkout's standing fetch refspec is unchanged
- No shared-cache ref rewrite — the cache's stale `refs/heads/*` head is left untouched
- No UI / schema change — no user-facing, API, or database surface is touched

## Related Issue

Fixes #8011

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/repocache/cache.go`: new `ensureBaseCommitInCheckoutContext` — called from `createIsolatedCheckoutContext` directly before `git checkout --detach <baseCommit>`. It verifies the fresh clone's object store contains the resolved base commit with a single `rev-parse --verify <sha>^{commit}` (one cheap call on the healthy path, where `--local` hard-links the full object store, so healthy behavior is unchanged). If the commit is missing, it fetches exactly the resolved ref from the **local bare cache** (`git fetch --no-tags <cache> <baseRef>` — single ref, FETCH_HEAD only; no network origin, no shared-cache ref rewrite, no unshallow, no refspec widening) and re-verifies. If the local cache cannot serve the commit either, it fails loudly with an error that names the resolved commit, the shallow cache path, and the failed recovery — it never falls back to the stale head.
- `server/internal/daemon/repocache/shallow_cache_test.go`: new regression test reproducing the exact stale-head/shallow-cache topology from #8011: bare origin → working clone → commit A → shared bare cache seeded as a depth-1 shallow clone → modern remote-tracking layout → advance `origin/master` with commit B → fetch through the production cache-fetch path. Mandatory preconditions are asserted before the code under test runs (cache is shallow; `refs/heads/master == A`; `refs/remotes/origin/master == B`; `B != A`; `B^{commit}` resolvable in the cache). The real `CreateWorktree(IsolatedGitMetadata: true)` path (the mode exercised by Linux/Windows Codex isolated checkouts) is used, and the assertions cover: the operation succeeds; checkout HEAD == B; the content introduced by B is visible; and the shared cache's stale `refs/heads/master` was **not** rewritten by the repair. The test fails on unmodified upstream `main` at `git checkout --detach` with the missing commit and passes with this change.

## How to Test

1. From `server/`: `go test ./internal/daemon/repocache/ -run 'TestCreateIsolatedCheckoutFromShallowCacheResolvesFetchedTip' -count=1 -v` — fails on unmodified `main`, passes with this change.
2. `go vet ./internal/daemon/repocache/...`
3. `git diff --check`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (focused regression suite; the 6 tests failing on this Windows host fail identically on unmodified `main` — pre-existing Windows-only `MAX_PATH` test-infra issue, unrelated to this PR; CI runs this package on ubuntu/macos)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (no UI change)
- [ ] I have updated relevant documentation to reflect my changes (no docs changed)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (worker-opencode + multica-agent)

**Prompt / approach:** The worker-opencode coding agent, orchestrated by multica-agent in a Multica workspace, developed this fix against upstream `main`: it first reproduced the #8011 topology with a deterministic local-only regression test and captured the pre-fix failure at the real production path (`CreateWorktree` with `IsolatedGitMetadata: true` fails at `git checkout --detach` on the just-resolved fetched tip), then applied the minimal patch enforcing the resolved-base-commit invariant with a bounded single-ref local recovery fetch. `go vet ./internal/daemon/repocache/...`, the focused regression suite, and `git diff --check` were run locally on the PR head; the change was then cross-validated by a second worker and an independent pre-flight check comparing the PR head with unmodified main (test PASS on head, FAIL on main).
