### PR TITLE
WS-4766: trace observed skill invocations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,6 +168,11 @@ MULTICA_DAEMON_POLL_INTERVAL=30s
 # Independent healthy-WebSocket safety poll upper bound; does not replace the ordinary poll interval.
 MULTICA_DAEMON_WS_CLAIM_POLL_INTERVAL=3m
 MULTICA_DAEMON_HEARTBEAT_INTERVAL=15s
+# Opt-in local audit stream. Only observed model skill selections are written;
+# mounting or advertising a skill does not count as invocation. Records contain
+# task and employee identifiers, so keep the file local and access-controlled.
+MULTICA_SKILL_TRACE_ENABLED=
+MULTICA_SKILL_TRACE_PATH=
 MULTICA_CODEX_PATH=codex
 MULTICA_CODEX_MODEL=
 MULTICA_CODEX_WORKDIR=

--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -273,6 +273,24 @@ Daemon behavior is configured via flags or environment variables:
 | GC Hermes memory TTL (per-agent `memories/`) | — | `MULTICA_GC_HERMES_MEMORY_TTL` | `2160h` (90d; set `0` to disable) |
 | GC Hermes session TTL (per-conversation `state.db`) | — | `MULTICA_GC_HERMES_SESSION_TTL` | `336h` (14d; set `0` to disable) |
 | GC task temp legacy TTL (pre-lock `multica-task-*`) | — | `MULTICA_GC_TASK_TEMP_LEGACY_TTL` | `0` (disabled; set a duration to opt in) |
+| Skill invocation trace | — | `MULTICA_SKILL_TRACE_ENABLED` | disabled (set `true`/`1`/`yes`/`on` to enable) |
+| Skill invocation trace path | — | `MULTICA_SKILL_TRACE_PATH` | `<workspaces_root>/skill-invocations.jsonl` |
+
+#### Skill invocation trace
+
+`MULTICA_SKILL_TRACE_ENABLED=true` enables an append-only, daemon-local JSONL
+audit stream. Each row is a `skill_invoked` event with task, workspace, agent,
+runtime, machine, employee, and skill identity plus the observed signal. The
+daemon records an invocation only when the provider emits a native Skill tool
+call or the model issues a tool call that reads the mounted skill's `SKILL.md`.
+Mounting, advertising, or enumerating the task's available skills writes no
+event, so inventory cannot be mistaken for adoption. `trigger=explicit` means
+the same skill was explicitly selected in the task's originating input;
+otherwise the trigger is `model`. `observed_via` distinguishes `native_skill_tool` from
+`skill_file_read` for downstream audits.
+
+The trace is disabled by default and is never uploaded by this feature. Records
+contain task and employee identifiers; protect the configured path accordingly.
 
 #### Workspace garbage collection
 

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -125,6 +125,8 @@ type Config struct {
 	GCHermesMemoryTTL              time.Duration         // reclaim a per-agent Hermes memory store (<profile dir>/hermes-state/<agent>/<profile>) untouched for at least this long, so a deleted agent's memory does not sit on disk forever (default: 90d, set 0 to disable)
 	GCHermesSessionTTL             time.Duration         // reclaim a per-conversation Hermes session store (<profile dir>/hermes-sessions/<agent>/<profile>/<conversation>) untouched for at least this long, so a done or abandoned conversation's transcript does not accumulate forever (default: 14d, set 0 to disable)
 	GCTaskTempLegacyTTL            time.Duration         // reclaim a per-task temp dir (<temp base>/multica-task-*) that carries no execution lock — i.e. left by a daemon predating the lock — once nothing inside it has been touched for this long. Dirs that DO carry the lock are reclaimed on liveness, never on age, so this knob does not apply to them. Neither does it reclaim a dir holding no task content — an old empty leftover, or a shell left by a daemon that died between creating the dir and publishing its lock — because holding no content is exactly what a dir currently being published looks like (default: 0, disabled — see DefaultGCTaskTempLegacyTTL)
+	SkillTraceEnabled              bool                  // opt-in daemon-local JSONL trace of observed skill invocations (default: false)
+	SkillTracePath                 string                // append-only JSONL target for observed skill invocation events
 	AutoUpdateEnabled              bool                  // periodically check for a newer CLI release and self-update when idle (default: true on Multica Cloud, false on self-host)
 	AutoUpdateCheckInterval        time.Duration         // how often the auto-update loop polls for a new release (default: 6h)
 	AutoReloadEnabled              bool                  // restart when the multica binary on disk no longer matches the running version (default: true for CLI-launched daemons)
@@ -566,6 +568,11 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	}
 	gcRepoMaintenanceEnabled := boolFromEnv("MULTICA_GC_REPO_MAINTENANCE_ENABLED", true)
 	gcArtifactPatterns := patternsFromEnv("MULTICA_GC_ARTIFACT_PATTERNS", DefaultGCArtifactPatterns)
+	skillTraceEnabled := boolFromEnv("MULTICA_SKILL_TRACE_ENABLED", false)
+	skillTracePath := strings.TrimSpace(os.Getenv("MULTICA_SKILL_TRACE_PATH"))
+	if skillTracePath == "" {
+		skillTracePath = filepath.Join(workspacesRoot, "skill-invocations.jsonl")
+	}
 
 	// Auto-update config: default -> env override -> CLI override.
 	//
@@ -622,6 +629,8 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		GCHermesMemoryTTL:               gcHermesMemoryTTL,
 		GCHermesSessionTTL:              gcHermesSessionTTL,
 		GCTaskTempLegacyTTL:             gcTaskTempLegacyTTL,
+		SkillTraceEnabled:               skillTraceEnabled,
+		SkillTracePath:                  skillTracePath,
 		AutoUpdateEnabled:               autoUpdateEnabled,
 		AutoUpdateCheckInterval:         autoUpdateInterval,
 		AutoReloadEnabled:               autoReloadEnabled,

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -142,6 +142,35 @@ func TestLoadConfig_CompletedTaskTTLDefaultsDisabledOnSelfHostAndReadsEnv(t *tes
 	}
 }
 
+func TestLoadConfig_SkillTraceIsOptInAndDefaultsUnderWorkspacesRoot(t *testing.T) {
+	stageFakeAgent(t)
+	root := t.TempDir()
+	t.Setenv("MULTICA_SKILL_TRACE_ENABLED", "")
+	t.Setenv("MULTICA_SKILL_TRACE_PATH", "")
+
+	cfg, err := LoadConfig(Overrides{ServerURL: "http://localhost:8080", WorkspacesRoot: root})
+	if err != nil {
+		t.Fatalf("LoadConfig default: %v", err)
+	}
+	if cfg.SkillTraceEnabled {
+		t.Fatal("skill trace should be disabled by default")
+	}
+	if want := filepath.Join(root, "skill-invocations.jsonl"); cfg.SkillTracePath != want {
+		t.Fatalf("SkillTracePath = %q, want %q", cfg.SkillTracePath, want)
+	}
+
+	custom := filepath.Join(t.TempDir(), "custom.jsonl")
+	t.Setenv("MULTICA_SKILL_TRACE_ENABLED", "yes")
+	t.Setenv("MULTICA_SKILL_TRACE_PATH", custom)
+	cfg, err = LoadConfig(Overrides{ServerURL: "http://localhost:8080", WorkspacesRoot: root})
+	if err != nil {
+		t.Fatalf("LoadConfig opt-in: %v", err)
+	}
+	if !cfg.SkillTraceEnabled || cfg.SkillTracePath != custom {
+		t.Fatalf("skill trace config = enabled:%v path:%q", cfg.SkillTraceEnabled, cfg.SkillTracePath)
+	}
+}
+
 func TestLoadConfig_WSClaimPollIntervalPrecedence(t *testing.T) {
 	stageFakeAgent(t)
 	t.Setenv("HOME", t.TempDir())

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -376,7 +376,12 @@ type Daemon struct {
 	client     *Client
 	repoCache  repoCacheBackend
 	skillCache *SkillBundleCache
+	skillTrace *SkillTraceRecorder
 	logger     *slog.Logger
+	// skillTraceTasks holds only tasks currently inside their provider run.
+	// sync.Map keeps the hot message-drain lookup independent per task while
+	// preserving a zero-value-safe Daemon for the many focused test fixtures.
+	skillTraceTasks sync.Map // task ID -> *skillInvocationTracker
 
 	mu           sync.Mutex
 	workspaces   map[string]*workspaceState
@@ -644,6 +649,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		client:                    client,
 		repoCache:                 repocache.New(cacheRoot, logger),
 		skillCache:                NewSkillBundleCache(skillCacheRoot),
+		skillTrace:                NewSkillTraceRecorder(cfg),
 		logger:                    logger,
 		workspaces:                make(map[string]*workspaceState),
 		runtimeIndex:              make(map[string]Runtime),
@@ -7847,6 +7853,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	stopPrepareLease()
 	prepareComplete = true
 	cancelPrepare()
+	stopSkillTrace := d.trackSkillInvocations(task, skills, provider, taskLog)
+	defer stopSkillTrace()
 	_ = d.client.ReportProgress(ctx, task.ID, fmt.Sprintf("Launching %s", provider), 1, 2)
 
 	resumeReachable := gateResumeToReachableSession(&task, &taskCtx, provider, env.WorkDir, sessionHomeReachable(provider, env, envReused), taskLog)
@@ -8856,6 +8864,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 				// slow downstream call (mu.Lock contention, batch resize)
 				// can't be misattributed to backend silence.
 				lastActivityAt.Store(time.Now().UnixNano())
+				d.observeSkillTraceMessage(taskID, msg)
 				switch msg.Type {
 				case agent.MessageStatus:
 					// Persist the session/work_dir as soon as the backend

--- a/server/internal/daemon/execenv/skill_visibility.go
+++ b/server/internal/daemon/execenv/skill_visibility.go
@@ -71,6 +71,14 @@ func resolveSkillSlugs(skills []SkillContextForEnv) []string {
 	return slugs
 }
 
+// ResolveSkillSlugs returns the provider-visible directory identity for each
+// skill in the original batch order. The daemon's invocation observer uses the
+// same names as writeSkillFiles so a read of one mounted SKILL.md can be joined
+// back to the exact task skill without maintaining a second slug algorithm.
+func ResolveSkillSlugs(skills []SkillContextForEnv) []string {
+	return resolveSkillSlugs(skills)
+}
+
 func skillModelInvocationVisible(skill SkillContextForEnv) bool {
 	return !skillDisablesModelInvocation(skill.Content)
 }

--- a/server/internal/daemon/skill_trace.go
+++ b/server/internal/daemon/skill_trace.go
@@ -1,0 +1,420 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+const (
+	SkillTraceEventInvoked = "skill_invoked"
+
+	SkillTraceTriggerModel    = "model"
+	SkillTraceTriggerExplicit = "explicit"
+
+	SkillTraceObservedNativeTool = "native_skill_tool"
+	SkillTraceObservedFileRead   = "skill_file_read"
+)
+
+type skillTraceMeta struct {
+	Provider         string
+	MachineID        string
+	DeviceName       string
+	DaemonProfile    string
+	RuntimeProfileID string
+}
+
+// SkillTraceEvent is one append-only observation that the model selected a
+// skill during a task. Merely mounting or advertising a skill is deliberately
+// not an event: the stream measures behavior, not inventory.
+type SkillTraceEvent struct {
+	EventType        string    `json:"event_type"`
+	TS               time.Time `json:"ts"`
+	WorkspaceID      string    `json:"workspace_id,omitempty"`
+	TaskID           string    `json:"task_id,omitempty"`
+	IssueID          string    `json:"issue_id,omitempty"`
+	ChatSessionID    string    `json:"chat_session_id,omitempty"`
+	AutopilotRunID   string    `json:"autopilot_run_id,omitempty"`
+	AgentID          string    `json:"agent_id,omitempty"`
+	AgentName        string    `json:"agent_name,omitempty"`
+	RuntimeID        string    `json:"runtime_id,omitempty"`
+	Provider         string    `json:"provider,omitempty"`
+	RuntimeProfileID string    `json:"runtime_profile_id,omitempty"`
+	DaemonProfile    string    `json:"daemon_profile,omitempty"`
+	MachineID        string    `json:"machine_id,omitempty"`
+	DeviceName       string    `json:"device_name,omitempty"`
+	EmployeeID       string    `json:"employee_id,omitempty"`
+	EmployeeName     string    `json:"employee_name,omitempty"`
+	EmployeeType     string    `json:"employee_type,omitempty"`
+	SkillID          string    `json:"skill_id,omitempty"`
+	SkillName        string    `json:"skill_name,omitempty"`
+	SkillSource      string    `json:"skill_source,omitempty"`
+	SkillHash        string    `json:"skill_hash,omitempty"`
+	Trigger          string    `json:"trigger"`
+	ObservedVia      string    `json:"observed_via"`
+	ToolCallID       string    `json:"tool_call_id,omitempty"`
+}
+
+// SkillTraceRecorder appends one JSON object per observed invocation. It is
+// local and opt-in because the records contain task and employee identifiers.
+type SkillTraceRecorder struct {
+	enabled bool
+	path    string
+	mu      sync.Mutex
+}
+
+func NewSkillTraceRecorder(cfg Config) *SkillTraceRecorder {
+	return &SkillTraceRecorder{
+		enabled: cfg.SkillTraceEnabled,
+		path:    cfg.SkillTracePath,
+	}
+}
+
+func (r *SkillTraceRecorder) Enabled() bool {
+	return r != nil && r.enabled
+}
+
+func (r *SkillTraceRecorder) Record(events []SkillTraceEvent) error {
+	if !r.Enabled() || len(events) == 0 {
+		return nil
+	}
+	if r.path == "" {
+		return fmt.Errorf("skill trace path is empty")
+	}
+
+	now := time.Now().UTC()
+	for i := range events {
+		if events[i].TS.IsZero() {
+			events[i].TS = now
+		}
+	}
+
+	// Marshal the whole batch before opening the file. Each append below is a
+	// single Write call, so separate daemon profiles sharing a trace path cannot
+	// interleave fragments of two JSON objects.
+	lines := make([][]byte, len(events))
+	for i, event := range events {
+		line, err := json.Marshal(event)
+		if err != nil {
+			return fmt.Errorf("marshal skill trace event: %w", err)
+		}
+		lines[i] = append(line, '\n')
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(r.path), 0o755); err != nil {
+		return fmt.Errorf("create skill trace directory: %w", err)
+	}
+	f, err := os.OpenFile(r.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("open skill trace file: %w", err)
+	}
+	defer f.Close()
+
+	for _, line := range lines {
+		if _, err := f.Write(line); err != nil {
+			return fmt.Errorf("write skill trace event: %w", err)
+		}
+	}
+	return nil
+}
+
+type skillTraceCandidate struct {
+	skill    SkillData
+	slug     string
+	explicit bool
+}
+
+type skillInvocationTracker struct {
+	recorder   *SkillTraceRecorder
+	base       SkillTraceEvent
+	candidates []skillTraceCandidate
+	logger     *slog.Logger
+
+	mu   sync.Mutex
+	seen map[string]struct{}
+}
+
+func newSkillInvocationTracker(recorder *SkillTraceRecorder, task Task, skills []SkillData, meta skillTraceMeta, logger *slog.Logger) *skillInvocationTracker {
+	if recorder == nil || !recorder.Enabled() || len(skills) == 0 {
+		return nil
+	}
+
+	selected := explicitSkillSelections(task)
+
+	slugs := execenv.ResolveSkillSlugs(convertSkillsForEnv(skills))
+	candidates := make([]skillTraceCandidate, 0, len(skills))
+	for i, skill := range skills {
+		_, explicit := selected[skill.ID]
+		candidates = append(candidates, skillTraceCandidate{
+			skill:    skill,
+			slug:     slugs[i],
+			explicit: explicit,
+		})
+	}
+
+	base := SkillTraceEvent{
+		EventType:        SkillTraceEventInvoked,
+		WorkspaceID:      task.WorkspaceID,
+		TaskID:           task.ID,
+		IssueID:          task.IssueID,
+		ChatSessionID:    task.ChatSessionID,
+		AutopilotRunID:   task.AutopilotRunID,
+		RuntimeID:        task.RuntimeID,
+		Provider:         meta.Provider,
+		RuntimeProfileID: meta.RuntimeProfileID,
+		DaemonProfile:    meta.DaemonProfile,
+		MachineID:        meta.MachineID,
+		DeviceName:       meta.DeviceName,
+	}
+	if task.Agent != nil {
+		base.AgentID = task.Agent.ID
+		base.AgentName = task.Agent.Name
+	}
+	populateSkillTraceEmployee(&base, task)
+
+	return &skillInvocationTracker{
+		recorder:   recorder,
+		base:       base,
+		candidates: candidates,
+		logger:     logger,
+		seen:       make(map[string]struct{}),
+	}
+}
+
+func (t *skillInvocationTracker) Observe(msg agent.Message) {
+	if t == nil || msg.Type != agent.MessageToolUse {
+		return
+	}
+
+	observedVia, matches := t.matches(msg)
+	if len(matches) == 0 {
+		return
+	}
+
+	events := make([]SkillTraceEvent, 0, len(matches))
+	t.mu.Lock()
+	for _, candidate := range matches {
+		key := msg.CallID + "\x00" + candidate.skill.ID
+		if msg.CallID != "" {
+			if _, duplicate := t.seen[key]; duplicate {
+				continue
+			}
+			t.seen[key] = struct{}{}
+		}
+
+		event := t.base
+		event.SkillID = candidate.skill.ID
+		event.SkillName = candidate.skill.Name
+		event.SkillSource = candidate.skill.Source
+		event.SkillHash = candidate.skill.Hash
+		event.Trigger = SkillTraceTriggerModel
+		if candidate.explicit {
+			event.Trigger = SkillTraceTriggerExplicit
+		}
+		event.ObservedVia = observedVia
+		event.ToolCallID = msg.CallID
+		events = append(events, event)
+	}
+	t.mu.Unlock()
+
+	if err := t.recorder.Record(events); err != nil && t.logger != nil {
+		t.logger.Warn("skill invocation trace write failed (non-fatal)", "error", err)
+	}
+}
+
+func (t *skillInvocationTracker) matches(msg agent.Message) (string, []skillTraceCandidate) {
+	tool := normalizeSkillTraceToolName(msg.Tool)
+
+	if tool == "skill" || tool == "skills_read" || tool == "skill_read" {
+		matches := t.matchNativeSkillInputs(skillTraceNativeSkillIdentities(msg.Input))
+		if len(matches) > 0 {
+			return SkillTraceObservedNativeTool, matches
+		}
+	}
+
+	if !skillTraceFileReadTool(tool) {
+		return "", nil
+	}
+	inputs := skillTraceInputStrings(msg.Input)
+	matches := make([]skillTraceCandidate, 0, 1)
+	for _, candidate := range t.candidates {
+		for _, input := range inputs {
+			if inputMentionsSkillFile(input, candidate.slug) {
+				matches = append(matches, candidate)
+				break
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return "", nil
+	}
+	return SkillTraceObservedFileRead, matches
+}
+
+func skillTraceNativeSkillIdentities(input map[string]any) []string {
+	identities := make([]string, 0, 2)
+	for _, key := range []string{"skill", "skill_name", "name", "id"} {
+		if value, ok := input[key].(string); ok {
+			identities = append(identities, value)
+		}
+	}
+	return identities
+}
+
+func (t *skillInvocationTracker) matchNativeSkillInputs(inputs []string) []skillTraceCandidate {
+	matches := make([]skillTraceCandidate, 0, 1)
+	for _, candidate := range t.candidates {
+		for _, input := range inputs {
+			identity := strings.ToLower(strings.Trim(strings.TrimSpace(input), "/"))
+			if identity == strings.ToLower(candidate.skill.ID) ||
+				identity == strings.ToLower(candidate.skill.Name) ||
+				identity == strings.ToLower(candidate.slug) {
+				matches = append(matches, candidate)
+				break
+			}
+		}
+	}
+	return matches
+}
+
+func normalizeSkillTraceToolName(name string) string {
+	return strings.Trim(strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return unicode.ToLower(r)
+		}
+		return '_'
+	}, name), "_")
+}
+
+func skillTraceFileReadTool(tool string) bool {
+	switch tool {
+	case "exec", "exec_command", "functions_exec", "bash", "shell", "terminal", "run_shell_command",
+		"read", "read_file", "readfile", "file_read", "open_file", "view_file":
+		return true
+	default:
+		return false
+	}
+}
+
+func skillTraceInputStrings(input map[string]any) []string {
+	var values []string
+	var visit func(any)
+	visit = func(value any) {
+		switch v := value.(type) {
+		case string:
+			values = append(values, v)
+		case []any:
+			for _, item := range v {
+				visit(item)
+			}
+		case map[string]any:
+			for _, item := range v {
+				visit(item)
+			}
+		}
+	}
+	visit(input)
+	return values
+}
+
+func inputMentionsSkillFile(input, slug string) bool {
+	input = "/" + strings.ToLower(strings.ReplaceAll(input, `\`, "/"))
+	slug = strings.ToLower(slug)
+	for from := 0; ; {
+		idx := strings.Index(input[from:], "/skill.md")
+		if idx < 0 {
+			return false
+		}
+		idx += from
+		prefix := input[:idx]
+		dirStart := strings.LastIndex(prefix, "/")
+		if dirStart >= 0 {
+			dir := prefix[dirStart+1:]
+			underSkillsRoot := strings.Contains(prefix[:dirStart+1], "/skills/")
+			if underSkillsRoot && dir == slug {
+				return true
+			}
+		}
+		from = idx + len("/skill.md")
+	}
+}
+
+func explicitSkillSelections(task Task) map[string]struct{} {
+	selected := make(map[string]struct{})
+	inputs := []string{
+		task.ChatMessage,
+		task.TriggerCommentContent,
+		task.QuickCreatePrompt,
+		task.HandoffNote,
+		task.AutopilotDescription,
+	}
+	for _, comment := range task.CoalescedComments {
+		inputs = append(inputs, comment.Content)
+	}
+	for _, input := range inputs {
+		for _, ref := range ExtractSlashSkills(input) {
+			selected[ref.ID] = struct{}{}
+		}
+	}
+	return selected
+}
+
+func populateSkillTraceEmployee(event *SkillTraceEvent, task Task) {
+	if task.InitiatorName != "" || task.InitiatorID != "" || task.InitiatorType != "" {
+		event.EmployeeID = task.InitiatorID
+		event.EmployeeName = task.InitiatorName
+		event.EmployeeType = task.InitiatorType
+		return
+	}
+	if task.RequestingUserName != "" {
+		event.EmployeeName = task.RequestingUserName
+		event.EmployeeType = "runtime_owner"
+	}
+}
+
+func (d *Daemon) skillTraceMetaForTask(task Task, provider string) skillTraceMeta {
+	meta := skillTraceMeta{
+		Provider:      provider,
+		MachineID:     d.cfg.DaemonID,
+		DeviceName:    d.cfg.DeviceName,
+		DaemonProfile: d.cfg.Profile,
+	}
+	if runtime := d.findRuntime(task.RuntimeID); runtime != nil {
+		meta.RuntimeProfileID = runtime.ProfileID
+	}
+	return meta
+}
+
+func (d *Daemon) trackSkillInvocations(task Task, skills []SkillData, provider string, logger *slog.Logger) func() {
+	if d.skillTrace == nil || !d.skillTrace.Enabled() {
+		return func() {}
+	}
+	tracker := newSkillInvocationTracker(d.skillTrace, task, skills, d.skillTraceMetaForTask(task, provider), logger)
+	if tracker == nil {
+		return func() {}
+	}
+	d.skillTraceTasks.Store(task.ID, tracker)
+	return func() {
+		d.skillTraceTasks.CompareAndDelete(task.ID, tracker)
+	}
+}
+
+func (d *Daemon) observeSkillTraceMessage(taskID string, msg agent.Message) {
+	tracker, ok := d.skillTraceTasks.Load(taskID)
+	if !ok {
+		return
+	}
+	tracker.(*skillInvocationTracker).Observe(msg)
+}

--- a/server/internal/daemon/skill_trace_test.go
+++ b/server/internal/daemon/skill_trace_test.go
@@ -1,0 +1,200 @@
+package daemon
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+func TestSkillTraceRecorderDisabledDoesNotCreateFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "skill-invocations.jsonl")
+	recorder := NewSkillTraceRecorder(Config{SkillTracePath: path})
+
+	if recorder.Enabled() {
+		t.Fatal("recorder should be disabled by default")
+	}
+	if err := recorder.Record([]SkillTraceEvent{{EventType: SkillTraceEventInvoked}}); err != nil {
+		t.Fatalf("Record disabled: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("disabled recorder created a file: %v", err)
+	}
+}
+
+func TestSkillInvocationTrackerRecordsNativeModelSelection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "skill-invocations.jsonl")
+	tracker := newSkillInvocationTracker(
+		NewSkillTraceRecorder(Config{SkillTraceEnabled: true, SkillTracePath: path}),
+		skillTraceTaskFixture(""),
+		[]SkillData{
+			{ID: "skill-1", Source: "workspace", Name: "Review Helper", Hash: "sha256:one"},
+			{ID: "skill-2", Source: "workspace", Name: "Another Skill", Hash: "sha256:two"},
+		},
+		skillTraceMeta{Provider: "claude", MachineID: "daemon-1", DeviceName: "laptop"},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	msg := agent.Message{
+		Type:   agent.MessageToolUse,
+		Tool:   "Skill",
+		CallID: "call-1",
+		Input:  map[string]any{"skill": "review-helper", "args": "another-skill"},
+	}
+	tracker.Observe(msg)
+	tracker.Observe(msg) // repeated provider progress for one call is not usage twice
+
+	events := readSkillTraceEvents(t, path)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1: %+v", len(events), events)
+	}
+	event := events[0]
+	if event.EventType != SkillTraceEventInvoked || event.SkillID != "skill-1" || event.SkillName != "Review Helper" {
+		t.Fatalf("unexpected invocation identity: %+v", event)
+	}
+	if event.Trigger != SkillTraceTriggerModel || event.ObservedVia != SkillTraceObservedNativeTool || event.ToolCallID != "call-1" {
+		t.Fatalf("unexpected invocation evidence: %+v", event)
+	}
+	if event.TaskID != "task-1" || event.WorkspaceID != "workspace-1" || event.Provider != "claude" || event.MachineID != "daemon-1" {
+		t.Fatalf("task/runtime metadata missing: %+v", event)
+	}
+	if event.EmployeeID != "member-1" || event.EmployeeName != "Jane" || event.EmployeeType != "member" {
+		t.Fatalf("initiator attribution missing: %+v", event)
+	}
+}
+
+func TestSkillInvocationTrackerRecordsActualSkillFileRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "skill-invocations.jsonl")
+	task := skillTraceTaskFixture("")
+	task.TriggerCommentContent = "[/Platform](slash://skill/skill-1)"
+	tracker := newSkillInvocationTracker(
+		NewSkillTraceRecorder(Config{SkillTraceEnabled: true, SkillTracePath: path}),
+		task,
+		[]SkillData{{ID: "skill-1", Source: "builtin", Name: "Multica Platform", Hash: "sha256:platform"}},
+		skillTraceMeta{Provider: "codex", DaemonProfile: "desktop"},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	tracker.Observe(agent.Message{
+		Type:   agent.MessageToolUse,
+		Tool:   "functions.exec",
+		CallID: "call-read",
+		Input: map[string]any{
+			"source": `await tools.exec_command({cmd: "sed -n '1,220p' /task/codex-home/skills/multica-platform/SKILL.md"})`,
+		},
+	})
+
+	events := readSkillTraceEvents(t, path)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1: %+v", len(events), events)
+	}
+	event := events[0]
+	if event.Trigger != SkillTraceTriggerExplicit || event.ObservedVia != SkillTraceObservedFileRead {
+		t.Fatalf("unexpected explicit read evidence: %+v", event)
+	}
+	if event.SkillID != "skill-1" || event.SkillHash != "sha256:platform" || event.Provider != "codex" {
+		t.Fatalf("unexpected skill/runtime fields: %+v", event)
+	}
+}
+
+func TestSkillInvocationTrackerDoesNotTreatInventoryOrMentionsAsUsage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "skill-invocations.jsonl")
+	tracker := newSkillInvocationTracker(
+		NewSkillTraceRecorder(Config{SkillTraceEnabled: true, SkillTracePath: path}),
+		skillTraceTaskFixture("review-helper is available"),
+		[]SkillData{{ID: "skill-1", Source: "workspace", Name: "Review Helper"}},
+		skillTraceMeta{Provider: "codex"},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	// Constructing the tracker represents task preparation/mounting and must
+	// not create the old false-positive skill_loaded inventory rows.
+	tracker.Observe(agent.Message{
+		Type:   agent.MessageToolUse,
+		Tool:   "exec_command",
+		CallID: "call-mention",
+		Input:  map[string]any{"command": "echo review-helper"},
+	})
+	tracker.Observe(agent.Message{
+		Type:   agent.MessageToolUse,
+		Tool:   "patch_apply",
+		CallID: "call-edit",
+		Input:  map[string]any{"path": "/task/codex-home/skills/review-helper/SKILL.md"},
+	})
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("non-invocation signals created trace output: %v", err)
+	}
+}
+
+func TestSkillInvocationTrackerMatchesDistinctMountedSkillSlugs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "skill-invocations.jsonl")
+	tracker := newSkillInvocationTracker(
+		NewSkillTraceRecorder(Config{SkillTraceEnabled: true, SkillTracePath: path}),
+		skillTraceTaskFixture(""),
+		[]SkillData{
+			{ID: "skill-1", Name: "A B"},
+			{ID: "skill-2", Name: "A-B"},
+		},
+		skillTraceMeta{Provider: "codex"},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	tracker.Observe(agent.Message{
+		Type:   agent.MessageToolUse,
+		Tool:   "exec_command",
+		CallID: "call-second",
+		Input:  map[string]any{"command": "cat /task/codex-home/skills/a-b-multica/SKILL.md"},
+	})
+
+	events := readSkillTraceEvents(t, path)
+	if len(events) != 1 || events[0].SkillID != "skill-2" {
+		t.Fatalf("resolved slug mapped to wrong skill: %+v", events)
+	}
+}
+
+func skillTraceTaskFixture(chatMessage string) Task {
+	return Task{
+		ID:            "task-1",
+		AgentID:       "agent-1",
+		RuntimeID:     "runtime-1",
+		IssueID:       "issue-1",
+		WorkspaceID:   "workspace-1",
+		ChatMessage:   chatMessage,
+		InitiatorType: "member",
+		InitiatorID:   "member-1",
+		InitiatorName: "Jane",
+		Agent: &AgentData{
+			ID:   "agent-1",
+			Name: "Builder",
+		},
+	}
+}
+
+func readSkillTraceEvents(t *testing.T, path string) []SkillTraceEvent {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open skill trace: %v", err)
+	}
+	defer f.Close()
+
+	var events []SkillTraceEvent
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var event SkillTraceEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("decode %q: %v", scanner.Text(), err)
+		}
+		events = append(events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan skill trace: %v", err)
+	}
+	return events
+}


### PR DESCRIPTION
## Summary

- add an opt-in daemon-local JSONL stream containing only observed `skill_invoked` events
- detect provider-native Skill calls and reads of mounted `SKILL.md` files, with task/runtime/initiator/skill correlation and per-call deduplication
- document the privacy boundary and configuration; mounting or advertising skills never emits adoption telemetry

## Verification

- `go test ./internal/daemon/... -count=1`
- `go test -race ./internal/daemon -run 'TestSkillTrace|TestSkillInvocation' -count=1`
- `go vet ./internal/daemon/...`
- `go build ./cmd/multica`

## Rollout

Enable with `MULTICA_SKILL_TRACE_ENABLED=true`; the default output is `<workspaces_root>/skill-invocations.jsonl`. Deployment/restart is intentionally separate from this PR because the active Desktop daemon hosts the current workspace task.
