### PR TITLE
MUL-7073: fix(usage): distinguish unknown model costs from zero

### DIFF
--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { BarChart3, RefreshCw } from "lucide-react";
+import { AlertCircle, BarChart3, RefreshCw } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@multica/ui/components/ui/button";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
@@ -29,10 +29,12 @@ import { useViewingTimezone } from "../../common/use-viewing-timezone";
 import { PAGE_GUTTER } from "../../layout/page-header";
 import { CollectionPageHeader } from "../../layout/collection-page";
 import { KpiCard } from "../../runtimes/components/shared";
+import { CustomPricingDialog } from "../../runtimes/components/custom-pricing-dialog";
 import { useNavigation } from "../../navigation";
 import {
   addDaysIso,
   aggregateByWeek,
+  collectUnmappedModels,
   formatTokens,
   todayIso,
 } from "../../runtimes/utils";
@@ -56,6 +58,8 @@ import {
   computeFailureTotals,
   isSyntheticAgentRow,
   mergeAgentDashboardRows,
+  summarizeCost,
+  type CostEstimate,
 } from "../utils";
 import {
   ALL_PROJECTS,
@@ -173,7 +177,7 @@ export function DashboardPage() {
 
   // The user can save model prices from the runtimes page; re-render when
   // they do so the dashboard reflects the new rates.
-  useCustomPricingStore((s) => s.pricings);
+  const pricings = useCustomPricingStore((s) => s.pricings);
 
   const { data: projects = [] } = useQuery(projectListOptions(wsId));
   const agentsQuery = useQuery(agentListOptions(wsId));
@@ -308,14 +312,16 @@ export function DashboardPage() {
     runTimeDailyRows.length === 0;
 
   // Cost / token math — re-derived when usage, days, or pricings change.
-  const totals = useMemo(
-    () => computeDailyTotals(dailyUsageInWindow),
-    [dailyUsageInWindow],
-  );
-  const dailyCost = useMemo(
-    () => aggregateDailyCost(dailyUsageInWindow),
-    [dailyUsageInWindow],
-  );
+  const totals = useMemo(() => {
+    // The pricing helpers read the store through getState(); this explicit
+    // snapshot read keeps React's memo tied to the subscribed store value.
+    void pricings;
+    return computeDailyTotals(dailyUsageInWindow);
+  }, [dailyUsageInWindow, pricings]);
+  const dailyCost = useMemo(() => {
+    void pricings;
+    return aggregateDailyCost(dailyUsageInWindow);
+  }, [dailyUsageInWindow, pricings]);
   const dailyTokens = useMemo(
     () => aggregateDailyTokens(dailyUsageInWindow),
     [dailyUsageInWindow],
@@ -385,12 +391,21 @@ export function DashboardPage() {
   // pre-zeroed inside the helpers, so sparse weeks render as empty bars
   // instead of being dropped (MUL-2382 weekly window scoping). Week
   // boundaries follow the viewer's timezone.
-  const weekly = useMemo(
-    () => aggregateByWeek(dailyUsage, viewTZ, weekCount),
-    [dailyUsage, viewTZ, weekCount],
-  );
+  const weekly = useMemo(() => {
+    void pricings;
+    return aggregateByWeek(dailyUsage, viewTZ, weekCount);
+  }, [dailyUsage, viewTZ, weekCount, pricings]);
   const weeklyCost = weekly.weeklyCostStack;
   const weeklyTokens = weekly.weeklyTokens;
+  const weeklyCostEstimate = useMemo(() => {
+    void pricings;
+    const first = weeklyCost.at(0)?.weekStart;
+    const last = weeklyCost.at(-1)?.weekEnd;
+    if (!first || !last) return summarizeCost([]);
+    return summarizeCost(
+      dailyUsage.filter((row) => row.date >= first && row.date <= last),
+    );
+  }, [dailyUsage, weeklyCost, pricings]);
   const weeklyTime = useMemo(
     () => aggregateWeeklyTime(runTimeDailyRows, viewTZ, weekCount),
     [runTimeDailyRows, viewTZ, weekCount],
@@ -403,10 +418,15 @@ export function DashboardPage() {
     () => aggregateWeeklyErrors(failureDailyRows, viewTZ, weekCount),
     [failureDailyRows, viewTZ, weekCount],
   );
-  const agentTokenRows = useMemo(
-    () => aggregateAgentTokens(byAgentUsage),
-    [byAgentUsage],
-  );
+  const agentTokenRows = useMemo(() => {
+    void pricings;
+    return aggregateAgentTokens(byAgentUsage);
+  }, [byAgentUsage, pricings]);
+
+  const unmappedModels = useMemo(() => {
+    void pricings;
+    return collectUnmappedModels([...dailyUsageInWindow, ...byAgentUsage]);
+  }, [dailyUsageInWindow, byAgentUsage, pricings]);
 
   // Run-time totals — taskCount + failedCount summed for the KPI row.
   const runTimeTotals = useMemo(() => {
@@ -533,12 +553,38 @@ export function DashboardPage() {
               <DashboardEmpty />
             ) : (
               <>
+                <DashboardCostNotice
+                  estimate={totals.costEstimate}
+                  unmappedModels={unmappedModels}
+                />
+
                 {/* KPI row — same 3-divide-x card grid the runtime usage
                     section uses, expanded to four tiles. */}
                 <div className="grid grid-cols-1 divide-y rounded-lg border bg-card sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
                   <KpiCard
                     label={t(($) => $.kpi.cost_label, { days })}
-                    value={<CurrencyNumberFlow value={totals.cost} locales={locales} />}
+                    value={
+                      totals.costEstimate.completeness === "unknown" ? (
+                        "—"
+                      ) : (
+                        <>
+                          <CurrencyNumberFlow
+                            value={totals.costEstimate.knownCost}
+                            locales={locales}
+                          />
+                          {totals.costEstimate.completeness === "partial"
+                            ? "+"
+                            : null}
+                        </>
+                      )
+                    }
+                    hint={
+                      totals.costEstimate.completeness === "partial"
+                        ? t(($) => $.kpi.cost_partial_hint)
+                        : totals.costEstimate.completeness === "unknown"
+                          ? t(($) => $.kpi.cost_unknown_hint)
+                          : undefined
+                    }
                   />
                   <KpiCard
                     label={t(($) => $.kpi.tokens_label, { days })}
@@ -603,6 +649,8 @@ export function DashboardPage() {
                   weeklyTokens={weeklyTokens}
                   weeklyTime={weeklyTime}
                   weeklyTasks={weeklyTasks}
+                  dailyCostEstimate={totals.costEstimate}
+                  weeklyCostEstimate={weeklyCostEstimate}
                   lessThanMinuteLabel={lessThanMinuteLabel}
                 />
 
@@ -646,6 +694,46 @@ function DashboardSkeleton() {
       <Skeleton className="h-28 rounded-lg" />
       <Skeleton className="h-56 rounded-lg" />
       <Skeleton className="h-48 rounded-lg" />
+    </div>
+  );
+}
+
+function DashboardCostNotice({
+  estimate,
+  unmappedModels,
+}: {
+  estimate: CostEstimate;
+  unmappedModels: readonly string[];
+}) {
+  const { t } = useT("usage");
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  if (estimate.completeness === "exact") return null;
+
+  return (
+    <div
+      role="alert"
+      className="flex flex-wrap items-center gap-3 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-caption"
+    >
+      <AlertCircle className="h-4 w-4 shrink-0 text-warning" />
+      <p className="min-w-0 flex-1 text-foreground">
+        {estimate.completeness === "partial"
+          ? t(($) => $.cost_notice.partial)
+          : t(($) => $.cost_notice.unknown)}
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setDialogOpen(true)}
+      >
+        {t(($) => $.cost_notice.configure)}
+      </Button>
+      <CustomPricingDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        unmappedModels={unmappedModels}
+      />
     </div>
   );
 }

--- a/packages/views/dashboard/components/leaderboard.test.tsx
+++ b/packages/views/dashboard/components/leaderboard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen, within } from "@testing-library/react";
+import { renderWithI18n } from "../../test/i18n";
+import type { AgentDashboardRow } from "../utils";
+import { Leaderboard } from "./leaderboard";
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => <span data-testid="actor-avatar" />,
+}));
+
+function row(
+  agentId: string,
+  cost: number,
+  hasUnpricedUsage: boolean,
+): AgentDashboardRow {
+  return {
+    agentId,
+    tokens: 1_000_000,
+    cost,
+    hasUnpricedUsage,
+    seconds: 60,
+    taskCount: 1,
+  };
+}
+
+describe("Leaderboard cost completeness", () => {
+  it("renders unknown, partial, and explicit-zero costs as distinct states", () => {
+    renderWithI18n(
+      <Leaderboard
+        rows={[
+          row("unknown", 0, true),
+          row("partial", 1.25, true),
+          row("free", 0, false),
+        ]}
+        agents={[
+          { id: "unknown", name: "Unknown price" },
+          { id: "partial", name: "Partially priced" },
+          { id: "free", name: "Explicitly free" },
+        ]}
+        deletedAgentCount={0}
+        lessThanMinuteLabel="<1m"
+      />,
+    );
+
+    const rows = within(screen.getByRole("list", { name: "Leaderboard" }))
+      .getAllByRole("listitem");
+    const findRow = (name: string) =>
+      rows.find((item) => item.textContent?.includes(name));
+
+    expect(findRow("Unknown price")).toHaveTextContent("—");
+    expect(findRow("Unknown price")?.querySelector("[title]")).toHaveAttribute(
+      "title",
+      "Cost excludes usage from models without pricing.",
+    );
+    expect(findRow("Partially priced")).toHaveTextContent("$1.25+");
+    expect(findRow("Explicitly free")).toHaveTextContent("$0.00");
+  });
+});

--- a/packages/views/dashboard/components/leaderboard.tsx
+++ b/packages/views/dashboard/components/leaderboard.tsx
@@ -200,6 +200,11 @@ export function Leaderboard({
                 const agent = agents.find((a) => a.id === row.agentId);
                 const value = SORT_METRIC[sortBy](row);
                 const pct = maxValue > 0 ? (value / maxValue) * 100 : 0;
+                const costLabel = row.hasUnpricedUsage
+                  ? row.cost > 0
+                    ? `$${row.cost.toFixed(2)}+`
+                    : "—"
+                  : `$${row.cost.toFixed(2)}`;
                 return (
                   <li
                     key={row.agentId}
@@ -249,8 +254,13 @@ export function Leaderboard({
                     </div>
                     <div
                       className={`text-right tabular-nums ${sortBy === "cost" ? "text-body font-medium" : "text-caption text-muted-foreground"}`}
+                      title={
+                        row.hasUnpricedUsage
+                          ? t(($) => $.leaderboard.cost_incomplete)
+                          : undefined
+                      }
                     >
-                      ${row.cost.toFixed(2)}
+                      {costLabel}
                     </div>
                     <div
                       className={`text-right text-caption tabular-nums ${sortBy === "time" ? "font-medium text-foreground" : "text-muted-foreground"}`}

--- a/packages/views/dashboard/components/leaderboard.tsx
+++ b/packages/views/dashboard/components/leaderboard.tsx
@@ -77,6 +77,21 @@ export function Leaderboard({
   // upstream `mergeAgentDashboardRows`'s tiebreaker (run time desc) still
   // applies inside an equal-bucket.
   const sortedRows = useMemo(() => {
+    if (sortBy === "cost") {
+      return rows.toSorted((a, b) => {
+        // Unknown and partial costs cannot participate in a strict dollar
+        // ranking. Keep that cohort visible ahead of the Top 10 cutoff and
+        // order it by the complete quantity we do have: token usage.
+        if (a.hasUnpricedUsage !== b.hasUnpricedUsage) {
+          return a.hasUnpricedUsage ? -1 : 1;
+        }
+        if (a.hasUnpricedUsage) {
+          if (b.tokens !== a.tokens) return b.tokens - a.tokens;
+          return b.cost - a.cost;
+        }
+        return b.cost - a.cost;
+      });
+    }
     const metric = SORT_METRIC[sortBy];
     return rows.toSorted((a, b) => metric(b) - metric(a));
   }, [rows, sortBy]);
@@ -85,9 +100,18 @@ export function Leaderboard({
   // means the same thing collapsed and expanded — the leader always fills the
   // track and nothing re-scales when the tail comes into view.
   const maxValue = useMemo(() => {
+    if (sortBy === "cost") {
+      return sortedRows.reduce(
+        (maximum, row) =>
+          row.hasUnpricedUsage ? maximum : Math.max(maximum, row.cost),
+        0,
+      );
+    }
     const metric = SORT_METRIC[sortBy];
     return sortedRows.reduce((m, r) => Math.max(m, metric(r)), 0);
   }, [sortedRows, sortBy]);
+
+  const hasIncompleteCost = rows.some((row) => row.hasUnpricedUsage);
 
   const visibleRows = showAll
     ? sortedRows
@@ -142,6 +166,11 @@ export function Leaderboard({
           ) : null}
         </div>
       </div>
+      {sortBy === "cost" && hasIncompleteCost ? (
+        <p className="border-b bg-warning/10 px-4 py-2 text-caption text-foreground">
+          {t(($) => $.leaderboard.cost_sort_incomplete)}
+        </p>
+      ) : null}
       {sortedRows.length === 0 ? (
         <p className="px-4 py-8 text-center text-caption text-muted-foreground">
           {t(($) => $.leaderboard.no_data)}
@@ -199,7 +228,16 @@ export function Leaderboard({
                 const isBucket = isDeletedBucket || isRestrictedBucket;
                 const agent = agents.find((a) => a.id === row.agentId);
                 const value = SORT_METRIC[sortBy](row);
-                const pct = maxValue > 0 ? (value / maxValue) * 100 : 0;
+                // An incomplete dollar amount has no comparable position on
+                // the priced-row scale. Leave its bar empty rather than
+                // drawing a made-up cost ratio; the visible note explains
+                // that this cohort is ordered by tokens.
+                const pct =
+                  sortBy === "cost" && row.hasUnpricedUsage
+                    ? 0
+                    : maxValue > 0
+                      ? (value / maxValue) * 100
+                      : 0;
                 const costLabel = row.hasUnpricedUsage
                   ? row.cost > 0
                     ? `$${row.cost.toFixed(2)}+`

--- a/packages/views/dashboard/components/usage-trend-card.tsx
+++ b/packages/views/dashboard/components/usage-trend-card.tsx
@@ -22,6 +22,7 @@ import {
   aggregateWeeklyTasks,
   aggregateWeeklyTime,
   formatDuration,
+  type CostEstimate,
 } from "../utils";
 import { Segmented, type Dim } from "./dashboard-shared";
 import { DimSegmented } from "./dim-segmented";
@@ -47,6 +48,8 @@ export function UsageTrendCard({
   weeklyTokens,
   weeklyTime,
   weeklyTasks,
+  dailyCostEstimate,
+  weeklyCostEstimate,
   lessThanMinuteLabel,
 }: {
   allowedDims: readonly Dim[];
@@ -58,6 +61,8 @@ export function UsageTrendCard({
   weeklyTokens: ReturnType<typeof aggregateByWeek>["weeklyTokens"];
   weeklyTime: ReturnType<typeof aggregateWeeklyTime>;
   weeklyTasks: ReturnType<typeof aggregateWeeklyTasks>;
+  dailyCostEstimate: CostEstimate;
+  weeklyCostEstimate: CostEstimate;
   lessThanMinuteLabel: string;
 }) {
   const { t } = useT("usage");
@@ -73,12 +78,11 @@ export function UsageTrendCard({
   // Empty-state is per-metric so each toggle option independently decides
   // whether it has data — e.g. tokens recorded but no terminal runs yet
   // should show Tokens normally while Time / Tasks fall through to empty.
-  const costData = weekly ? weeklyCost : dailyCost;
   const tokensData = weekly ? weeklyTokens : dailyTokens;
   const timeData = weekly ? weeklyTime : dailyTime;
   const tasksData = weekly ? weeklyTasks : dailyTasks;
+  const costEstimate = weekly ? weeklyCostEstimate : dailyCostEstimate;
 
-  const totalCost = costData.reduce((sum, d) => sum + d.total, 0);
   const totalTokens = tokensData.reduce(
     (sum, d) => sum + d.input + d.output + d.cacheRead + d.cacheWrite,
     0,
@@ -87,7 +91,7 @@ export function UsageTrendCard({
   const totalTasks = tasksData.reduce((sum, d) => sum + d.completed + d.failed, 0);
   const isEmpty =
     metric === "cost"
-      ? totalCost === 0
+      ? totalTokens === 0
       : metric === "tokens"
         ? totalTokens === 0
         : metric === "time"
@@ -129,6 +133,13 @@ export function UsageTrendCard({
           <DimSegmented allowedDims={allowedDims} value={effectiveDim} onChange={setDim} />
         </div>
       </div>
+      {metric === "cost" && costEstimate.completeness !== "exact" ? (
+        <p className="mb-3 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-caption text-foreground">
+          {costEstimate.completeness === "partial"
+            ? t(($) => $.daily.cost_partial)
+            : t(($) => $.daily.cost_unknown)}
+        </p>
+      ) : null}
       <div className="min-h-[240px]">
         {isEmpty ? (
           <div className="flex aspect-[3/1] flex-col items-center justify-center gap-2 rounded-md border border-dashed bg-muted/20 p-6 text-center">

--- a/packages/views/dashboard/utils.test.ts
+++ b/packages/views/dashboard/utils.test.ts
@@ -135,8 +135,41 @@ describe("aggregateAgentTokens", () => {
 
     expect(rows.map((r) => r.agentId)).toEqual(["big-spender", "small-spender"]);
     expect(rows[0]?.taskCount).toBe(5);
+    expect(rows[0]?.hasUnpricedUsage).toBe(false);
     // big-spender across two models — verify cost > small-spender's.
     expect(rows[0]!.cost).toBeGreaterThan(rows[1]!.cost);
+  });
+
+  it("marks unknown model spend without conflating it with an explicit zero rate", () => {
+    // Reproduces the real dashboard failure: 263.1M tokens from an unpriced
+    // Antigravity model rendered as the same $0.00 as a known-free Flash SKU.
+    const rows = aggregateAgentTokens([
+      {
+        agent_id: "unknown-price",
+        provider: "antigravity",
+        model: "gemini-3.8-flash-high",
+        input_tokens: 263_100_000,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        task_count: 232,
+      },
+      {
+        agent_id: "explicitly-free",
+        provider: "zhipu",
+        model: "glm-4.7-flash",
+        input_tokens: 25_700_000,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        task_count: 47,
+      },
+    ]);
+
+    const unknown = rows.find((row) => row.agentId === "unknown-price");
+    const free = rows.find((row) => row.agentId === "explicitly-free");
+    expect(unknown).toMatchObject({ cost: 0, hasUnpricedUsage: true });
+    expect(free).toMatchObject({ cost: 0, hasUnpricedUsage: false });
   });
 });
 
@@ -181,6 +214,7 @@ describe("mergeAgentDashboardRows", () => {
         agentId: "agent-a",
         tokens: 3_000_000,
         cost: 12,
+        hasUnpricedUsage: false,
         taskCount: 2, // overcounted because (model-1: 1) + (model-2: 1)
       },
     ];
@@ -204,7 +238,15 @@ describe("mergeAgentDashboardRows", () => {
     // rollup is silent on this agent. Keep the token-side estimate
     // instead of dropping the agent from the table entirely.
     const merged = mergeAgentDashboardRows(
-      [{ agentId: "agent-b", tokens: 100, cost: 0.5, taskCount: 1 }],
+      [
+        {
+          agentId: "agent-b",
+          tokens: 100,
+          cost: 0.5,
+          hasUnpricedUsage: false,
+          taskCount: 1,
+        },
+      ],
       [],
     );
     expect(merged[0]!.taskCount).toBe(1);
@@ -228,9 +270,27 @@ describe("mergeAgentDashboardRows", () => {
   it("sorts by cost desc with run-time as a tiebreaker", () => {
     const merged = mergeAgentDashboardRows(
       [
-        { agentId: "low", tokens: 100, cost: 1, taskCount: 1 },
-        { agentId: "high", tokens: 100, cost: 9, taskCount: 1 },
-        { agentId: "zero-cost-long", tokens: 0, cost: 0, taskCount: 0 },
+        {
+          agentId: "low",
+          tokens: 100,
+          cost: 1,
+          hasUnpricedUsage: false,
+          taskCount: 1,
+        },
+        {
+          agentId: "high",
+          tokens: 100,
+          cost: 9,
+          hasUnpricedUsage: false,
+          taskCount: 1,
+        },
+        {
+          agentId: "zero-cost-long",
+          tokens: 0,
+          cost: 0,
+          hasUnpricedUsage: false,
+          taskCount: 0,
+        },
       ],
       [
         { agent_id: "zero-cost-long", total_seconds: 1000, task_count: 5, failed_count: 0, cancelled_count: 0 },
@@ -241,11 +301,19 @@ describe("mergeAgentDashboardRows", () => {
 });
 
 describe("bucketUnknownAgentRows", () => {
-  const live = { agentId: "live", tokens: 100, cost: 1, seconds: 10, taskCount: 1 };
+  const live = {
+    agentId: "live",
+    tokens: 100,
+    cost: 1,
+    hasUnpricedUsage: false,
+    seconds: 10,
+    taskCount: 1,
+  };
   const archived = {
     agentId: "archived",
     tokens: 80,
     cost: 0.8,
+    hasUnpricedUsage: false,
     seconds: 8,
     taskCount: 2,
   };
@@ -253,6 +321,7 @@ describe("bucketUnknownAgentRows", () => {
     agentId: "deleted-a",
     tokens: 50,
     cost: 0.5,
+    hasUnpricedUsage: false,
     seconds: 5,
     taskCount: 1,
   };
@@ -260,6 +329,7 @@ describe("bucketUnknownAgentRows", () => {
     agentId: "deleted-b",
     tokens: 30,
     cost: 0.25,
+    hasUnpricedUsage: false,
     seconds: 3,
     taskCount: 4,
   };
@@ -326,6 +396,7 @@ describe("bucketUnknownAgentRows", () => {
       agentId: RESTRICTED_AGENTS_ROW_ID,
       tokens: 70,
       cost: 0.7,
+      hasUnpricedUsage: false,
       seconds: 42,
       taskCount: 3,
     };

--- a/packages/views/dashboard/utils.ts
+++ b/packages/views/dashboard/utils.ts
@@ -16,6 +16,7 @@ import {
   estimateCost,
   estimateCostBreakdown,
   formatShortDate,
+  hasUnpricedUsage,
   todayIso,
   weekStartIso,
   type DailyTokenData,
@@ -175,12 +176,14 @@ export interface AgentCostRow {
   agentId: string;
   tokens: number;
   cost: number;
+  hasUnpricedUsage: boolean;
   taskCount: number;
 }
 
 // Fold per-(agent, model) rows into one row per agent. Cost is the sum
-// across this agent's models, which is the figure the user cares about.
-// Sort by cost desc so the heaviest spender lands first.
+// across this agent's models. `hasUnpricedUsage` travels beside that numeric
+// lower bound so presentation can distinguish an incomplete estimate from a
+// real zero. Sort by the known cost desc; unknown portions are not invented.
 export function aggregateAgentTokens(rows: DashboardUsageByAgent[]): AgentCostRow[] {
   const map = new Map<string, AgentCostRow>();
   for (const r of rows) {
@@ -188,11 +191,13 @@ export function aggregateAgentTokens(rows: DashboardUsageByAgent[]): AgentCostRo
       agentId: r.agent_id,
       tokens: 0,
       cost: 0,
+      hasUnpricedUsage: false,
       taskCount: 0,
     };
     entry.tokens +=
       r.input_tokens + r.output_tokens + r.cache_read_tokens + r.cache_write_tokens;
     entry.cost += estimateCost(r);
+    entry.hasUnpricedUsage ||= hasUnpricedUsage(r);
     entry.taskCount += r.task_count;
     map.set(r.agent_id, entry);
   }
@@ -203,6 +208,7 @@ export interface AgentDashboardRow {
   agentId: string;
   tokens: number;
   cost: number;
+  hasUnpricedUsage: boolean;
   seconds: number;
   taskCount: number;
 }
@@ -230,6 +236,7 @@ export function mergeAgentDashboardRows(
       agentId: r.agentId,
       tokens: r.tokens,
       cost: r.cost,
+      hasUnpricedUsage: r.hasUnpricedUsage,
       seconds: rt?.total_seconds ?? 0,
       taskCount: rt ? rt.task_count : r.taskCount,
     });
@@ -243,6 +250,7 @@ export function mergeAgentDashboardRows(
       agentId: r.agent_id,
       tokens: 0,
       cost: 0,
+      hasUnpricedUsage: false,
       seconds: r.total_seconds,
       taskCount: r.task_count,
     });
@@ -303,6 +311,7 @@ export function bucketUnknownAgentRows(
     agentId: DELETED_AGENTS_ROW_ID,
     tokens: 0,
     cost: 0,
+    hasUnpricedUsage: false,
     seconds: 0,
     taskCount: 0,
   };
@@ -315,6 +324,7 @@ export function bucketUnknownAgentRows(
     hasDeleted = true;
     bucket.tokens += r.tokens;
     bucket.cost += r.cost;
+    bucket.hasUnpricedUsage ||= r.hasUnpricedUsage;
   }
   return hasDeleted ? [...known, bucket] : known;
 }

--- a/packages/views/dashboard/utils.ts
+++ b/packages/views/dashboard/utils.ts
@@ -20,6 +20,7 @@ import {
   todayIso,
   weekStartIso,
   type DailyTokenData,
+  type Priceable,
 } from "../runtimes/utils";
 import type {
   DailyTimeData,
@@ -150,7 +151,35 @@ export interface DashboardTokenTotals {
   cacheRead: number;
   cacheWrite: number;
   cost: number;
+  costEstimate: CostEstimate;
   taskCount: number;
+}
+
+export type CostCompleteness = "exact" | "partial" | "unknown";
+
+export interface CostEstimate {
+  /** Cost from rows whose model pricing is known. This is a lower bound unless exact. */
+  knownCost: number;
+  completeness: CostCompleteness;
+}
+
+/**
+ * One cost contract for every dashboard surface. A numeric zero is only free
+ * when completeness is exact; otherwise it means the recorded usage cannot be
+ * priced yet. Custom rates participate because estimateCost and
+ * hasUnpricedUsage resolve through the same pricing store.
+ */
+export function summarizeCost(usage: readonly Priceable[]): CostEstimate {
+  let knownCost = 0;
+  let hasGap = false;
+  for (const row of usage) {
+    knownCost += estimateCost(row);
+    hasGap ||= hasUnpricedUsage(row);
+  }
+  return {
+    knownCost,
+    completeness: hasGap ? (knownCost > 0 ? "partial" : "unknown") : "exact",
+  };
 }
 
 // Whole-window totals for the KPI tiles. taskCount sums DISTINCT task counts
@@ -159,7 +188,8 @@ export interface DashboardTokenTotals {
 // acceptable for a KPI ("rough volume") and the per-agent run-time card
 // gives the precise figure.
 export function computeDailyTotals(usage: DashboardUsageDaily[]): DashboardTokenTotals {
-  return usage.reduce<DashboardTokenTotals>(
+  const costEstimate = summarizeCost(usage);
+  const totals = usage.reduce<Omit<DashboardTokenTotals, "costEstimate">>(
     (acc, u) => ({
       input: acc.input + u.input_tokens,
       output: acc.output + u.output_tokens,
@@ -170,6 +200,7 @@ export function computeDailyTotals(usage: DashboardUsageDaily[]): DashboardToken
     }),
     { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, taskCount: 0 },
   );
+  return { ...totals, costEstimate };
 }
 
 export interface AgentCostRow {

--- a/packages/views/locales/en/usage.json
+++ b/packages/views/locales/en/usage.json
@@ -92,6 +92,7 @@
     "header_agent": "Agent",
     "header_tokens": "Tokens",
     "header_cost": "Cost",
+    "cost_incomplete": "Cost excludes usage from models without pricing.",
     "header_time": "Time",
     "header_tasks": "Runs",
     "show_all": "Show all",

--- a/packages/views/locales/en/usage.json
+++ b/packages/views/locales/en/usage.json
@@ -12,12 +12,19 @@
   },
   "kpi": {
     "cost_label": "Cost · {{days}}D",
+    "cost_partial_hint": "Known priced usage only",
+    "cost_unknown_hint": "Unavailable until model pricing is set",
     "tokens_label": "Tokens · {{days}}D",
     "tokens_hint": "Input {{input}} · Output {{output}}",
     "run_time_label": "Run time · {{days}}D",
     "run_time_hint": "Across {{tasks}} runs",
     "tasks_label": "Runs · {{days}}D",
     "tasks_hint": "{{failed}} failed"
+  },
+  "cost_notice": {
+    "partial": "Some usage has no model price. Cost shows known priced usage only.",
+    "unknown": "Token usage was recorded, but none of it can be priced yet.",
+    "configure": "Set custom pricing"
   },
   "dim": {
     "label": "Dimension",
@@ -34,6 +41,8 @@
     "metric_tokens": "Tokens",
     "metric_time": "Time",
     "metric_tasks": "Runs",
+    "cost_partial": "This chart includes known priced usage only; the actual cost is higher.",
+    "cost_unknown": "Usage exists, but cost cannot be charted until model pricing is set.",
     "no_data": "No usage in this window.",
     "metric_label": "Metric"
   },
@@ -93,6 +102,7 @@
     "header_tokens": "Tokens",
     "header_cost": "Cost",
     "cost_incomplete": "Cost excludes usage from models without pricing.",
+    "cost_sort_incomplete": "Agents with incomplete cost are listed first by token usage; fully priced agents follow by cost.",
     "header_time": "Time",
     "header_tasks": "Runs",
     "show_all": "Show all",

--- a/packages/views/locales/ja/usage.json
+++ b/packages/views/locales/ja/usage.json
@@ -92,6 +92,7 @@
     "header_agent": "エージェント",
     "header_tokens": "トークン",
     "header_cost": "コスト",
+    "cost_incomplete": "料金が未設定のモデルの使用量は含まれていません。",
     "header_time": "時間",
     "header_tasks": "実行",
     "show_all": "すべて表示",

--- a/packages/views/locales/ja/usage.json
+++ b/packages/views/locales/ja/usage.json
@@ -12,12 +12,19 @@
   },
   "kpi": {
     "cost_label": "コスト · {{days}}日",
+    "cost_partial_hint": "価格設定済みの使用量のみ",
+    "cost_unknown_hint": "モデル価格の設定後に計算可能",
     "tokens_label": "トークン · {{days}}日",
     "tokens_hint": "入力 {{input}} · 出力 {{output}}",
     "run_time_label": "実行時間 · {{days}}日",
     "run_time_hint": "{{tasks}} 件の実行全体",
     "tasks_label": "実行 · {{days}}日",
     "tasks_hint": "{{failed}} 件失敗"
+  },
+  "cost_notice": {
+    "partial": "一部の使用量にモデル価格がありません。コストには価格設定済みの使用量のみが含まれます。",
+    "unknown": "トークン使用量は記録されていますが、まだコストを計算できません。",
+    "configure": "カスタム価格を設定"
   },
   "dim": {
     "label": "単位",
@@ -34,6 +41,8 @@
     "metric_tokens": "トークン",
     "metric_time": "時間",
     "metric_tasks": "実行",
+    "cost_partial": "このグラフには価格設定済みの使用量のみが含まれ、実際のコストはさらに高くなります。",
+    "cost_unknown": "使用量はありますが、モデル価格を設定するまでコストを表示できません。",
     "no_data": "この期間に使用量はありません。",
     "metric_label": "指標"
   },
@@ -93,6 +102,7 @@
     "header_tokens": "トークン",
     "header_cost": "コスト",
     "cost_incomplete": "料金が未設定のモデルの使用量は含まれていません。",
+    "cost_sort_incomplete": "コストが不完全なエージェントをトークン使用量順に先に表示し、価格設定済みのエージェントをコスト順に表示します。",
     "header_time": "時間",
     "header_tasks": "実行",
     "show_all": "すべて表示",

--- a/packages/views/locales/ko/usage.json
+++ b/packages/views/locales/ko/usage.json
@@ -92,6 +92,7 @@
     "header_agent": "에이전트",
     "header_tokens": "토큰",
     "header_cost": "비용",
+    "cost_incomplete": "가격이 설정되지 않은 모델의 사용량은 포함되지 않습니다.",
     "header_time": "시간",
     "header_tasks": "실행",
     "show_all": "전체 보기",

--- a/packages/views/locales/ko/usage.json
+++ b/packages/views/locales/ko/usage.json
@@ -12,12 +12,19 @@
   },
   "kpi": {
     "cost_label": "비용 · {{days}}일",
+    "cost_partial_hint": "가격이 설정된 사용량만 포함",
+    "cost_unknown_hint": "모델 가격 설정 후 계산 가능",
     "tokens_label": "토큰 · {{days}}일",
     "tokens_hint": "입력 {{input}} · 출력 {{output}}",
     "run_time_label": "실행 시간 · {{days}}일",
     "run_time_hint": "실행 {{tasks}}개 기준",
     "tasks_label": "실행 · {{days}}일",
     "tasks_hint": "실패 {{failed}}개"
+  },
+  "cost_notice": {
+    "partial": "일부 사용량에 모델 가격이 없습니다. 비용에는 가격이 설정된 사용량만 포함됩니다.",
+    "unknown": "토큰 사용량은 기록되었지만 아직 비용을 계산할 수 없습니다.",
+    "configure": "사용자 지정 가격 설정"
   },
   "dim": {
     "label": "단위",
@@ -34,6 +41,8 @@
     "metric_tokens": "토큰",
     "metric_time": "시간",
     "metric_tasks": "실행",
+    "cost_partial": "이 차트에는 가격이 설정된 사용량만 포함되며 실제 비용은 더 높습니다.",
+    "cost_unknown": "사용량은 있지만 모델 가격을 설정해야 비용을 표시할 수 있습니다.",
     "no_data": "이 기간에는 사용량이 없습니다.",
     "metric_label": "지표"
   },
@@ -93,6 +102,7 @@
     "header_tokens": "토큰",
     "header_cost": "비용",
     "cost_incomplete": "가격이 설정되지 않은 모델의 사용량은 포함되지 않습니다.",
+    "cost_sort_incomplete": "비용이 불완전한 에이전트는 토큰 사용량순으로 먼저 표시하고, 가격이 설정된 에이전트는 비용순으로 표시합니다.",
     "header_time": "시간",
     "header_tasks": "실행",
     "show_all": "전체 보기",

--- a/packages/views/locales/zh-Hans/usage.json
+++ b/packages/views/locales/zh-Hans/usage.json
@@ -92,6 +92,7 @@
     "header_agent": "智能体",
     "header_tokens": "Token",
     "header_cost": "费用",
+    "cost_incomplete": "费用未包含缺少价格的模型用量。",
     "header_time": "耗时",
     "header_tasks": "运行数",
     "show_all": "展开全部",

--- a/packages/views/locales/zh-Hans/usage.json
+++ b/packages/views/locales/zh-Hans/usage.json
@@ -12,12 +12,19 @@
   },
   "kpi": {
     "cost_label": "费用 · {{days}}天",
+    "cost_partial_hint": "仅包含已定价用量",
+    "cost_unknown_hint": "设置模型价格后才可计算",
     "tokens_label": "Token · {{days}}天",
     "tokens_hint": "输入 {{input}} · 输出 {{output}}",
     "run_time_label": "耗时 · {{days}}天",
     "run_time_hint": "共 {{tasks}} 次运行",
     "tasks_label": "运行数 · {{days}}天",
     "tasks_hint": "失败 {{failed}} 个"
+  },
+  "cost_notice": {
+    "partial": "部分用量缺少模型价格，当前费用仅包含已定价用量。",
+    "unknown": "已记录 Token 用量，但目前没有任何用量可计算费用。",
+    "configure": "设置自定义价格"
   },
   "dim": {
     "label": "维度",
@@ -34,6 +41,8 @@
     "metric_tokens": "Token",
     "metric_time": "耗时",
     "metric_tasks": "运行数",
+    "cost_partial": "此图仅包含已定价用量，实际费用会更高。",
+    "cost_unknown": "已有用量，但设置模型价格后才能绘制费用图。",
     "no_data": "所选时间范围内暂无消耗。",
     "metric_label": "指标"
   },
@@ -93,6 +102,7 @@
     "header_tokens": "Token",
     "header_cost": "费用",
     "cost_incomplete": "费用未包含缺少价格的模型用量。",
+    "cost_sort_incomplete": "费用不完整的 Agent 会先按 Token 用量排列；费用完整的 Agent 再按费用排列。",
     "header_time": "耗时",
     "header_tasks": "运行数",
     "show_all": "展开全部",

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -12,6 +12,7 @@ import {
   estimateCost,
   estimateCostBreakdown,
   formatTokens,
+  hasUnpricedUsage,
   isModelPriced,
   isSelfHealingRuntime,
   sliceWindow,
@@ -132,6 +133,21 @@ describe("estimateCost", () => {
       output_tokens: 1_000_000,
     });
     expect(cost).toBeCloseTo(5 + 25, 5);
+  });
+
+  it("prices Antigravity's Claude thinking-mode ID as the underlying Claude SKU", () => {
+    // A production Antigravity run reported `claude-opus-4-6-thinking`.
+    // The mode suffix describes inference behavior, not a separate Anthropic
+    // SKU, so its 495K+ tokens must not fall through as a $0 unknown cost.
+    const usage = {
+      ...zeroUsage,
+      provider: "antigravity",
+      model: "claude-opus-4-6-thinking",
+      input_tokens: 495_500,
+    };
+    expect(estimateCost(usage)).toBeCloseTo(2.4775, 5);
+    expect(hasUnpricedUsage(usage)).toBe(false);
+    expect(collectUnmappedModels([usage])).toEqual([]);
   });
 
   it("prices Claude Fable 5 at the Mythos-class tier", () => {
@@ -950,6 +966,25 @@ describe("collectUnmappedModels", () => {
       { ...zeroUsage, model: "fictional-model-x" },
     ];
     expect(collectUnmappedModels(rows)).toEqual(["fictional-model-x"]);
+  });
+
+  it("distinguishes an unknown model from an explicitly free model", () => {
+    const unknown = {
+      ...zeroUsage,
+      provider: "antigravity",
+      model: "gemini-3.8-flash-high",
+      input_tokens: 263_100_000,
+    };
+    const free = {
+      ...zeroUsage,
+      provider: "zhipu",
+      model: "glm-4.7-flash",
+      input_tokens: 25_700_000,
+    };
+    expect(estimateCost(unknown)).toBe(0);
+    expect(estimateCost(free)).toBe(0);
+    expect(hasUnpricedUsage(unknown)).toBe(true);
+    expect(hasUnpricedUsage(free)).toBe(false);
   });
 });
 

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -374,7 +374,7 @@ const MODEL_PRICING: Record<
   "cursor":                   { input: 3,    output: 15,   cacheRead: 0.5,    cacheWrite: 0 },
 };
 
-// Resolve a model string to its pricing tier. Exact match, with four
+// Resolve a model string to its pricing tier. Exact match, with five
 // tolerances applied in order:
 //
 //  1. Provider-prefixed IDs (`anthropic/claude-opus-4.7` from openclaw /
@@ -385,10 +385,13 @@ const MODEL_PRICING: Record<
 //     SKU, two transports. We canonicalize `claude-*` IDs to the dashed
 //     form Anthropic itself publishes. Scoped to `claude-*` because for
 //     OpenAI the separator IS semantic (`gpt-5.4` ≠ `gpt-5-4`).
-//  3. Trailing dated snapshots (`claude-sonnet-4-5-20250929`,
+//  3. Claude inference-mode suffixes (`claude-opus-4-6-thinking`) —
+//     routing CLIs expose the mode in the model ID, but Anthropic prices it
+//     under the base model SKU.
+//  4. Trailing dated snapshots (`claude-sonnet-4-5-20250929`,
 //     `gpt-5-2025-08-07`) — the family is what we price, the date is
 //     volatile, so we strip a trailing date / "latest" tag.
-//  4. Trailing context-window tag (`claude-opus-4-7[1m]`) — Anthropic's
+//  5. Trailing context-window tag (`claude-opus-4-7[1m]`) — Anthropic's
 //     1M-context beta is the same SKU at standard rates for prompts
 //     ≤200K input tokens, with a 2× surcharge above that. Aggregated
 //     usage rows don't carry per-request prompt sizes, so we price the
@@ -525,6 +528,12 @@ function canonicalCandidates(model: string): string[] {
   // semantic, so we leave `gpt-5.4` etc. alone.
   const canonAnthropic = (s: string) =>
     s.startsWith("claude-") ? s.replace(/\./g, "-") : s;
+  // Some routing CLIs append the inference mode to Claude's SKU even though
+  // Anthropic prices thinking and non-thinking requests under the same model.
+  // Strip only these exact trailing mode tokens and only for Claude IDs; model
+  // suffixes from other vendors may identify genuinely different products.
+  const stripClaudeMode = (s: string) =>
+    s.startsWith("claude-") ? s.replace(/-(thinking|non-thinking)$/, "") : s;
   // Trailing context-window tag (`claude-opus-4-7[1m]`). Same family,
   // same price tier — see resolver comment above for the 1M-context
   // pricing trade-off.
@@ -533,12 +542,16 @@ function canonicalCandidates(model: string): string[] {
   const raw = model;
   const noProvider = stripProvider(raw);
   const dashed = canonAnthropic(noProvider);
+  const noDate = stripDate(dashed);
   const noTag = stripContextTag(dashed);
 
   push(raw);
   push(noProvider);
   push(dashed);
+  push(stripClaudeMode(dashed));
+  push(stripClaudeMode(noDate));
   push(noTag);
+  push(stripClaudeMode(noTag));
   push(stripDate(raw));
   push(stripDate(noProvider));
   push(stripDate(dashed));
@@ -640,6 +653,20 @@ function uncostedTokens(usage: Priceable): {
     cacheRead: usage.uncosted_cache_read_tokens ?? 0,
     cacheWrite: usage.uncosted_cache_write_tokens ?? 0,
   };
+}
+
+// Whether this row contains tokens whose cost neither the provider nor the
+// local rate table can supply. Keep this separate from `estimateCost`: a
+// numeric zero can mean either "explicitly free" or "unknown", and callers
+// must not present those two states as the same claim.
+export function hasUnpricedUsage(usage: Priceable): boolean {
+  const uncosted = uncostedTokens(usage);
+  const needsEstimate =
+    uncosted.input > 0 ||
+    uncosted.output > 0 ||
+    uncosted.cacheRead > 0 ||
+    uncosted.cacheWrite > 0;
+  return needsEstimate && !isModelPriced(usage.model, usage.provider);
 }
 
 // Cost of a usage row: what the provider actually charged, plus a rate-table

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -528,12 +528,11 @@ function canonicalCandidates(model: string): string[] {
   // semantic, so we leave `gpt-5.4` etc. alone.
   const canonAnthropic = (s: string) =>
     s.startsWith("claude-") ? s.replace(/\./g, "-") : s;
-  // Some routing CLIs append the inference mode to Claude's SKU even though
-  // Anthropic prices thinking and non-thinking requests under the same model.
-  // Strip only these exact trailing mode tokens and only for Claude IDs; model
-  // suffixes from other vendors may identify genuinely different products.
+  // Some routing CLIs append `-thinking` to Claude's SKU even though Anthropic
+  // prices the request under the base model. Only that observed identifier is
+  // normalized; other suffixes may identify genuinely different products.
   const stripClaudeMode = (s: string) =>
-    s.startsWith("claude-") ? s.replace(/-(thinking|non-thinking)$/, "") : s;
+    s.startsWith("claude-") ? s.replace(/-thinking$/, "") : s;
   // Trailing context-window tag (`claude-opus-4-7[1m]`). Same family,
   // same price tier — see resolver comment above for the 1M-context
   // pricing trade-off.


### PR DESCRIPTION
## Problem

The workspace leaderboard currently renders an unpriced usage row as `$0.00`. That makes two materially different states look identical:

- a model with an explicit zero-dollar rate;
- a model whose price Multica cannot determine.

This was observed in a real workspace rather than a synthetic edge case:

| Runtime-reported model | Tokens shown | Previous cost | What the value actually meant |
| --- | ---: | ---: | --- |
| `antigravity/gemini-3.8-flash-high` | 263.1M | `$0.00` | No matching rate and no provider-reported cost |
| `zhipu/glm-4.7-flash` | 25.7M | `$0.00` | Explicitly free rate |
| `antigravity/claude-opus-4-6-thinking` | 495.5K | `$0.00` | Same priced Claude Opus 4.6 SKU, but the routing CLI appended a mode suffix |

The first and third rows looked free even though Multica only lacked enough information to calculate them. At this volume, `$0.00` is a false financial claim rather than a harmless rounding artifact.

## What changed

- Track whether each per-agent total contains tokens that have neither provider-reported cost nor a matching local rate.
- Render a fully unknown cost as `—` instead of `$0.00`.
- Render a mixed total as `$known+`, making the displayed number an explicit lower bound.
- Keep `$0.00` for models that really have an explicit zero rate.
- Normalize the exact Claude `-thinking` / `-non-thinking` routing suffixes to the underlying Claude pricing SKU.
- Add the explanatory tooltip in all four shipped locales.

Provider-reported cost remains authoritative. This does not guess rates for private or subscription-only models, change stored usage, or change the API.

## Tests

- `pnpm --filter @multica/views exec vitest run dashboard/utils.test.ts runtimes/utils.test.ts dashboard/components/leaderboard.test.tsx` — 143 passed
- `pnpm --filter @multica/views exec vitest run locales/parity.test.ts` — 160 passed
- `pnpm --filter @multica/views typecheck` — passed
- `pnpm --filter @multica/views test` — 4,897 passed
- ESLint on the six changed TypeScript files — 0 errors
