### PR TITLE
MUL-7069: fix(agent): retry transient Antigravity auth timeouts

### DIFF
--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -41,6 +41,10 @@ type antigravityBackend struct {
 }
 
 func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	return b.execute(ctx, prompt, opts, true)
+}
+
+func (b *antigravityBackend) execute(ctx context.Context, prompt string, opts ExecOptions, allowAuthRetry bool) (*Session, error) {
 	execPath := b.cfg.ExecutablePath
 	if execPath == "" {
 		execPath = "agy"
@@ -51,18 +55,21 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 
 	// Guard against agy's silent no-op on an unrecognised --model: it exits 0
 	// with empty output, which would otherwise surface as a "completed" but
-	// empty task. opts.Model is the single funnel for both agent.model and the
-	// daemon-wide MULTICA_ANTIGRAVITY_MODEL default (resolved in daemon.go), so
-	// validating it here covers every source — UI free-text, API, a persisted
-	// value, and the env default alike. Reject a non-empty model the installed
-	// CLI definitively does not advertise, with an actionable error. Validation
-	// is fail-OPEN: if the `agy models` catalog can't be discovered we let agy
-	// resolve the value itself rather than blocking the run on a discovery
-	// hiccup (see antigravityModelError).
+	// empty task. opts.Model is the single funnel for agent.model and the
+	// daemon-wide MULTICA_ANTIGRAVITY_MODEL default (resolved in daemon.go).
+	// Validate any source when the normal discovery path already cached a live
+	// catalog, but never refresh that catalog here: starting `agy models`
+	// immediately before `agy -p`
+	// intermittently makes agy 1.1.26 on WSL/file credential storage ignore a
+	// valid token and enter its 60s OAuth flow (google-antigravity/
+	// antigravity-cli#944). On a cache miss, fail open and let agy resolve the
+	// model rather than putting a second agy process on the task's launch path.
 	if opts.Model != "" {
-		catalog, _ := ListModels(ctx, "antigravity", b.cfg.commandAt(execPath))
-		if err := antigravityModelError(opts.Model, catalog.Models); err != nil {
-			return nil, err
+		key := discoveryCacheKey("antigravity", b.cfg.commandAt(execPath))
+		if catalog, ok := cachedDiscoveryOnly(key); ok {
+			if err := antigravityModelError(opts.Model, catalog.Models); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -208,6 +215,28 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 
 		b.cfg.Logger.Info("agy finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
 
+		if allowAuthRetry && runCtx.Err() == nil && antigravityAuthTimeoutRetrySafe(finalStatus, finalOutput, sessionID, stderrBuf.Tail()) {
+			// agy can intermittently ignore a valid file credential on WSL and
+			// enter an OAuth flow that times out. No stdout and no conversation id
+			// prove the prompt was not dispatched, so one retry cannot duplicate
+			// model output, tool calls, or file edits. Never retry after either
+			// signal appears: that attempt may already have caused side effects.
+			b.cfg.Logger.Warn("agy authentication timed out before dispatch; retrying once", "pid", cmd.Process.Pid)
+			retrySession, retryErr := b.execute(runCtx, prompt, opts, false)
+			if retryErr == nil {
+				for msg := range retrySession.Messages {
+					trySend(msgCh, msg)
+				}
+				if retryResult, ok := <-retrySession.Result; ok {
+					retryResult.DurationMs += duration.Milliseconds()
+					resCh <- retryResult
+					return
+				}
+				retryErr = fmt.Errorf("result channel closed without a value")
+			}
+			finalError = fmt.Sprintf("%s; agy authentication retry failed: %v", finalError, retryErr)
+		}
+
 		resCh <- Result{
 			Status:     finalStatus,
 			Output:     finalOutput,
@@ -222,6 +251,17 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// antigravityAuthTimeoutRetrySafe identifies the one agy failure that can be
+// repeated without duplicating work. The exact timeout marker alone is not
+// enough: empty output and an absent conversation id are the evidence that agy
+// never dispatched the prompt or began a turn.
+func antigravityAuthTimeoutRetrySafe(status, output, sessionID, stderr string) bool {
+	return status == "failed" &&
+		strings.TrimSpace(output) == "" &&
+		sessionID == "" &&
+		strings.Contains(strings.ToLower(stderr), "error: authentication timed out")
 }
 
 // antigravityConversationIDRe matches the glog line printmode.go writes when

--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -60,7 +60,7 @@ func (b *antigravityBackend) execute(ctx context.Context, prompt string, opts Ex
 	// Validate any source when the normal discovery path already cached a live
 	// catalog, but never refresh that catalog here: starting `agy models`
 	// immediately before `agy -p`
-	// intermittently makes agy 1.1.26 on WSL/file credential storage ignore a
+	// intermittently makes agy 1.1.26 and 1.1.27 on WSL/file credential storage ignore a
 	// valid token and enter its 60s OAuth flow (google-antigravity/
 	// antigravity-cli#944). On a cache miss, fail open and let agy resolve the
 	// model rather than putting a second agy process on the task's launch path.

--- a/server/pkg/agent/antigravity_test.go
+++ b/server/pkg/agent/antigravity_test.go
@@ -364,6 +364,174 @@ exit 0
 `
 }
 
+func fakeAgyInvocationRecorderScript(recordPath string) string {
+	return `#!/bin/sh
+printf '%s\n' "$1" >> "` + recordPath + `"
+if [ "$1" = "models" ]; then
+  printf 'gemini-3.6-flash-high\tGemini 3.6 Flash (High)\n'
+  exit 0
+fi
+printf 'task completed\n'
+`
+}
+
+func fakeAgyTransientAuthScript() string {
+	return `#!/bin/sh
+printf 'run\n' >> "$MULTICA_TEST_AGY_INVOCATIONS"
+count=$(wc -l < "$MULTICA_TEST_AGY_INVOCATIONS")
+if [ "$count" -eq 1 ]; then
+  printf 'Error: authentication timed out.\n' >&2
+  exit 1
+fi
+log=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --log-file) log="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$log" ]; then
+  printf 'I0905 01:41:50.000000 1 printmode.go:156] Print mode: conversation=44a57718-801c-41e7-9691-3225be2b1cb8, sending message\n' >> "$log"
+fi
+printf 'retry completed\n'
+`
+}
+
+func fakeAgyPartialAuthFailureScript() string {
+	return `#!/bin/sh
+printf 'run\n' >> "$MULTICA_TEST_AGY_INVOCATIONS"
+printf 'partial reply already emitted\n'
+printf 'Error: authentication timed out.\n' >&2
+exit 1
+`
+}
+
+func readInvocationCount(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read invocation record: %v", err)
+	}
+	return len(strings.Fields(string(data)))
+}
+
+func awaitAntigravityResult(t *testing.T, session *Session) Result {
+	t.Helper()
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		return result
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+		return Result{}
+	}
+}
+
+func TestAntigravityBackendDoesNotProbeModelsBeforeTask(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	fakePath := filepath.Join(dir, "agy")
+	recordPath := filepath.Join(dir, "invocations")
+	writeTestExecutable(t, fakePath, []byte(fakeAgyInvocationRecorderScript(recordPath)))
+
+	backend, err := New("antigravity", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"MULTICA_TEST_AGY_INVOCATIONS": recordPath},
+		Logger:         quietAntigravityLogger(),
+	})
+	if err != nil {
+		t.Fatalf("new antigravity backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "prompt-ignored", ExecOptions{Model: "gemini-3.6-flash-high"})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	result := awaitAntigravityResult(t, session)
+	if result.Status != "completed" {
+		t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+	}
+	if got := readInvocationCount(t, recordPath); got != 1 {
+		t.Fatalf("task execution must not launch a preceding `agy models` process: got %d invocations, want 1", got)
+	}
+}
+
+func TestAntigravityBackendRetriesZeroOutputAuthTimeoutOnce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	fakePath := filepath.Join(dir, "agy")
+	recordPath := filepath.Join(dir, "invocations")
+	writeTestExecutable(t, fakePath, []byte(fakeAgyTransientAuthScript()))
+
+	backend, err := New("antigravity", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"MULTICA_TEST_AGY_INVOCATIONS": recordPath},
+		Logger:         quietAntigravityLogger(),
+	})
+	if err != nil {
+		t.Fatalf("new antigravity backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "prompt-ignored", ExecOptions{})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	result := awaitAntigravityResult(t, session)
+	if result.Status != "completed" {
+		t.Fatalf("expected retry to complete, got status=%q error=%q", result.Status, result.Error)
+	}
+	if result.Output != "retry completed" {
+		t.Fatalf("unexpected retry output: %q", result.Output)
+	}
+	if result.SessionID != "44a57718-801c-41e7-9691-3225be2b1cb8" {
+		t.Fatalf("unexpected retry session id: %q", result.SessionID)
+	}
+	if got := readInvocationCount(t, recordPath); got != 2 {
+		t.Fatalf("expected exactly one retry, got %d invocations", got)
+	}
+}
+
+func TestAntigravityBackendDoesNotRetryAuthTimeoutAfterOutput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	fakePath := filepath.Join(dir, "agy")
+	recordPath := filepath.Join(dir, "invocations")
+	writeTestExecutable(t, fakePath, []byte(fakeAgyPartialAuthFailureScript()))
+
+	backend, err := New("antigravity", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"MULTICA_TEST_AGY_INVOCATIONS": recordPath},
+		Logger:         quietAntigravityLogger(),
+	})
+	if err != nil {
+		t.Fatalf("new antigravity backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "prompt-ignored", ExecOptions{})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	result := awaitAntigravityResult(t, session)
+	if result.Status != "failed" {
+		t.Fatalf("expected partial-output failure to remain failed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Output, "partial reply already emitted") {
+		t.Fatalf("expected partial output to be preserved, got %q", result.Output)
+	}
+	if got := readInvocationCount(t, recordPath); got != 1 {
+		t.Fatalf("an attempt that emitted output must not be retried: got %d invocations", got)
+	}
+}
+
 // TestAntigravityBackendPrintTimeoutSurfacesAsTimeout is the end-to-end guard for
 // MUL-3570: agy aborts a long turn by printing its timeout sentinel and exiting
 // 0, so the backend must classify the result as a timeout (not a truncated
@@ -458,12 +626,10 @@ func TestAntigravityBackendProviderErrorSurfacesAsFailed(t *testing.T) {
 }
 
 // TestAntigravityModelError is the regression guard for the silent-no-op fix:
-// agy exits 0 with empty output on an unrecognised --model, so Execute must
-// reject a non-empty model that isn't in the `agy models` catalog instead of
-// letting it run to a fake "completed + empty" success. This covers the same
-// validation regardless of whether opts.Model originated from agent.model, a
-// persisted/API value, or the daemon-wide MULTICA_ANTIGRAVITY_MODEL default —
-// they all collapse to opts.Model before Execute runs this check.
+// agy exits 0 with empty output on an unrecognised --model, so Execute uses
+// this check whenever normal model discovery has already cached a live
+// `agy models` catalog. opts.Model is the same input whether it originated
+// from agent.model, a persisted/API value, or the daemon-wide default.
 func TestAntigravityModelError(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/antigravity_test.go
+++ b/server/pkg/agent/antigravity_test.go
@@ -380,6 +380,9 @@ func fakeAgyTransientAuthScript() string {
 printf 'run\n' >> "$MULTICA_TEST_AGY_INVOCATIONS"
 count=$(wc -l < "$MULTICA_TEST_AGY_INVOCATIONS")
 if [ "$count" -eq 1 ]; then
+	printf 'Authentication required. Please visit the URL to log in:\n  <redacted-oauth-url>\n\n' >&2
+	printf 'Waiting for authentication (timeout 60s)...\n' >&2
+	printf 'Or, paste the authorization code here and press Enter:\n' >&2
   printf 'Error: authentication timed out.\n' >&2
   exit 1
 fi
@@ -401,6 +404,24 @@ func fakeAgyPartialAuthFailureScript() string {
 	return `#!/bin/sh
 printf 'run\n' >> "$MULTICA_TEST_AGY_INVOCATIONS"
 printf 'partial reply already emitted\n'
+printf 'Error: authentication timed out.\n' >&2
+exit 1
+`
+}
+
+func fakeAgyDispatchedAuthFailureScript() string {
+	return `#!/bin/sh
+printf 'run\n' >> "$MULTICA_TEST_AGY_INVOCATIONS"
+log=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --log-file) log="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$log" ]; then
+  printf 'I0907 03:26:09.000000 1 printmode.go:156] Print mode: conversation=44a57718-801c-41e7-9691-3225be2b1cb8, sending message\n' >> "$log"
+fi
 printf 'Error: authentication timed out.\n' >&2
 exit 1
 `
@@ -529,6 +550,39 @@ func TestAntigravityBackendDoesNotRetryAuthTimeoutAfterOutput(t *testing.T) {
 	}
 	if got := readInvocationCount(t, recordPath); got != 1 {
 		t.Fatalf("an attempt that emitted output must not be retried: got %d invocations", got)
+	}
+}
+
+func TestAntigravityBackendDoesNotRetryAuthTimeoutAfterDispatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	fakePath := filepath.Join(dir, "agy")
+	recordPath := filepath.Join(dir, "invocations")
+	writeTestExecutable(t, fakePath, []byte(fakeAgyDispatchedAuthFailureScript()))
+
+	backend, err := New("antigravity", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"MULTICA_TEST_AGY_INVOCATIONS": recordPath},
+		Logger:         quietAntigravityLogger(),
+	})
+	if err != nil {
+		t.Fatalf("new antigravity backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "prompt-ignored", ExecOptions{})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	result := awaitAntigravityResult(t, session)
+	if result.Status != "failed" {
+		t.Fatalf("expected post-dispatch failure to remain failed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if result.SessionID != "44a57718-801c-41e7-9691-3225be2b1cb8" {
+		t.Fatalf("expected dispatched conversation id to be preserved, got %q", result.SessionID)
+	}
+	if got := readInvocationCount(t, recordPath); got != 1 {
+		t.Fatalf("an attempt that dispatched the prompt must not be retried: got %d invocations", got)
 	}
 }
 

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -506,13 +506,9 @@ func modelHasKnownPrefix(model string) bool {
 // protocol family never share one memo entry when they enumerate different
 // binaries.
 func cachedDiscovery(key string, fn func() (Catalog, error)) (Catalog, error) {
-	modelCacheMu.Lock()
-	if entry, ok := modelCache[key]; ok && time.Now().Before(entry.expiresAt) {
-		out, unavailable := entry.models, entry.unavailable
-		modelCacheMu.Unlock()
-		return Catalog{Models: out, Unavailable: unavailable}, nil
+	if catalog, ok := cachedDiscoveryOnly(key); ok {
+		return catalog, nil
 	}
-	modelCacheMu.Unlock()
 
 	catalog, err := fn()
 	if err != nil {
@@ -542,6 +538,20 @@ func cachedDiscovery(key string, fn func() (Catalog, error)) (Catalog, error) {
 	}
 	modelCacheMu.Unlock()
 	return catalog, nil
+}
+
+// cachedDiscoveryOnly returns a live discovery-cache entry without invoking a
+// provider CLI on a miss. Execution paths use this when a provider probe would
+// interfere with the task process they are about to launch; UI catalog reads
+// continue through cachedDiscovery and refresh normally.
+func cachedDiscoveryOnly(key string) (Catalog, bool) {
+	modelCacheMu.Lock()
+	defer modelCacheMu.Unlock()
+	entry, ok := modelCache[key]
+	if !ok || !time.Now().Before(entry.expiresAt) {
+		return Catalog{}, false
+	}
+	return Catalog{Models: entry.models, Unavailable: entry.unavailable}, true
 }
 
 // discoveryCacheKey scopes a discovery memo to the binary it enumerated.


### PR DESCRIPTION
## What does this PR do?

Prevents an intermittent Antigravity CLI authentication failure from blocking an otherwise healthy Multica task.

The upstream CLI bug is tracked in [google-antigravity/antigravity-cli#944](https://github.com/google-antigravity/antigravity-cli/issues/944). It was first captured on `agy 1.1.26`; a [new reproduction on `agy 1.1.27`](https://github.com/google-antigravity/antigravity-cli/issues/944#issuecomment-5561626083) confirms that the failure persists: a fresh headless process unexpectedly enters OAuth, times out after 60 seconds with zero output and no conversation ID, while starting a fresh process by resending the message succeeds without login or credential changes.

The observed user-facing failure is:

```text
authentication failed or timed out
Authentication required. Please visit the URL to log in:
...
Error: authentication timed out.
```

The OAuth URL is intentionally omitted because it contains request-specific parameters.

This PR removes an avoidable trigger from the task hot path and adds one narrowly guarded recovery attempt:

1. Task execution no longer starts `agy models` on a model-cache miss immediately before `agy -p`. It still validates the configured model when normal UI/runtime discovery has already populated a live cache entry.
2. If `agy -p` exits with the exact `authentication timed out` marker, Multica starts it once more only when stdout is empty and the agy log contains no conversation ID. Those conditions establish that the prompt was not dispatched, so retrying cannot duplicate output, tool calls, or file edits.
3. If either output or a conversation ID exists, the failure is preserved and no retry occurs.

### Thinking path and safety boundary

`antigravityBackend.Execute` previously called `ListModels` whenever `opts.Model` was set. The catalog cache expires after 60 seconds, so an ordinary turn after that interval could synchronously launch `agy models`, then launch `agy -p` milliseconds later. Incident logs establish correlation with this two-process sequence but do not prove agy's internal cause because its implementation is not published in the public repository.

The Multica-side mitigation is deliberately limited:

- remove the extra CLI process from task startup without disabling model discovery for the UI;
- recognize only the exact observed authentication timeout;
- require both zero output and no dispatched conversation;
- permit one retry, never an unbounded retry loop;
- keep partial-output and post-dispatch failures visible to the user.

Risk: when no live catalog is cached, an invalid manually entered Antigravity model is no longer rejected before process launch. Normal picker-driven selections retain cached validation, and agy remains the final authority on manually supplied model IDs.

## Related issue and field evidence

- Upstream report: [google-antigravity/antigravity-cli#944](https://github.com/google-antigravity/antigravity-cli/issues/944)
- `agy 1.1.27` reproduction: [issue comment with sanitized timeline](https://github.com/google-antigravity/antigravity-cli/issues/944#issuecomment-5561626083)
- Related upstream reports: [#14](https://github.com/google-antigravity/antigravity-cli/issues/14), [#854](https://github.com/google-antigravity/antigravity-cli/issues/854)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes made

- `server/pkg/agent/antigravity.go`: use only an already-cached model catalog during task launch and retry one pre-dispatch authentication timeout.
- `server/pkg/agent/models.go`: add a cache-only lookup that never invokes a provider CLI.
- `server/pkg/agent/antigravity_test.go`: reproduce the complete OAuth-timeout stderr sequence and cover successful one-shot recovery, no pre-task model probe, no retry after output, and no retry after a conversation ID proves dispatch.

## Verification

```text
go test -race ./pkg/agent -run 'TestAntigravityBackend(DoesNotProbeModelsBeforeTask|RetriesZeroOutputAuthTimeoutOnce|DoesNotRetryAuthTimeoutAfterOutput|DoesNotRetryAuthTimeoutAfterDispatch)$' -count=10
ok github.com/multica-ai/multica/server/pkg/agent

go test ./pkg/agent -run 'Antigravity' -count=1
ok github.com/multica-ai/multica/server/pkg/agent

go vet ./pkg/agent
```

No release build or deployment was performed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented the retry safety boundary
- [x] I will address all reviewer comments before requesting merge

## AI disclosure

**AI tool used:** Codex through Multica

**Prompt / approach:** Correlate sanitized Antigravity and daemon logs, establish the zero-dispatch boundary, then implement an Antigravity-only one-shot retry with regression tests that prevent duplicate side effects.
