### PR TITLE
MUL-7016: Route daemon workspace sync reads to replica

### DIFF
--- a/server/internal/dbreader/selector.go
+++ b/server/internal/dbreader/selector.go
@@ -28,8 +28,9 @@ type Business struct {
 }
 
 var (
-	BusinessDashboard = Business{label: "dashboard"}
-	businessUnknown   = Business{label: "unknown"}
+	BusinessDashboard        = Business{label: "dashboard"}
+	BusinessDaemonWorkspaces = Business{label: "daemon_workspaces"}
+	businessUnknown          = Business{label: "unknown"}
 )
 
 type Consistency string

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
+	"github.com/multica-ai/multica/server/internal/dbreader"
 	"github.com/multica-ai/multica/server/internal/issuestatus"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -25,6 +27,20 @@ import (
 	"github.com/multica-ai/multica/server/pkg/protocol"
 	"github.com/multica-ai/multica/server/pkg/remotemcp"
 )
+
+type daemonWorkspaceReadRoute struct {
+	business string
+	role     string
+	reason   string
+}
+
+type daemonWorkspaceReadRecorder struct {
+	routes []daemonWorkspaceReadRoute
+}
+
+func (r *daemonWorkspaceReadRecorder) RecordReadRoute(business, role, reason string) {
+	r.routes = append(r.routes, daemonWorkspaceReadRoute{business: business, role: role, reason: reason})
+}
 
 // slowProbeLocalSkillListStore wraps a LocalSkillListStore but blocks inside
 // HasPending until the provided context is cancelled. PopPending delegates
@@ -152,6 +168,46 @@ func TestListDaemonWorkspaces_DaemonTokenIsWorkspaceScoped(t *testing.T) {
 	w.JSON(&workspaces)
 	if len(workspaces) != 1 || workspaces[0].ID != testWorkspaceID {
 		t.Fatalf("daemon-token workspaces = %+v, want only %s", workspaces, testWorkspaceID)
+	}
+}
+
+func TestListDaemonWorkspacesUsesReplicaForBothAuthScopes(t *testing.T) {
+	tests := []struct {
+		name string
+		req  func() *http.Request
+	}{
+		{
+			name: "user token",
+			req: func() *http.Request {
+				return newRequest(http.MethodGet, "/api/daemon/workspaces", nil)
+			},
+		},
+		{
+			name: "daemon token",
+			req: func() *http.Request {
+				return newDaemonTokenRequest(http.MethodGet, "/api/daemon/workspaces", nil, testWorkspaceID, "daemon-test")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &daemonWorkspaceReadRecorder{}
+			h := *testHandler
+			queries := db.New(testPool)
+			h.ReadSelector = dbreader.New(queries, queries, recorder)
+
+			testutil.Call(t, h.ListDaemonWorkspaces, tt.req()).Want(http.StatusOK)
+
+			want := []daemonWorkspaceReadRoute{{
+				business: "daemon_workspaces",
+				role:     "replica",
+				reason:   "replica_selected",
+			}}
+			if !reflect.DeepEqual(recorder.routes, want) {
+				t.Fatalf("read routes = %+v, want %+v", recorder.routes, want)
+			}
+		})
 	}
 }
 

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -18,7 +17,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
-	"github.com/multica-ai/multica/server/internal/dbreader"
 	"github.com/multica-ai/multica/server/internal/issuestatus"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -27,20 +25,6 @@ import (
 	"github.com/multica-ai/multica/server/pkg/protocol"
 	"github.com/multica-ai/multica/server/pkg/remotemcp"
 )
-
-type daemonWorkspaceReadRoute struct {
-	business string
-	role     string
-	reason   string
-}
-
-type daemonWorkspaceReadRecorder struct {
-	routes []daemonWorkspaceReadRoute
-}
-
-func (r *daemonWorkspaceReadRecorder) RecordReadRoute(business, role, reason string) {
-	r.routes = append(r.routes, daemonWorkspaceReadRoute{business: business, role: role, reason: reason})
-}
 
 // slowProbeLocalSkillListStore wraps a LocalSkillListStore but blocks inside
 // HasPending until the provided context is cancelled. PopPending delegates
@@ -168,46 +152,6 @@ func TestListDaemonWorkspaces_DaemonTokenIsWorkspaceScoped(t *testing.T) {
 	w.JSON(&workspaces)
 	if len(workspaces) != 1 || workspaces[0].ID != testWorkspaceID {
 		t.Fatalf("daemon-token workspaces = %+v, want only %s", workspaces, testWorkspaceID)
-	}
-}
-
-func TestListDaemonWorkspacesUsesReplicaForBothAuthScopes(t *testing.T) {
-	tests := []struct {
-		name string
-		req  func() *http.Request
-	}{
-		{
-			name: "user token",
-			req: func() *http.Request {
-				return newRequest(http.MethodGet, "/api/daemon/workspaces", nil)
-			},
-		},
-		{
-			name: "daemon token",
-			req: func() *http.Request {
-				return newDaemonTokenRequest(http.MethodGet, "/api/daemon/workspaces", nil, testWorkspaceID, "daemon-test")
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			recorder := &daemonWorkspaceReadRecorder{}
-			h := *testHandler
-			queries := db.New(testPool)
-			h.ReadSelector = dbreader.New(queries, queries, recorder)
-
-			testutil.Call(t, h.ListDaemonWorkspaces, tt.req()).Want(http.StatusOK)
-
-			want := []daemonWorkspaceReadRoute{{
-				business: "daemon_workspaces",
-				role:     "replica",
-				reason:   "replica_selected",
-			}}
-			if !reflect.DeepEqual(recorder.routes, want) {
-				t.Fatalf("read routes = %+v, want %+v", recorder.routes, want)
-			}
-		})
 	}
 }
 

--- a/server/internal/handler/daemon_workspace.go
+++ b/server/internal/handler/daemon_workspace.go
@@ -1,13 +1,16 @@
 package handler
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/dbreader"
 	"github.com/multica-ai/multica/server/internal/middleware"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 type DaemonWorkspaceResponse struct {
@@ -18,11 +21,21 @@ type DaemonWorkspaceResponse struct {
 // ListDaemonWorkspaces returns the minimal workspace membership projection
 // needed by local daemons. User-scoped PAT/JWT callers receive every workspace
 // they belong to; workspace-scoped daemon tokens receive only their bound
-// workspace.
+// workspace. This reconciliation read is eventual-consistency safe: daemons
+// repeat it on hints and timers, and downstream daemon APIs authorize their own
+// requests instead of treating this response as an admission decision.
 func (h *Handler) ListDaemonWorkspaces(w http.ResponseWriter, r *http.Request) {
 	var resp []DaemonWorkspaceResponse
 	if userID := requestUserID(r); userID != "" {
-		rows, err := h.Queries.ListDaemonWorkspaces(r.Context(), parseUUID(userID))
+		rows, err := dbreader.Read(
+			r.Context(),
+			h.ReadSelector,
+			dbreader.BusinessDaemonWorkspaces,
+			dbreader.EventualConsistency,
+			func(ctx context.Context, q *db.Queries) ([]db.ListDaemonWorkspacesRow, error) {
+				return q.ListDaemonWorkspaces(ctx, parseUUID(userID))
+			},
+		)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to list daemon workspaces")
 			return
@@ -37,7 +50,15 @@ func (h *Handler) ListDaemonWorkspaces(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusUnauthorized, "daemon workspace identity required")
 			return
 		}
-		row, err := h.Queries.GetDaemonWorkspace(r.Context(), parseUUID(workspaceID))
+		row, err := dbreader.Read(
+			r.Context(),
+			h.ReadSelector,
+			dbreader.BusinessDaemonWorkspaces,
+			dbreader.EventualConsistency,
+			func(ctx context.Context, q *db.Queries) (db.GetDaemonWorkspaceRow, error) {
+				return q.GetDaemonWorkspace(ctx, parseUUID(workspaceID))
+			},
+		)
 		if err != nil {
 			writeError(w, http.StatusNotFound, "workspace not found")
 			return


### PR DESCRIPTION
## Summary

- route the Daemon's `GET /api/daemon/workspaces` reconciliation reads through the replica-aware selector
- register a bounded `daemon_workspaces` routing label
- cover both user-scoped and workspace-scoped daemon authentication branches

## Safety

Authentication still completes before the handler, and downstream Daemon APIs continue to authorize their own requests. Replica lag can delay workspace-set reconciliation, but it is retried by WebSocket hints and the periodic sync. Deployments without a replica keep using primary, and replica availability failures fall back to primary inside `dbreader`.

## Tests

- `go test ./internal/dbreader -count=1`
- `go test ./internal/handler -run '^TestListDaemonWorkspaces' -count=1`
- `env -u MULTICA_TASK_CONFIG_ROOT -u MULTICA_TASK_WORKSPACES_ROOT go test ./internal/daemon -count=1`
- `go vet ./internal/dbreader ./internal/handler ./internal/daemon`
- `go build ./...`

The full local handler suite is currently blocked by an existing stale test database schema (for example, missing `conversation_starters` and `durable_work_dir` columns); the focused handler tests above pass.
