### PR TITLE
MUL-7053 fix(daemon): explain the codex retired-compaction 404

### DIFF
--- a/server/internal/daemon/codex_compaction_annotation_test.go
+++ b/server/internal/daemon/codex_compaction_annotation_test.go
@@ -40,6 +40,16 @@ func TestAnnotateCodexRetiredCompaction(t *testing.T) {
 				t.Errorf("hint must mention %q, got: %s", want, got)
 			}
 		}
+		// Having sent people to look at Multica-side launch arguments, the
+		// hint must not then tell them nothing on the Multica side needs
+		// changing. The only target it can safely exclude is the generated
+		// per-task copy, which is rebuilt from the shared config every run.
+		if strings.Contains(strings.ToLower(got), "nothing needs changing") {
+			t.Errorf("hint contradicts its own instruction to check launch arguments, got: %s", got)
+		}
+		if !strings.Contains(got, "per-task codex config") {
+			t.Errorf("hint must name the copy that is regenerated, got: %s", got)
+		}
 	})
 
 	t.Run("leaves unrelated failures alone", func(t *testing.T) {

--- a/server/internal/daemon/codex_compaction_annotation_test.go
+++ b/server/internal/daemon/codex_compaction_annotation_test.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+// codexRetiredCompactionError is the failure exactly as GH #8000 reported it.
+const codexRetiredCompactionError = `Error running remote compact task: unexpected status 404 Not Found: ` +
+	`{"detail":"Not Found"}, url: https://chatgpt.com/backend-api/codex/responses/compact, ` +
+	`cf-ray: a35507973eee3d57-SJC, request id: 9eed88ee-822d-446e-9b73-df49d56fe7e0`
+
+func TestAnnotateCodexRetiredCompaction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("explains what codex could not", func(t *testing.T) {
+		t.Parallel()
+		got := annotateCodexRetiredCompaction(codexRetiredCompactionError, "codex")
+
+		// The original text has to survive: it is what the runtime actually
+		// said, and the hint is additive context, not a replacement.
+		if !strings.Contains(got, "Error running remote compact task") {
+			t.Errorf("the runtime's own message must be preserved, got: %s", got)
+		}
+		// The hint has to name the thing Codex's own error never mentions:
+		// which key, in which file, and what to do with it.
+		for _, want := range []string{"remote_compaction_v2", "config.toml", "delete that line"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("hint must mention %q, got: %s", want, got)
+			}
+		}
+	})
+
+	t.Run("leaves unrelated failures alone", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name     string
+			errMsg   string
+			provider string
+		}{
+			// Only the codex backend can emit this text; a lookalike from
+			// another runtime must not be sent to edit ~/.codex.
+			{"other provider", codexRetiredCompactionError, "claude"},
+			// A compaction failure the remedy does not fix — the v2 route is
+			// already in use and the config key is not the problem.
+			{
+				"transient compaction failure",
+				`Error running remote compact task: unexpected status 503 Service Unavailable, ` +
+					`url: https://chatgpt.com/backend-api/codex/responses`,
+				"codex",
+			},
+			{"unrelated codex failure", "codex turn/start failed: broken pipe", "codex"},
+			{"empty", "", "codex"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				if got := annotateCodexRetiredCompaction(tc.errMsg, tc.provider); got != tc.errMsg {
+					t.Errorf("error text must be untouched, got: %s", got)
+				}
+			})
+		}
+	})
+}
+
+// TestCodexCompactionAnnotationCannotChangeMachineDecisions is the same guard
+// TestAnnotationCannotChangeMachineDecisions applies to the Hermes hint, and it
+// matters more here: the error this hint rides on already contains "Not Found",
+// so a single word — "model" — anywhere in the prose would flip the failure out
+// of agent_error.unknown into model_not_found_or_unavailable, and an "HTTP 404"
+// spelled out in the advice would do the same.
+//
+// The annotated text does not stop at the daemon: it is persisted in
+// agent_task_queue.error and re-scanned there for the life of the row, by
+// service.ResumeUnsafeFailure on the write path and by the ILIKE/regex guards
+// in GetLastTaskSession / GetLastChatTaskSession on every later resume lookup.
+// Those guards decide whether a session pointer survives — and this failure in
+// particular must keep its pointer, since the thread resumes normally once the
+// user deletes the config line.
+func TestCodexCompactionAnnotationCannotChangeMachineDecisions(t *testing.T) {
+	t.Parallel()
+
+	// Reasons paired with the error texts a real run reports them for.
+	cases := []struct {
+		name   string
+		errMsg string
+		reason string
+	}{
+		{"the failure this hint targets", codexRetiredCompactionError, "agent_error.unknown"},
+		{"poisoned request", `API error 400: {"type":"invalid_request_error","message":"bad image"}`, "api_invalid_request"},
+		{"resume overflow", "codex thread/resume failed: token too long", "codex_resume_oversized"},
+		{"auth method unresolved", "codex session/resume failed: Could not resolve authentication method", "agent_error.unknown"},
+		{"empty assistant message", `messages.2: assistant message content must not be empty`, "agent_error.unknown"},
+		{"context overflow", "API Error: prompt is too long: 250000 tokens > 200000 maximum", "agent_error.context_overflow"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Annotate unconditionally — the gate is tested above; here we
+			// want the hint attached to every shape to prove it is inert.
+			annotated := tc.errMsg + codexRetiredCompactionHint
+
+			if got, want := taskfailure.Classify(annotated), taskfailure.Classify(tc.errMsg); got != want {
+				t.Errorf("hint moved the failure reason: %q -> %q", want, got)
+			}
+			if got, want := service.ResumeUnsafeFailure(tc.reason, annotated),
+				service.ResumeUnsafeFailure(tc.reason, tc.errMsg); got != want {
+				t.Errorf("hint changed resume safety: %v -> %v", want, got)
+			}
+		})
+	}
+}
+
+// TestCodexRetiredCompactionKeepsSessionResumable pins the deliberate decision
+// behind this being a text-only change: the thread must stay resumable.
+//
+// The failure looks like the poisoned ones around it — it repeats on every
+// following turn and does not recover on its own — but the cause is one line in
+// a config file, not the transcript. Once that line is gone the same
+// conversation compacts and continues, so retiring the session would destroy
+// the context the fix restores. If someone later adds this text to a resume
+// guard, this test is where they find out that was the wrong lesson.
+func TestCodexRetiredCompactionKeepsSessionResumable(t *testing.T) {
+	t.Parallel()
+
+	reason := taskfailure.Classify(codexRetiredCompactionError).String()
+	annotated := annotateCodexRetiredCompaction(codexRetiredCompactionError, "codex")
+	if service.ResumeUnsafeFailure(reason, annotated) {
+		t.Errorf("compaction 404 must stay resume-safe, reason %q", reason)
+	}
+	if _, poisoned := classifyPoisonedError(annotated); poisoned {
+		t.Error("compaction 404 must not be classified as a poisoned session")
+	}
+	if _, unsafe := classifyResumeUnsafeTransport("codex", annotated); unsafe {
+		t.Error("compaction 404 must not be classified as a resume-unsafe transport failure")
+	}
+}

--- a/server/internal/daemon/codex_compaction_annotation_test.go
+++ b/server/internal/daemon/codex_compaction_annotation_test.go
@@ -25,9 +25,17 @@ func TestAnnotateCodexRetiredCompaction(t *testing.T) {
 		if !strings.Contains(got, "Error running remote compact task") {
 			t.Errorf("the runtime's own message must be preserved, got: %s", got)
 		}
-		// The hint has to name the thing Codex's own error never mentions:
-		// which key, in which file, and what to do with it.
-		for _, want := range []string{"remote_compaction_v2", "config.toml", "delete that line"} {
+		// The hint has to name what Codex's own error never mentions: the
+		// setting, and every place it can be turned off. Being a constant, it
+		// cannot know which source applied — so naming only the config file
+		// would send anyone who set it in launch arguments to edit a line that
+		// is not there, the same dead end this hint exists to prevent.
+		for _, want := range []string{
+			"remote_compaction_v2",
+			"config.toml",
+			"--disable remote_compaction_v2",
+			"-c features.remote_compaction_v2=false",
+		} {
 			if !strings.Contains(got, want) {
 				t.Errorf("hint must mention %q, got: %s", want, got)
 			}
@@ -44,12 +52,26 @@ func TestAnnotateCodexRetiredCompaction(t *testing.T) {
 			// Only the codex backend can emit this text; a lookalike from
 			// another runtime must not be sent to edit ~/.codex.
 			{"other provider", codexRetiredCompactionError, "claude"},
-			// A compaction failure the remedy does not fix — the v2 route is
-			// already in use and the config key is not the problem.
+			// Compaction failures on the v2 route. They carry the same
+			// "Error running remote compact task" prefix and can carry the
+			// same status, so firing here would tell a user whose setting is
+			// already correct to go turn it off.
 			{
-				"transient compaction failure",
-				`Error running remote compact task: unexpected status 503 Service Unavailable, ` +
+				"v2 route returning the same status",
+				`Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"}, ` +
 					`url: https://chatgpt.com/backend-api/codex/responses`,
+				"codex",
+			},
+			{
+				"v2 route failing some other way",
+				`Error running remote compact task: remote compaction v2 stream closed before response.completed`,
+				"codex",
+			},
+			// No url tail, so nothing identifies the route — see
+			// CodexRetiredCompactionError for why that stays a false negative.
+			{
+				"no url tail",
+				`Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"}`,
 				"codex",
 			},
 			{"unrelated codex failure", "codex turn/start failed: broken pipe", "codex"},

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -8489,13 +8489,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			// fact.
 			failureReason = taskfailure.Classify(errMsg).String()
 		}
-		// After the classifiers above have read errMsg. The hint is fixed
+		// After the classifiers above have read errMsg. Each hint is fixed
 		// prose chosen to match none of the resume guards (see its const), so
 		// ordering is not what makes it safe — but it keeps the machine
 		// decisions reading exactly what the runtime reported, and leaves the
-		// annotation on the outside where a future edit is visibly a change to
-		// human-facing text rather than to classifier input.
+		// annotations on the outside where a future edit is visibly a change
+		// to human-facing text rather than to classifier input. They are
+		// mutually exclusive by provider, so they cannot stack.
 		errMsg = annotateHermesProviderUnconfigured(errMsg, provider, env.HermesHome != "")
+		errMsg = annotateCodexRetiredCompaction(errMsg, provider)
 		return TaskResult{
 			Status:        "blocked",
 			Comment:       errMsg,
@@ -9606,6 +9608,48 @@ func annotateHermesProviderUnconfigured(errMsg, provider string, overlayActive b
 		return errMsg
 	}
 	return errMsg + hermesProviderUnconfiguredHint
+}
+
+// codexRetiredCompactionHint is appended verbatim to a Codex compaction
+// failure against the retired endpoint. Like hermesProviderUnconfiguredHint
+// above it is a CONSTANT, for the same correctness reason — see
+// annotateCodexRetiredCompaction — and is worded to stay clear of every
+// phrase the resume guards and taskfailure.Classify match, since it is
+// persisted in agent_task_queue.error and re-scanned there indefinitely.
+// TestCodexCompactionAnnotationCannotChangeMachineDecisions pins that.
+const codexRetiredCompactionHint = " [multica] codex could not compact this conversation: it called a " +
+	"compaction endpoint OpenAI has retired. That route is selected by `remote_compaction_v2 = false` " +
+	"under `[features]` in your codex config (~/.codex/config.toml by default) — delete that line, or " +
+	"set it to true, and run this task again. Nothing needs changing on the multica side: the per-task " +
+	"codex config is re-copied from your shared one between runs, and a thread stuck this way continues " +
+	"where it left off once compaction works."
+
+// annotateCodexRetiredCompaction explains a compaction 404 that Codex itself
+// cannot explain.
+//
+// Codex reports the failing URL and status and stops there. The line that
+// chose that URL — `remote_compaction_v2 = false` — appears nowhere in the
+// text, so the error names no file, no key, and no remedy; the reporter in
+// GH #8000 had to open an issue to find out the fix was deleting one line.
+// Nor does the failure resolve on its own: the conversation stays above the
+// auto-compact threshold, so every following turn retries the same retired
+// call.
+//
+// Text only. This changes no reason, status, or control flow — in particular
+// it does NOT retire the session. That is a deliberate choice, not an
+// omission: unlike the resume-unsafe failures classified above, this thread is
+// recoverable, and it recovers by itself once the flag is gone. Dropping the
+// session pointer would discard the conversation the one-line fix brings back.
+//
+// Scoped to the codex provider, which is exactly the set of runs that can
+// produce this text (only "codex" resolves to codexBackend), so the check
+// costs nothing and keeps a lookalike string from another runtime out.
+func annotateCodexRetiredCompaction(errMsg, provider string) string {
+	if strings.ToLower(strings.TrimSpace(provider)) != "codex" ||
+		!agent.CodexRetiredCompactionError(errMsg) {
+		return errMsg
+	}
+	return errMsg + codexRetiredCompactionHint
 }
 
 func layerCustomEnvAndHermesHome(agentEnv, customEnv map[string]string, overlayHome string, logger *slog.Logger) {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -9611,35 +9611,46 @@ func annotateHermesProviderUnconfigured(errMsg, provider string, overlayActive b
 }
 
 // codexRetiredCompactionHint is appended verbatim to a Codex compaction
-// failure against the retired endpoint. Like hermesProviderUnconfiguredHint
+// failure against the retired route. Like hermesProviderUnconfiguredHint
 // above it is a CONSTANT, for the same correctness reason — see
 // annotateCodexRetiredCompaction — and is worded to stay clear of every
 // phrase the resume guards and taskfailure.Classify match, since it is
 // persisted in agent_task_queue.error and re-scanned there indefinitely.
 // TestCodexCompactionAnnotationCannotChangeMachineDecisions pins that.
-const codexRetiredCompactionHint = " [multica] codex could not compact this conversation: it called a " +
-	"compaction endpoint OpenAI has retired. That route is selected by `remote_compaction_v2 = false` " +
-	"under `[features]` in your codex config (~/.codex/config.toml by default) — delete that line, or " +
-	"set it to true, and run this task again. Nothing needs changing on the multica side: the per-task " +
-	"codex config is re-copied from your shared one between runs, and a thread stuck this way continues " +
-	"where it left off once compaction works."
-
-// annotateCodexRetiredCompaction explains a compaction 404 that Codex itself
-// cannot explain.
 //
-// Codex reports the failing URL and status and stops there. The line that
-// chose that URL — `remote_compaction_v2 = false` — appears nowhere in the
-// text, so the error names no file, no key, and no remedy; the reporter in
-// GH #8000 had to open an issue to find out the fix was deleting one line.
-// Nor does the failure resolve on its own: the conversation stays above the
-// auto-compact threshold, so every following turn retries the same retired
-// call.
+// It names every place the setting can be off, because being a constant means
+// it cannot know which one applied. The shared config is the common case and
+// the only one the upstream reports mention, but the launch arguments reach
+// the same state: nothing strips `--disable remote_compaction_v2` or
+// `-c features.remote_compaction_v2=false` out of an agent's custom args, a
+// daemon's extra args, or a custom runtime profile's launch prefix — only
+// fast_mode gets that treatment, and only when a service tier is selected.
+// Naming just the file would send anyone in that case to edit a line that is
+// not there, which is the failure mode this hint exists to prevent.
+const codexRetiredCompactionHint = " [multica] codex could not compact this conversation: it called a " +
+	"compaction endpoint OpenAI has retired. That route is selected by turning `remote_compaction_v2` " +
+	"off, so look in both places it can be off: `[features]` in the codex config this agent uses " +
+	"(~/.codex/config.toml by default), and the codex launch arguments on the agent, the daemon, or a " +
+	"custom runtime profile (`--disable remote_compaction_v2`, `-c features.remote_compaction_v2=false`). " +
+	"Remove it wherever it appears — or set it to true — and run this task again. Nothing needs changing " +
+	"on the multica side: the per-task codex config is re-copied from your shared one between runs, and a " +
+	"thread stuck this way continues where it left off once compaction works."
+
+// annotateCodexRetiredCompaction explains a retired-route compaction failure
+// that Codex itself cannot explain.
+//
+// Codex reports the failing URL and status and stops there. The setting that
+// chose that URL — `remote_compaction_v2` — appears nowhere in the text, so the
+// error names no file, no key and no remedy; the reporter in GH #8000 had to
+// open an issue to learn the fix was deleting one line. Nor does the failure
+// resolve on its own: the conversation stays above the auto-compact threshold,
+// so every following turn retries the same retired call.
 //
 // Text only. This changes no reason, status, or control flow — in particular
 // it does NOT retire the session. That is a deliberate choice, not an
 // omission: unlike the resume-unsafe failures classified above, this thread is
-// recoverable, and it recovers by itself once the flag is gone. Dropping the
-// session pointer would discard the conversation the one-line fix brings back.
+// recoverable, and it recovers by itself once the setting is right. Dropping
+// the session pointer would discard the conversation the fix brings back.
 //
 // Scoped to the codex provider, which is exactly the set of runs that can
 // produce this text (only "codex" resolves to codexBackend), so the check

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -9627,14 +9627,23 @@ func annotateHermesProviderUnconfigured(errMsg, provider string, overlayActive b
 // fast_mode gets that treatment, and only when a service tier is selected.
 // Naming just the file would send anyone in that case to edit a line that is
 // not there, which is the failure mode this hint exists to prevent.
+//
+// For the same reason the closing line excludes only the generated per-task
+// copy, rather than claiming nothing on the Multica side needs changing. Once
+// the hint sends people to look at custom_args, a daemon's extra args, or a
+// profile's fixed args, "nothing to change here" contradicts the instruction
+// directly above it and strands exactly the users the argument half was added
+// for. The per-task copy is the one target that is genuinely wrong to edit: it
+// is rebuilt from the shared config every run, so an edit there is discarded.
 const codexRetiredCompactionHint = " [multica] codex could not compact this conversation: it called a " +
 	"compaction endpoint OpenAI has retired. That route is selected by turning `remote_compaction_v2` " +
 	"off, so look in both places it can be off: `[features]` in the codex config this agent uses " +
 	"(~/.codex/config.toml by default), and the codex launch arguments on the agent, the daemon, or a " +
 	"custom runtime profile (`--disable remote_compaction_v2`, `-c features.remote_compaction_v2=false`). " +
-	"Remove it wherever it appears — or set it to true — and run this task again. Nothing needs changing " +
-	"on the multica side: the per-task codex config is re-copied from your shared one between runs, and a " +
-	"thread stuck this way continues where it left off once compaction works."
+	"Remove it wherever it appears — or set it to true — and run this task again; both sources are re-read " +
+	"on the next run. The one place not to edit is the per-task codex config this run used: it is " +
+	"regenerated from your shared one every run, so a change there is lost. A thread stuck this way " +
+	"continues where it left off once compaction works."
 
 // annotateCodexRetiredCompaction explains a retired-route compaction failure
 // that Codex itself cannot explain.

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -232,6 +232,15 @@ var codexCompactNotFoundWitnesses = []string{"status 404", "404 not found"}
 // once the flag is gone compaction succeeds and the same conversation
 // continues, so retiring the session here would throw away exactly the context
 // the fix restores. Text only.
+//
+// Delete once no Codex old enough to select the retired route is still in use.
+// Upstream intends to mark the flag Stage::Removed or fall back on the 404,
+// and under either fix this predicate simply stops matching: it overrides no
+// config and stands between nobody and a flag they may legitimately want off,
+// so it costs one substring check on an already-failing path until then and
+// comes out in a single commit. That is the difference from forcing
+// `--enable remote_compaction_v2`, which was declined for the opposite reason
+// (GH #8019) — an override outlives the defect and blocks the legitimate case.
 func CodexRetiredCompactionError(errText string) bool {
 	if errText == "" {
 		return false

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -190,55 +190,57 @@ func CodexResumeOverflowError(errText string) bool {
 	return strings.Contains(lower, codexResumeMarker) && strings.Contains(lower, codexLineOverflowMarker)
 }
 
-// codexRemoteCompactMarker opens the error Codex writes when the compaction
-// task it runs on the user's behalf fails, and codexRetiredCompactPath is the
-// request path only the legacy compaction route ever calls. The v2 route
-// compacts on the ordinary /responses stream instead, so this segment appears
-// only when the legacy route was selected.
-const (
-	codexRemoteCompactMarker = "remote compact task"
-	codexRetiredCompactPath  = "responses/compact"
-)
+// codexRetiredCompactPath is the request path only the legacy remote-compaction
+// route ever calls. The v2 route compacts on the ordinary /responses stream
+// instead, so this segment appears only when the legacy route was selected.
+const codexRetiredCompactPath = "responses/compact"
 
-// codexCompactNotFoundWitnesses are the two renderings of the 404 the retired
-// endpoint answers with. Both are HTTP status phrasings, which is what keeps
-// them safe to match: a bare "404" also occurs inside the hex request id and
-// cf-ray the same error carries, and those say nothing about the status.
-var codexCompactNotFoundWitnesses = []string{"status 404", "404 not found"}
+// codexRemoteCompactMarker opens the error Codex writes when a remote
+// compaction task fails. Both routes share it — compact_remote_v2.rs labels its
+// own failures with the same phrase — so it establishes only that compaction is
+// what failed, never which route ran.
+const codexRemoteCompactMarker = "remote compact task"
 
 // CodexRetiredCompactionError reports whether an agent error is Codex failing
-// to compact a conversation because it called the compaction endpoint OpenAI
-// has retired, e.g.
+// to compact a conversation over the route OpenAI has retired, e.g.
 //
 //	Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"},
 //	url: https://chatgpt.com/backend-api/codex/responses/compact, cf-ray: ..., request id: ...
 //
-// The route is chosen by `remote_compaction_v2 = false` under `[features]` in
-// the user's codex config. Codex versions before 26.901 ignored that value, so
-// a line pasted years ago as a workaround for an unrelated defect starts
-// failing on upgrade without the user touching anything (GH #8000, upstream
-// openai/codex#42468). Nothing in the text names the config key, so the
-// failure is unreadable on its own — which is the whole reason this predicate
-// exists: callers use it to attach the one-line remedy.
+// The route is chosen by turning `remote_compaction_v2` off. Older Codex builds
+// ignored that setting, so a value added as a workaround for an unrelated,
+// since-fixed defect can start failing on upgrade without the user touching
+// anything (GH #8000, upstream openai/codex#42468). Nothing in the text names
+// the setting, so the failure is unreadable on its own — which is the whole
+// reason this predicate exists: callers use it to attach the remedy.
 //
-// The compaction marker is required, and on its own is not enough: a transient
-// 5xx or a rate limit on the SAME call is a compaction failure the remedy does
-// not fix, and pointing those at the config key would send users to edit a
-// file that was never the problem. Either witness of "this route is gone"
-// settles it — the 404 status, or the legacy path itself, which is evidence of
-// the stale flag whatever status came back.
+// The retired PATH is what has to be present. The compaction marker alone is
+// not evidence of anything: the v2 route wraps its own failures in the same
+// "Error running remote compact task" prefix, and a v2 stream can return 404
+// too — so keying on the marker plus a status code would tell a user whose
+// setting is already correct to go turn it off, the exact opposite of the fix.
+// The path cannot be produced that way; a compaction request reaching
+// /responses/compact at all means the legacy route was selected, whatever
+// status came back.
+//
+// That leaves a deliberate false negative: a Codex build that reports this
+// failure without the url tail gets no hint. There is no second signal in the
+// text that identifies the route, and the two errors are otherwise
+// indistinguishable, so the choice is between missing some cases and
+// misdirecting the users whose config was never the problem. A missed hint
+// costs what today already costs; a wrong hint spends someone's afternoon.
 //
 // Deliberately NOT a resume-safety predicate. The stuck thread is recoverable:
-// once the flag is gone compaction succeeds and the same conversation
+// once the setting is right compaction succeeds and the same conversation
 // continues, so retiring the session here would throw away exactly the context
 // the fix restores. Text only.
 //
 // Delete once no Codex old enough to select the retired route is still in use.
 // Upstream intends to mark the flag Stage::Removed or fall back on the 404,
 // and under either fix this predicate simply stops matching: it overrides no
-// config and stands between nobody and a flag they may legitimately want off,
-// so it costs one substring check on an already-failing path until then and
-// comes out in a single commit. That is the difference from forcing
+// config and stands between nobody and a setting they may legitimately want
+// off, so it costs one substring check on an already-failing path until then
+// and comes out in a single commit. That is the difference from forcing
 // `--enable remote_compaction_v2`, which was declined for the opposite reason
 // (GH #8019) — an override outlives the defect and blocks the legitimate case.
 func CodexRetiredCompactionError(errText string) bool {
@@ -246,18 +248,8 @@ func CodexRetiredCompactionError(errText string) bool {
 		return false
 	}
 	lower := strings.ToLower(errText)
-	if !strings.Contains(lower, codexRemoteCompactMarker) {
-		return false
-	}
-	if strings.Contains(lower, codexRetiredCompactPath) {
-		return true
-	}
-	for _, witness := range codexCompactNotFoundWitnesses {
-		if strings.Contains(lower, witness) {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(lower, codexRemoteCompactMarker) &&
+		strings.Contains(lower, codexRetiredCompactPath)
 }
 
 // codexModelCatalogRefreshFailureSignal matches the Codex models-manager error

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -190,6 +190,67 @@ func CodexResumeOverflowError(errText string) bool {
 	return strings.Contains(lower, codexResumeMarker) && strings.Contains(lower, codexLineOverflowMarker)
 }
 
+// codexRemoteCompactMarker opens the error Codex writes when the compaction
+// task it runs on the user's behalf fails, and codexRetiredCompactPath is the
+// request path only the legacy compaction route ever calls. The v2 route
+// compacts on the ordinary /responses stream instead, so this segment appears
+// only when the legacy route was selected.
+const (
+	codexRemoteCompactMarker = "remote compact task"
+	codexRetiredCompactPath  = "responses/compact"
+)
+
+// codexCompactNotFoundWitnesses are the two renderings of the 404 the retired
+// endpoint answers with. Both are HTTP status phrasings, which is what keeps
+// them safe to match: a bare "404" also occurs inside the hex request id and
+// cf-ray the same error carries, and those say nothing about the status.
+var codexCompactNotFoundWitnesses = []string{"status 404", "404 not found"}
+
+// CodexRetiredCompactionError reports whether an agent error is Codex failing
+// to compact a conversation because it called the compaction endpoint OpenAI
+// has retired, e.g.
+//
+//	Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"},
+//	url: https://chatgpt.com/backend-api/codex/responses/compact, cf-ray: ..., request id: ...
+//
+// The route is chosen by `remote_compaction_v2 = false` under `[features]` in
+// the user's codex config. Codex versions before 26.901 ignored that value, so
+// a line pasted years ago as a workaround for an unrelated defect starts
+// failing on upgrade without the user touching anything (GH #8000, upstream
+// openai/codex#42468). Nothing in the text names the config key, so the
+// failure is unreadable on its own — which is the whole reason this predicate
+// exists: callers use it to attach the one-line remedy.
+//
+// The compaction marker is required, and on its own is not enough: a transient
+// 5xx or a rate limit on the SAME call is a compaction failure the remedy does
+// not fix, and pointing those at the config key would send users to edit a
+// file that was never the problem. Either witness of "this route is gone"
+// settles it — the 404 status, or the legacy path itself, which is evidence of
+// the stale flag whatever status came back.
+//
+// Deliberately NOT a resume-safety predicate. The stuck thread is recoverable:
+// once the flag is gone compaction succeeds and the same conversation
+// continues, so retiring the session here would throw away exactly the context
+// the fix restores. Text only.
+func CodexRetiredCompactionError(errText string) bool {
+	if errText == "" {
+		return false
+	}
+	lower := strings.ToLower(errText)
+	if !strings.Contains(lower, codexRemoteCompactMarker) {
+		return false
+	}
+	if strings.Contains(lower, codexRetiredCompactPath) {
+		return true
+	}
+	for _, witness := range codexCompactNotFoundWitnesses {
+		if strings.Contains(lower, witness) {
+			return true
+		}
+	}
+	return false
+}
+
 // codexModelCatalogRefreshFailureSignal matches the Codex models-manager error
 // emitted when the model catalog could not be refreshed. Codex reports several
 // distinct causes under this prefix ("timeout waiting for child process to

--- a/server/pkg/agent/codex_compaction_test.go
+++ b/server/pkg/agent/codex_compaction_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import "testing"
+
+// codexRetiredCompactionLiveError is the failure exactly as GH #8000 reported
+// it, request id and cf-ray included — the hex ids are part of the fixture on
+// purpose, since a bare "404" substring match would find one inside them.
+const codexRetiredCompactionLiveError = `Error running remote compact task: unexpected status 404 Not Found: ` +
+	`{"detail":"Not Found"}, url: https://chatgpt.com/backend-api/codex/responses/compact, ` +
+	`cf-ray: a35507973eee3d57-SJC, request id: 9eed88ee-822d-446e-9b73-df49d56fe7e0`
+
+func TestCodexRetiredCompactionError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		errText string
+		want    bool
+	}{
+		{"live failure", codexRetiredCompactionLiveError, true},
+		// Older/shorter renderings of the same failure: the upstream issue
+		// quotes it without the url tail, and the status phrase alone has to
+		// carry it there.
+		{
+			"no url tail",
+			`Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"}`,
+			true,
+		},
+		// The path is evidence of the stale flag whatever status came back —
+		// a compaction call reaching that route at all means v2 is disabled.
+		{
+			"retired path without a 404",
+			`Error running remote compact task: unexpected status 502 Bad Gateway, ` +
+				`url: https://chatgpt.com/backend-api/codex/responses/compact`,
+			true,
+		},
+		{"case insensitive", `ERROR RUNNING REMOTE COMPACT TASK: UNEXPECTED STATUS 404 NOT FOUND`, true},
+
+		// Compaction failures the remedy does not fix. Pointing these at the
+		// config key would send users to edit a file that was never the
+		// problem, so the marker alone must not be enough.
+		{
+			"transient status on the v2 route",
+			`Error running remote compact task: unexpected status 503 Service Unavailable, ` +
+				`url: https://chatgpt.com/backend-api/codex/responses`,
+			false,
+		},
+		{
+			"rate limited compaction",
+			`Error running remote compact task: unexpected status 429 Too Many Requests`,
+			false,
+		},
+		// A 404 from somewhere else in the turn says nothing about compaction.
+		{
+			"unrelated 404",
+			`Error running turn: unexpected status 404 Not Found, url: https://chatgpt.com/backend-api/codex/responses`,
+			false,
+		},
+		// The digits of a request id are not a status code.
+		{
+			"404 only inside a request id",
+			`Error running remote compact task: stream disconnected, request id: 9eed404e-822d-446e-9b73-df49d56fe7e0`,
+			false,
+		},
+		{"empty", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := CodexRetiredCompactionError(tc.errText); got != tc.want {
+				t.Errorf("CodexRetiredCompactionError(%q) = %v, want %v", tc.errText, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/pkg/agent/codex_compaction_test.go
+++ b/server/pkg/agent/codex_compaction_test.go
@@ -1,10 +1,14 @@
 package agent
 
-import "testing"
+import (
+	"slices"
+	"strings"
+	"testing"
+)
 
 // codexRetiredCompactionLiveError is the failure exactly as GH #8000 reported
 // it, request id and cf-ray included — the hex ids are part of the fixture on
-// purpose, since a bare "404" substring match would find one inside them.
+// purpose, since a status-code match would find digits inside them.
 const codexRetiredCompactionLiveError = `Error running remote compact task: unexpected status 404 Not Found: ` +
 	`{"detail":"Not Found"}, url: https://chatgpt.com/backend-api/codex/responses/compact, ` +
 	`cf-ray: a35507973eee3d57-SJC, request id: 9eed88ee-822d-446e-9b73-df49d56fe7e0`
@@ -18,50 +22,54 @@ func TestCodexRetiredCompactionError(t *testing.T) {
 		want    bool
 	}{
 		{"live failure", codexRetiredCompactionLiveError, true},
-		// Older/shorter renderings of the same failure: the upstream issue
-		// quotes it without the url tail, and the status phrase alone has to
-		// carry it there.
+		// The path is what identifies the route, so any status on it counts:
+		// a compaction request reaching /responses/compact at all means the
+		// legacy route was selected, and the remedy is the same either way.
 		{
-			"no url tail",
-			`Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"}`,
-			true,
-		},
-		// The path is evidence of the stale flag whatever status came back —
-		// a compaction call reaching that route at all means v2 is disabled.
-		{
-			"retired path without a 404",
+			"retired path with a non-404 status",
 			`Error running remote compact task: unexpected status 502 Bad Gateway, ` +
 				`url: https://chatgpt.com/backend-api/codex/responses/compact`,
 			true,
 		},
-		{"case insensitive", `ERROR RUNNING REMOTE COMPACT TASK: UNEXPECTED STATUS 404 NOT FOUND`, true},
-
-		// Compaction failures the remedy does not fix. Pointing these at the
-		// config key would send users to edit a file that was never the
-		// problem, so the marker alone must not be enough.
 		{
-			"transient status on the v2 route",
-			`Error running remote compact task: unexpected status 503 Service Unavailable, ` +
+			"case insensitive",
+			`ERROR RUNNING REMOTE COMPACT TASK: UNEXPECTED STATUS 404 NOT FOUND, ` +
+				`URL: HTTPS://CHATGPT.COM/BACKEND-API/CODEX/RESPONSES/COMPACT`,
+			true,
+		},
+
+		// The reason the path is required rather than the status. Codex wraps
+		// v2 compaction failures in the SAME "Error running remote compact
+		// task" prefix (compact_remote_v2.rs), and a v2 stream can answer 404
+		// too. Firing here would tell a user whose setting is already correct
+		// to go turn it off — the exact opposite of the fix.
+		{
+			"v2 route returning the same status",
+			`Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"}, ` +
 				`url: https://chatgpt.com/backend-api/codex/responses`,
 			false,
 		},
 		{
-			"rate limited compaction",
-			`Error running remote compact task: unexpected status 429 Too Many Requests`,
+			"v2 route failing some other way",
+			`Error running remote compact task: remote compaction v2 stream closed before response.completed`,
 			false,
 		},
-		// A 404 from somewhere else in the turn says nothing about compaction.
+		// The accepted false negative: without the url tail nothing in the
+		// text says which route ran, and guessing would land on the case
+		// above. No hint costs what today already costs; a wrong hint is worse.
 		{
-			"unrelated 404",
-			`Error running turn: unexpected status 404 Not Found, url: https://chatgpt.com/backend-api/codex/responses`,
+			"no url tail",
+			`Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"}`,
 			false,
 		},
-		// The digits of a request id are not a status code.
+		// The path without the compaction marker is some other request.
 		{
-			"404 only inside a request id",
-			`Error running remote compact task: stream disconnected, request id: 9eed404e-822d-446e-9b73-df49d56fe7e0`,
+			"path outside a compaction failure",
+			`Error running turn: unexpected status 404 Not Found, ` +
+				`url: https://chatgpt.com/backend-api/codex/responses/compact`,
 			false,
 		},
+		{"unrelated codex failure", "codex thread/resume failed: token too long", false},
 		{"empty", "", false},
 	}
 
@@ -70,6 +78,72 @@ func TestCodexRetiredCompactionError(t *testing.T) {
 			t.Parallel()
 			if got := CodexRetiredCompactionError(tc.errText); got != tc.want {
 				t.Errorf("CodexRetiredCompactionError(%q) = %v, want %v", tc.errText, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCodexLaunchArgsCanSelectTheRetiredCompactionRoute is the behavioural
+// basis for the hint naming launch arguments alongside the config file.
+//
+// The remedy text is a constant, so it cannot know which source turned the
+// setting off — which makes "is an argument even a real source?" a claim the
+// code has to back. It is: codexBlockedArgs blocks only --listen, and the only
+// feature-conflict stripping in this package is scoped to fast_mode under an
+// explicit service tier. So both spellings survive normalization from every
+// argv region a user can write into, and the file is not the only place to look.
+//
+// If a future change starts stripping these — the #8019 override, say — this
+// test fails, which is the signal to drop that half of the hint rather than
+// keep pointing users at a source that no longer exists.
+func TestCodexLaunchArgsCanSelectTheRetiredCompactionRoute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"disable flag", []string{"--disable", "remote_compaction_v2"}},
+		{"disable flag with inline value", []string{"--disable=remote_compaction_v2"}},
+		{"config override", []string{"-c", "features.remote_compaction_v2=false"}},
+		{"config override shell-quoted", []string{"'-c'", "'features.remote_compaction_v2=false'"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Both argv regions, since custom_args and a daemon's extra args
+			// are separate inputs and the hint names both.
+			for region, args := range map[string][]string{
+				"extra_args":  tc.args,
+				"custom_args": tc.args,
+			} {
+				var extra, custom []string
+				if region == "extra_args" {
+					extra = args
+				} else {
+					custom = args
+				}
+				got := NormalizeCodexLaunchArgs(extra, custom, nil, nil)
+				if !slices.Contains(got, "remote_compaction_v2") &&
+					!slices.Contains(got, "--disable=remote_compaction_v2") &&
+					!slices.Contains(got, "features.remote_compaction_v2=false") {
+					t.Errorf("%s: setting did not survive normalization: %q", region, got)
+				}
+			}
+
+			// The one place this package does strip a --disable is the
+			// fast_mode conflict removal under an explicit service tier.
+			// It is scoped to that feature, and the effective argv is where
+			// that has to hold.
+			effective := buildCodexArgs(ExecOptions{
+				CustomArgs:  tc.args,
+				ServiceTier: codexFastServiceTier,
+			}, nil)
+			if !slices.ContainsFunc(effective, func(arg string) bool {
+				return strings.Contains(arg, "remote_compaction_v2")
+			}) {
+				t.Errorf("priority tier stripped an unrelated setting: %q", effective)
 			}
 		})
 	}

--- a/server/pkg/agent/codex_compaction_test.go
+++ b/server/pkg/agent/codex_compaction_test.go
@@ -88,10 +88,12 @@ func TestCodexRetiredCompactionError(t *testing.T) {
 //
 // The remedy text is a constant, so it cannot know which source turned the
 // setting off — which makes "is an argument even a real source?" a claim the
-// code has to back. It is: codexBlockedArgs blocks only --listen, and the only
-// feature-conflict stripping in this package is scoped to fast_mode under an
-// explicit service tier. So both spellings survive normalization from every
-// argv region a user can write into, and the file is not the only place to look.
+// code has to back. It is: codexBlockedArgs blocks only --listen, and every
+// feature-conflict filter here is scoped to fast_mode or the managed
+// mcp_servers namespace. So both spellings survive from all three argv regions
+// the hint names — an agent's custom args, a daemon's extra args, and a custom
+// runtime profile's fixed args — and the config file is not the only place to
+// look.
 //
 // If a future change starts stripping these — the #8019 override, say — this
 // test fails, which is the signal to drop that half of the hint rather than
@@ -140,11 +142,33 @@ func TestCodexLaunchArgsCanSelectTheRetiredCompactionRoute(t *testing.T) {
 				CustomArgs:  tc.args,
 				ServiceTier: codexFastServiceTier,
 			}, nil)
-			if !slices.ContainsFunc(effective, func(arg string) bool {
-				return strings.Contains(arg, "remote_compaction_v2")
-			}) {
+			if !mentionsRemoteCompactionV2(effective) {
 				t.Errorf("priority tier stripped an unrelated setting: %q", effective)
+			}
+
+			// The third argv region the hint names: a custom runtime profile's
+			// fixed args. It reaches the child through the launch prefix, not
+			// through NormalizeCodexLaunchArgs, so it has its own filters —
+			// all three of which the setting has to survive for the hint to be
+			// telling the truth about where to look.
+			prefix := FilterLaunchPrefix("codex", tc.args, nil)
+			if !mentionsRemoteCompactionV2(prefix) {
+				t.Errorf("launch prefix filter dropped the setting: %q", prefix)
+			}
+			if got := filterCodexCustomConfigOverrides(prefix, nil); !mentionsRemoteCompactionV2(got) {
+				t.Errorf("managed mcp_config prefix filter dropped the setting: %q", got)
+			}
+			if got := stripCodexFastModeConflicts(prefix, nil); !mentionsRemoteCompactionV2(got) {
+				t.Errorf("priority tier prefix filter dropped the setting: %q", got)
 			}
 		})
 	}
+}
+
+// mentionsRemoteCompactionV2 reports whether the setting survived in any of its
+// spellings — as a standalone --disable value, an inline one, or a -c override.
+func mentionsRemoteCompactionV2(args []string) bool {
+	return slices.ContainsFunc(args, func(arg string) bool {
+		return strings.Contains(arg, "remote_compaction_v2")
+	})
 }


### PR DESCRIPTION
## Summary

Codex fails a turn with

```
Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"},
url: https://chatgpt.com/backend-api/codex/responses/compact, cf-ray: ..., request id: ...
```

and stops there. The line that chose that URL — `remote_compaction_v2 = false` under `[features]` in `~/.codex/config.toml` — appears nowhere in the text, so the error names no file, no key and no remedy. It also doesn't recover on its own: the conversation stays above the auto-compact threshold, so every following turn retries the same retired call. The reporter in #8000 had to open an issue to learn the fix was deleting one line.

The error is completely unclassified on our side today — `grep -r "remote compact"` had zero hits — so it dodges every hint path we have and lands in `agent_error.unknown`.

This recognises the failure and appends the remedy to the error text, the same mechanism as the Hermes "no LLM provider configured" hint. The raw error still reaches the user unchanged; the hint rides behind it:

> `Error running remote compact task: unexpected status 404 Not Found: {"detail":"Not Found"}, url: …/responses/compact` **[multica] codex could not compact this conversation: it called a compaction endpoint OpenAI has retired. That route is selected by turning `remote_compaction_v2` off, so look in both places it can be off: `[features]` in the codex config this agent uses (~/.codex/config.toml by default), and the codex launch arguments on the agent, the daemon, or a custom runtime profile (`--disable remote_compaction_v2`, `-c features.remote_compaction_v2=false`). Remove it wherever it appears — or set it to true — and run this task again; both sources are re-read on the next run. The one place not to edit is the per-task codex config this run used: it is regenerated from your shared one every run, so a change there is lost. A thread stuck this way continues where it left off once compaction works.**

## Design notes

**It keys on the route, not the status.** The compaction marker alone is no evidence: Codex wraps v2 compaction failures in the same `Error running remote compact task` prefix (`compact_remote_v2.rs`), and a v2 stream can answer 404 too — so matching marker + status would tell a user whose setting is already correct to go turn it off. The required witness is the retired `/responses/compact` path, which the v2 route cannot produce; a compaction request reaching it means the legacy route was selected whatever status came back.

That gives up the case where Codex reports the failure without the url tail. Nothing else in that text identifies the route, so the choice was between missing some cases and misdirecting users whose config was never the problem — a missed hint costs what today already costs, a wrong one spends someone's afternoon.

**The hint names both sources of the setting.** The shared config file is the common case and the only one upstream mentions, but launch arguments reach the same state: `codexBlockedArgs` blocks only `--listen`, and the sole feature-conflict stripping here is scoped to `fast_mode` under an explicit service tier — so `--disable remote_compaction_v2` and `-c features.remote_compaction_v2=false` survive from custom args, daemon extra args, and a custom runtime profile's prefix alike. Naming only the file would send anyone in that case to edit a line that isn't there. The text stays a constant (load-bearing, see below), so it can't narrow itself to whichever source applied; `TestCodexLaunchArgsCanSelectTheRetiredCompactionRoute` pins that the argument half describes something real and fails if a later change starts stripping those spellings.

**The hint is a constant, and that is a correctness property.** The annotated text is persisted in `agent_task_queue.error` and re-scanned there for the life of the row — by `service.ResumeUnsafeFailure` on the write path and by the ILIKE/regex guards in `GetLastTaskSession` / `GetLastChatTaskSession` on every later resume lookup. Anything embedded in it gets a vote on session recovery. It also has to dodge `taskfailure.Classify`, and that bites harder here than for the Hermes hint: the error it rides on already contains "Not Found", so a single stray "model" in the prose would flip the failure into `model_not_found_or_unavailable`. `TestCodexCompactionAnnotationCannotChangeMachineDecisions` pins both.

**Text only — it deliberately does NOT retire the session.** The failure looks like the poisoned ones classified alongside it (repeats every turn, no self-recovery), but the cause is one line in a config file, not the transcript. Once that line is gone the same conversation compacts and continues, so dropping the session pointer would destroy exactly the context the fix restores. `TestCodexRetiredCompactionKeepsSessionResumable` is there so a future reader finds out that was the wrong lesson before acting on it.

**Not doing what #8019 proposed** — forcing `--enable remote_compaction_v2` in daemon-managed sessions. That override carries no Multica semantics (unlike `fast_mode`, which honours a tier the user paid for), upstream has stated it will fix the flag, and it would then be permanent dead code that blocks anyone with a legitimate reason to disable it. See the discussion on that PR.

**Left out on purpose:** no new `failure_reason`. The taxonomy addition would touch the reason enum, the MUL-1949 backfill SQL, and copy maps in web/views/mobile — for a failure whose only real harm was the missing remedy. `agent_error.unknown` is already correct behaviourally here (not on the retry allowlist, and retrying reproduces it).

Closes #8000.
Upstream: openai/codex#42468

## Test plan

- `go test ./pkg/agent -run 'TestCodexRetiredCompactionError|TestCodexLaunchArgsCanSelectTheRetiredCompactionRoute' -count=1` — table over the live #8000 text and a non-404 on the retired path (both match), against the v2 route answering the same 404, a v2 stream failure, the url-less rendering, and the path outside a compaction failure (all negative); plus both launch-argument spellings surviving normalization from either argv region and through the priority-tier path.
- `go test ./internal/daemon -run 'TestAnnotateCodexRetiredCompaction|TestCodexCompactionAnnotation|TestCodexRetiredCompactionKeepsSessionResumable|TestAnnotationCannotChangeMachineDecisions' -count=1` — includes the hint naming every source, and the v2 shapes staying unannotated.
- `go test ./internal/daemon/execenv/ -run ByteIdentical -count=1` — pass.
- `go test ./pkg/agent ./pkg/taskfailure -count=1` — pass.
- `go vet ./pkg/agent ./internal/daemon` — clean.
- `go test ./internal/daemon -count=1` — 7 failures, all pre-existing on a clean tree in this sandbox (`TestLoadConfig_BackendOverrides_BackwardCompat_NoConfigFile`, `TestPrepareReasonixTaskStateHome`, `TestPrepareDshTaskSessionRoot`, and the four `TestEnsureDaemonID_*` / `TestLegacyDaemonUUIDs_*`); they read ambient `MULTICA_CONFIG_DIR` / `OPENCLAW_STATE_DIR` from the environment. Verified by re-running them with the change stashed.


