### PR TITLE
fix(opencode): preserve tool call durations in run transcripts

### DIFF
--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -350,6 +350,9 @@ export const TaskMessagePayloadSchema: z.ZodType<TaskMessagePayload> = z.object(
   input: z.record(z.string(), z.unknown()).optional(),
   output: z.string().optional(),
   created_at: z.string().optional(),
+  // Provider-reported tool-call duration in ms (e.g. OpenCode's
+  // part.state.time). Absent = unknown; consumers fall back to created_at.
+  duration_ms: z.number().optional(),
 }).loose();
 
 export const TaskMessageListSchema = z.array(TaskMessagePayloadSchema).default([]);

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -298,7 +298,9 @@ export interface TaskMessagePayload {
   /** Provider-reported wall-clock duration of a tool call, in ms. Present
    *  only when the runtime measured the call itself (e.g. OpenCode's
    *  part.state.time); absent means the consumer falls back to the
-   *  created_at difference. 0 is treated as unknown, like absence. */
+   *  created_at difference. Absence is the only unknown — daemons omit the
+   *  field when they don't know, so an explicit 0 that does arrive is the
+   *  provider's word and wins over the fallback. */
   duration_ms?: number;
 }
 

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -295,6 +295,11 @@ export interface TaskMessagePayload {
   input?: Record<string, unknown>;
   output?: string;
   created_at?: string;
+  /** Provider-reported wall-clock duration of a tool call, in ms. Present
+   *  only when the runtime measured the call itself (e.g. OpenCode's
+   *  part.state.time); absent means the consumer falls back to the
+   *  created_at difference. 0 is treated as unknown, like absence. */
+  duration_ms?: number;
 }
 
 export interface TaskQueuedPayload {

--- a/packages/views/common/task-transcript/build-steps.test.ts
+++ b/packages/views/common/task-transcript/build-steps.test.ts
@@ -157,6 +157,39 @@ describe("buildSteps", () => {
 
     expect(steps[0]!.durationMs).toBe(5000);
   });
+
+  it("lets an explicit duration_ms of 0 beat the created_at difference", () => {
+    // 0 on the wire is a deliberate provider value (the daemon omits the
+    // field entirely when it doesn't know) — it wins like any other number.
+    const steps = buildSteps([
+      { seq: 1, type: "tool_use", tool: "Bash", created_at: at(0) },
+      { seq: 2, type: "tool_result", tool: "Bash", output: "ok", created_at: at(4), duration_ms: 0 },
+    ]) as TraceCallStep[];
+
+    expect(steps[0]!.durationMs).toBe(0);
+  });
+
+  it("keeps the transcript renderable when a provider duration is huge", () => {
+    // end - durationMs can land outside the Date range (±8.64e15 ms), where
+    // toISOString() throws a RangeError that would break the whole transcript
+    // view. The step must keep the number and its real timestamps instead.
+    const steps = buildSteps([
+      { seq: 1, type: "tool_use", tool: "Bash", created_at: at(0) },
+      {
+        seq: 2,
+        type: "tool_result",
+        tool: "Bash",
+        output: "ok",
+        created_at: at(4),
+        duration_ms: Number.MAX_VALUE,
+      },
+    ]) as TraceCallStep[];
+
+    const step = steps[0]!;
+    expect(step.durationMs).toBe(Number.MAX_VALUE);
+    expect(step.startedAt).toBe(at(0));
+    expect(step.endedAt).toBe(at(4));
+  });
 });
 
 describe("groupSteps", () => {

--- a/packages/views/common/task-transcript/build-steps.test.ts
+++ b/packages/views/common/task-transcript/build-steps.test.ts
@@ -93,6 +93,70 @@ describe("buildSteps", () => {
 
     expect(steps[0]!.durationMs).toBeUndefined();
   });
+
+  // Regression for multica-ai/multica#8025: OpenCode runs show every tool call
+  // as 0s because the pair's created_at stamps are both flush-time. The
+  // provider's own duration (part.state.time) must win over that 0s diff.
+  it("prefers the provider duration_ms over a 0s created_at difference", () => {
+    const steps = buildSteps([
+      { seq: 1, type: "tool_use", tool: "Bash", created_at: at(0) },
+      { seq: 2, type: "tool_result", tool: "Bash", output: "ok", created_at: at(0), duration_ms: 5000 },
+    ]) as TraceCallStep[];
+
+    expect(steps[0]!.durationMs).toBe(5000);
+  });
+
+  it("reconstructs the interval from the provider duration when it is present", () => {
+    const steps = buildSteps([
+      { seq: 1, type: "tool_use", tool: "Bash", created_at: at(0) },
+      { seq: 2, type: "tool_result", tool: "Bash", output: "ok", created_at: at(0), duration_ms: 5000 },
+    ]) as TraceCallStep[];
+
+    const step = steps[0]!;
+    expect(step.endedAt).toBe(at(0));
+    expect(step.startedAt).toBe(at(-5));
+  });
+
+  it("falls back to the created_at difference when duration_ms is absent", () => {
+    const steps = buildSteps([
+      { seq: 1, type: "tool_use", tool: "Bash", created_at: at(0) },
+      { seq: 2, type: "tool_result", tool: "Bash", output: "ok", created_at: at(4) },
+    ]) as TraceCallStep[];
+
+    expect(steps[0]!.durationMs).toBe(4000);
+    expect(steps[0]!.startedAt).toBe(at(0));
+  });
+
+  it("ignores a malformed duration_ms and falls back to the created_at difference", () => {
+    for (const bad of [-3, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const steps = buildSteps([
+        { seq: 1, type: "tool_use", tool: "Bash", created_at: at(0) },
+        { seq: 2, type: "tool_result", tool: "Bash", output: "ok", created_at: at(4), duration_ms: bad },
+      ]) as TraceCallStep[];
+
+      expect(steps[0]!.durationMs).toBe(4000);
+      expect(steps[0]!.startedAt).toBe(at(0));
+    }
+  });
+
+  it("uses a provider duration alone when the pair carries no timestamps", () => {
+    const steps = buildSteps([
+      { seq: 1, type: "tool_use", tool: "Bash" },
+      { seq: 2, type: "tool_result", tool: "Bash", output: "ok", duration_ms: 5000 },
+    ]) as TraceCallStep[];
+
+    expect(steps[0]!.durationMs).toBe(5000);
+    expect(steps[0]!.startedAt).toBeUndefined();
+    expect(steps[0]!.endedAt).toBeUndefined();
+  });
+
+  it("carries duration_ms through an orphan tool_result", () => {
+    const steps = buildSteps([
+      { seq: 1, type: "tool_result", tool: "Bash", output: "ok", created_at: at(0), duration_ms: 5000 },
+    ]) as TraceCallStep[];
+
+    expect(steps[0]!.durationMs).toBe(5000);
+  });
 });
 
 describe("groupSteps", () => {

--- a/packages/views/common/task-transcript/build-steps.ts
+++ b/packages/views/common/task-transcript/build-steps.ts
@@ -95,13 +95,15 @@ function durationBetween(start?: string, end?: string): number | undefined {
 /**
  * The provider's own measurement of a tool call, when the runtime carried one
  * across the wire (OpenCode's part.state.time.start/end arrives as
- * `duration_ms`). 0 means unknown, like absence — the daemon treats it that
- * way before it ever reaches the wire. Anything malformed (negative, NaN,
+ * `duration_ms`). Any finite, non-negative number is the provider's word and
+ * wins over the server-arrival-stamp fallback — including an explicit 0:
+ * the daemon omits the field entirely when it doesn't know, so a 0 on the
+ * wire is deliberate, not a missing value. Anything malformed (negative, NaN,
  * infinity) is ignored so a garbage number can't poison the display.
  */
 function providerDurationMs(result: TimelineItem | undefined): number | undefined {
   const d = result?.duration_ms;
-  if (d === undefined || !Number.isFinite(d) || d <= 0) return undefined;
+  if (d === undefined || !Number.isFinite(d) || d < 0) return undefined;
   return d;
 }
 
@@ -148,7 +150,15 @@ export function buildSteps(items: TimelineItem[]): TraceStep[] {
           pending.durationMs = provider;
           const end = timeMs(pending.endedAt);
           if (end !== undefined) {
-            pending.startedAt = new Date(end - provider).toISOString();
+            // Guard the Date range: a huge provider number next to a real
+            // arrival stamp can land outside the ±8.64e15 ms window where
+            // Date is defined, and toISOString() would throw a RangeError
+            // that takes the whole transcript down with it. Outside the
+            // window, keep the number and the real timestamps.
+            const startedMs = end - provider;
+            if (Number.isFinite(startedMs) && Math.abs(startedMs) <= 8.64e15) {
+              pending.startedAt = new Date(startedMs).toISOString();
+            }
           }
         } else {
           pending.durationMs = durationBetween(pending.startedAt, item.created_at);

--- a/packages/views/common/task-transcript/build-steps.ts
+++ b/packages/views/common/task-transcript/build-steps.ts
@@ -92,6 +92,19 @@ function durationBetween(start?: string, end?: string): number | undefined {
   return Math.max(0, b - a);
 }
 
+/**
+ * The provider's own measurement of a tool call, when the runtime carried one
+ * across the wire (OpenCode's part.state.time.start/end arrives as
+ * `duration_ms`). 0 means unknown, like absence — the daemon treats it that
+ * way before it ever reaches the wire. Anything malformed (negative, NaN,
+ * infinity) is ignored so a garbage number can't poison the display.
+ */
+function providerDurationMs(result: TimelineItem | undefined): number | undefined {
+  const d = result?.duration_ms;
+  if (d === undefined || !Number.isFinite(d) || d <= 0) return undefined;
+  return d;
+}
+
 /** Fold `tool_use` / `tool_result` pairs into single steps, in stream order. */
 export function buildSteps(items: TimelineItem[]): TraceStep[] {
   const steps: TraceStep[] = [];
@@ -123,7 +136,23 @@ export function buildSteps(items: TimelineItem[]): TraceStep[] {
       if (pending) {
         pending.result = item;
         pending.endedAt = item.created_at;
-        pending.durationMs = durationBetween(pending.startedAt, item.created_at);
+        const provider = providerDurationMs(item);
+        if (provider !== undefined) {
+          // The provider measured the call itself, so its number is the
+          // duration — not the gap between two server arrival stamps that
+          // both land at flush time (a 12s call would otherwise render 0s,
+          // multica-ai/multica#8025). Reconstruct the interval from the
+          // result's arrival stamp only when it parses; a missing or
+          // unparseable one leaves the timestamps untouched rather than
+          // fabricating them.
+          pending.durationMs = provider;
+          const end = timeMs(pending.endedAt);
+          if (end !== undefined) {
+            pending.startedAt = new Date(end - provider).toISOString();
+          }
+        } else {
+          pending.durationMs = durationBetween(pending.startedAt, item.created_at);
+        }
         continue;
       }
       // Orphan result: keep it as a step of its own so no output is dropped.
@@ -134,6 +163,7 @@ export function buildSteps(items: TimelineItem[]): TraceStep[] {
         result: item,
         startedAt: item.created_at,
         endedAt: item.created_at,
+        durationMs: providerDurationMs(item),
       });
       continue;
     }

--- a/packages/views/common/task-transcript/build-timeline.ts
+++ b/packages/views/common/task-transcript/build-timeline.ts
@@ -10,6 +10,9 @@ export interface TimelineItem {
   input?: Record<string, unknown>;
   output?: string;
   created_at?: string;
+  /** Provider-reported tool-call duration in ms, when the runtime measured
+   *  it. Absent/0 = unknown; consumers fall back to created_at differences. */
+  duration_ms?: number;
 }
 
 function canMergeStreamingText(prev: TimelineItem, next: TimelineItem): boolean {
@@ -61,6 +64,7 @@ export function buildTimeline(msgs: TaskMessagePayload[]): TimelineItem[] {
       input: msg.input,
       output: msg.output,
       created_at: msg.created_at,
+      duration_ms: msg.duration_ms,
     });
   }
   return redactTimelineItems(coalesceTimelineItems(items));

--- a/packages/views/common/task-transcript/build-timeline.ts
+++ b/packages/views/common/task-transcript/build-timeline.ts
@@ -11,7 +11,9 @@ export interface TimelineItem {
   output?: string;
   created_at?: string;
   /** Provider-reported tool-call duration in ms, when the runtime measured
-   *  it. Absent/0 = unknown; consumers fall back to created_at differences. */
+   *  it. Absent = unknown — consumers fall back to created_at differences.
+   *  An explicit 0 on the wire is deliberate (the daemon omits the field
+   *  when it doesn't know) and wins like any other number. */
   duration_ms?: number;
 }
 

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -514,6 +514,12 @@ type TaskMessageData struct {
 	Content string         `json:"content,omitempty"`
 	Input   map[string]any `json:"input,omitempty"`
 	Output  string         `json:"output,omitempty"`
+	// DurationMs is the provider's own tool-call duration, in ms, attached to
+	// the paired tool_result row. omitempty keeps the wire payload byte-for-
+	// byte identical to pre-duration daemons whenever the provider didn't
+	// measure timing (0 = unknown), so old daemons keep talking to new
+	// servers and vice versa unchanged.
+	DurationMs int64 `json:"duration_ms,omitempty"`
 }
 
 func (c *Client) ReportTaskMessages(ctx context.Context, taskID string, messages []TaskMessageData) error {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -8944,10 +8944,11 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 					taskLog.Info("tool_result observed", "seq", s, "tool", toolName, "call_id", msg.CallID)
 					mu.Lock()
 					batch = append(batch, TaskMessageData{
-						Seq:    int(s),
-						Type:   "tool_result",
-						Tool:   toolName,
-						Output: output,
+						Seq:        int(s),
+						Type:       "tool_result",
+						Tool:       toolName,
+						Output:     output,
+						DurationMs: msg.DurationMs,
 					})
 					mu.Unlock()
 				case agent.MessageThinking:

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -4601,6 +4601,10 @@ type TaskMessageRequest struct {
 	Content string         `json:"content,omitempty"`
 	Input   map[string]any `json:"input,omitempty"`
 	Output  string         `json:"output,omitempty"`
+	// DurationMs is the provider-reported tool-call duration (tool_result
+	// rows). Absent/0 = unknown; a negative value is malformed and clamped to
+	// unknown below rather than stored.
+	DurationMs int64 `json:"duration_ms,omitempty"`
 }
 
 type TaskMessageBatchRequest struct {
@@ -4649,14 +4653,15 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 	// string means SQL NULL, applied by the query's NULLIF.
 	n := len(req.Messages)
 	params := db.CreateTaskMessagesParams{
-		TaskID:   parseUUID(taskID),
-		Ids:      make([]pgtype.UUID, 0, n),
-		Seqs:     make([]int32, 0, n),
-		Types:    make([]string, 0, n),
-		Tools:    make([]string, 0, n),
-		Contents: make([]string, 0, n),
-		Inputs:   make([]string, 0, n),
-		Outputs:  make([]string, 0, n),
+		TaskID:      parseUUID(taskID),
+		Ids:         make([]pgtype.UUID, 0, n),
+		Seqs:        make([]int32, 0, n),
+		Types:       make([]string, 0, n),
+		Tools:       make([]string, 0, n),
+		Contents:    make([]string, 0, n),
+		Inputs:      make([]string, 0, n),
+		Outputs:     make([]string, 0, n),
+		DurationMss: make([]int64, 0, n),
 	}
 	for _, msg := range req.Messages {
 		id, err := uuid.NewV7()
@@ -4705,6 +4710,15 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 			inputJSON = string(encoded)
 		}
 
+		// A duration the daemon never sent (or sent as 0) is "unknown"; a
+		// negative one is malformed, not a measurement. Both land as SQL NULL
+		// via the query's NULLIF/GREATEST so old-daemon transcripts keep
+		// reading exactly as before.
+		durationMs := msg.DurationMs
+		if durationMs < 0 {
+			durationMs = 0
+		}
+
 		params.Ids = append(params.Ids, pgtype.UUID{Bytes: [16]byte(id), Valid: true})
 		params.Seqs = append(params.Seqs, int32(msg.Seq))
 		params.Types = append(params.Types, msg.Type)
@@ -4712,6 +4726,7 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		params.Contents = append(params.Contents, msg.Content)
 		params.Inputs = append(params.Inputs, inputJSON)
 		params.Outputs = append(params.Outputs, msg.Output)
+		params.DurationMss = append(params.DurationMss, durationMs)
 	}
 
 	created, err := h.Queries.CreateTaskMessages(r.Context(), params)
@@ -4850,7 +4865,7 @@ func taskMessageToPayload(m db.TaskMessage, taskID, issueID string) protocol.Tas
 	if m.CreatedAt.Valid {
 		createdAt = m.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
 	}
-	return protocol.TaskMessagePayload{
+	p := protocol.TaskMessagePayload{
 		TaskID:    taskID,
 		IssueID:   issueID,
 		Seq:       int(m.Seq),
@@ -4861,6 +4876,12 @@ func taskMessageToPayload(m db.TaskMessage, taskID, issueID string) protocol.Tas
 		Output:    m.Output.String,
 		CreatedAt: createdAt,
 	}
+	// 0 keeps the field off the payload (omitempty), so clients that predate
+	// provider durations see byte-identical messages.
+	if m.DurationMs.Valid && m.DurationMs.Int64 > 0 {
+		p.DurationMs = m.DurationMs.Int64
+	}
+	return p
 }
 
 // ListTaskMessages returns the persisted messages for a task (for catch-up after reconnect).

--- a/server/internal/handler/task_message_batch_test.go
+++ b/server/internal/handler/task_message_batch_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -199,14 +200,15 @@ func TestCreateTaskMessagesBatchIsAtomic(t *testing.T) {
 	})
 
 	_, err := testHandler.Queries.CreateTaskMessages(ctx, db.CreateTaskMessagesParams{
-		TaskID:   util.MustParseUUID(taskID),
-		Ids:      []pgtype.UUID{util.MustParseUUID("018f0000-0000-7000-8000-000000000002"), util.MustParseUUID(dupID)},
-		Seqs:     []int32{2, 3},
-		Types:    []string{"text", "text"},
-		Tools:    []string{"", ""},
-		Contents: []string{"ok", "collides"},
-		Inputs:   []string{"", ""},
-		Outputs:  []string{"", ""},
+		TaskID:      util.MustParseUUID(taskID),
+		Ids:         []pgtype.UUID{util.MustParseUUID("018f0000-0000-7000-8000-000000000002"), util.MustParseUUID(dupID)},
+		Seqs:        []int32{2, 3},
+		Types:       []string{"text", "text"},
+		Tools:       []string{"", ""},
+		Contents:    []string{"ok", "collides"},
+		Inputs:      []string{"", ""},
+		Outputs:     []string{"", ""},
+		DurationMss: []int64{0, 0},
 	})
 	if err == nil {
 		t.Fatal("CreateTaskMessages accepted a batch with a duplicate primary key")
@@ -216,5 +218,100 @@ func TestCreateTaskMessagesBatchIsAtomic(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("task_message rows after the failed batch = %d, want 1 (only the seeded row) — "+
 			"the batch persisted a prefix instead of rolling back", count)
+	}
+}
+
+// TestReportTaskMessagesRoundTripsDurationMs pins the provider-duration path
+// end to end (multica-ai/multica#8025): OpenCode measures each tool call
+// itself (part.state.time.start/end), and the run view must show that number —
+// not the 0s the arrival-stamp difference collapses to. The duration has to
+// survive every hop: HTTP request → task_message column → catch-up response
+// AND the realtime publish. Rows without a duration persist NULL and come back
+// without the field, so transcripts from runtimes that never measure timing
+// are byte-identical to before; a negative value is malformed, not a
+// measurement, and lands as unknown rather than poisoning the row.
+func TestReportTaskMessagesRoundTripsDurationMs(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	taskID := seedBatchTask(t, "batch-duration")
+
+	sharedBus := testHandler.Bus
+	testHandler.Bus = events.New()
+	t.Cleanup(func() { testHandler.Bus = sharedBus })
+
+	var mu sync.Mutex
+	published := map[int]int64{}
+	testHandler.Bus.Subscribe(protocol.EventTaskMessage, func(e events.Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		if e.TaskID != taskID {
+			return
+		}
+		if payload, ok := e.Payload.(protocol.TaskMessagePayload); ok {
+			published[payload.Seq] = payload.DurationMs
+		}
+	})
+
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 1, "type": "tool_result", "tool": "bash", "output": "ok", "duration_ms": 12345},
+		map[string]any{"seq": 2, "type": "tool_result", "tool": "read", "output": "ok"},
+		map[string]any{"seq": 3, "type": "tool_result", "tool": "edit", "output": "ok", "duration_ms": -5},
+	})).Want(http.StatusOK)
+
+	// Persisted column: measured duration survives; absent and negative land
+	// as NULL (unknown) so every other consumer sees exactly the old shape.
+	stored, err := testHandler.Queries.ListTaskMessages(context.Background(), util.MustParseUUID(taskID))
+	if err != nil {
+		t.Fatalf("list persisted task messages: %v", err)
+	}
+	if len(stored) != 3 {
+		t.Fatalf("persisted %d rows, want 3", len(stored))
+	}
+	if !stored[0].DurationMs.Valid || stored[0].DurationMs.Int64 != 12345 {
+		t.Fatalf("seq 1 duration_ms = %+v, want 12345", stored[0].DurationMs)
+	}
+	if stored[1].DurationMs.Valid {
+		t.Fatalf("seq 2 duration_ms = %+v, want NULL", stored[1].DurationMs)
+	}
+	if stored[2].DurationMs.Valid {
+		t.Fatalf("seq 3 duration_ms = %+v, want NULL (a negative value is malformed, not a measurement)", stored[2].DurationMs)
+	}
+
+	// Catch-up response: the payload carries the duration only where one was
+	// reported — 0 stays off the wire via omitempty.
+	listReq := testutil.JSONRequest(http.MethodGet, "/api/daemon/tasks/"+taskID+"/messages", nil)
+	listReq = testutil.WithURLParams(listReq, "taskId", taskID)
+	listReq = listReq.WithContext(middleware.WithDaemonContext(
+		listReq.Context(), testWorkspaceID, "batch-messages-daemon"))
+	resp := testutil.Call(t, testHandler.ListTaskMessages, listReq).Want(http.StatusOK)
+	var got []protocol.TaskMessagePayload
+	resp.JSON(&got)
+	if len(got) != 3 {
+		t.Fatalf("catch-up returned %d payloads, want 3", len(got))
+	}
+	if got[0].DurationMs != 12345 {
+		t.Fatalf("catch-up seq 1 duration_ms = %d, want 12345", got[0].DurationMs)
+	}
+	if got[1].DurationMs != 0 {
+		t.Fatalf("catch-up seq 2 duration_ms = %d, want 0 (omitted)", got[1].DurationMs)
+	}
+	// Raw body, not just the decoded struct: absence is the compatibility
+	// contract — an old client parsing this response must not see the field.
+	if !strings.Contains(resp.Body.String(), `"duration_ms":12345`) {
+		t.Fatalf("catch-up body missing duration_ms for seq 1: %s", resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), `"duration_ms":-`) {
+		t.Fatalf("catch-up body carries a negative duration_ms: %s", resp.Body.String())
+	}
+
+	// Realtime publish: subscribers render these events as they arrive, so
+	// the live transcript shows the same number the row stored.
+	mu.Lock()
+	defer mu.Unlock()
+	for seq, want := range map[int]int64{1: 12345, 2: 0, 3: 0} {
+		if got := published[seq]; got != want {
+			t.Fatalf("published seq %d duration_ms = %d, want %d", seq, got, want)
+		}
 	}
 }

--- a/server/internal/handler/task_message_batch_test.go
+++ b/server/internal/handler/task_message_batch_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/middleware"
@@ -111,6 +112,53 @@ func TestReportTaskMessagesPersistsWholeBatch(t *testing.T) {
 	}
 	if stored[2].Type != "text" || stored[2].Content.String != "done" {
 		t.Fatalf("text row = %+v, want type=text content=done", stored[2])
+	}
+}
+
+// TestCreateTaskMessageClampsSingleRowDuration covers the single-row insert,
+// which no handler currently drives with a duration but any direct caller can:
+// outside the handler path a pgtype.Int8 can carry anything, so the query
+// itself has to clamp. Same contract as the batch insert — 0 stays NULL (not
+// reported) and a negative value is malformed rather than a measurement.
+func TestCreateTaskMessageClampsSingleRowDuration(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	taskID := util.MustParseUUID(seedBatchTask(t, "single-duration"))
+
+	for i, tc := range []struct {
+		name    string
+		param   pgtype.Int8
+		wantSet bool
+		want    int64
+	}{
+		{"measured duration is stored", pgtype.Int8{Valid: true, Int64: 4321}, true, 4321},
+		{"explicit zero stays NULL", pgtype.Int8{Valid: true}, false, 0},
+		{"negative stays NULL", pgtype.Int8{Valid: true, Int64: -7}, false, 0},
+		{"unset stays NULL", pgtype.Int8{}, false, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := uuid.NewV7()
+			if err != nil {
+				t.Fatalf("new v7: %v", err)
+			}
+			row, err := testHandler.Queries.CreateTaskMessage(ctx, db.CreateTaskMessageParams{
+				ID:         pgtype.UUID{Bytes: id, Valid: true},
+				TaskID:     taskID,
+				Seq:        int32(i + 1),
+				Type:       "tool_result",
+				Tool:       pgtype.Text{Valid: true, String: "bash"},
+				Output:     pgtype.Text{Valid: true, String: "ok"},
+				DurationMs: tc.param,
+			})
+			if err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			if row.DurationMs.Valid != tc.wantSet || row.DurationMs.Int64 != tc.want {
+				t.Fatalf("duration_ms = %+v, want Valid=%v %d", row.DurationMs, tc.wantSet, tc.want)
+			}
+		})
 	}
 }
 

--- a/server/migrations/451_task_message_duration_ms.down.sql
+++ b/server/migrations/451_task_message_duration_ms.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task_message
+    DROP COLUMN duration_ms;

--- a/server/migrations/451_task_message_duration_ms.up.sql
+++ b/server/migrations/451_task_message_duration_ms.up.sql
@@ -1,0 +1,8 @@
+-- Provider-reported tool-call duration (multica-ai/multica#8025). OpenCode
+-- measures each tool call itself (part.state.time.start/end); without a column
+-- to carry it across the transcript boundary, the run view rendered every
+-- OpenCode call as 0s. NULL = the provider reported no duration (all other
+-- runtimes today); >= 0 = the provider measured the call. created_at keeps its
+-- server-clock semantics untouched.
+ALTER TABLE task_message
+    ADD COLUMN duration_ms BIGINT;

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -169,9 +169,15 @@ type Message struct {
 	CallID    string         // tool call ID (ToolUse, ToolResult)
 	Input     map[string]any // tool input (ToolUse)
 	Output    string         // tool output (ToolResult)
-	Status    string         // agent status string (Status)
-	Level     string         // log level (Log)
-	SessionID string         // backend session id (Status), for early resume-pointer pinning
+	// DurationMs carries the provider's own wall-clock measurement of a tool
+	// call, attached to the paired tool_result message (OpenCode reports it
+	// as part.state.time.start/end). Zero means unknown: providers that don't
+	// measure timing leave it at zero, and every consumer downstream falls
+	// back to the timestamp difference it used before this field existed.
+	DurationMs int64
+	Status     string // agent status string (Status)
+	Level      string // log level (Log)
+	SessionID  string // backend session id (Status), for early resume-pointer pinning
 }
 
 // TokenUsage tracks token consumption for a single model.

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -556,13 +556,30 @@ func (b *opencodeBackend) handleToolUseEvent(event opencodeEvent, ch chan<- Mess
 		if state.Status == "error" && state.Error != "" {
 			outputStr = state.Error
 		}
+		var durationMs int64
+		if state.Time != nil {
+			durationMs = opencodeDurationMs(state.Time.Start, state.Time.End)
+		}
 		trySend(ch, Message{
-			Type:   MessageToolResult,
-			Tool:   event.Part.Tool,
-			CallID: event.Part.CallID,
-			Output: outputStr,
+			Type:       MessageToolResult,
+			Tool:       event.Part.Tool,
+			CallID:     event.Part.CallID,
+			Output:     outputStr,
+			DurationMs: durationMs,
 		})
 	}
+}
+
+// opencodeDurationMs converts OpenCode's reported tool timing (epoch
+// milliseconds for part.state.time.start/end) into a duration. Zero means
+// unknown: any malformed window — missing, non-positive, or end before start
+// — falls back to 0 rather than producing a nonsense duration or failing the
+// run. end >= start with both positive cannot under/overflow int64.
+func opencodeDurationMs(start, end int64) int64 {
+	if start <= 0 || end <= 0 || end < start {
+		return 0
+	}
+	return end - start
 }
 
 // handleErrorEvent processes "error" events from opencode. OpenCode can exit
@@ -721,12 +738,21 @@ type opencodeCacheTokens struct {
 	Write int64 `json:"write"`
 }
 
+// opencodeToolTime carries the wall-clock window OpenCode reports for a tool
+// execution: epoch milliseconds for when the call started and ended. Present
+// on terminal states (completed / error) in OpenCode's stream.
+type opencodeToolTime struct {
+	Start int64 `json:"start,omitempty"`
+	End   int64 `json:"end,omitempty"`
+}
+
 // opencodeToolState represents the state of a tool invocation.
 type opencodeToolState struct {
-	Status string          `json:"status,omitempty"`
-	Input  json.RawMessage `json:"input,omitempty"`
-	Output any             `json:"output,omitempty"`
-	Error  string          `json:"error,omitempty"`
+	Status string            `json:"status,omitempty"`
+	Input  json.RawMessage   `json:"input,omitempty"`
+	Output any               `json:"output,omitempty"`
+	Error  string            `json:"error,omitempty"`
+	Time   *opencodeToolTime `json:"time,omitempty"`
 }
 
 // opencodeError represents an error event from opencode.

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -746,6 +746,36 @@ type opencodeToolTime struct {
 	End   int64 `json:"end,omitempty"`
 }
 
+// UnmarshalJSON absorbs malformed timing so a bad window can never fail the
+// enclosing event. Timing is best-effort metadata: a "time":"bad" string or
+// a start value outside int64 must leave the tool_use/result intact (a
+// dropped event would surface as an empty step and flip the run to failed),
+// with the window simply staying unknown.
+func (t *opencodeToolTime) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil // not even an object, e.g. "time":"bad" — keep unknown
+	}
+	t.Start = opencodeTimeMs(fields["start"])
+	t.End = opencodeTimeMs(fields["end"])
+	return nil
+}
+
+// opencodeTimeMs decodes a single epoch-milliseconds field. Anything that is
+// not a plain positive in-range integer — strings, fractions, overflow,
+// non-positive values — decodes to 0 = unknown.
+func opencodeTimeMs(raw json.RawMessage) int64 {
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0
+	}
+	v, err := n.Int64()
+	if err != nil || v <= 0 {
+		return 0
+	}
+	return v
+}
+
 // opencodeToolState represents the state of a tool invocation.
 type opencodeToolState struct {
 	Status string            `json:"status,omitempty"`

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -220,6 +220,76 @@ func TestOpencodeHandleToolUseEventNilState(t *testing.T) {
 	}
 }
 
+// ── Tool duration tests (multica-ai/multica#8025) ──
+
+// toolResultFrom parses a real `opencode run --format json` tool_use line and
+// returns the paired tool_result message the backend emits for it.
+func toolResultFrom(t *testing.T, line string) Message {
+	t.Helper()
+	b := &opencodeBackend{}
+	ch := make(chan Message, 10)
+	var event opencodeEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	b.handleToolUseEvent(event, ch)
+	for {
+		msg, ok := <-ch
+		if !ok {
+			t.Fatal("no tool_result message emitted")
+		}
+		if msg.Type == MessageToolResult {
+			return msg
+		}
+	}
+}
+
+func TestOpencodeToolDurationCompleted(t *testing.T) {
+	t.Parallel()
+
+	// Real terminal tool event shape: completed with a measured window.
+	msg := toolResultFrom(t, `{"type":"tool_use","timestamp":1002,"sessionID":"ses_dur","part":{"tool":"bash","callID":"call_dur","state":{"status":"completed","input":{"command":"go test"},"output":"ok","time":{"start":100000,"end":112345}}}}`)
+	if msg.DurationMs != 12345 {
+		t.Errorf("duration: got %d, want 12345", msg.DurationMs)
+	}
+}
+
+func TestOpencodeToolDurationMissingTime(t *testing.T) {
+	t.Parallel()
+
+	// No time block at all — the duration stays 0 (unknown), the run is
+	// unaffected, and the result is still emitted.
+	msg := toolResultFrom(t, `{"type":"tool_use","timestamp":1002,"sessionID":"ses_dur","part":{"tool":"bash","callID":"call_dur","state":{"status":"completed","input":{"command":"go test"},"output":"ok"}}}`)
+	if msg.DurationMs != 0 {
+		t.Errorf("duration: got %d, want 0", msg.DurationMs)
+	}
+}
+
+func TestOpencodeToolDurationEndBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	// end < start is a malformed window — fall back to 0 (unknown), not a
+	// negative or nonsense duration.
+	msg := toolResultFrom(t, `{"type":"tool_use","timestamp":1002,"sessionID":"ses_dur","part":{"tool":"bash","callID":"call_dur","state":{"status":"completed","input":{"command":"go test"},"output":"ok","time":{"start":112345,"end":100000}}}}`)
+	if msg.DurationMs != 0 {
+		t.Errorf("duration: got %d, want 0", msg.DurationMs)
+	}
+}
+
+func TestOpencodeToolDurationErrorStatePreserved(t *testing.T) {
+	t.Parallel()
+
+	// A recovered tool error still carries the real execution window: the
+	// duration must be preserved alongside the error output.
+	msg := toolResultFrom(t, `{"type":"tool_use","timestamp":1002,"sessionID":"ses_dur","part":{"tool":"bash","callID":"call_dur","state":{"status":"error","input":{"command":"exit 1"},"error":"command failed","time":{"start":100000,"end":112345}}}}`)
+	if msg.DurationMs != 12345 {
+		t.Errorf("duration: got %d, want 12345", msg.DurationMs)
+	}
+	if msg.Output != "command failed" {
+		t.Errorf("output: got %q, want %q", msg.Output, "command failed")
+	}
+}
+
 // ── Error event tests ──
 
 func TestOpencodeHandleErrorEvent(t *testing.T) {

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -290,6 +290,79 @@ func TestOpencodeToolDurationErrorStatePreserved(t *testing.T) {
 	}
 }
 
+// ── Malformed timing must never drop the event ──
+
+// A time.start that is not a number (e.g. an OpenCode version emitting a
+// string) previously failed the WHOLE event's json.Unmarshal, dropping the
+// tool_use/result and leaving the daemon with an empty step that flipped the
+// run to failed. The event must survive with an unknown duration instead.
+func TestOpencodeToolDurationMalformedStartString(t *testing.T) {
+	t.Parallel()
+
+	msg := toolResultFrom(t, `{"type":"tool_use","timestamp":1002,"sessionID":"ses_dur","part":{"tool":"bash","callID":"call_dur","state":{"status":"completed","input":{"command":"go test"},"output":"ok","time":{"start":"bad","end":112345}}}}`)
+	if msg.DurationMs != 0 {
+		t.Errorf("duration: got %d, want 0", msg.DurationMs)
+	}
+	if msg.Output != "ok" {
+		t.Errorf("output: got %q, want %q — event was dropped", msg.Output, "ok")
+	}
+}
+
+// time itself not an object — same survival rule as malformed fields.
+func TestOpencodeToolDurationTimeNotObject(t *testing.T) {
+	t.Parallel()
+
+	msg := toolResultFrom(t, `{"type":"tool_use","timestamp":1002,"sessionID":"ses_dur","part":{"tool":"bash","callID":"call_dur","state":{"status":"completed","input":{"command":"go test"},"output":"ok","time":"bad"}}}`)
+	if msg.DurationMs != 0 {
+		t.Errorf("duration: got %d, want 0", msg.DurationMs)
+	}
+	if msg.Output != "ok" {
+		t.Errorf("output: got %q, want %q — event was dropped", msg.Output, "ok")
+	}
+}
+
+// Epoch values beyond int64 (e.g. 1e19) overflow int64 decoding — they must
+// degrade to unknown, not poison the event.
+func TestOpencodeToolDurationOverflow(t *testing.T) {
+	t.Parallel()
+
+	msg := toolResultFrom(t, `{"type":"tool_use","timestamp":1002,"sessionID":"ses_dur","part":{"tool":"bash","callID":"call_dur","state":{"status":"completed","input":{"command":"go test"},"output":"ok","time":{"start":10000000000000000000,"end":20000000000000000000}}}}`)
+	if msg.DurationMs != 0 {
+		t.Errorf("duration: got %d, want 0", msg.DurationMs)
+	}
+	if msg.Output != "ok" {
+		t.Errorf("output: got %q, want %q — event was dropped", msg.Output, "ok")
+	}
+}
+
+// Non-positive bounds are malformed, not measurements.
+func TestOpencodeToolDurationNonPositive(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		time string
+	}{
+		{"zero start", `{"start":0,"end":112345}`},
+		{"negative start", `{"start":-5,"end":112345}`},
+		{"zero end", `{"start":100000,"end":0}`},
+		{"negative end", `{"start":100000,"end":-5}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			line := fmt.Sprintf(`{"type":"tool_use","timestamp":1002,"sessionID":"ses_dur","part":{"tool":"bash","callID":"call_dur","state":{"status":"completed","input":{"command":"go test"},"output":"ok","time":%s}}}`, tt.time)
+			msg := toolResultFrom(t, line)
+			if msg.DurationMs != 0 {
+				t.Errorf("duration: got %d, want 0", msg.DurationMs)
+			}
+			if msg.Output != "ok" {
+				t.Errorf("output: got %q, want %q — event was dropped", msg.Output, "ok")
+			}
+		})
+	}
+}
+
 // ── Error event tests ──
 
 func TestOpencodeHandleErrorEvent(t *testing.T) {

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -1310,15 +1310,16 @@ type SysCronExecution struct {
 }
 
 type TaskMessage struct {
-	ID        pgtype.UUID        `json:"id"`
-	TaskID    pgtype.UUID        `json:"task_id"`
-	Seq       int32              `json:"seq"`
-	Type      string             `json:"type"`
-	Tool      pgtype.Text        `json:"tool"`
-	Content   pgtype.Text        `json:"content"`
-	Input     []byte             `json:"input"`
-	Output    pgtype.Text        `json:"output"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	ID         pgtype.UUID        `json:"id"`
+	TaskID     pgtype.UUID        `json:"task_id"`
+	Seq        int32              `json:"seq"`
+	Type       string             `json:"type"`
+	Tool       pgtype.Text        `json:"tool"`
+	Content    pgtype.Text        `json:"content"`
+	Input      []byte             `json:"input"`
+	Output     pgtype.Text        `json:"output"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	DurationMs pgtype.Int8        `json:"duration_ms"`
 }
 
 type TaskToken struct {

--- a/server/pkg/db/generated/task_message.sql.go
+++ b/server/pkg/db/generated/task_message.sql.go
@@ -13,7 +13,7 @@ import (
 
 const createTaskMessage = `-- name: CreateTaskMessage :one
 INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output, duration_ms)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULLIF(GREATEST($9::bigint, 0), 0))
 RETURNING id, task_id, seq, type, tool, content, input, output, created_at, duration_ms
 `
 
@@ -31,6 +31,9 @@ type CreateTaskMessageParams struct {
 
 // duration_ms carries the provider-reported tool-call duration (NULL = not
 // reported). Nullable BIGINT param: pass a zero Int8 for "no duration".
+// Same clamp as the batch insert below: 0 stays NULL (not reported) and a
+// negative value is malformed rather than a duration, so neither ever
+// reaches the column as a number.
 func (q *Queries) CreateTaskMessage(ctx context.Context, arg CreateTaskMessageParams) (TaskMessage, error) {
 	row := q.db.QueryRow(ctx, createTaskMessage,
 		arg.ID,

--- a/server/pkg/db/generated/task_message.sql.go
+++ b/server/pkg/db/generated/task_message.sql.go
@@ -12,22 +12,25 @@ import (
 )
 
 const createTaskMessage = `-- name: CreateTaskMessage :one
-INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, task_id, seq, type, tool, content, input, output, created_at
+INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output, duration_ms)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING id, task_id, seq, type, tool, content, input, output, created_at, duration_ms
 `
 
 type CreateTaskMessageParams struct {
-	ID      pgtype.UUID `json:"id"`
-	TaskID  pgtype.UUID `json:"task_id"`
-	Seq     int32       `json:"seq"`
-	Type    string      `json:"type"`
-	Tool    pgtype.Text `json:"tool"`
-	Content pgtype.Text `json:"content"`
-	Input   []byte      `json:"input"`
-	Output  pgtype.Text `json:"output"`
+	ID         pgtype.UUID `json:"id"`
+	TaskID     pgtype.UUID `json:"task_id"`
+	Seq        int32       `json:"seq"`
+	Type       string      `json:"type"`
+	Tool       pgtype.Text `json:"tool"`
+	Content    pgtype.Text `json:"content"`
+	Input      []byte      `json:"input"`
+	Output     pgtype.Text `json:"output"`
+	DurationMs pgtype.Int8 `json:"duration_ms"`
 }
 
+// duration_ms carries the provider-reported tool-call duration (NULL = not
+// reported). Nullable BIGINT param: pass a zero Int8 for "no duration".
 func (q *Queries) CreateTaskMessage(ctx context.Context, arg CreateTaskMessageParams) (TaskMessage, error) {
 	row := q.db.QueryRow(ctx, createTaskMessage,
 		arg.ID,
@@ -38,6 +41,7 @@ func (q *Queries) CreateTaskMessage(ctx context.Context, arg CreateTaskMessagePa
 		arg.Content,
 		arg.Input,
 		arg.Output,
+		arg.DurationMs,
 	)
 	var i TaskMessage
 	err := row.Scan(
@@ -50,6 +54,7 @@ func (q *Queries) CreateTaskMessage(ctx context.Context, arg CreateTaskMessagePa
 		&i.Input,
 		&i.Output,
 		&i.CreatedAt,
+		&i.DurationMs,
 	)
 	return i, err
 }
@@ -68,45 +73,51 @@ WITH incoming AS (
         unnest($4::text[]) AS tool,
         unnest($5::text[]) AS content,
         unnest($6::text[]) AS input,
-        unnest($7::text[]) AS output
+        unnest($7::text[]) AS output,
+        unnest($8::bigint[]) AS duration_ms
 ), inserted AS (
-    INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output)
+    INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output, duration_ms)
     SELECT
         m.id,
-        $8::uuid,
+        $9::uuid,
         m.seq,
         m.type,
         NULLIF(m.tool, ''),
         NULLIF(m.content, ''),
         NULLIF(m.input, '')::jsonb,
-        NULLIF(m.output, '')
+        NULLIF(m.output, ''),
+        -- 0 = not reported (NULL); a negative value is malformed rather than
+        -- a duration, so it is clamped to unknown instead of stored.
+        NULLIF(GREATEST(m.duration_ms, 0), 0)
     FROM incoming AS m
-    RETURNING id, task_id, seq, type, tool, content, input, output, created_at
+    RETURNING id, task_id, seq, type, tool, content, input, output, created_at, duration_ms
 )
-SELECT id, task_id, seq, type, tool, content, input, output, created_at FROM inserted ORDER BY seq ASC
+SELECT id, task_id, seq, type, tool, content, input, output, created_at, duration_ms FROM inserted ORDER BY seq ASC
 `
 
 type CreateTaskMessagesParams struct {
-	Ids      []pgtype.UUID `json:"ids"`
-	Seqs     []int32       `json:"seqs"`
-	Types    []string      `json:"types"`
-	Tools    []string      `json:"tools"`
-	Contents []string      `json:"contents"`
-	Inputs   []string      `json:"inputs"`
-	Outputs  []string      `json:"outputs"`
-	TaskID   pgtype.UUID   `json:"task_id"`
+	Ids         []pgtype.UUID `json:"ids"`
+	Seqs        []int32       `json:"seqs"`
+	Types       []string      `json:"types"`
+	Tools       []string      `json:"tools"`
+	Contents    []string      `json:"contents"`
+	Inputs      []string      `json:"inputs"`
+	Outputs     []string      `json:"outputs"`
+	DurationMss []int64       `json:"duration_mss"`
+	TaskID      pgtype.UUID   `json:"task_id"`
 }
 
 type CreateTaskMessagesRow struct {
-	ID        pgtype.UUID        `json:"id"`
-	TaskID    pgtype.UUID        `json:"task_id"`
-	Seq       int32              `json:"seq"`
-	Type      string             `json:"type"`
-	Tool      pgtype.Text        `json:"tool"`
-	Content   pgtype.Text        `json:"content"`
-	Input     []byte             `json:"input"`
-	Output    pgtype.Text        `json:"output"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	ID         pgtype.UUID        `json:"id"`
+	TaskID     pgtype.UUID        `json:"task_id"`
+	Seq        int32              `json:"seq"`
+	Type       string             `json:"type"`
+	Tool       pgtype.Text        `json:"tool"`
+	Content    pgtype.Text        `json:"content"`
+	Input      []byte             `json:"input"`
+	Output     pgtype.Text        `json:"output"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	DurationMs pgtype.Int8        `json:"duration_ms"`
 }
 
 // Batch variant of CreateTaskMessage: persists a whole daemon-reported batch in
@@ -157,6 +168,7 @@ func (q *Queries) CreateTaskMessages(ctx context.Context, arg CreateTaskMessages
 		arg.Contents,
 		arg.Inputs,
 		arg.Outputs,
+		arg.DurationMss,
 		arg.TaskID,
 	)
 	if err != nil {
@@ -176,6 +188,7 @@ func (q *Queries) CreateTaskMessages(ctx context.Context, arg CreateTaskMessages
 			&i.Input,
 			&i.Output,
 			&i.CreatedAt,
+			&i.DurationMs,
 		); err != nil {
 			return nil, err
 		}
@@ -198,7 +211,7 @@ func (q *Queries) DeleteTaskMessages(ctx context.Context, taskID pgtype.UUID) er
 }
 
 const listTaskMessages = `-- name: ListTaskMessages :many
-SELECT id, task_id, seq, type, tool, content, input, output, created_at FROM task_message
+SELECT id, task_id, seq, type, tool, content, input, output, created_at, duration_ms FROM task_message
 WHERE task_id = $1
 ORDER BY seq ASC
 `
@@ -222,6 +235,7 @@ func (q *Queries) ListTaskMessages(ctx context.Context, taskID pgtype.UUID) ([]T
 			&i.Input,
 			&i.Output,
 			&i.CreatedAt,
+			&i.DurationMs,
 		); err != nil {
 			return nil, err
 		}
@@ -234,7 +248,7 @@ func (q *Queries) ListTaskMessages(ctx context.Context, taskID pgtype.UUID) ([]T
 }
 
 const listTaskMessagesSince = `-- name: ListTaskMessagesSince :many
-SELECT id, task_id, seq, type, tool, content, input, output, created_at FROM task_message
+SELECT id, task_id, seq, type, tool, content, input, output, created_at, duration_ms FROM task_message
 WHERE task_id = $1 AND seq > $2
 ORDER BY seq ASC
 `
@@ -263,6 +277,7 @@ func (q *Queries) ListTaskMessagesSince(ctx context.Context, arg ListTaskMessage
 			&i.Input,
 			&i.Output,
 			&i.CreatedAt,
+			&i.DurationMs,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/task_message.sql
+++ b/server/pkg/db/queries/task_message.sql
@@ -1,6 +1,8 @@
 -- name: CreateTaskMessage :one
-INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+-- duration_ms carries the provider-reported tool-call duration (NULL = not
+-- reported). Nullable BIGINT param: pass a zero Int8 for "no duration".
+INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output, duration_ms)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING *;
 
 -- name: CreateTaskMessages :many
@@ -56,9 +58,10 @@ WITH incoming AS (
         unnest(sqlc.arg('tools')::text[]) AS tool,
         unnest(sqlc.arg('contents')::text[]) AS content,
         unnest(sqlc.arg('inputs')::text[]) AS input,
-        unnest(sqlc.arg('outputs')::text[]) AS output
+        unnest(sqlc.arg('outputs')::text[]) AS output,
+        unnest(sqlc.arg('duration_mss')::bigint[]) AS duration_ms
 ), inserted AS (
-    INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output)
+    INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output, duration_ms)
     SELECT
         m.id,
         sqlc.arg('task_id')::uuid,
@@ -67,7 +70,10 @@ WITH incoming AS (
         NULLIF(m.tool, ''),
         NULLIF(m.content, ''),
         NULLIF(m.input, '')::jsonb,
-        NULLIF(m.output, '')
+        NULLIF(m.output, ''),
+        -- 0 = not reported (NULL); a negative value is malformed rather than
+        -- a duration, so it is clamped to unknown instead of stored.
+        NULLIF(GREATEST(m.duration_ms, 0), 0)
     FROM incoming AS m
     RETURNING *
 )

--- a/server/pkg/db/queries/task_message.sql
+++ b/server/pkg/db/queries/task_message.sql
@@ -1,8 +1,11 @@
 -- name: CreateTaskMessage :one
 -- duration_ms carries the provider-reported tool-call duration (NULL = not
 -- reported). Nullable BIGINT param: pass a zero Int8 for "no duration".
+-- Same clamp as the batch insert below: 0 stays NULL (not reported) and a
+-- negative value is malformed rather than a duration, so neither ever
+-- reaches the column as a number.
 INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output, duration_ms)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULLIF(GREATEST(sqlc.narg('duration_ms')::bigint, 0), 0))
 RETURNING *;
 
 -- name: CreateTaskMessages :many

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -195,6 +195,11 @@ type TaskMessagePayload struct {
 	Input     map[string]any `json:"input,omitempty"`   // tool input (tool_use only)
 	Output    string         `json:"output,omitempty"`  // tool output (tool_result only)
 	CreatedAt string         `json:"created_at,omitempty"`
+	// DurationMs is the provider-reported tool-call duration in ms, carried on
+	// tool_result rows when the runtime measured the call itself. omitempty:
+	// rows without a provider duration look exactly as they did before the
+	// field existed, so older clients are unaffected.
+	DurationMs int64 `json:"duration_ms,omitempty"`
 }
 
 // DaemonRegisterPayload is sent from daemon to server on connection.


### PR DESCRIPTION
## What does this PR do?

OpenCode measures every tool call itself — `part.state.time.start/end` (epoch ms) is right there in the stream — but the Multica adapter dropped that window and the transcript only kept the server's arrival stamps. Since the daemon flushes both the `tool_use` and its `tool_result` in the same 500ms batch, the two timestamps are identical: **every OpenCode tool call renders as `0s` in the run view**, whether it took 12.3 seconds or five minutes.

This PR carries the provider's own duration through the ingest → persist → render pipeline as a small, additive change. `task_message.created_at` semantics are untouched (no provider clock becomes canonical), and runtimes that don't measure timing behave exactly as before.

## Related Issue

Closes #8025

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

**OpenCode parser** (`server/pkg/agent/opencode.go`, `agent.go`)
- New `opencodeToolTime` struct parsed from `part.state.time`; `Message.DurationMs` (additive, zero = unknown) is computed on terminal states (`completed` / `error`) and attached to the paired `tool_result`.
- **Tolerant timing decode**: the time block has its own `UnmarshalJSON`, so a `time:"bad"` string or a start value beyond int64 degrades that field to 0 (unknown) while the enclosing event is processed exactly as before. Without this, malformed timing failed the whole event's `json.Unmarshal`, dropping the `tool_use`/`tool_result` and leaving the daemon an empty step that flipped the run to `failed`.
- Defensive: `time == nil`, `start <= 0`, `end <= 0`, `end < start`, non-object time, string/fraction/overflow fields all fall back to 0 (unknown) — a bad window can never fail the run or lose an event.

**Daemon → server contract** (`server/internal/daemon/client.go`, `daemon.go`, `server/internal/handler/daemon.go`, `server/pkg/protocol/messages.go`)
- `duration_ms` added additively (`omitempty`) to `TaskMessageData` → `TaskMessageRequest` → `TaskMessagePayload`. A daemon with no provider duration sends a byte-identical payload; old daemons ↔ new servers (and the reverse) are unaffected.

**Database** (`server/migrations/451_*`, `server/pkg/db/queries/task_message.sql`, sqlc regenerated)
- `task_message.duration_ms BIGINT` nullable: `NULL` = provider reported nothing, `> 0` = measured. Negative values are malformed, not measurements — the handler clamps them to unknown, **and both insert paths clamp at the SQL layer**: the batch insert's `NULLIF(GREATEST(...))` and the single-row `CreateTaskMessage` (via `sqlc.narg`, so the `pgtype.Int8` signature is unchanged) — a direct caller outside the handler can never store a negative duration either.

**Frontend** (`packages/core/types/events.ts`, `packages/views/common/task-transcript/build-timeline.ts`, `build-steps.ts`, `apps/mobile/data/schemas.ts`)
- `duration_ms?: number` on `TaskMessagePayload` / `TimelineItem`. Type comments spell out the wire contract: absence is the only unknown (daemons omit the field when they don't know); an explicit 0 that does arrive is the provider's word and wins.
- `buildSteps()` priority: a finite `tool_result.duration_ms >= 0` wins over the created-at difference — including an explicit 0, which is deliberate on the wire; malformed (negative / NaN / infinite) values are ignored. The interval is reconstructed (`startedAt = endedAt - duration`) only when the computed start is finite and inside the ±8.64e15 ms `Date` window — outside it, `toISOString()` would throw a `RangeError` that takes the whole transcript down, so the number and the real timestamps are kept instead. Without a provider duration the existing fallback stays.

## How to Test

1. Parser: `(cd server && go test ./pkg/agent/ -run TestOpencodeToolDuration -count=1)` — completed + `time{100000,112345}` → `12345`; missing time → `0`; `end < start` → `0`; `error` state + valid time → preserved; `time.start` as a string, `time` not an object, overflow (`1e19`), and non-positive bounds → the event survives (output intact) with `0`.
2. Round trip + direct query (needs a local Postgres migrated up): `(cd server && go test ./internal/handler/ -run 'TestReportTaskMessages|TestCreateTaskMessageClamps|TestCreateTaskMessagesBatchIsAtomic' -count=1)` — `duration_ms` survives HTTP request → `task_message` → catch-up response (raw body checked for `omitempty`) → realtime publish; absent/negative → `NULL`. The single-row insert driven directly outside the handler clamps 0/negative/unset to `NULL` and keeps a measured value.
3. Frontend: `(cd packages/views && pnpm exec vitest run common/task-transcript)` — the regression test proves the old behavior rendered `0s` for a call whose provider duration was 5000 (assertion failed with `expected +0 to be 5000` before the fix) and renders `5s` after; an explicit `duration_ms: 0` beats a 4s created-at difference; a huge duration (`Number.MAX_VALUE`) next to real timestamps keeps the step renderable (previously `RangeError: Invalid time value`) with the number alone; the timestamp-diff fallback still yields `4s` for a runtime without `duration_ms`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (the displayed value changes — 0s → the provider's real duration — but there is no UI design change; see Screenshots below)
- [x] I have updated relevant documentation to reflect my changes (N/A — additive nullable column and type fields; no user-facing documentation is affected)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (worker-opencode, OpenCode runtime)

**Prompt / approach:**
Autonomous fix of #8025: read the issue spec, traced the whole data path (`opencode.go` parser → daemon batch reporting → handler ingest → sqlc/Postgres → timeline/steps rendering), implemented the smallest additive change at each hop, and proved the renderer regression RED→GREEN before touching `build-steps.ts`. After an independent cross-review found four defensive gaps, each was reproduced with a failing test first and then fixed in place.

## Screenshots (optional)

N/A (no UI design change; durations now display the provider's real value).
