### PR TITLE
MUL-6986 docs(squads): drop the comment pointing at a deleted source map

### DIFF
--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -29,8 +29,7 @@ import (
 // it changes here. Do not restate it on another surface, and do not say so
 // inside the text: this const is sent to the model on every leader turn, so
 // a note addressed to maintainers is tokens the leader pays for and cannot
-// act on. multica-squads/references/squad-source-map.md records the same
-// ownership for anyone reading from the skill side.
+// act on.
 const squadOperatingProtocolHeader = `## Squad Operating Protocol
 
 **If you are reading this section, you have been activated as a squad LEADER


### PR DESCRIPTION
## What

One sentence removed from the ownership comment above `squadOperatingProtocolHeader`.

```diff
 // a note addressed to maintainers is tokens the leader pays for and cannot
-// act on. multica-squads/references/squad-source-map.md records the same
-// ownership for anyone reading from the skill side.
+// act on.
```

## Why

That file no longer exists. #7968 deleted all eight `references/*-source-map.md` files, so the comment points at nothing.

## Why deleted rather than repointed

The nearest surviving file is `multica-platform/references/squads.md`, but it is not an equivalent target. It states the agent-facing **behavior** — post one short comment when the `squad activity` write fails, and only when the turn has not already commented — not **which file owns the `no_action` rule**.

Ownership is maintainer-facing evidence. Keeping that class of content out of the shipped skill payload is precisely what #7968 was for: those payloads are written to machines with no checkout of this repo, where a pointer to a source file resolves to nothing. Repointing the sentence at `squads.md` would either be inaccurate, or would push maintainer evidence back into the payload.

The comment itself, sitting next to the const it describes, is already the right home for that statement — which is what the rest of it says.

## Verification

- `go build ./...` — clean
- `go vet ./internal/handler/` — clean
- `go test ./internal/handler/ -run 'Squad.*Brief|Briefing'` — pass
- Grepped `server/` for any other non-test reference to a deleted source map: none remain.

Comment-only change; no behavior, no prompt text. The const's contents are untouched, so the leader briefing is byte-identical.
