### PR TITLE
MUL-7057 fix(mcp): use a configure icon for the MCP server configuration action

### DIFF
--- a/packages/views/agents/components/tabs/mcp-config-tab.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.tsx
@@ -387,7 +387,6 @@ export function McpConfigTab({
                   remove: t(($) => $.tab_body.mcp_config.delete_action_short),
                   removeAria: t(($) => $.tab_body.mcp_config.delete_aria),
                 }}
-                configureKind="edit"
                 onRenameStart={() => startRename(server)}
                 onConfigure={() => openEditDialog(server)}
                 onRemove={() => {

--- a/packages/views/common/mcp-server-row.test.tsx
+++ b/packages/views/common/mcp-server-row.test.tsx
@@ -33,7 +33,6 @@ describe("McpServerRow", () => {
             remove: "Delete",
             removeAria: "Delete MCP server",
           }}
-          configureKind="edit"
           onRenameStart={vi.fn()}
           onConfigure={vi.fn()}
           onRemove={vi.fn()}
@@ -53,6 +52,42 @@ describe("McpServerRow", () => {
     expect(
       screen.getByRole("button", { name: "Delete MCP server linear" }),
     ).toBeInTheDocument();
+  });
+
+  // Regression: the configure action opens the server's configuration dialog,
+  // so it must not wear the circular-arrows icon this repo uses everywhere for
+  // "refresh" (MUL-7057). That reading survived because the workspace library
+  // calls the same action "Replace configuration".
+  it("marks the configure action with the configure icon, not a refresh icon", () => {
+    render(
+      <ul>
+        <McpServerRow
+          name="linear"
+          transport="stdio"
+          canManage
+          labels={{
+            rename: "Rename",
+            renameAria: "Rename server",
+            renameSave: "Save name",
+            renameCancel: "Cancel rename",
+            configure: "Replace configuration",
+            configureAria: "Replace configuration",
+            remove: "Delete",
+            removeAria: "Delete MCP server",
+          }}
+          onRenameStart={vi.fn()}
+          onConfigure={vi.fn()}
+          onRemove={vi.fn()}
+        />
+      </ul>,
+    );
+
+    const icon = screen
+      .getByRole("button", { name: "Replace configuration linear" })
+      .querySelector("svg");
+
+    expect(icon).toHaveClass("lucide-sliders-horizontal");
+    expect(icon?.getAttribute("class")).not.toMatch(/refresh|rotate/i);
   });
 
   it("cancels inline rename when Escape is pressed", async () => {
@@ -82,7 +117,6 @@ describe("McpServerRow", () => {
             remove: "Delete",
             removeAria: "Delete MCP server",
           }}
-          configureKind="edit"
           onRenameStart={vi.fn()}
           onConfigure={vi.fn()}
           onRemove={vi.fn()}

--- a/packages/views/common/mcp-server-row.tsx
+++ b/packages/views/common/mcp-server-row.tsx
@@ -6,7 +6,6 @@ import {
   Globe2,
   Loader2,
   Pencil,
-  RefreshCw,
   Server,
   SlidersHorizontal,
   SquareTerminal,
@@ -113,7 +112,9 @@ export function McpRemoveButton({
  * Data writes remain the caller's responsibility: workspace settings replaces
  * a write-only config, while an agent edits its readable local config. Keeping
  * those semantics outside this component prevents the visual treatment and
- * the security contract from becoming coupled again.
+ * the security contract from becoming coupled again. Both open the same
+ * configuration dialog, so both carry the same "configure" icon; only the
+ * caller's tooltip and accessible name say whether it edits or replaces.
  */
 export function McpServerRow({
   name,
@@ -123,7 +124,6 @@ export function McpServerRow({
   actionsDisabled = false,
   rename,
   labels,
-  configureKind,
   onRenameStart,
   onConfigure,
   onRemove,
@@ -135,14 +135,11 @@ export function McpServerRow({
   actionsDisabled?: boolean;
   rename?: McpServerRenameState;
   labels: McpServerRowLabels;
-  configureKind: "edit" | "replace";
   onRenameStart: () => void;
   onConfigure: () => void;
   onRemove: () => void;
 }) {
   const errorId = `${useId()}-rename-error`;
-  const ConfigureIcon =
-    configureKind === "replace" ? RefreshCw : SlidersHorizontal;
 
   return (
     <li className="group flex min-h-16 items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/30">
@@ -251,7 +248,7 @@ export function McpServerRow({
                   disabled={actionsDisabled}
                   aria-label={`${labels.configureAria} ${name}`}
                 >
-                  <ConfigureIcon />
+                  <SlidersHorizontal />
                 </Button>
               }
             />

--- a/packages/views/settings/components/mcp-tab.tsx
+++ b/packages/views/settings/components/mcp-tab.tsx
@@ -272,7 +272,6 @@ export function McpTab() {
                     remove: t(($) => $.mcp.remove_action),
                     removeAria: t(($) => $.mcp.remove_server),
                   }}
-                  configureKind="replace"
                   onRenameStart={() => startRename(server)}
                   onConfigure={() => {
                     cancelRename();


### PR DESCRIPTION
## Summary

In the workspace MCP library (Settings → MCP), each server row's configuration action was drawn with `RefreshCw`. Clicking it opens the configuration dialog, but the circular-arrows icon reads as "refresh this server" — every other use of `RefreshCw` in this app really is a refresh (`lark-tab`, `composio-tab`, `vcs-tab`, `billing-tab`, `model-search-header`), and the agent MCP tab even renders a genuine `RefreshCw` refresh button a few rows below this one.

The icon came from `McpServerRow`'s `configureKind` prop: `"replace"` → `RefreshCw`, `"edit"` → `SlidersHorizontal`. That was its only effect.

Both surfaces open the same `McpServerDialog`, so both now use the same `SlidersHorizontal` configure icon and `configureKind` is removed. The edit-vs-replace distinction is a data-write semantic, not a different affordance, and it stays where a user can act on it: the tooltip and accessible name (`Replace configuration` vs `Edit configuration`), the section note about write-only values, and the dialog's own empty replacement form.

## Changes

- `packages/views/common/mcp-server-row.tsx` — drop `configureKind`, always render `SlidersHorizontal`.
- `packages/views/settings/components/mcp-tab.tsx`, `packages/views/agents/components/tabs/mcp-config-tab.tsx` — drop the now-removed prop.
- `packages/views/common/mcp-server-row.test.tsx` — regression test pinning the configure action to the configure icon and asserting it is not a refresh icon.

## Verification

- `pnpm exec vitest run` over `packages/views` (`common/`, `settings/`, `agents/components/tabs/`) — 64 files, 781 tests pass.
- The new regression test was confirmed to fail when `SlidersHorizontal` is reverted to `RefreshCw` (`expected lucide lucide-refresh-cw to have class lucide-sliders-horizontal`), so it genuinely guards the fix.
- `pnpm typecheck` — 9/9 tasks pass.
- `pnpm --filter @multica/views lint` — no new warnings; the two `mcp-config-tab.tsx` `exhaustive-deps` warnings are pre-existing on `main`.
