### PR TITLE
MUL-7046: Gate deferred promotion polling

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1270,6 +1270,9 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	// verdict cannot represent a claim response lost after commit. Missing or
 	// failed Redis state keeps the historical PostgreSQL fallback.
 	h.TaskService.ReclaimCheck = service.NewReclaimCheckCache(rdb)
+	// Deferred promotion follows the same advisory-schedule pattern: Redis can
+	// skip impossible work, while missing/error state preserves DB promotion.
+	h.TaskService.DeferredPromotionCheck = service.NewDeferredPromotionCheckCache(rdb)
 
 	// Wire WS heartbeat after stores are finalized so the WS path uses the
 	// same (possibly Redis-backed) stores as the HTTP path.

--- a/server/internal/service/deferred_promotion_check_cache.go
+++ b/server/internal/service/deferred_promotion_check_cache.go
@@ -1,0 +1,264 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	deferredPromotionCheckSchedulePrefix = "mul:claim:runtime:deferred-promotion-schedule:"
+	deferredPromotionCheckBackstopPrefix = "mul:claim:runtime:deferred-promotion-backstop:"
+	deferredPromotionCheckRetryBatchSize = 256
+
+	// Match the existing empty-claim safety net: enqueue-time hints normally
+	// schedule the exact fire_at deadline, while this bounds a missed write or
+	// rolling-deploy gap without restoring two SQL statements on every poll.
+	DeferredPromotionCheckBackstopInterval = EmptyClaimCacheTTL
+	// A due task that remains deferred because its runtime or issue+agent slot is
+	// temporarily ineligible is retried at the daemon's normal polling cadence.
+	DeferredPromotionCheckRetryInterval = 30 * time.Second
+	// Track gives every schedule at least two backstop windows after its latest
+	// known deadline. Longer-lived deferred tasks receive a correspondingly
+	// longer TTL so their hints cannot expire before fire_at.
+	DeferredPromotionCheckMinScheduleTTL = 2 * DeferredPromotionCheckBackstopInterval
+)
+
+// These scripts intentionally use only Redis 2.6-era primitives, matching
+// ReclaimCheckCache's self-hosted compatibility floor.
+const deferredPromotionCheckTrackScript = `
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
+local current_ttl = redis.call('PTTL', KEYS[1])
+if current_ttl < tonumber(ARGV[3]) then
+    redis.call('PEXPIRE', KEYS[1], ARGV[3])
+end
+return 1
+`
+
+const deferredPromotionCheckDeferDueScript = `
+local members = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1], 'LIMIT', '0', ARGV[3])
+for _, member in ipairs(members) do
+    redis.call('ZADD', KEYS[1], ARGV[2], member)
+end
+return #members
+`
+
+// DeferredPromotionCheckCache keeps claim polling from issuing the cancel and
+// promote-deferred statements when no task can have reached fire_at yet.
+//
+// Each runtime owns a sorted set of deferred task IDs scored by fire_at. A
+// separate last-checked timestamp forces a periodic PostgreSQL reconciliation
+// for pre-deployment rows, rolling deploys, or a missed enqueue-time write.
+// PostgreSQL remains authoritative for promotion eligibility; missing state and
+// Redis errors always mean "check PostgreSQL now".
+type DeferredPromotionCheckCache struct {
+	rdb *redis.Client
+}
+
+func NewDeferredPromotionCheckCache(rdb *redis.Client) *DeferredPromotionCheckCache {
+	if rdb == nil {
+		return nil
+	}
+	return &DeferredPromotionCheckCache{rdb: rdb}
+}
+
+func deferredPromotionCheckScheduleKey(runtimeID string) string {
+	return deferredPromotionCheckSchedulePrefix + runtimeID
+}
+
+func deferredPromotionCheckBackstopKey(runtimeID string) string {
+	return deferredPromotionCheckBackstopPrefix + runtimeID
+}
+
+func (c *DeferredPromotionCheckCache) bounded(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, emptyClaimRedisTimeout)
+}
+
+// DueRuntimeIDs returns runtimes with a due task hint or elapsed backstop while
+// preserving input order. A nil cache, missing/malformed backstop, or Redis
+// failure fails open. Batch callers use any due member to check their complete
+// machine-level runtime set so fixed SQL costs and backstops stay aligned.
+func (c *DeferredPromotionCheckCache) DueRuntimeIDs(ctx context.Context, runtimeIDs []string, now time.Time) []string {
+	due, _ := c.dueRuntimeIDs(ctx, runtimeIDs, now)
+	return due
+}
+
+// dueRuntimeIDs also reports whether Redis answered the complete decision.
+// Claim paths use that bit to avoid adding a reconciliation SELECT while Redis
+// is unavailable: the fail-open path must cost no more SQL than it did before
+// the cache existed.
+func (c *DeferredPromotionCheckCache) dueRuntimeIDs(ctx context.Context, runtimeIDs []string, now time.Time) ([]string, bool) {
+	if len(runtimeIDs) == 0 {
+		return nil, false
+	}
+	validRuntimeIDs := make([]string, 0, len(runtimeIDs))
+	for _, runtimeID := range runtimeIDs {
+		if runtimeID != "" {
+			validRuntimeIDs = append(validRuntimeIDs, runtimeID)
+		}
+	}
+	if len(validRuntimeIDs) == 0 {
+		return nil, false
+	}
+	if c == nil {
+		return validRuntimeIDs, false
+	}
+
+	bctx, cancel := c.bounded(ctx)
+	defer cancel()
+	backstopKeys := make([]string, 0, len(validRuntimeIDs))
+	for _, runtimeID := range validRuntimeIDs {
+		backstopKeys = append(backstopKeys, deferredPromotionCheckBackstopKey(runtimeID))
+	}
+	backstops, err := c.rdb.MGet(bctx, backstopKeys...).Result()
+	if err != nil {
+		slog.Warn("deferred_promotion_check_cache: backstop read failed; falling back to DB", "error", err)
+		return validRuntimeIDs, false
+	}
+	if len(backstops) != len(validRuntimeIDs) {
+		slog.Warn("deferred_promotion_check_cache: incomplete backstop read; falling back to DB")
+		return validRuntimeIDs, false
+	}
+
+	nowMillis := now.UnixMilli()
+	type scheduleCommand struct {
+		index int
+		count *redis.IntCmd
+	}
+	due := make([]bool, len(validRuntimeIDs))
+	pipe := c.rdb.Pipeline()
+	scheduleCommands := make([]scheduleCommand, 0, len(validRuntimeIDs))
+	for i, runtimeID := range validRuntimeIDs {
+		backstop, ok := backstops[i].(string)
+		if !ok {
+			due[i] = true
+			continue
+		}
+		checkedMillis, err := strconv.ParseInt(backstop, 10, 64)
+		if err != nil {
+			due[i] = true
+			continue
+		}
+		nextBackstop := checkedMillis + DeferredPromotionCheckBackstopInterval.Milliseconds()
+		if nextBackstop < checkedMillis || nextBackstop <= nowMillis {
+			due[i] = true
+			continue
+		}
+		scheduleCommands = append(scheduleCommands, scheduleCommand{
+			index: i,
+			count: pipe.ZCount(
+				bctx,
+				deferredPromotionCheckScheduleKey(runtimeID),
+				"-inf",
+				strconv.FormatInt(nowMillis, 10),
+			),
+		})
+	}
+	if len(scheduleCommands) > 0 {
+		if _, err := pipe.Exec(bctx); err != nil {
+			slog.Warn("deferred_promotion_check_cache: schedule read failed; falling back to DB", "error", err)
+			return validRuntimeIDs, false
+		}
+		for _, command := range scheduleCommands {
+			count, err := command.count.Result()
+			if err != nil {
+				slog.Warn("deferred_promotion_check_cache: schedule result failed; falling back to DB", "error", err)
+				return validRuntimeIDs, false
+			}
+			if count > 0 {
+				due[command.index] = true
+			}
+		}
+	}
+
+	dueRuntimeIDs := make([]string, 0, len(validRuntimeIDs))
+	for i, runtimeID := range validRuntimeIDs {
+		if due[i] {
+			dueRuntimeIDs = append(dueRuntimeIDs, runtimeID)
+		}
+	}
+	return dueRuntimeIDs, true
+}
+
+// Track records one committed deferred task at its application-clock fire_at.
+// It returns true only when Redis accepted the hint, allowing a DB
+// reconciliation caller to avoid publishing a misleading fresh backstop.
+func (c *DeferredPromotionCheckCache) Track(ctx context.Context, runtimeID, taskID string, fireAt time.Time) bool {
+	if c == nil || runtimeID == "" || taskID == "" || fireAt.IsZero() {
+		return false
+	}
+	ttl := time.Until(fireAt) + DeferredPromotionCheckMinScheduleTTL
+	if ttl < DeferredPromotionCheckMinScheduleTTL {
+		ttl = DeferredPromotionCheckMinScheduleTTL
+	}
+	bctx, cancel := c.bounded(ctx)
+	defer cancel()
+	if err := c.rdb.Eval(
+		bctx,
+		deferredPromotionCheckTrackScript,
+		[]string{deferredPromotionCheckScheduleKey(runtimeID)},
+		taskID,
+		fireAt.UnixMilli(),
+		ttl.Milliseconds(),
+	).Err(); err != nil {
+		slog.Warn("deferred_promotion_check_cache: track failed; DB fallback remains active", "error", err)
+		return false
+	}
+	return true
+}
+
+// Forget removes a task that is no longer deferred. Failure can only leave a
+// stale hint that causes an extra DB check; it cannot promote an ineligible row.
+func (c *DeferredPromotionCheckCache) Forget(ctx context.Context, runtimeID, taskID string) {
+	if c == nil || runtimeID == "" || taskID == "" {
+		return
+	}
+	bctx, cancel := c.bounded(ctx)
+	defer cancel()
+	if err := c.rdb.ZRem(bctx, deferredPromotionCheckScheduleKey(runtimeID), taskID).Err(); err != nil {
+		slog.Warn("deferred_promotion_check_cache: forget failed; stale hint will expire", "error", err)
+	}
+}
+
+// MarkChecked records a successful PostgreSQL cancel/promote/reconciliation
+// pass. Hints due at the start of the pass move to retryAfter instead of being
+// deleted: runtime health, occupied issue+agent slots, and concurrent rows can
+// legitimately leave them deferred. Newer concurrent hints stay untouched.
+func (c *DeferredPromotionCheckCache) MarkChecked(ctx context.Context, runtimeIDs []string, checkedThrough, retryAfter time.Time) {
+	if c == nil || len(runtimeIDs) == 0 {
+		return
+	}
+	if retryAfter.IsZero() || !retryAfter.After(checkedThrough) {
+		retryAfter = checkedThrough.Add(DeferredPromotionCheckRetryInterval)
+	}
+	bctx, cancel := c.bounded(ctx)
+	defer cancel()
+	checkedMillis := strconv.FormatInt(checkedThrough.UnixMilli(), 10)
+	retryMillis := strconv.FormatInt(retryAfter.UnixMilli(), 10)
+	pipe := c.rdb.Pipeline()
+	for _, runtimeID := range runtimeIDs {
+		if runtimeID == "" {
+			continue
+		}
+		pipe.Eval(
+			bctx,
+			deferredPromotionCheckDeferDueScript,
+			[]string{deferredPromotionCheckScheduleKey(runtimeID)},
+			checkedMillis,
+			retryMillis,
+			deferredPromotionCheckRetryBatchSize,
+		)
+		pipe.Set(
+			bctx,
+			deferredPromotionCheckBackstopKey(runtimeID),
+			checkedMillis,
+			DeferredPromotionCheckBackstopInterval,
+		)
+	}
+	if _, err := pipe.Exec(bctx); err != nil {
+		slog.Warn("deferred_promotion_check_cache: mark checked failed; falling back to DB", "error", err)
+	}
+}

--- a/server/internal/service/deferred_promotion_check_cache_test.go
+++ b/server/internal/service/deferred_promotion_check_cache_test.go
@@ -1,0 +1,188 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestDeferredPromotionCheckCache_NilFallsBackToEveryRuntime(t *testing.T) {
+	var cache *DeferredPromotionCheckCache
+	runtimes := []string{"rt-a", "rt-b"}
+	due, cacheReady := cache.dueRuntimeIDs(context.Background(), runtimes, time.Now())
+	if len(due) != len(runtimes) || due[0] != runtimes[0] || due[1] != runtimes[1] {
+		t.Fatalf("nil cache due runtimes = %v, want %v", due, runtimes)
+	}
+	if cacheReady {
+		t.Fatal("nil cache must not trigger DB reconciliation for cache refresh")
+	}
+	if cache.Track(context.Background(), "rt-a", "task-a", time.Now()) {
+		t.Fatal("nil cache unexpectedly accepted a hint")
+	}
+	cache.Forget(context.Background(), "rt-a", "task-a")
+	cache.MarkChecked(context.Background(), runtimes, time.Now(), time.Now().Add(DeferredPromotionCheckRetryInterval))
+}
+
+func TestNewDeferredPromotionCheckCache_NilRedisReturnsNil(t *testing.T) {
+	if cache := NewDeferredPromotionCheckCache(nil); cache != nil {
+		t.Fatalf("NewDeferredPromotionCheckCache(nil) = %#v, want nil", cache)
+	}
+}
+
+func TestDeferredPromotionCheckCache_RedisFailureFallsBackToEveryRuntime(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})
+	if err := rdb.Close(); err != nil {
+		t.Fatalf("close Redis client: %v", err)
+	}
+	cache := NewDeferredPromotionCheckCache(rdb)
+	runtimes := []string{"rt-a", "rt-b"}
+	due, cacheReady := cache.dueRuntimeIDs(context.Background(), runtimes, time.Now())
+	if len(due) != len(runtimes) || due[0] != runtimes[0] || due[1] != runtimes[1] {
+		t.Fatalf("failed Redis due runtimes = %v, want %v", due, runtimes)
+	}
+	if cacheReady {
+		t.Fatal("failed Redis must not trigger an extra DB reconciliation query")
+	}
+}
+
+func TestDeferredPromotionCheckCache_TracksDeadlineAndRetriesDueHint(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewDeferredPromotionCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+	fireAt := now.Add(20 * time.Second)
+
+	cache.MarkChecked(ctx, []string{"rt-a"}, now, now.Add(DeferredPromotionCheckRetryInterval))
+	if !cache.Track(ctx, "rt-a", "task-a", fireAt) {
+		t.Fatal("track failed")
+	}
+	newerFireAt := fireAt.Add(DeferredPromotionCheckRetryInterval + 10*time.Second)
+	if !cache.Track(ctx, "rt-a", "task-b", newerFireAt) {
+		t.Fatal("track newer task failed")
+	}
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, fireAt.Add(-time.Millisecond)); len(due) != 0 {
+		t.Fatalf("task became due before fire_at: %v", due)
+	}
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, fireAt.Add(time.Millisecond)); len(due) != 1 {
+		t.Fatalf("task did not become due after fire_at: %v", due)
+	}
+
+	retryAt := fireAt.Add(DeferredPromotionCheckRetryInterval)
+	cache.MarkChecked(ctx, []string{"rt-a"}, fireAt, retryAt)
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, retryAt.Add(-time.Millisecond)); len(due) != 0 {
+		t.Fatalf("checked task retriggered before retry deadline: %v", due)
+	}
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, retryAt.Add(time.Millisecond)); len(due) != 1 {
+		t.Fatalf("checked task did not retrigger after retry deadline: %v", due)
+	}
+	if score, err := rdb.ZScore(ctx, deferredPromotionCheckScheduleKey("rt-a"), "task-a").Result(); err != nil {
+		t.Fatalf("read retry score: %v", err)
+	} else if int64(score) != retryAt.UnixMilli() {
+		t.Fatalf("retry score = %d, want %d", int64(score), retryAt.UnixMilli())
+	}
+	if score, err := rdb.ZScore(ctx, deferredPromotionCheckScheduleKey("rt-a"), "task-b").Result(); err != nil {
+		t.Fatalf("read newer task score: %v", err)
+	} else if int64(score) != newerFireAt.UnixMilli() {
+		t.Fatalf("newer task score = %d, want %d", int64(score), newerFireAt.UnixMilli())
+	}
+}
+
+func TestDeferredPromotionCheckCache_LongDeadlineOutlivesFireAt(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewDeferredPromotionCheckCache(rdb)
+	ctx := context.Background()
+	fireAt := time.Now().Add(24 * time.Hour)
+
+	if !cache.Track(ctx, "rt-a", "task-a", fireAt) {
+		t.Fatal("track failed")
+	}
+	// Adding an earlier task must not shorten the shared ZSET's TTL below the
+	// later task's deadline.
+	if !cache.Track(ctx, "rt-a", "task-b", time.Now().Add(time.Minute)) {
+		t.Fatal("track earlier task failed")
+	}
+	ttl, err := rdb.PTTL(ctx, deferredPromotionCheckScheduleKey("rt-a")).Result()
+	if err != nil {
+		t.Fatalf("schedule PTTL: %v", err)
+	}
+	if ttl <= time.Until(fireAt) {
+		t.Fatalf("schedule TTL %v does not outlive fire_at %v", ttl, fireAt)
+	}
+}
+
+func TestDeferredPromotionCheckCache_ForgetAndBackstop(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewDeferredPromotionCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+
+	if due, cacheReady := cache.dueRuntimeIDs(ctx, []string{"rt-a"}, now); len(due) != 1 || !cacheReady {
+		t.Fatalf("missing backstop decision = due:%v cacheReady:%v, want due + refreshable", due, cacheReady)
+	}
+	cache.MarkChecked(ctx, []string{"rt-a"}, now, now.Add(DeferredPromotionCheckRetryInterval))
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(time.Second)); len(due) != 0 {
+		t.Fatalf("fresh backstop unexpectedly due: %v", due)
+	}
+	if !cache.Track(ctx, "rt-a", "task-a", now.Add(time.Second)) {
+		t.Fatal("track failed")
+	}
+	cache.Forget(ctx, "rt-a", "task-a")
+	if _, err := rdb.ZScore(ctx, deferredPromotionCheckScheduleKey("rt-a"), "task-a").Result(); !errors.Is(err, redis.Nil) {
+		t.Fatalf("forgotten task score error = %v, want redis.Nil", err)
+	}
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(DeferredPromotionCheckBackstopInterval+time.Millisecond)); len(due) != 1 {
+		t.Fatalf("elapsed backstop did not force DB check: %v", due)
+	}
+}
+
+func TestDeferredPromotionCheckCache_DueRuntimeIDsPreservesInputOrder(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewDeferredPromotionCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+
+	cache.MarkChecked(ctx, []string{"rt-b"}, now, now.Add(DeferredPromotionCheckRetryInterval))
+	cache.Track(ctx, "rt-b", "task-b", now.Add(time.Second))
+	cache.MarkChecked(
+		ctx,
+		[]string{"rt-a"},
+		now.Add(-DeferredPromotionCheckBackstopInterval-time.Second),
+		now.Add(DeferredPromotionCheckRetryInterval),
+	)
+
+	runtimes := []string{"rt-b", "rt-a"}
+	if due := cache.DueRuntimeIDs(ctx, runtimes, now.Add(2*time.Second)); len(due) != 2 || due[0] != runtimes[0] || due[1] != runtimes[1] {
+		t.Fatalf("due runtimes = %v, want input order %v", due, runtimes)
+	}
+}
+
+func TestDeferredPromotionCheckCache_MarkCheckedBatchLimitFailsOpen(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewDeferredPromotionCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+
+	members := make([]redis.Z, 0, deferredPromotionCheckRetryBatchSize+1)
+	for i := 0; i <= deferredPromotionCheckRetryBatchSize; i++ {
+		members = append(members, redis.Z{
+			Score:  float64(now.Add(-time.Second).UnixMilli()),
+			Member: "task-" + strconv.Itoa(i),
+		})
+	}
+	key := deferredPromotionCheckScheduleKey("rt-a")
+	if err := rdb.ZAdd(ctx, key, members...).Err(); err != nil {
+		t.Fatalf("seed due hints: %v", err)
+	}
+	if err := rdb.Expire(ctx, key, DeferredPromotionCheckMinScheduleTTL).Err(); err != nil {
+		t.Fatalf("expire due hints: %v", err)
+	}
+	cache.MarkChecked(ctx, []string{"rt-a"}, now, now.Add(DeferredPromotionCheckRetryInterval))
+
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(time.Second)); len(due) != 1 {
+		t.Fatalf("overflow hint did not fail open to another check: %v", due)
+	}
+}

--- a/server/internal/service/issue.go
+++ b/server/internal/service/issue.go
@@ -481,6 +481,10 @@ func (s *IssueService) Create(ctx context.Context, p IssueCreateParams, opts Iss
 	var assignedTaskID pgtype.UUID
 	if !opts.AssignedAgentRunFireAt.IsZero() {
 		assignedTaskID = assignedTask.ID
+		// The task was inserted through transaction-bound Queries, whose
+		// TaskService intentionally has no Redis dependencies. Publish the
+		// deferred deadline only after the issue+task commit is durable.
+		s.TaskService.trackTaskForDeferredPromotion(assignedTask)
 		if assignedTaskID.Valid {
 			// The deferred task became durable with the issue at commit. Refresh the
 			// daemon's schedule only now so a wakeup can never race uncommitted data.

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -63,6 +63,9 @@ type TaskService struct {
 	// stale dispatched task. It removes the unconditional reclaim UPDATE from
 	// idle claim polls while missing/error states preserve the DB fallback.
 	ReclaimCheck *ReclaimCheckCache
+	// DeferredPromotionCheck schedules PostgreSQL's cancel/promote-deferred
+	// pass. Missing/error state preserves the historical promote-first path.
+	DeferredPromotionCheck *DeferredPromotionCheckCache
 	// Composio computes the per-task MCP overlay (Stage 3 of the Composio
 	// epic, MUL-3721) — the integration's "current user's connected apps
 	// → MCP session URL" hook called from each Enqueue* path. Optional: a
@@ -238,6 +241,33 @@ func (s *TaskService) forgetTaskReclaim(task db.AgentTaskQueue) {
 		context.Background(),
 		util.UUIDToString(task.RuntimeID),
 		util.UUIDToString(task.ID),
+	)
+}
+
+func (s *TaskService) trackTaskForDeferredPromotion(task db.AgentTaskQueue) {
+	if task.Status != "deferred" || !task.RuntimeID.Valid || !task.ID.Valid || !task.FireAt.Valid {
+		return
+	}
+	s.DeferredPromotionCheck.Track(
+		context.Background(),
+		util.UUIDToString(task.RuntimeID),
+		util.UUIDToString(task.ID),
+		task.FireAt.Time,
+	)
+}
+
+func (s *TaskService) forgetTaskDeferredPromotion(task db.AgentTaskQueue) {
+	s.forgetDeferredPromotion(task.RuntimeID, task.ID)
+}
+
+func (s *TaskService) forgetDeferredPromotion(runtimeID, taskID pgtype.UUID) {
+	if !runtimeID.Valid || !taskID.Valid {
+		return
+	}
+	s.DeferredPromotionCheck.Forget(
+		context.Background(),
+		util.UUIDToString(runtimeID),
+		util.UUIDToString(taskID),
 	)
 }
 
@@ -1327,6 +1357,11 @@ func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue
 		slog.Error("task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", err)
 		return db.AgentTaskQueue{}, fmt.Errorf("create task: %w", err)
 	}
+	if fireAt.Valid {
+		// Direct callers commit with the statement. Transaction-bound callers use
+		// a cache-less TaskService and publish this hint after the outer commit.
+		s.trackTaskForDeferredPromotion(task)
+	}
 
 	slog.Info("task enqueued",
 		"task_id", util.UUIDToString(task.ID),
@@ -1530,6 +1565,7 @@ func (s *TaskService) EnqueueDeferredAssigneeFallback(ctx context.Context, issue
 		return db.AgentTaskQueue{}, fmt.Errorf("create deferred task: %w", err)
 	}
 
+	s.trackTaskForDeferredPromotion(task)
 	slog.Info("deferred fallback task enqueued",
 		"task_id", util.UUIDToString(task.ID),
 		"issue_id", util.UUIDToString(issue.ID),
@@ -2164,6 +2200,7 @@ func (s *TaskService) enqueueChatTaskTx(
 // FinalizeChatTaskEnqueue performs only post-commit effects.
 func (s *TaskService) FinalizeChatTaskEnqueue(ctx context.Context, task db.AgentTaskQueue) {
 	if task.Status == "deferred" {
+		s.trackTaskForDeferredPromotion(task)
 		slog.Info("chat task deferred for channel media",
 			"task_id", util.UUIDToString(task.ID),
 			"chat_session_id", util.UUIDToString(task.ChatSessionID),
@@ -3637,9 +3674,21 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 	}()
 
 	runtimeKey := util.UUIDToString(runtimeID)
-	if err := s.PromoteDueDeferredTasksForRuntime(ctx, runtimeID); err != nil {
-		outcome = "error_promote_deferred"
-		return nil, err
+	deferredCheckStarted := time.Now()
+	deferredDue, deferredCacheReady := s.DeferredPromotionCheck.dueRuntimeIDs(ctx, []string{runtimeKey}, deferredCheckStarted)
+	if len(deferredDue) > 0 {
+		if err := s.PromoteDueDeferredTasksForRuntime(ctx, runtimeID); err != nil {
+			outcome = "error_promote_deferred"
+			return nil, err
+		}
+		if deferredCacheReady {
+			s.refreshDeferredPromotionCheck(
+				ctx,
+				[]pgtype.UUID{runtimeID},
+				[]string{runtimeKey},
+				deferredCheckStarted,
+			)
+		}
 	}
 
 	// Keep stale-response recovery before EmptyClaim because the queued-only
@@ -3827,7 +3876,9 @@ func (s *TaskService) RequeueTaskAfterClaimFailure(ctx context.Context, task db.
 // request (and one promote/reclaim/list cycle) per runtime.
 //
 // It preserves the exact per-runtime semantics, just set-ified:
-//  1. promote due deferred tasks across the set (one UPDATE);
+//  1. when its Redis schedule/backstop is due, cancel superseded retries and
+//     promote due deferred tasks across the set, then reconcile the next legacy
+//     deadline; missing/error cache state preserves this PostgreSQL path;
 //  2. reclaim up to maxTasks stale-dispatched tasks across the set (one UPDATE)
 //     — done before the empty-cache check because a lost claim response moves
 //     the task out of `queued`, which the empty-queued cache cannot represent;
@@ -3863,6 +3914,10 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 	}
 
 	claimed := make([]db.AgentTaskQueue, 0, maxTasks)
+	runtimeKeys := make([]string, 0, len(uniqueIDs))
+	for _, rid := range uniqueIDs {
+		runtimeKeys = append(runtimeKeys, util.UUIDToString(rid))
+	}
 
 	// 1. Promote due deferred tasks across the whole set (promote-first, like
 	// the singular path). Replay the per-row side effects the singular service
@@ -3873,28 +3928,35 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 	// MarkEmpty from a prior idle poll would short-circuit the runtime and the
 	// promoted task would sit unclaimed until the empty key's TTL. Also emits
 	// the deferred→queued UI event and the enqueue analytics sample.
-	s.cancelSupersededDeferredRetries(ctx, uniqueIDs)
-	promoted, err := s.Queries.PromoteDueDeferredTasksForRuntimes(ctx, db.PromoteDueDeferredTasksForRuntimesParams{
-		RuntimeIds:       uniqueIDs,
-		RuntimeStaleSecs: RuntimeClaimFreshnessSeconds,
-	})
-	if isDuplicatePendingTaskErr(err) {
-		// Same tolerance as the single-runtime path, and it matters more here:
-		// one contended row would otherwise fail the claim for EVERY runtime in
-		// the batch. Promote nothing this tick and let the claim continue.
-		slog.Info("promote deferred tasks (batch): slot taken by a concurrent enqueue, skipping this tick")
-		promoted = nil
-	} else if err != nil {
-		return nil, fmt.Errorf("promote deferred tasks: %w", err)
-	}
-	for _, task := range promoted {
-		slog.Info("deferred fallback task promoted (batch)",
-			"task_id", util.UUIDToString(task.ID),
-			"runtime_id", util.UUIDToString(task.RuntimeID),
-			"agent_id", util.UUIDToString(task.AgentID),
-		)
-		s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, task)
-		s.NotifyTaskEnqueued(ctx, task)
+	deferredCheckStarted := time.Now()
+	deferredDue, deferredCacheReady := s.DeferredPromotionCheck.dueRuntimeIDs(ctx, runtimeKeys, deferredCheckStarted)
+	if len(deferredDue) > 0 {
+		s.cancelSupersededDeferredRetries(ctx, uniqueIDs)
+		promoted, err := s.Queries.PromoteDueDeferredTasksForRuntimes(ctx, db.PromoteDueDeferredTasksForRuntimesParams{
+			RuntimeIds:       uniqueIDs,
+			RuntimeStaleSecs: RuntimeClaimFreshnessSeconds,
+		})
+		if isDuplicatePendingTaskErr(err) {
+			// Same tolerance as the single-runtime path, and it matters more here:
+			// one contended row would otherwise fail the claim for EVERY runtime in
+			// the batch. Promote nothing this tick and let the claim continue.
+			slog.Info("promote deferred tasks (batch): slot taken by a concurrent enqueue, skipping this tick")
+			promoted = nil
+		} else if err != nil {
+			return nil, fmt.Errorf("promote deferred tasks: %w", err)
+		}
+		for _, task := range promoted {
+			slog.Info("deferred fallback task promoted (batch)",
+				"task_id", util.UUIDToString(task.ID),
+				"runtime_id", util.UUIDToString(task.RuntimeID),
+				"agent_id", util.UUIDToString(task.AgentID),
+			)
+			s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, task)
+			s.NotifyTaskEnqueued(ctx, task)
+		}
+		if deferredCacheReady {
+			s.refreshDeferredPromotionCheck(ctx, uniqueIDs, runtimeKeys, deferredCheckStarted)
+		}
 	}
 
 	// 2. Reclaim lost-response dispatched tasks when any runtime's task schedule
@@ -3902,14 +3964,13 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 	// machine-level set so per-runtime backstops stay aligned and fixed UPDATE
 	// setup/locking cost is paid at a predictable cadence. A nil/missing/failed
 	// cache preserves the historical query path.
-	runtimeKeys := make([]string, 0, len(uniqueIDs))
-	for _, rid := range uniqueIDs {
-		runtimeKeys = append(runtimeKeys, util.UUIDToString(rid))
-	}
 	checkStarted := time.Now()
 	dueKeys := s.ReclaimCheck.DueRuntimeIDs(ctx, runtimeKeys, checkStarted)
-	var reclaimed []db.AgentTaskQueue
-	var reclaimCheckAfter time.Time
+	var (
+		reclaimed         []db.AgentTaskQueue
+		err               error
+		reclaimCheckAfter time.Time
+	)
 	if len(dueKeys) > 0 {
 		reclaimCheckAfter = time.Now().Add(claimResponseRecoveryWindow + ReclaimCheckHintSafetyMargin)
 		reclaimed, err = s.Queries.ReclaimStaleDispatchedTasksForRuntimes(ctx, db.ReclaimStaleDispatchedTasksForRuntimesParams{
@@ -4051,6 +4112,7 @@ func (s *TaskService) cancelSupersededDeferredRetries(ctx context.Context, runti
 		return
 	}
 	for _, task := range cancelled {
+		s.forgetTaskDeferredPromotion(task)
 		slog.Info("deferred auto-retry cancelled: superseded by an active task",
 			"task_id", util.UUIDToString(task.ID),
 			"issue_id", util.UUIDToString(task.IssueID),
@@ -4060,6 +4122,38 @@ func (s *TaskService) cancelSupersededDeferredRetries(ctx context.Context, runti
 		s.ReconcileAgentStatus(ctx, task.AgentID)
 		s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, task)
 	}
+}
+
+// refreshDeferredPromotionCheck makes a completed DB pass safe to cache across
+// rolling deploys. The query seeds the earliest still-deferred row per runtime,
+// including rows inserted by an older server that did not publish Redis hints.
+// If reconciliation fails, no backstop is advanced and the next claim retries
+// the historical DB path.
+func (s *TaskService) refreshDeferredPromotionCheck(ctx context.Context, runtimeIDs []pgtype.UUID, runtimeKeys []string, checkedThrough time.Time) {
+	if s.DeferredPromotionCheck == nil || len(runtimeIDs) == 0 {
+		return
+	}
+	next, err := s.Queries.ListNextDeferredTasksForRuntimes(ctx, runtimeIDs)
+	if err != nil {
+		slog.Warn("refresh deferred promotion schedule failed; DB fallback remains active", "error", err)
+		return
+	}
+	for _, task := range next {
+		if !s.DeferredPromotionCheck.Track(
+			ctx,
+			util.UUIDToString(task.RuntimeID),
+			util.UUIDToString(task.ID),
+			checkedThrough.Add(task.FireAt.Time.Sub(task.DatabaseNow.Time)),
+		) {
+			return
+		}
+	}
+	s.DeferredPromotionCheck.MarkChecked(
+		ctx,
+		runtimeKeys,
+		checkedThrough,
+		time.Now().Add(DeferredPromotionCheckRetryInterval),
+	)
 }
 
 func (s *TaskService) PromoteDueDeferredTasksForRuntime(ctx context.Context, runtimeID pgtype.UUID) error {
@@ -4150,6 +4244,7 @@ func (s *TaskService) cancelDeferredEscalationsForTask(ctx context.Context, task
 		return
 	}
 	for _, task := range cancelled {
+		s.forgetDeferredPromotion(task.RuntimeID, task.ID)
 		slog.Info("deferred fallback task cancelled",
 			"task_id", util.UUIDToString(task.ID),
 			"primary_task_id", util.UUIDToString(taskID),
@@ -4171,6 +4266,7 @@ func (s *TaskService) CancelDeferredEscalationsForIssueAgent(ctx context.Context
 		return
 	}
 	for _, task := range cancelled {
+		s.forgetDeferredPromotion(task.RuntimeID, task.ID)
 		slog.Info("deferred fallback task cancelled",
 			"task_id", util.UUIDToString(task.ID),
 			"issue_id", util.UUIDToString(issueID),
@@ -5043,7 +5139,9 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 			"max_attempts", retried.MaxAttempts,
 			"status", retried.Status,
 		)
-		if retried.Status == "queued" {
+		if retried.Status == "deferred" {
+			s.trackTaskForDeferredPromotion(*retried)
+		} else if retried.Status == "queued" {
 			s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, *retried)
 			s.NotifyTaskEnqueued(ctx, *retried)
 		}
@@ -5444,7 +5542,9 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 	// queued first, then notify the daemon — see EnqueueTaskForIssue for ordering
 	// rationale. A deferred child (backoff armed) stays inert until
 	// PromoteDueDeferredTasksForRuntime fires its queued event + wakeup.
-	if child.Status == "queued" {
+	if child.Status == "deferred" {
+		s.trackTaskForDeferredPromotion(child)
+	} else if child.Status == "queued" {
 		s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, child)
 		s.NotifyTaskEnqueued(ctx, child)
 	}
@@ -6916,6 +7016,7 @@ func (s *TaskService) NotifyTaskEnqueued(ctx context.Context, task db.AgentTaskQ
 // become claimable because an agent-capacity or serialization barrier cleared.
 func (s *TaskService) NotifyTaskFinished(task db.AgentTaskQueue) {
 	s.forgetTaskReclaim(task)
+	s.forgetTaskDeferredPromotion(task)
 	s.notifyRuntimeMayHaveWork(task.RuntimeID, "")
 }
 
@@ -6929,6 +7030,7 @@ func (s *TaskService) notifyTasksFinished(tasks []db.AgentTaskQueue) {
 			continue
 		}
 		s.forgetTaskReclaim(task)
+		s.forgetTaskDeferredPromotion(task)
 		runtimeKey := util.UUIDToString(task.RuntimeID)
 		if _, ok := seen[runtimeKey]; ok {
 			continue
@@ -6946,6 +7048,7 @@ func (s *TaskService) notifyTasksFinished(tasks []db.AgentTaskQueue) {
 // otherwise the wakeup-driven claim could read the still-current
 // empty verdict and return null.
 func (s *TaskService) notifyTaskAvailable(task db.AgentTaskQueue) {
+	s.forgetTaskDeferredPromotion(task)
 	s.notifyRuntimeMayHaveWork(task.RuntimeID, util.UUIDToString(task.ID))
 }
 

--- a/server/internal/service/task_batch_claim_deferred_test.go
+++ b/server/internal/service/task_batch_claim_deferred_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
+	"github.com/redis/go-redis/v9"
 )
 
 // TestClaimTasksForRuntimes_PromotesDeferredAndEmitsQueuedEvent is the
@@ -58,6 +60,96 @@ func TestClaimTasksForRuntimes_PromotesDeferredAndEmitsQueuedEvent(t *testing.T)
 	mu.Unlock()
 	if n != 1 {
 		t.Fatalf("expected exactly one task:queued event for the promoted task, got %d", n)
+	}
+}
+
+// TestClaimTasksForRuntimes_DeferredPromotionGateRehydratesLegacyTask proves a
+// cache miss still runs the historical DB promotion pass and then discovers a
+// future row that predates Redis hint publication. The refreshed hint closes
+// the rolling-deploy hole without making Redis authoritative.
+func TestClaimTasksForRuntimes_DeferredPromotionGateRehydratesLegacyTask(t *testing.T) {
+	ctx := context.Background()
+	rdb := newRedisTestClient(t)
+	pool := newTaskClaimRacePool(t)
+	svc := NewTaskService(db.New(pool), pool, nil, events.New())
+	svc.DeferredPromotionCheck = NewDeferredPromotionCheckCache(rdb)
+
+	runtimeID, taskID := deferredBatchFixture(t, ctx, pool)
+	fireAt := time.Now().Add(time.Hour)
+	if _, err := pool.Exec(ctx, `UPDATE agent_task_queue SET fire_at = $2 WHERE id = $1`, taskID, fireAt); err != nil {
+		t.Fatalf("move deferred task into future: %v", err)
+	}
+
+	claimed, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{util.MustParseUUID(runtimeID)}, 5)
+	if err != nil {
+		t.Fatalf("batch claim: %v", err)
+	}
+	if len(claimed) != 0 {
+		t.Fatalf("claimed future deferred task: %v", claimed)
+	}
+	if score, err := rdb.ZScore(ctx, deferredPromotionCheckScheduleKey(runtimeID), taskID).Result(); err != nil {
+		t.Fatalf("legacy deferred task was not rehydrated: %v", err)
+	} else if got := time.UnixMilli(int64(score)); got.Before(fireAt.Add(-time.Second)) || got.After(fireAt.Add(time.Second)) {
+		t.Fatalf("rehydrated fire_at = %v, want approximately %v", got, fireAt)
+	}
+	if due := svc.DeferredPromotionCheck.DueRuntimeIDs(ctx, []string{runtimeID}, time.Now()); len(due) != 0 {
+		t.Fatalf("future task bypassed fresh promotion gate: %v", due)
+	}
+}
+
+func TestClaimTasksForRuntimes_DeferredPromotionGatePromotesDueHint(t *testing.T) {
+	ctx := context.Background()
+	rdb := newRedisTestClient(t)
+	pool := newTaskClaimRacePool(t)
+	svc := NewTaskService(db.New(pool), pool, nil, events.New())
+	svc.DeferredPromotionCheck = NewDeferredPromotionCheckCache(rdb)
+
+	runtimeID, taskID := deferredBatchFixture(t, ctx, pool)
+	now := time.Now()
+	svc.DeferredPromotionCheck.MarkChecked(ctx, []string{runtimeID}, now, now.Add(DeferredPromotionCheckRetryInterval))
+	if !svc.DeferredPromotionCheck.Track(ctx, runtimeID, taskID, now.Add(-time.Second)) {
+		t.Fatal("track due task")
+	}
+
+	claimed, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{util.MustParseUUID(runtimeID)}, 5)
+	if err != nil {
+		t.Fatalf("batch claim: %v", err)
+	}
+	if len(claimed) != 1 || util.UUIDToString(claimed[0].ID) != taskID {
+		t.Fatalf("due hinted task %s was not promoted and claimed: %v", taskID, claimed)
+	}
+	if _, err := rdb.ZScore(ctx, deferredPromotionCheckScheduleKey(runtimeID), taskID).Result(); !errors.Is(err, redis.Nil) {
+		t.Fatalf("promoted task hint error = %v, want redis.Nil", err)
+	}
+}
+
+// TestClaimTaskForRuntime_DeferredPromotionGatePromotesDueHint covers the
+// legacy single-runtime endpoint independently from the machine-level batch
+// implementation. This is the high-volume compatibility path the gate is
+// intended to remove idle promotion SQL from.
+func TestClaimTaskForRuntime_DeferredPromotionGatePromotesDueHint(t *testing.T) {
+	ctx := context.Background()
+	rdb := newRedisTestClient(t)
+	pool := newTaskClaimRacePool(t)
+	svc := NewTaskService(db.New(pool), pool, nil, events.New())
+	svc.DeferredPromotionCheck = NewDeferredPromotionCheckCache(rdb)
+
+	runtimeID, taskID := deferredBatchFixture(t, ctx, pool)
+	now := time.Now()
+	svc.DeferredPromotionCheck.MarkChecked(ctx, []string{runtimeID}, now, now.Add(DeferredPromotionCheckRetryInterval))
+	if !svc.DeferredPromotionCheck.Track(ctx, runtimeID, taskID, now.Add(-time.Second)) {
+		t.Fatal("track due task")
+	}
+
+	claimed, err := svc.ClaimTaskForRuntime(ctx, util.MustParseUUID(runtimeID))
+	if err != nil {
+		t.Fatalf("legacy claim: %v", err)
+	}
+	if claimed == nil || util.UUIDToString(claimed.ID) != taskID {
+		t.Fatalf("due hinted task %s was not promoted and claimed: %v", taskID, claimed)
+	}
+	if _, err := rdb.ZScore(ctx, deferredPromotionCheckScheduleKey(runtimeID), taskID).Result(); !errors.Is(err, redis.Nil) {
+		t.Fatalf("promoted task hint error = %v, want redis.Nil", err)
 	}
 }
 

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -5712,6 +5712,57 @@ func (q *Queries) ListChatFinalizeDeferredExpired(ctx context.Context, arg ListC
 	return items, nil
 }
 
+const listNextDeferredTasksForRuntimes = `-- name: ListNextDeferredTasksForRuntimes :many
+SELECT DISTINCT ON (runtime_id)
+    id,
+    runtime_id,
+    fire_at,
+    now()::timestamptz AS database_now
+FROM agent_task_queue
+WHERE runtime_id = ANY($1::uuid[])
+  AND status = 'deferred'
+  AND fire_at IS NOT NULL
+ORDER BY runtime_id, fire_at, id
+`
+
+type ListNextDeferredTasksForRuntimesRow struct {
+	ID          pgtype.UUID        `json:"id"`
+	RuntimeID   pgtype.UUID        `json:"runtime_id"`
+	FireAt      pgtype.Timestamptz `json:"fire_at"`
+	DatabaseNow pgtype.Timestamptz `json:"database_now"`
+}
+
+// Rehydrates the advisory deferred-promotion schedule after a periodic DB
+// backstop. One row per runtime is sufficient: enqueue-time writes track every
+// new task, and the next backstop/promotion pass discovers the following legacy
+// row after this earliest one leaves deferred. The partial fire_at index serves
+// both the runtime filter and ordering. Return a relative delay so Redis never
+// compares the PostgreSQL host's wall clock directly with the Server's clock.
+func (q *Queries) ListNextDeferredTasksForRuntimes(ctx context.Context, runtimeIds []pgtype.UUID) ([]ListNextDeferredTasksForRuntimesRow, error) {
+	rows, err := q.db.Query(ctx, listNextDeferredTasksForRuntimes, runtimeIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListNextDeferredTasksForRuntimesRow{}
+	for rows.Next() {
+		var i ListNextDeferredTasksForRuntimesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.RuntimeID,
+			&i.FireAt,
+			&i.DatabaseNow,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPendingDelegatedFailureRecoveries = `-- name: ListPendingDelegatedFailureRecoveries :many
 SELECT recovery.id, recovery.issue_id, recovery.author_type, recovery.author_id, recovery.content, recovery.type, recovery.created_at, recovery.updated_at, recovery.parent_id, recovery.workspace_id, recovery.resolved_at, recovery.resolved_by_type, recovery.resolved_by_id, recovery.source_task_id, recovery.quick_action_id, recovery.via_plugin_id, recovery.revision, recovery.recovery_settled_at
 FROM comment recovery

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -2233,6 +2233,24 @@ WHERE r.runtime_id = ANY(@runtime_ids::uuid[])
   )
 RETURNING *;
 
+-- name: ListNextDeferredTasksForRuntimes :many
+-- Rehydrates the advisory deferred-promotion schedule after a periodic DB
+-- backstop. One row per runtime is sufficient: enqueue-time writes track every
+-- new task, and the next backstop/promotion pass discovers the following legacy
+-- row after this earliest one leaves deferred. The partial fire_at index serves
+-- both the runtime filter and ordering. Return a relative delay so Redis never
+-- compares the PostgreSQL host's wall clock directly with the Server's clock.
+SELECT DISTINCT ON (runtime_id)
+    id,
+    runtime_id,
+    fire_at,
+    now()::timestamptz AS database_now
+FROM agent_task_queue
+WHERE runtime_id = ANY(@runtime_ids::uuid[])
+  AND status = 'deferred'
+  AND fire_at IS NOT NULL
+ORDER BY runtime_id, fire_at, id;
+
 -- name: PromoteDueDeferredTasksForRuntime :many
 -- Promotion is fenced against the single queued/dispatched slot
 -- idx_one_pending_task_per_issue_agent_v2 allows per (issue, agent). A deferred


### PR DESCRIPTION
## Summary

- add an advisory per-runtime Redis schedule/backstop that gates deferred cancellation and promotion in both singular and batch claim paths
- publish and clear deadline hints across the deferred task lifecycle, with periodic PostgreSQL reconciliation for pre-deployment rows and rolling server upgrades
- fail open to the historical PostgreSQL path when Redis is absent or unhealthy, without changing runtime authentication

## Safety

- PostgreSQL remains authoritative for task eligibility, runtime health, and serialization; Redis can only skip work before a known deadline
- the cache uses Redis 2.6-compatible primitives and requires no database migration
- old servers and daemons remain compatible; rollback leaves only inert TTL-bound Redis keys

## Validation

- `make sqlc`
- `go test ./... -run '^$' -count=1`
- `go vet ./internal/service ./cmd/server`
- focused cache and claim-path tests against a freshly migrated PostgreSQL database and isolated Redis instance

Closes MUL-7046
