### PR TITLE
MUL-7047 fix(migrations): rewrite retired platform skill names in stored instructions

### DIFF
--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -29,8 +29,8 @@ import (
 // it changes here. Do not restate it on another surface, and do not say so
 // inside the text: this const is sent to the model on every leader turn, so
 // a note addressed to maintainers is tokens the leader pays for and cannot
-// act on. multica-squads/references/squad-source-map.md records the same
-// ownership for anyone reading from the skill side.
+// act on. multica-platform/references/squads.md records the same ownership
+// for anyone reading from the skill side.
 const squadOperatingProtocolHeader = `## Squad Operating Protocol
 
 **If you are reading this section, you have been activated as a squad LEADER

--- a/server/internal/migrations/legacy_platform_skill_names_migration_test.go
+++ b/server/internal/migrations/legacy_platform_skill_names_migration_test.go
@@ -1,0 +1,208 @@
+package migrations
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const legacyPlatformSkillNamesMigrationTestSchema = "legacy_platform_skill_names_migration_test"
+
+// TestLegacyPlatformSkillNamesMigrationRewritesOnlyRetiredNames pins the two
+// halves of migration 451 that are easy to get wrong in opposite directions: a
+// rewrite that misses an occurrence leaves an agent pointing at a skill the
+// server no longer ships, and a rewrite that is too eager corrupts a name that
+// still resolves. The survivors below are the real ones, not hypotheticals --
+// `multica-working-on-issues` is still shipped as a redirect stub, and a
+// workspace is free to own a skill whose slug merely starts with a retired
+// name.
+func TestLegacyPlatformSkillNamesMigrationRewritesOnlyRetiredNames(t *testing.T) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("integration test requires Postgres at DATABASE_URL")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("connect to Postgres: %v", err)
+	}
+	defer pool.Close()
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire Postgres connection: %v", err)
+	}
+	defer conn.Release()
+
+	cleanup := func() {
+		_, _ = pool.Exec(context.Background(), "DROP SCHEMA IF EXISTS "+legacyPlatformSkillNamesMigrationTestSchema+" CASCADE")
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+	if _, err := conn.Exec(ctx, "CREATE SCHEMA "+legacyPlatformSkillNamesMigrationTestSchema); err != nil {
+		t.Fatalf("create isolated migration schema: %v", err)
+	}
+	if _, err := conn.Exec(ctx, `SELECT set_config('search_path', $1, false)`, legacyPlatformSkillNamesMigrationTestSchema); err != nil {
+		t.Fatalf("set isolated migration search path: %v", err)
+	}
+
+	// Only the columns the migration reads and writes. The real tables carry
+	// far more, none of which the rewrite can observe.
+	if _, err := conn.Exec(ctx, `
+		CREATE TABLE agent (
+			id UUID PRIMARY KEY,
+			instructions TEXT NOT NULL DEFAULT '',
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+		);
+		CREATE TABLE squad (
+			id UUID PRIMARY KEY,
+			instructions TEXT NOT NULL DEFAULT '',
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+		);
+	`); err != nil {
+		t.Fatalf("create agent and squad fixtures: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		id    string
+		given string
+		want  string
+	}{
+		{
+			name:  "retired name in backticks",
+			id:    "00000000-0000-0000-0000-000000000001",
+			given: "Load the `multica-squads` skill before delegating.",
+			want:  "Load the `multica-platform` skill before delegating.",
+		},
+		{
+			name:  "several retired names in one body",
+			id:    "00000000-0000-0000-0000-000000000002",
+			given: "See multica-autopilots and multica-mentioning.",
+			want:  "See multica-platform and multica-platform.",
+		},
+		{
+			name:  "longest retired slug",
+			id:    "00000000-0000-0000-0000-000000000003",
+			given: "multica-projects-and-resources at line start",
+			want:  "multica-platform at line start",
+		},
+		{
+			name:  "remaining retired names",
+			id:    "00000000-0000-0000-0000-000000000004",
+			given: "multica-creating-agents multica-runtimes-and-repos multica-skill-importing",
+			want:  "multica-platform multica-platform multica-platform",
+		},
+		{
+			name:  "already migrated",
+			id:    "00000000-0000-0000-0000-000000000005",
+			given: "Load the multica-platform skill.",
+			want:  "Load the multica-platform skill.",
+		},
+		{
+			name:  "workspace skill extending a retired slug",
+			id:    "00000000-0000-0000-0000-000000000006",
+			given: "Our own multica-squads-qa skill owns this.",
+			want:  "Our own multica-squads-qa skill owns this.",
+		},
+		{
+			name:  "retired slug as a suffix of another token",
+			id:    "00000000-0000-0000-0000-000000000007",
+			given: "Our own acme-multica-squads skill owns this.",
+			want:  "Our own acme-multica-squads skill owns this.",
+		},
+		{
+			name:  "still-shipped redirect stub",
+			id:    "00000000-0000-0000-0000-000000000008",
+			given: "Read multica-working-on-issues for the issue contracts.",
+			want:  "Read multica-working-on-issues for the issue contracts.",
+		},
+		{
+			name:  "unrelated built-in",
+			id:    "00000000-0000-0000-0000-000000000009",
+			given: "Mika owns multica-onboarding.",
+			want:  "Mika owns multica-onboarding.",
+		},
+		{
+			name:  "no skill reference at all",
+			id:    "00000000-0000-0000-0000-00000000000a",
+			given: "Answer in Chinese and keep replies short.",
+			want:  "Answer in Chinese and keep replies short.",
+		},
+	}
+
+	for _, tc := range cases {
+		for _, table := range []string{"agent", "squad"} {
+			if _, err := conn.Exec(ctx,
+				"INSERT INTO "+table+" (id, instructions) VALUES ($1, $2)",
+				tc.id, tc.given,
+			); err != nil {
+				t.Fatalf("seed %s %s: %v", table, tc.name, err)
+			}
+		}
+	}
+
+	// An untouched row must keep its original updated_at, so the timestamps
+	// have to be distinguishable from the migration's now().
+	if _, err := conn.Exec(ctx, `
+		UPDATE agent SET updated_at = TIMESTAMPTZ '2020-01-01 00:00:00+00';
+		UPDATE squad SET updated_at = TIMESTAMPTZ '2020-01-01 00:00:00+00';
+	`); err != nil {
+		t.Fatalf("age fixture rows: %v", err)
+	}
+
+	applyMigrationFile(t, ctx, conn.Conn(), "451_rewrite_legacy_platform_skill_names.up.sql")
+
+	for _, tc := range cases {
+		for _, table := range []string{"agent", "squad"} {
+			var got string
+			var touched bool
+			if err := conn.QueryRow(ctx,
+				"SELECT instructions, updated_at > TIMESTAMPTZ '2020-01-01 00:00:00+00' FROM "+table+" WHERE id = $1",
+				tc.id,
+			).Scan(&got, &touched); err != nil {
+				t.Fatalf("read %s %s: %v", table, tc.name, err)
+			}
+			if got != tc.want {
+				t.Errorf("%s %s: instructions = %q, want %q", table, tc.name, got, tc.want)
+			}
+			// updated_at moves exactly with the text, so an unchanged row is
+			// not reported to the rest of the system as edited.
+			if wantTouched := tc.given != tc.want; touched != wantTouched {
+				t.Errorf("%s %s: updated_at bumped = %v, want %v", table, tc.name, touched, wantTouched)
+			}
+		}
+	}
+
+	// Re-running must be a no-op. Migrations are applied once, but a rewrite
+	// that is not idempotent is a rewrite that can still match its own output.
+	applyMigrationFile(t, ctx, conn.Conn(), "451_rewrite_legacy_platform_skill_names.up.sql")
+
+	var remaining int
+	if err := conn.QueryRow(ctx, `
+		SELECT count(*) FROM (
+			SELECT instructions FROM agent
+			UNION ALL
+			SELECT instructions FROM squad
+		) rows
+		WHERE instructions ~ '(?<![A-Za-z0-9-])multica-(autopilots|creating-agents|mentioning|projects-and-resources|runtimes-and-repos|skill-importing|squads)(?![A-Za-z0-9-])'
+	`).Scan(&remaining); err != nil {
+		t.Fatalf("recount retired names: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("retired skill names still present in %d rows, want 0", remaining)
+	}
+
+	for _, tc := range cases {
+		var got string
+		if err := conn.QueryRow(ctx, "SELECT instructions FROM agent WHERE id = $1", tc.id).Scan(&got); err != nil {
+			t.Fatalf("re-read agent %s: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("agent %s after second apply: instructions = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/server/migrations/451_rewrite_legacy_platform_skill_names.down.sql
+++ b/server/migrations/451_rewrite_legacy_platform_skill_names.down.sql
@@ -1,0 +1,12 @@
+-- Not reversible, by decision rather than by oversight. Reversing would mean
+-- restoring which retired name each occurrence of `multica-platform` used to
+-- be, and the up migration keeps no pre-image to read that from. A backup
+-- table was considered and declined: the rows it would protect are pointers to
+-- a skill that no longer exists, and rolling this one rewrite back on its own
+-- -- while leaving the merged skill in place -- would only reintroduce names
+-- that resolve to nothing.
+--
+-- Rewriting `multica-platform` back to any single retired name would be worse
+-- than doing nothing: it would corrupt rows that always said `multica-platform`
+-- and rows this migration never touched.
+SELECT 1;

--- a/server/migrations/451_rewrite_legacy_platform_skill_names.up.sql
+++ b/server/migrations/451_rewrite_legacy_platform_skill_names.up.sql
@@ -1,0 +1,61 @@
+-- Merging the eight built-in platform skills into `multica-platform` retired
+-- seven names, and they live on in user-persisted text. `agent.instructions`
+-- and `squad.instructions` are both copied verbatim into a task brief, so an
+-- agent is still told to load a skill this server no longer ships. A snapshot
+-- taken before this migration found 275 agents across 148 workspaces naming at
+-- least one, 48 of them having started a task in the preceding seven days.
+--
+-- Rewriting persisted user text needs a reason beyond tidiness. These names
+-- were not typed by a person: nothing in this repo templates them into an
+-- agent, so they arrived at runtime -- most plausibly an agent copying the
+-- skill listing out of its own brief into the instructions of an agent it was
+-- creating. The distribution supports that reading, since all seven names
+-- appear rather than the one or two a hand-written pointer would use. So this
+-- corrects platform-generated text, not a sentence someone composed.
+--
+-- The redirect-stub route is deliberately not extended to cover these.
+-- A stub under builtin_skills_legacy answers for a daemon whose own brief
+-- still names the old skill, and it retires on its own because the server
+-- gates it on a daemon capability. Instructions carry no version, so a stub
+-- serving them would have no retirement condition -- it would keep the stale
+-- text working, which is what stops the text from ever being fixed.
+--
+-- Every retired name maps to the same target because each former skill is now
+-- one domain inside `multica-platform`, named in that skill's routing table.
+-- Instructions that referenced several of them therefore end up naming
+-- `multica-platform` more than once. That is left alone: the pointer resolves
+-- either way, and collapsing the repetition would mean editing the surrounding
+-- sentence, which is the one thing a mechanical rewrite must not attempt.
+--
+-- The boundaries around the alternation keep the rewrite to whole slugs, so a
+-- workspace skill that merely starts with a retired name (`multica-squads-qa`)
+-- and the still-shipped `multica-working-on-issues` stub are both left intact.
+-- `updated_at` moves with the row, matching every other write to these tables;
+-- nothing reads it for cache invalidation or daemon sync.
+
+UPDATE agent AS a
+SET instructions = regexp_replace(
+        a.instructions, pattern.re, 'multica-platform', 'g'
+    ),
+    updated_at = now()
+FROM (
+    SELECT '(?<![A-Za-z0-9-])multica-(autopilots|creating-agents|mentioning'
+        || '|projects-and-resources|runtimes-and-repos|skill-importing'
+        || '|squads)(?![A-Za-z0-9-])' AS re
+) AS pattern
+WHERE a.instructions ~ pattern.re;
+
+-- Squad instructions reach a leader's brief through the same path and were
+-- written by the same agents, so they carry the same stale names. They were
+-- outside the original count, which only looked at `agent`.
+UPDATE squad AS s
+SET instructions = regexp_replace(
+        s.instructions, pattern.re, 'multica-platform', 'g'
+    ),
+    updated_at = now()
+FROM (
+    SELECT '(?<![A-Za-z0-9-])multica-(autopilots|creating-agents|mentioning'
+        || '|projects-and-resources|runtimes-and-repos|skill-importing'
+        || '|squads)(?![A-Za-z0-9-])' AS re
+) AS pattern
+WHERE s.instructions ~ pattern.re;


### PR DESCRIPTION
## Summary

MUL-6986 merged the eight built-in platform skills into `multica-platform`, retiring seven names. Those names live on in user-persisted text: `agent.instructions` and `squad.instructions` are both copied verbatim into a task brief, so an agent is still told to load a skill this server no longer ships. A pre-migration snapshot found **275 agents across 148 workspaces** naming at least one, **48 of them having started a task in the preceding seven days**.

Migration 451 rewrites those occurrences to `multica-platform`.

## Why a rewrite rather than redirect stubs

`builtin_skills_legacy` already answers for a daemon whose *own brief* still names a retired skill, and it retires on its own because the server gates it on a daemon capability. Instructions carry no version, so stubs serving them would have no retirement condition — they would keep the stale text working indefinitely, which is precisely what stops the text from ever being fixed.

Rewriting persisted user text needs a reason beyond tidiness. These names were not typed by a person: nothing in this repo templates them into an agent, and all seven appear rather than the one or two a hand-written pointer would use. They arrived at runtime — most plausibly an agent copying the skill listing out of its own brief into the instructions of an agent it was creating. So this corrects platform-generated text, not a sentence someone composed.

## Scope notes

- **`squad.instructions` is included.** It was outside the original count, which only looked at `agent`, but it reaches a leader's brief through the same path and was written by the same agents.
- **`agent_builder_draft.draft` is not.** It is an opaque client-owned JSONB for in-flight creation conversations; the server never reads a field inside it.
- **Repeated targets are left alone.** Every retired name maps to `multica-platform`, so instructions that referenced several end up naming it more than once. The pointer resolves either way, and collapsing the repetition would mean editing the surrounding sentence — the one thing a mechanical rewrite must not attempt.
- **Not reversible, deliberately.** The down migration is `SELECT 1;` with the reasoning: no pre-image is kept, and rewriting `multica-platform` back to any single retired name would corrupt rows that always said it. A backup table was considered and declined — the rows it would protect are pointers to a skill that no longer exists.
- `updated_at` moves only with rows that actually change; nothing reads `agent.updated_at` for cache invalidation or daemon sync (the `updated_at` comparisons in `agent.sql` are all on `runtime`, not `agent`).

Also fixes a comment in `squad_briefing.go` pointing at `multica-squads/references/squad-source-map.md`, deleted in the merge.

## Verification

Run locally against PostgreSQL 16:

- **New migration test** (`legacy_platform_skill_names_migration_test.go`) — 10 cases × 2 tables. Covers each retired name, multiple names in one body, and the survivors that matter: `multica-platform` (already migrated), `multica-squads-qa` (workspace skill extending a retired slug), `acme-multica-squads` (retired slug as a suffix), `multica-working-on-issues` (still-shipped stub), `multica-onboarding`. Asserts `updated_at` is bumped exactly on rows whose text changed, and that a second apply is a no-op.
- **Full migration chain** applied to a clean database through 451. Only the `pg_bigm`-dependent index migrations were skipped — that extension is absent from the stock `postgres:16` image, unrelated to this change.
- **Seeded run against the real schema**: an agent with two retired names in one body was rewritten; an agent naming `multica-squads-qa` and `multica-working-on-issues` was untouched; a squad row was rewritten; re-running reported `UPDATE 0` on the already-rewritten table.
- `go build ./...`, `go vet`, `go test ./internal/migrations/`, plus the service and squad-briefing handler suites — all pass.

CI is running on this PR.

## After merge

Re-run the count query from MUL-7047 to confirm it reaches zero, and add a line to the MUL-6986 release note.
