### PR TITLE
MUL-7038: fix(repocache): import shallow cache tip before checkout

### DIFF
--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -1109,14 +1109,19 @@ func createIsolatedCheckoutContext(ctx context.Context, barePath, repoURL, check
 			return "", err
 		}
 	}
+	// A shallow bare cache can have a freshly fetched base commit reachable
+	// only from refs/remotes/origin/* while its copied refs/heads/* remain
+	// stale. Git ignores --local for a shallow source and the initial clone can
+	// therefore omit baseCommit even though it exists in the cache. Import the
+	// cache refs and selected base before trying to check it out.
+	if err := syncIsolatedCheckoutRefsContext(ctx, barePath, checkoutPath, baseRef); err != nil {
+		return "", err
+	}
 
 	if out, err := runGitCombinedOutputContext(ctx, "-C", checkoutPath, "checkout", "--detach", baseCommit); err != nil {
 		return "", fmt.Errorf("git checkout --detach: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	if err := deleteAllLocalBranchesContext(ctx, checkoutPath); err != nil {
-		return "", err
-	}
-	if err := syncIsolatedCheckoutRefsContext(ctx, barePath, checkoutPath, baseRef); err != nil {
 		return "", err
 	}
 	if out, err := runGitCombinedOutputContext(ctx, "-C", checkoutPath, "config", isolatedCheckoutConfigKey, isolatedCheckoutConfigValue); err != nil {

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -827,6 +827,81 @@ func TestCreateWorktreeWithIsolatedGitMetadata(t *testing.T) {
 	}
 }
 
+func TestCreateIsolatedCheckoutImportsFetchedTipFromShallowCache(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	originPath := filepath.Join(root, "origin.git")
+	workPath := filepath.Join(root, "work")
+	cachePath := filepath.Join(root, "cache.git")
+	checkoutPath := filepath.Join(root, "checkout")
+
+	if err := runGit("init", "--bare", originPath); err != nil {
+		t.Fatalf("init bare origin: %v", err)
+	}
+	if err := os.Mkdir(workPath, 0o755); err != nil {
+		t.Fatalf("create work repo directory: %v", err)
+	}
+	createTestRepoAt(t, workPath)
+	branch := currentBranchName(t, workPath)
+	runGitAuthored(t, workPath, "remote", "add", "origin", originPath)
+	runGitAuthored(t, workPath, "push", "-u", "origin", branch)
+	if err := runGit("-C", originPath, "symbolic-ref", "HEAD", "refs/heads/"+branch); err != nil {
+		t.Fatalf("set origin HEAD: %v", err)
+	}
+
+	originURL := "file://" + originPath
+	if out, err := runGitCombinedOutput("clone", "--bare", "--depth=1", originURL, cachePath); err != nil {
+		t.Fatalf("create shallow cache: %s: %v", strings.TrimSpace(string(out)), err)
+	}
+	if out, err := runGitOutput("-C", cachePath, "rev-parse", "--is-shallow-repository"); err != nil {
+		t.Fatalf("inspect shallow cache: %v", err)
+	} else if got := strings.TrimSpace(string(out)); got != "true" {
+		t.Fatalf("test cache is shallow = %q, want true", got)
+	}
+
+	oldTip := gitHead(t, workPath)
+	if err := runGit("-C", cachePath, "config", "remote.origin.fetch", modernFetchRefspec); err != nil {
+		t.Fatalf("set cache fetch refspec: %v", err)
+	}
+
+	addEmptyCommit(t, workPath, "advance origin")
+	newTip := gitHead(t, workPath)
+	runGitAuthored(t, workPath, "push", "origin", branch)
+	if err := runGitFetch(cachePath); err != nil {
+		t.Fatalf("fetch updated origin into shallow cache: %v", err)
+	}
+
+	baseRef := "refs/remotes/origin/" + branch
+	if got := gitRefCommit(t, cachePath, "refs/heads/"+branch); got != oldTip {
+		t.Fatalf("cache local head = %s, want stale tip %s", got, oldTip)
+	}
+	if got := gitRefCommit(t, cachePath, baseRef); got != newTip {
+		t.Fatalf("cache remote-tracking head = %s, want fetched tip %s", got, newTip)
+	}
+	if err := runGit("-C", cachePath, "cat-file", "-e", newTip+"^{commit}"); err != nil {
+		t.Fatalf("fetched tip is missing from shallow cache: %v", err)
+	}
+
+	const taskBranch = "agent/test/shallow-cache"
+	actualBranch, err := createIsolatedCheckout(
+		cachePath,
+		originURL,
+		checkoutPath,
+		taskBranch,
+		baseRef,
+		newTip,
+	)
+	if err != nil {
+		t.Fatalf("create isolated checkout from shallow cache: %v", err)
+	}
+	if actualBranch != taskBranch {
+		t.Fatalf("isolated branch = %q, want %q", actualBranch, taskBranch)
+	}
+	if got := gitHead(t, checkoutPath); got != newTip {
+		t.Fatalf("isolated checkout HEAD = %s, want fetched tip %s", got, newTip)
+	}
+}
+
 func TestCreateWorktreeReusesIsolatedGitMetadata(t *testing.T) {
 	t.Parallel()
 	sourceRepo := createTestRepo(t)


### PR DESCRIPTION
## What does this PR do?

Fresh isolated checkouts cloned the shared cache, swapped the remote, and tried to check out `baseCommit` before synchronizing cache refs. For a shallow bare cache, Git ignores `--local`; a freshly fetched tip reachable only from `refs/remotes/origin/*` can therefore be omitted from the clone even though the object exists in the cache.

This moves the existing cache-ref synchronization before the detached checkout, so the selected base is present before Git tries to use it. Full and partial caches keep the same synchronization path; only its ordering changes.

## Related Issue

Closes #8011

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Move `syncIsolatedCheckoutRefsContext` before the first detached checkout in `server/internal/daemon/repocache/cache.go`.
- Add a deterministic regression test that constructs a shallow bare cache with a stale local head and a newer remote-tracking tip, then verifies the isolated checkout starts at that newer commit.

## How to Test

1. Run `go test ./internal/daemon/repocache -run TestCreateIsolatedCheckoutImportsFetchedTipFromShallowCache -count=1` from `server/`.
2. Run `go test ./internal/daemon/repocache -count=1` from `server/`.
3. Both commands should pass; the regression test fails on the old ordering with `fatal: reference is not a tree`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] UI screenshots are not applicable because this is an internal daemon fix
- [x] Documentation changes are not required because the public behavior and configuration are unchanged
- [x] Landing copy and product documentation synchronization are not applicable
- [x] Chinese product copy conventions are not applicable
- [x] I have considered and documented the risk: the same existing ref synchronization runs earlier, before its selected commit is consumed
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** I asked Codex to select an unclaimed issue, reproduce the shallow-cache Git topology described in #8011 with a deterministic test, make the smallest safe ordering change, and run the focused plus full repocache test package.

## Screenshots (optional)

Not applicable.