### PR TITLE
fix(cursor): fail managed runs on background shell launch

### DIFF
--- a/server/pkg/agent/claude_deadlock_test.go
+++ b/server/pkg/agent/claude_deadlock_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -27,6 +28,15 @@ func TestMain(m *testing.M) {
 	if os.Getenv(opencodeStdinHelperEnv) == "1" {
 		runFakeOpencodeStdinHelper()
 		os.Exit(0)
+	}
+	switch mode := os.Getenv("CURSOR_FAKE_MODE"); mode {
+	case "":
+	case "background_shell_no_result":
+		runFakeCursorBackgroundShellNoResult()
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown CURSOR_FAKE_MODE: %q\n", mode)
+		os.Exit(2)
 	}
 	switch mode := os.Getenv("CLAUDE_FAKE_MODE"); mode {
 	case "":
@@ -153,6 +163,24 @@ func runFakeClaudeAsyncLaunchedToolResult() {
 	fmt.Println(`{"type":"system","session_id":"sess-async-launched"}`)
 	fmt.Println(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call-async","content":{"status":"async_launched","message":"background task launched"}}]}}`)
 	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-async-launched","result":"parent turn completed early"}`)
+}
+
+// runFakeCursorBackgroundShellNoResult reproduces the GH #7833 failure shape:
+// cursor-agent launches a shell in background mode (the completed shellToolCall
+// result carries "isBackground": true) and then never emits its terminal result
+// while the background process stays alive. Like the real CLI, the fake reads
+// the prompt to EOF, streams the init/started/completed events, and then blocks
+// without ever sending a result.
+func runFakeCursorBackgroundShellNoResult() {
+	if _, err := io.ReadAll(os.Stdin); err != nil {
+		fmt.Fprintf(os.Stderr, "read prompt: %v\n", err)
+		os.Exit(51)
+	}
+	fmt.Println(`{"type":"system","subtype":"init","session_id":"sess-cursor-bg"}`)
+	fmt.Println(`{"type":"tool_call","subtype":"started","call_id":"call-bg","tool_call":{"shellToolCall":{"args":{"command":"long-running-server"}},"toolCallId":"call-bg"}}`)
+	fmt.Println(`{"type":"tool_call","subtype":"completed","call_id":"call-bg","tool_call":{"shellToolCall":{"args":{"command":"long-running-server"},"result":{"success":{"exitCode":0},"isBackground":true}},"toolCallId":"call-bg"}}`)
+	// No terminal result: block until the managed process is torn down.
+	time.Sleep(2 * time.Minute)
 }
 
 // TestClaudeExecuteDoesNotDeadlockOnStartupStdoutBurst verifies that the

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -112,6 +112,12 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		invalidEventCount := 0
 		assistantEventCount := 0
 		toolUseCount := 0
+		// backgroundShellDetected latches the authoritative completed-shell
+		// "isBackground": true signal. Once set it outranks both a later
+		// terminal result and context cancellation at finalization: the run
+		// failed because Cursor launched a shell it cannot own in a managed
+		// run, regardless of anything the stream says afterwards.
+		backgroundShellDetected := false
 		// unhandledSubtypeCount tracks thinking/tool_call events whose subtype we
 		// don't recognize. They are ignored (never synthesized into a message)
 		// and surfaced once as a bounded, content-free diagnostic so an upstream
@@ -215,12 +221,26 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					})
 				case "completed":
 					call := parseCursorToolCall(&evt)
+
 					trySend(msgCh, Message{
 						Type:   MessageToolResult,
 						Tool:   call.Name,
 						CallID: call.CallID,
 						Output: call.Result,
 					})
+
+					// Guard only the observed protocol shape: a completed
+					// shellToolCall whose result itself reports isBackground
+					// true. Arguments (block_until_ms etc.), command strings,
+					// and other tool types are never inspected — args are
+					// request intent, this field is what Cursor actually did.
+					if call.Name == "shell" && call.Background && !backgroundShellDetected {
+						backgroundShellDetected = true
+						b.cfg.Logger.Warn("cursor-agent launched a background shell; cancelling managed run")
+						// Use the existing lifecycle ownership: context
+						// cancellation tears down the owned process group.
+						cancel()
+					}
 				default:
 					unhandledSubtypeCount++
 				}
@@ -339,7 +359,14 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// on a full pipe has returned by now; the writer sends exactly once.
 		writeErr := <-writeErrCh
 
-		if resultSeen {
+		// The background guard outranks everything: a terminal result that
+		// follows the background signal (or its absence — the usual case, the
+		// stream simply stops) does not change the verdict, and it must not be
+		// rewritten into the generic "aborted" that cancellation would produce.
+		if backgroundShellDetected {
+			finalStatus = "failed"
+			finalError = cursorBackgroundShellGuardError
+		} else if resultSeen {
 			// A parsed result is the protocol boundary. Ignore the cancellation and
 			// exit error caused by stopping a Cursor worker that lingers afterward.
 			if finalStatus == "failed" && finalError == "" {
@@ -452,6 +479,12 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 }
 
 const cursorIncompleteFinalizationWarning = "actions completed before finalization may already have taken effect"
+
+// cursorBackgroundShellGuardError is the content-free failure reason for a
+// managed Cursor run in which Cursor itself confirmed (shellToolCall result
+// "isBackground": true) that it launched a shell in background mode. It must
+// stay free of the command, its output, paths, or any provider payload.
+const cursorBackgroundShellGuardError = "cursor-agent launched a background shell; Multica-managed runs require foreground execution"
 
 func cursorFailureDiagnostic(message string, exitErr, scanErr error, eventCount, invalidEventCount int, lastEventType string) string {
 	return fmt.Sprintf(
@@ -669,6 +702,12 @@ type cursorToolCall struct {
 	CallID string
 	Input  map[string]any
 	Result string
+	// Background is authoritative lifecycle evidence from a completed
+	// shellToolCall result: Cursor sets "isBackground": true only when it
+	// actually launched the shell in background mode. It is read from the
+	// result object's own field (never from args or a string search) and
+	// drives the managed-run background guard in Execute.
+	Background bool
 }
 
 // cursorToolCallKeySuffix is how Cursor names the per-tool payload: the tool is
@@ -714,6 +753,17 @@ func parseCursorToolCall(evt *cursorStreamEvent) cursorToolCall {
 	call.Input = payload.Args
 	if len(payload.Result) > 0 {
 		call.Result = string(payload.Result)
+
+		// Read only the result object's own isBackground field. A string search
+		// would fire on tool output that merely mentions the key (e.g. an echo
+		// of a command's own JSON), so this must stay structural; and a result
+		// we cannot decode must not fail the whole tool parse.
+		var resultMeta struct {
+			IsBackground bool `json:"isBackground"`
+		}
+		if json.Unmarshal(payload.Result, &resultMeta) == nil {
+			call.Background = resultMeta.IsBackground
+		}
 	}
 	return call
 }

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -1,11 +1,14 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildCursorArgs(t *testing.T) {
@@ -740,12 +743,13 @@ func TestParseCursorToolCall(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		event      string
-		wantName   string
-		wantCallID string
-		wantArg    string
-		wantResult string
+		name           string
+		event          string
+		wantName       string
+		wantCallID     string
+		wantArg        string
+		wantResult     string
+		wantBackground bool
 	}{
 		{
 			name: "started names the tool from the nested key",
@@ -765,6 +769,55 @@ func TestParseCursorToolCall(t *testing.T) {
 			wantCallID: "call-2",
 			wantArg:    "x",
 			wantResult: `{"success":{"exitCode":0}}`,
+		},
+		{
+			// Case A (GH #7833): Cursor confirmed it actually launched the
+			// shell in background mode. The completed result's isBackground
+			// field is the authoritative signal; the raw result is preserved.
+			name: "background shell result is authoritative",
+			event: `{"type":"tool_call","subtype":"completed",
+				"call_id":"call-bg",
+				"tool_call":{"shellToolCall":{"args":{"command":"vite"},"result":{"success":{"exitCode":0},"isBackground":true}}}}`,
+			wantName:       "shell",
+			wantCallID:     "call-bg",
+			wantResult:     `{"success":{"exitCode":0},"isBackground":true}`,
+			wantBackground: true,
+		},
+		{
+			// Case B: an explicit false stays foreground.
+			name: "explicit foreground result stays foreground",
+			event: `{"type":"tool_call","subtype":"completed",
+				"call_id":"call-fg",
+				"tool_call":{"shellToolCall":{"args":{"command":"ls"},"result":{"success":{"exitCode":0},"isBackground":false}}}}`,
+			wantName:       "shell",
+			wantCallID:     "call-fg",
+			wantResult:     `{"success":{"exitCode":0},"isBackground":false}`,
+			wantBackground: false,
+		},
+		{
+			// Case C: tool output that merely mentions the key must never be
+			// mistaken for the field itself — a strings.Contains implementation
+			// would fail this case.
+			name: "mentioned-in-stdout isBackground does not leak into detection",
+			event: `{"type":"tool_call","subtype":"completed",
+				"call_id":"call-fp",
+				"tool_call":{"shellToolCall":{"args":{"command":"echo"},"result":{"success":{"stdout":"example payload: {\"isBackground\":true}"},"isBackground":false}}}}`,
+			wantName:       "shell",
+			wantCallID:     "call-fp",
+			wantResult:     `{"success":{"stdout":"example payload: {\"isBackground\":true}"},"isBackground":false}`,
+			wantBackground: false,
+		},
+		{
+			// Case D: a result that is not a decodeable object must keep the
+			// rest of the tool parsing intact and stay foreground, without a panic.
+			name: "malformed result payload keeps parsing and stays foreground",
+			event: `{"type":"tool_call","subtype":"completed",
+				"call_id":"call-md",
+				"tool_call":{"shellToolCall":{"args":{"command":"echo"},"result":"plain-string"}}}`,
+			wantName:       "shell",
+			wantCallID:     "call-md",
+			wantResult:     `"plain-string"`,
+			wantBackground: false,
 		},
 		{
 			name: "call id falls back to the nested tool call id",
@@ -807,7 +860,76 @@ func TestParseCursorToolCall(t *testing.T) {
 			if call.Result != tt.wantResult {
 				t.Errorf("Result = %q, want %q", call.Result, tt.wantResult)
 			}
+			if call.Background != tt.wantBackground {
+				t.Errorf("Background = %v, want %v", call.Background, tt.wantBackground)
+			}
 		})
+	}
+}
+
+// TestCursorExecuteFailsPromptlyOnBackgroundShellWithoutTerminalResult is the
+// end-to-end regression for GH #7833: Cursor can report a successful
+// background shellToolCall ("isBackground": true on the completed result) and
+// then never emit a terminal result while the shell stays alive. The backend
+// must treat that signal as a hard guard — cancel the managed process through
+// the existing owned-process path and finalise as failed — instead of waiting
+// for a terminal result that never arrives (before the fix, the run only ended
+// at the exec timeout as "timeout" and misclassified the failure).
+func TestCursorExecuteFailsPromptlyOnBackgroundShellWithoutTerminalResult(t *testing.T) {
+	t.Parallel()
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	backend, err := New("cursor", Config{
+		ExecutablePath: self,
+		Env:            map[string]string{"CURSOR_FAKE_MODE": "background_shell_no_result"},
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("New(cursor): %v", err)
+	}
+
+	// The outer context and exec timeout only bound the test; the assertion is
+	// that the result arrives well before either of them fires.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "run a long-running server", ExecOptions{Timeout: 8 * time.Second})
+	if err != nil {
+		t.Fatalf("execute returned error: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Status == "aborted" || result.Status == "timeout" {
+			t.Fatalf("background guard must not be misclassified as %q", result.Status)
+		}
+		for _, want := range []string{"background shell", "foreground execution"} {
+			if !strings.Contains(result.Error, want) {
+				t.Fatalf("expected error to contain %q, got %q", want, result.Error)
+			}
+		}
+		if result.Output != "" {
+			t.Fatalf("partial transcript must not surface as Result.Output, got %q", result.Output)
+		}
+		if result.SessionID != "sess-cursor-bg" {
+			t.Fatalf("expected session id sess-cursor-bg, got %q", result.SessionID)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for result — cursor backend did not fail promptly on a background shell without a terminal result")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Cursor can report a successful background `shellToolCall` and then never emit its terminal result while the shell remains alive. Multica currently waits for that result/process exit, so the task can retain a runtime slot until the global idle watchdog.

**Root cause:** the Cursor stream already reports `"isBackground": true` on the completed shell result, but `parseCursorToolCall` currently discards that lifecycle meaning. The backend only cancels Cursor proactively after a terminal result — precisely the event missing in this failure mode.

**Fix:** parse the authoritative `shellToolCall.result.isBackground` (JSON root boolean only, no string/command heuristics). When a completed shell call reports `true`, mark a provider-specific foreground-execution guard, cancel the Cursor managed process using the existing runtime ownership path (`cancel()` → owned process group SIGKILL), and preserve the guard as the final failure reason instead of letting context cancellation rewrite it to generic `aborted`. Partial assistant output is never exposed as `Result.Output`, and completion is never synthesized from assistant text or tool side effects.

This PR changes only the Cursor adapter rather than weakening global watchdog semantics or adding generic process-tree machinery.

The primary fix closes the task-slot/liveness failure by failing the managed Cursor run as soon as Cursor confirms that a shell was launched in background mode and by cancelling the runtime through the existing owned-process-tree path.

A Unix descendant that deliberately leaves that process group is the broader process-ownership limitation and is not solved here without a provider-supplied process identity (see #7615 as a related follow-up).

## Related Issue

Addresses #7833 (deliberately not auto-close: the secondary process-group-escape limitation tracked in #7615 remains open)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/cursor.go`
  - Add `Background bool` to `cursorToolCall`; `parseCursorToolCall` structurally reads the JSON root `isBackground` boolean of the completed shell result (raw `Result` preserved; malformed results never fail the whole parse; no string/command heuristics).
  - In the `completed` tool_call handler, after the normal `MessageToolResult` is forwarded, a `shell` call with `Background == true` sets `backgroundShellDetected` and invokes the existing `cancel()` path (no new process-tree helpers; `proc_*.go`/`launch.go` untouched).
  - Finalization precedence: background guard > terminal result > timeout > external cancellation > scanner/protocol/prompt-write/exit errors > missing result. Guarded runs end `failed` with the new constant `cursorBackgroundShellGuardError` ("cursor-agent launched a background shell; Multica-managed runs require foreground execution") instead of generic "execution cancelled"; `cursorFailureDiagnostic` and stderr tail sanitization are preserved; `Result.Output` stays empty and the session ID is preserved.
- `server/pkg/agent/cursor_test.go`
  - Extend the `TestParseCursorToolCall` table with `wantBackground`: background result (`isBackground: true`), explicit false, false-positive guard (stdout containing the text `"isBackground":true` must not trip detection), malformed/missing result.
  - Add end-to-end `TestCursorExecuteFailsPromptlyOnBackgroundShellWithoutTerminalResult` using a fake Cursor CLI (outer ctx ~10s, exec timeout ~8s, asserts return well within 5s): `Status == "failed"`, error mentions background shell/foreground execution, not `aborted`/`timeout`, `Result.Output == ""`, `SessionID == "sess-cursor-bg"`. This test is RED on unpatched main and GREEN after the fix.
- `server/pkg/agent/claude_deadlock_test.go`
  - Package-wide `TestMain`: add `CURSOR_FAKE_MODE=background_shell_no_result` dispatch and `runFakeCursorBackgroundShellNoResult()` helper (reads stdin to EOF, emits init → tool_call started → completed with `result.isBackground: true`, then blocks without a terminal result — reproducing the exact #7833 state).

## How to Test

1. Red check on unpatched main (with the new tests): `go test ./pkg/agent -run 'TestCursorExecuteFailsPromptlyOnBackgroundShellWithoutTerminalResult' -count=1` → FAIL (task does not return before timeout).
2. After the fix: `go test ./pkg/agent -run 'TestParseCursorToolCall|TestCursorExecuteFailsPromptlyOnBackgroundShellWithoutTerminalResult' -count=1` → PASS.
3. Full package + vet + whitespace: `go test ./pkg/agent -count=1`, `go vet ./pkg/agent`, `git diff --check` → PASS (on Windows runners a pre-existing set of unrelated environment failures exists; the failure set is identical before/after the patch, added=0/removed=0).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (multi-agent squad pipeline)

**Prompt / approach:**
Implemented by a Go-focused agent worker from a written implementation spec, independently cross-verified by a second agent worker (diff review against the spec + local re-run of vet/tests with a baseline failure-set comparison), followed by an automated pre-flight check of conventions and this PR template. Verification evidence: commit `9637a36b384b834100816d82306eb9f6eb8583ea`, RED→GREEN for `TestCursorExecuteFailsPromptlyOnBackgroundShellWithoutTerminalResult`, `go vet ./pkg/agent` PASS, `git diff --check` PASS.
