### PR TITLE
MUL-7050 perf(search): remove unused exact search counts

### DIFF
--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -388,12 +388,10 @@ const SearchProjectResultSchema = ProjectSchema.safeExtend({
 
 export const SearchProjectsResponseSchema = z.object({
   projects: z.array(SearchProjectResultSchema).default([]),
-  total: z.number().default(0),
 }).loose();
 
 export const EMPTY_SEARCH_PROJECTS_RESPONSE: SearchProjectsResponse = {
   projects: [],
-  total: 0,
 };
 
 // =====================================================

--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -375,12 +375,10 @@ const SearchIssueResultSchema = IssueSchema.safeExtend({
 
 export const SearchIssuesResponseSchema = z.object({
   issues: z.array(SearchIssueResultSchema).default([]),
-  total: z.number().default(0),
 }).loose();
 
 export const EMPTY_SEARCH_ISSUES_RESPONSE: SearchIssuesResponse = {
   issues: [],
-  total: 0,
 };
 
 const SearchProjectResultSchema = ProjectSchema.safeExtend({

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -320,7 +320,14 @@ describe("ApiClient schema fallback", () => {
       stubFetchJson({ issues: "not-an-array", total: 0 });
       const client = new ApiClient("https://api.example.test");
       const res = await client.searchIssues({ q: "bug" });
-      expect(res).toEqual({ issues: [], total: 0 });
+      expect(res).toEqual({ issues: [] });
+    });
+
+    it("accepts a response without an exact total", async () => {
+      stubFetchJson({ issues: [] });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.searchIssues({ q: "bug" });
+      expect(res).toEqual({ issues: [] });
     });
   });
 

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -336,7 +336,14 @@ describe("ApiClient schema fallback", () => {
       stubFetchJson({ projects: "not-an-array", total: 0 });
       const client = new ApiClient("https://api.example.test");
       const res = await client.searchProjects({ q: "roadmap" });
-      expect(res).toEqual({ projects: [], total: 0 });
+      expect(res).toEqual({ projects: [] });
+    });
+
+    it("accepts a response without an exact total", async () => {
+      stubFetchJson({ projects: [] });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.searchProjects({ q: "roadmap" });
+      expect(res).toEqual({ projects: [] });
     });
   });
 

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -1287,12 +1287,10 @@ const SearchIssueResultSchema = IssueSchema.extend({
 
 export const SearchIssuesResponseSchema = z.object({
   issues: z.array(SearchIssueResultSchema).default([]),
-  total: z.number().default(0),
 }).loose();
 
 export const EMPTY_SEARCH_ISSUES_RESPONSE: SearchIssuesResponse = {
   issues: [],
-  total: 0,
 };
 
 const ProjectSchema = z.object({

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -1322,12 +1322,10 @@ const SearchProjectResultSchema = ProjectSchema.extend({
 
 export const SearchProjectsResponseSchema = z.object({
   projects: z.array(SearchProjectResultSchema).default([]),
-  total: z.number().default(0),
 }).loose();
 
 export const EMPTY_SEARCH_PROJECTS_RESPONSE: SearchProjectsResponse = {
   projects: [],
-  total: 0,
 };
 
 const IssueAssigneeGroupSchema = z.object({

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -442,9 +442,9 @@ export function issueDetailOptions(wsId: string, id: string) {
  *
  * It deliberately does NOT use `/api/issues/search`: that endpoint runs the
  * workspace-wide full-text query (title/description/comment `LIKE`, ranking,
- * snippet subquery, `COUNT(*) OVER()`) which is orders of magnitude more
- * expensive than a point read, and autolink resolution was the dominant
- * caller of it (MUL-6268).
+ * and snippet subqueries) which is orders of magnitude more expensive than a
+ * point read, and autolink resolution was the dominant caller of it
+ * (MUL-6268).
  *
  * Server state → TanStack Query; the key includes `wsId` and the identifier,
  * so identical identifiers across the app share one request. Caller gates

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -516,7 +516,6 @@ export interface SearchIssueResult extends Issue {
 
 export interface SearchIssuesResponse {
   issues: SearchIssueResult[];
-  total: number;
 }
 
 export interface SearchProjectResult extends Project {

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -525,7 +525,6 @@ export interface SearchProjectResult extends Project {
 
 export interface SearchProjectsResponse {
   projects: SearchProjectResult[];
-  total: number;
 }
 
 export interface UpdateMeRequest {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -611,7 +611,6 @@ func parseQueryNumber(q string) (int, bool) {
 // searchResult holds a raw row from the dynamic search query.
 type searchResult struct {
 	issue                 db.Issue
-	totalCount            int64
 	matchSource           string
 	matchedCommentContent string
 }
@@ -861,7 +860,6 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 		i.parent_issue_id, i.acceptance_criteria, i.context_refs, i.position,
 		i.start_date, i.due_date, i.created_at, i.updated_at, i.last_activity_at, i.number, i.project_id,
 		i.revision,
-		COUNT(*) OVER() AS total_count,
 		%s AS match_source,
 		%s AS matched_comment_content
 	FROM issue i
@@ -960,7 +958,6 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 				&sr.issue.Number,
 				&sr.issue.ProjectID,
 				&sr.issue.Revision,
-				&sr.totalCount,
 				&sr.matchSource,
 				&sr.matchedCommentContent,
 			); err != nil {
@@ -987,11 +984,6 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("search issues failed", "error", err, "workspace_id", workspaceID, "query", q)
 		writeError(w, http.StatusInternalServerError, "failed to search issues")
 		return
-	}
-
-	var total int64
-	if len(results) > 0 {
-		total = results[0].totalCount
 	}
 
 	prefix := h.getIssuePrefix(ctx, wsUUID)
@@ -1022,10 +1014,8 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 		resp[i] = sir
 	}
 
-	w.Header().Set("X-Total-Count", strconv.FormatInt(total, 10))
 	writeJSON(w, http.StatusOK, map[string]any{
 		"issues": resp,
-		"total":  total,
 	})
 }
 

--- a/server/internal/handler/issue_collection_revision_test.go
+++ b/server/internal/handler/issue_collection_revision_test.go
@@ -103,20 +103,10 @@ func TestIssueCollectionProjectionsIncludePositiveRevision(t *testing.T) {
 	if searchRecorder.Code != http.StatusOK {
 		t.Fatalf("search issues status = %d: %s", searchRecorder.Code, searchRecorder.Body.String())
 	}
-	if got := searchRecorder.Header().Get("X-Total-Count"); got != "" {
-		t.Fatalf("search issues X-Total-Count = %q, want absent", got)
-	}
-	var searchPayload map[string]json.RawMessage
-	if err := json.Unmarshal(searchRecorder.Body.Bytes(), &searchPayload); err != nil {
-		t.Fatalf("decode issue search payload: %v", err)
-	}
-	if _, ok := searchPayload["total"]; ok {
-		t.Fatalf("search issues response unexpectedly contains exact total: %s", searchRecorder.Body.String())
-	}
 	var searchResponse struct {
 		Issues []IssueResponse `json:"issues"`
 	}
-	if err := json.Unmarshal(searchRecorder.Body.Bytes(), &searchResponse); err != nil {
+	if err := json.NewDecoder(searchRecorder.Body).Decode(&searchResponse); err != nil {
 		t.Fatalf("decode issue search: %v", err)
 	}
 	if len(searchResponse.Issues) != 1 || searchResponse.Issues[0].ID != issueID || searchResponse.Issues[0].Revision != 7 {

--- a/server/internal/handler/issue_collection_revision_test.go
+++ b/server/internal/handler/issue_collection_revision_test.go
@@ -103,10 +103,20 @@ func TestIssueCollectionProjectionsIncludePositiveRevision(t *testing.T) {
 	if searchRecorder.Code != http.StatusOK {
 		t.Fatalf("search issues status = %d: %s", searchRecorder.Code, searchRecorder.Body.String())
 	}
+	if got := searchRecorder.Header().Get("X-Total-Count"); got != "" {
+		t.Fatalf("search issues X-Total-Count = %q, want absent", got)
+	}
+	var searchPayload map[string]json.RawMessage
+	if err := json.Unmarshal(searchRecorder.Body.Bytes(), &searchPayload); err != nil {
+		t.Fatalf("decode issue search payload: %v", err)
+	}
+	if _, ok := searchPayload["total"]; ok {
+		t.Fatalf("search issues response unexpectedly contains exact total: %s", searchRecorder.Body.String())
+	}
 	var searchResponse struct {
 		Issues []IssueResponse `json:"issues"`
 	}
-	if err := json.NewDecoder(searchRecorder.Body).Decode(&searchResponse); err != nil {
+	if err := json.Unmarshal(searchRecorder.Body.Bytes(), &searchResponse); err != nil {
 		t.Fatalf("decode issue search: %v", err)
 	}
 	if len(searchResponse.Issues) != 1 || searchResponse.Issues[0].ID != issueID || searchResponse.Issues[0].Revision != 7 {

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -801,7 +801,6 @@ func buildProjectSearchQuery(phrase string, terms []string, includeClosed bool) 
 		p.status, p.priority, p.lead_type, p.lead_id,
 		p.start_date, p.due_date,
 		p.created_at, p.updated_at,
-		COUNT(*) OVER() AS total_count,
 		%s AS match_source
 	FROM project p
 	WHERE p.workspace_id = %s AND %s
@@ -860,7 +859,6 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 
 	type projectSearchRow struct {
 		project     db.Project
-		totalCount  int64
 		matchSource string
 	}
 
@@ -882,7 +880,6 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 				&row.project.DueDate,
 				&row.project.CreatedAt,
 				&row.project.UpdatedAt,
-				&row.totalCount,
 				&row.matchSource,
 			); err != nil {
 				return fmt.Errorf("scan: %w", err)
@@ -905,11 +902,6 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("search projects failed", "error", err, "workspace_id", workspaceID, "query", q)
 		writeError(w, http.StatusInternalServerError, "failed to search projects")
 		return
-	}
-
-	var total int64
-	if len(results) > 0 {
-		total = results[0].totalCount
 	}
 
 	// Batch-fetch issue stats and resource counts
@@ -964,9 +956,7 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 		resp[i] = spr
 	}
 
-	w.Header().Set("X-Total-Count", strconv.FormatInt(total, 10))
 	writeJSON(w, http.StatusOK, map[string]any{
 		"projects": resp,
-		"total":    total,
 	})
 }

--- a/server/internal/handler/search_response_test.go
+++ b/server/internal/handler/search_response_test.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSearchIssuesOmitsExactTotal(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	recorder := httptest.NewRecorder()
+	testHandler.SearchIssues(recorder, newRequest(http.MethodGet, "/api/issues/search?q=exact-total-contract-test", nil))
+	assertSearchResponseOmitsExactTotal(t, recorder, "issues")
+}
+
+func TestSearchProjectsOmitsExactTotal(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	recorder := httptest.NewRecorder()
+	testHandler.SearchProjects(recorder, newRequest(http.MethodGet, "/api/projects/search?q=exact-total-contract-test", nil))
+	assertSearchResponseOmitsExactTotal(t, recorder, "projects")
+}
+
+func assertSearchResponseOmitsExactTotal(t *testing.T, recorder *httptest.ResponseRecorder, collectionKey string) {
+	t.Helper()
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("search status = %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("X-Total-Count"); got != "" {
+		t.Fatalf("search X-Total-Count = %q, want absent", got)
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode search payload: %v", err)
+	}
+	if _, ok := payload[collectionKey]; !ok {
+		t.Fatalf("search response missing %q: %s", collectionKey, recorder.Body.String())
+	}
+	if _, ok := payload["total"]; ok {
+		t.Fatalf("search response unexpectedly contains exact total: %s", recorder.Body.String())
+	}
+}

--- a/server/internal/handler/search_test.go
+++ b/server/internal/handler/search_test.go
@@ -44,6 +44,14 @@ func TestBuildSearchQuery_SingleTerm(t *testing.T) {
 	}
 }
 
+func TestBuildSearchQuery_OmitsUnusedExactTotal(t *testing.T) {
+	query, _ := buildSearchQuery("Hello", []string{"Hello"}, 0, false, false, []string{"done", "cancelled"})
+
+	if strings.Contains(query, "COUNT(*) OVER()") || strings.Contains(query, "total_count") {
+		t.Fatalf("search query should not calculate an unused exact total:\n%s", query)
+	}
+}
+
 func TestBuildSearchQuery_CustomTerminalStatuses(t *testing.T) {
 	terminalStatusKeys := []string{"done", "cancelled", "verified"}
 	query, args := buildSearchQuery(

--- a/server/internal/handler/search_test.go
+++ b/server/internal/handler/search_test.go
@@ -52,6 +52,14 @@ func TestBuildSearchQuery_OmitsUnusedExactTotal(t *testing.T) {
 	}
 }
 
+func TestBuildProjectSearchQuery_OmitsUnusedExactTotal(t *testing.T) {
+	query, _ := buildProjectSearchQuery("Hello", []string{"Hello"}, false)
+
+	if strings.Contains(query, "COUNT(*) OVER()") || strings.Contains(query, "total_count") {
+		t.Fatalf("project search query should not calculate an unused exact total:\n%s", query)
+	}
+}
+
 func TestBuildSearchQuery_CustomTerminalStatuses(t *testing.T) {
 	terminalStatusKeys := []string{"done", "cancelled", "verified"}
 	query, args := buildSearchQuery(


### PR DESCRIPTION
## What does this PR do?

Removes the unused exact result counts from `GET /api/issues/search` and `GET /api/projects/search`.

Both search queries currently run `COUNT(*) OVER()` before applying `LIMIT`, even though all first-party callers only consume the returned issue or project rows. This PR removes that calculation and aligns the server, shared API types, and mobile schemas with the smaller responses.

Normal issue list/table/query endpoints keep their own pagination totals and are not changed.

## Related Issue

MUL-7050

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure
- [x] Performance improvement (intentional API response change)

## Changes Made

- Remove `COUNT(*) OVER()`, `total_count` scanning, the JSON `total`, and the `X-Total-Count` header from issue and project search.
- Remove the unused `total` property from shared and mobile response schemas/types.
- Add focused SQL and response-contract regression tests, separate from unrelated projection tests.

## Compatibility and Risk

This intentionally removes the raw `total` field and `X-Total-Count` header from two authenticated, undocumented search endpoints. No first-party Web, mobile, picker, mention, or CLI code consumes either value, and none uses offset pagination for these searches. Existing first-party clients tolerate the missing field because their schemas default it to zero; updated schemas remain loose and therefore tolerate older servers that still return it.

This change should not be expected to materially reduce the observed broad multi-term search 503s. It removes a `WindowAgg` over matching rows, but does not reduce the workspace scan, comment posting scans, ranking, or snippet work that dominates those timeouts. The candidate-first query rewrite remains the structural follow-up.

## How to Test

1. `cd server && go build ./...`
2. `cd server && go test ./internal/handler -run 'TestBuildSearchQuery|TestBuildProjectSearchQuery|TestSearchIssuesOmitsExactTotal|TestSearchProjectsOmitsExactTotal|TestIssueCollectionProjectionsIncludePositiveRevision|TestSearchProjectsCarriesDates' -count=1`
3. `pnpm --filter @multica/core exec vitest run api/schema.test.ts`
4. `pnpm --filter @multica/views exec vitest run search/search-command.test.tsx editor/extensions/mention-suggestion.test.tsx`
5. Run typechecks for `@multica/core`, `@multica/views`, and `@multica/mobile`.
6. Run `@multica/core` and `@multica/mobile` lint, plus the full `@multica/mobile` test suite.

All checks above pass. Lint reports only existing warnings outside this change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] This change does not affect the UI
- [x] No documentation update is required for these undocumented endpoints
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:** Traced every repository caller of issue and project search, verified that neither exact total has a first-party consumer, removed both counts end to end, and added focused regression coverage for the SQL and response contracts.

## Screenshots

Not applicable; there is no UI change.
