### PR TITLE
MUL-7076 fix(lark): fallback to group notice when binding card unavailable

### DIFF
--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -71,24 +71,19 @@ const (
 	// transfers off the connector ACK path.
 	maxMessageResourceBytes = 100 << 20
 
-	// Access-credential rejections. Seeing one means the token we
-	// presented is not usable, so drop the cached entry and re-mint from
-	// /tenant_access_token/internal. Both are from Lark's generic
-	// error-code table:
-	// open.feishu.cn/document/server-docs/api-call-guide/generic-error-code.
-	//
-	// 99991663 covers BOTH halves for the only credential this client
-	// mints — "tenant_access_token 已过期" and "凭证无效" share the one
-	// code — and is the code the wedged-cache bug reported in #7611 hit.
-	//
-	// 99991664 is app_access_token, which this client never mints. It
-	// stays in the class deliberately: it is unambiguously "the
-	// credential you presented was rejected", and if Lark ever answers it
-	// for a call we authenticated with a tenant token, re-minting is the
-	// only recovery. Being wrong costs one bounded refresh and one
-	// replay, while leaving it out would cost another wedged cache.
-	codeTenantTokenInvalid = 99991663
-	codeAppTokenInvalid    = 99991664
+	// Lark's "invalid tenant_access_token" / "tenant_access_token
+	// expired" error codes. When we see either, drop the cached token
+	// so the next call refreshes from /tenant_access_token/internal.
+	// 99991663 = expired, 99991664 = invalid. Documented at:
+	// open.feishu.cn/document/server-docs/api-call-guide/server-error-codes.
+	codeTokenExpired = 99991663
+	codeTokenInvalid = 99991664
+
+	// codeNoAvailability means the bot cannot send private messages to the user
+	// because they are not in the bot's visible scope. In that case, the
+	// connector should keep the group-level reply path visible so users still get
+	// guidance.
+	codeNoAvailability = 230013
 )
 
 // HTTPClientConfig configures the production Lark HTTP APIClient.
@@ -272,48 +267,6 @@ func (c *httpAPIClient) invalidateToken(appID string) {
 	c.mu.Unlock()
 }
 
-// InvalidateTokenCache drops the cached tenant_access_token for an
-// app_id from outside the client. It exists for credential rotation:
-// re-registering a Bot issues a new app_secret, which makes Lark revoke
-// every token minted from the previous one, and the cache — keyed by
-// app_id, which does NOT change — would otherwise keep replaying a
-// token Lark now rejects.
-func (c *httpAPIClient) InvalidateTokenCache(appID string) {
-	c.invalidateToken(appID)
-}
-
-// doAuthedJSON performs one tenant_access_token-authenticated call. When
-// Lark rejects the token itself, it drops the cached entry, mints a
-// fresh token and replays the request exactly once.
-//
-// Replaying is safe for every caller here: Lark rejects a bad token
-// during authentication, before the request is processed, so nothing was
-// delivered and the retry cannot duplicate a message. Without it the
-// refresh would only help the NEXT call and the reply that triggered it
-// would still be lost.
-//
-// Only token errors are retried. Business codes, 5xx and network
-// failures are returned untouched — those are either definitive or
-// ambiguous about delivery, and neither is fixed by a new token.
-func (c *httpAPIClient) doAuthedJSON(ctx context.Context, creds InstallationCredentials, method, path string, body, out any) error {
-	token, err := c.tenantAccessToken(ctx, creds)
-	if err != nil {
-		return err
-	}
-	err = c.doJSON(ctx, c.resolveBaseURL(creds), method, path, token, body, out)
-	if !isTokenError(larkErrorCode(err)) {
-		return err
-	}
-	c.cfg.Logger.Warn("lark http client: tenant_access_token rejected; refreshing and retrying once",
-		"app_id", creds.AppID, "path", path, "err", err)
-	c.invalidateToken(creds.AppID)
-	fresh, refreshErr := c.tenantAccessToken(ctx, creds)
-	if refreshErr != nil {
-		return fmt.Errorf("%w (token refresh failed: %v)", err, refreshErr)
-	}
-	return c.doJSON(ctx, c.resolveBaseURL(creds), method, path, fresh, body, out)
-}
-
 // outboundMessageRequest builds the (path, body) the three send methods
 // share. When target.IsSet() the message is routed through Lark's reply
 // endpoint (POST /im/v1/messages/{message_id}/reply) so it threads back
@@ -350,6 +303,10 @@ func (c *httpAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 	if p.CardJSON == "" {
 		return "", errors.New("lark http client: missing card json")
 	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return "", err
+	}
 	path, body := outboundMessageRequest(p.ChatID, "interactive", p.CardJSON, p.ReplyTarget)
 	var resp struct {
 		Code int    `json:"code"`
@@ -358,7 +315,7 @@ func (c *httpAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 			MessageID string `json:"message_id"`
 		} `json:"data"`
 	}
-	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: send interactive card: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.MessageID == "" {
@@ -383,6 +340,10 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 	if p.Text == "" {
 		return "", errors.New("lark http client: missing text")
 	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return "", err
+	}
 	// Lark's `text` msg_type expects content = JSON-encoded {"text": "..."}.
 	// json.Marshal handles the escape of newlines / quotes / unicode so
 	// the agent's reply round-trips intact.
@@ -398,7 +359,7 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 			MessageID string `json:"message_id"`
 		} `json:"data"`
 	}
-	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: send text message: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.MessageID == "" {
@@ -432,6 +393,10 @@ func (c *httpAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCard
 	if p.Markdown == "" {
 		return "", errors.New("lark http client: missing markdown body")
 	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return "", err
+	}
 	card := map[string]any{
 		"schema": "2.0",
 		"body": map[string]any{
@@ -457,7 +422,7 @@ func (c *httpAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCard
 			MessageID string `json:"message_id"`
 		} `json:"data"`
 	}
-	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: send markdown card: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.MessageID == "" {
@@ -479,13 +444,17 @@ func (c *httpAPIClient) PatchInteractiveCard(ctx context.Context, p PatchCardPar
 	if p.CardJSON == "" {
 		return errors.New("lark http client: missing card json")
 	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return err
+	}
 	body := map[string]string{"content": p.CardJSON}
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
 	}
 	path := "/open-apis/im/v1/messages/" + url.PathEscape(p.LarkCardMessageID)
-	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPatch, path, body, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPatch, path, token, body, &resp); err != nil {
 		return fmt.Errorf("lark http client: patch interactive card: %w", err)
 	}
 	if resp.Code != 0 {
@@ -512,6 +481,10 @@ func (c *httpAPIClient) SendBindingPromptCard(ctx context.Context, p BindingProm
 	if err != nil {
 		return fmt.Errorf("lark http client: render binding prompt: %w", err)
 	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return err
+	}
 	q := url.Values{}
 	q.Set("receive_id_type", "open_id")
 	body := map[string]string{
@@ -524,14 +497,14 @@ func (c *httpAPIClient) SendBindingPromptCard(ctx context.Context, p BindingProm
 		Msg  string `json:"msg"`
 	}
 	path := "/open-apis/im/v1/messages?" + q.Encode()
-	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
 		return fmt.Errorf("lark http client: send binding prompt: %w", err)
 	}
 	if resp.Code != 0 {
 		if isTokenError(resp.Code) {
 			c.invalidateToken(p.InstallationID.AppID)
 		}
-		return fmt.Errorf("lark http client: send binding prompt: code=%d msg=%q", resp.Code, resp.Msg)
+		return &APIError{Op: "send binding prompt", Code: resp.Code, Msg: resp.Msg}
 	}
 	return nil
 }
@@ -569,6 +542,10 @@ func (c *httpAPIClient) GetBotInfo(ctx context.Context, creds InstallationCreden
 	if creds.AppID == "" || creds.AppSecret == "" {
 		return BotInfo{}, errors.New("lark http client: missing app credentials for GetBotInfo")
 	}
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return BotInfo{}, err
+	}
 	var botResp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
@@ -576,7 +553,7 @@ func (c *httpAPIClient) GetBotInfo(ctx context.Context, creds InstallationCreden
 			OpenID string `json:"open_id"`
 		} `json:"bot"`
 	}
-	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, "/open-apis/bot/v3/info", nil, &botResp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, "/open-apis/bot/v3/info", token, nil, &botResp); err != nil {
 		return BotInfo{}, fmt.Errorf("lark http client: bot info: %w", err)
 	}
 	if botResp.Code != 0 {
@@ -593,7 +570,7 @@ func (c *httpAPIClient) GetBotInfo(ctx context.Context, creds InstallationCreden
 	// return the BotInfo with empty UnionID. Callers (Registration-
 	// Service.finishSuccess) accept the gap and persist what they
 	// have.
-	unionID, lookupErr := c.fetchBotUnionID(ctx, creds, botResp.Bot.OpenID)
+	unionID, lookupErr := c.fetchBotUnionID(ctx, c.resolveBaseURL(creds), creds.AppID, token, botResp.Bot.OpenID)
 	if lookupErr != nil {
 		c.cfg.Logger.Warn("lark http client: bot union_id lookup failed; continuing without it",
 			"app_id", creds.AppID,
@@ -621,6 +598,10 @@ func (c *httpAPIClient) GetMessage(ctx context.Context, creds InstallationCreden
 	if messageID == "" {
 		return nil, errors.New("lark http client: missing message_id")
 	}
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("user_id_type", "open_id")
 	path := "/open-apis/im/v1/messages/" + url.PathEscape(messageID) + "?" + q.Encode()
@@ -632,7 +613,7 @@ func (c *httpAPIClient) GetMessage(ctx context.Context, creds InstallationCreden
 			Items []larkRESTMessageItem `json:"items"`
 		} `json:"data"`
 	}
-	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, path, token, nil, &resp); err != nil {
 		return nil, fmt.Errorf("lark http client: get message: %w", err)
 	}
 	if resp.Code != 0 {
@@ -676,6 +657,10 @@ func (c *httpAPIClient) ListChatMessages(ctx context.Context, creds Installation
 	} else if size > larkListMessagesMaxPageSize {
 		size = larkListMessagesMaxPageSize
 	}
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	if p.ThreadID != "" {
 		// Topic-scoped window: only this 话题's messages, so a @-mention
@@ -704,7 +689,7 @@ func (c *httpAPIClient) ListChatMessages(ctx context.Context, creds Installation
 			Items []larkRESTMessageItem `json:"items"`
 		} `json:"data"`
 	}
-	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, path, token, nil, &resp); err != nil {
 		return nil, fmt.Errorf("lark http client: list chat messages: %w", err)
 	}
 	if resp.Code != 0 {
@@ -754,6 +739,10 @@ func (c *httpAPIClient) DownloadMessageResourceStream(ctx context.Context, creds
 	if p.FileKey == "" {
 		return DownloadedResourceStream{}, errors.New("lark http client: missing file_key")
 	}
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return DownloadedResourceStream{}, err
+	}
 	q := url.Values{}
 	if p.Type != "" {
 		q.Set("type", p.Type)
@@ -763,28 +752,6 @@ func (c *httpAPIClient) DownloadMessageResourceStream(ctx context.Context, creds
 		path += "?" + encoded
 	}
 
-	// Same refresh-and-retry contract as doAuthedJSON: Lark rejects a bad
-	// token before it serves any bytes, so replaying the GET once cannot
-	// produce a half-downloaded resource.
-	for attempt := 0; ; attempt++ {
-		token, err := c.tenantAccessToken(ctx, creds)
-		if err != nil {
-			return DownloadedResourceStream{}, err
-		}
-		stream, err := c.downloadMessageResourceStreamOnce(ctx, creds, path, token)
-		if err == nil {
-			return stream, nil
-		}
-		if attempt > 0 || !isTokenError(larkErrorCode(err)) {
-			return DownloadedResourceStream{}, err
-		}
-		c.cfg.Logger.Warn("lark http client: tenant_access_token rejected on resource download; refreshing and retrying once",
-			"app_id", creds.AppID, "err", err)
-		c.invalidateToken(creds.AppID)
-	}
-}
-
-func (c *httpAPIClient) downloadMessageResourceStreamOnce(ctx context.Context, creds InstallationCredentials, path, token string) (DownloadedResourceStream, error) {
 	downloadCtx := ctx
 	var cancel context.CancelFunc
 	if c.cfg.ResourceDownloadTimeout > 0 {
@@ -821,13 +788,7 @@ func (c *httpAPIClient) downloadMessageResourceStreamOnce(ctx context.Context, c
 		if readErr != nil {
 			return DownloadedResourceStream{}, readErr
 		}
-		code, msg := parseLarkErrorBody(rawBody)
-		return DownloadedResourceStream{}, fmt.Errorf("lark http client: download resource: %w", &larkAPIStatusError{
-			StatusCode: resp.StatusCode,
-			Code:       code,
-			Msg:        msg,
-			Raw:        truncate(string(rawBody), 512),
-		})
+		return DownloadedResourceStream{}, fmt.Errorf("lark http client: download resource: http %d: %s", resp.StatusCode, truncate(string(rawBody), 512))
 	}
 	contentType := resp.Header.Get("Content-Type")
 	if strings.Contains(strings.ToLower(contentType), "json") {
@@ -841,8 +802,9 @@ func (c *httpAPIClient) downloadMessageResourceStreamOnce(ctx context.Context, c
 			Msg  string `json:"msg"`
 		}
 		if err := json.Unmarshal(rawBody, &apiResp); err == nil && apiResp.Code != 0 {
-			// Token invalidation is the retry loop's job in the caller —
-			// it owns both this shape and the non-2xx one.
+			if isTokenError(apiResp.Code) {
+				c.invalidateToken(creds.AppID)
+			}
 			return DownloadedResourceStream{}, &APIError{Op: "download resource", Code: apiResp.Code, Msg: apiResp.Msg}
 		}
 		return DownloadedResourceStream{
@@ -948,6 +910,10 @@ func (c *httpAPIClient) AddMessageReaction(ctx context.Context, p AddReactionPar
 	if p.EmojiType == "" {
 		return "", errors.New("lark http client: missing emoji_type")
 	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return "", err
+	}
 	body := map[string]any{
 		"reaction_type": map[string]string{"emoji_type": p.EmojiType},
 	}
@@ -959,7 +925,7 @@ func (c *httpAPIClient) AddMessageReaction(ctx context.Context, p AddReactionPar
 			ReactionID string `json:"reaction_id"`
 		} `json:"data"`
 	}
-	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: add message reaction: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.ReactionID == "" {
@@ -980,12 +946,16 @@ func (c *httpAPIClient) DeleteMessageReaction(ctx context.Context, p DeleteReact
 	if p.ReactionID == "" {
 		return errors.New("lark http client: missing reaction_id")
 	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return err
+	}
 	path := "/open-apis/im/v1/messages/" + url.PathEscape(p.MessageID) + "/reactions/" + url.PathEscape(p.ReactionID)
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
 	}
-	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodDelete, path, nil, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodDelete, path, token, nil, &resp); err != nil {
 		return fmt.Errorf("lark http client: delete message reaction: %w", err)
 	}
 	if resp.Code != 0 {
@@ -1011,6 +981,10 @@ func (c *httpAPIClient) BatchGetUsers(ctx context.Context, creds InstallationCre
 	if len(openIDs) > larkBatchGetUsersMaxIDs {
 		openIDs = openIDs[:larkBatchGetUsersMaxIDs]
 	}
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("user_id_type", "open_id")
 	for _, id := range openIDs {
@@ -1030,7 +1004,7 @@ func (c *httpAPIClient) BatchGetUsers(ctx context.Context, creds InstallationCre
 			} `json:"items"`
 		} `json:"data"`
 	}
-	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, path, token, nil, &resp); err != nil {
 		return nil, fmt.Errorf("lark http client: batch get users: %w", err)
 	}
 	if resp.Code != 0 {
@@ -1107,7 +1081,7 @@ func (it larkRESTMessageItem) normalize() LarkMessage {
 // scope is restricted. Caller logs and continues; the decoder still
 // works in single-bot deployments where open_id-based matching is
 // unambiguous.
-func (c *httpAPIClient) fetchBotUnionID(ctx context.Context, creds InstallationCredentials, openID string) (string, error) {
+func (c *httpAPIClient) fetchBotUnionID(ctx context.Context, baseURL, appID, token, openID string) (string, error) {
 	if openID == "" {
 		return "", errors.New("empty open_id")
 	}
@@ -1123,7 +1097,7 @@ func (c *httpAPIClient) fetchBotUnionID(ctx context.Context, creds InstallationC
 			} `json:"user"`
 		} `json:"data"`
 	}
-	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
+	if err := c.doJSON(ctx, baseURL, http.MethodGet, path, token, nil, &resp); err != nil {
 		return "", fmt.Errorf("contact users: %w", err)
 	}
 	if resp.Code != 0 {
@@ -1132,7 +1106,7 @@ func (c *httpAPIClient) fetchBotUnionID(ctx context.Context, creds InstallationC
 		// the bearer would do nothing and a stale token would keep
 		// being reused on every retry until natural TTL expiry.
 		if isTokenError(resp.Code) {
-			c.invalidateToken(creds.AppID)
+			c.invalidateToken(appID)
 		}
 		return "", fmt.Errorf("contact users: code=%d msg=%q", resp.Code, resp.Msg)
 	}
@@ -1174,17 +1148,7 @@ func (c *httpAPIClient) doJSON(ctx context.Context, baseURL, method, path, token
 		return fmt.Errorf("read body: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		// Lark still reports its business code in the body of a non-2xx
-		// reply, so parse it instead of collapsing the response into an
-		// opaque transport error. Everything that classifies by code —
-		// token invalidation above all — is unreachable otherwise.
-		code, msg := parseLarkErrorBody(rawBody)
-		return &larkAPIStatusError{
-			StatusCode: resp.StatusCode,
-			Code:       code,
-			Msg:        msg,
-			Raw:        truncate(string(rawBody), 512),
-		}
+		return fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(rawBody), 512))
 	}
 	if out != nil && len(rawBody) > 0 {
 		if err := json.Unmarshal(rawBody, out); err != nil {
@@ -1194,70 +1158,8 @@ func (c *httpAPIClient) doJSON(ctx context.Context, baseURL, method, path, token
 	return nil
 }
 
-// parseLarkErrorBody best-effort extracts Lark's {code, msg} envelope
-// from an error body. A body that is not JSON at all (a proxy's HTML
-// error page, an empty 502) yields 0 / "" — no code, nothing to
-// classify — which keeps such failures on the plain-transport path.
-func parseLarkErrorBody(raw []byte) (int, string) {
-	var env struct {
-		Code int    `json:"code"`
-		Msg  string `json:"msg"`
-	}
-	if err := json.Unmarshal(raw, &env); err != nil {
-		return 0, ""
-	}
-	return env.Code, env.Msg
-}
-
 func isTokenError(code int) bool {
-	return code == codeTenantTokenInvalid || code == codeAppTokenInvalid
-}
-
-// larkAPIStatusError is a Lark reply that failed with a NON-2xx HTTP
-// status. It carries the business code Lark put in the body, because
-// Lark reports authentication failures that way: an invalid or expired
-// tenant_access_token comes back as HTTP 400 with {"code":99991663},
-// not as a 2xx envelope (#7611). A client that only reads the body of
-// 2xx replies can therefore never notice its cached token died, and
-// replays the dead token until the process restarts.
-//
-// Code is 0 when the body carried no parsable Lark envelope.
-type larkAPIStatusError struct {
-	StatusCode int
-	Code       int
-	Msg        string
-	Raw        string
-}
-
-func (e *larkAPIStatusError) Error() string {
-	// Preserve the historical wording — operators grep their logs for it.
-	return fmt.Sprintf("http %d: %s", e.StatusCode, e.Raw)
-}
-
-// larkErrorCode digs the Lark business code out of err, from either
-// shape that carries one: a non-2xx reply (larkAPIStatusError) or a 2xx
-// envelope a call site rejected (APIError). Returns 0 for anything else,
-// including network failures and timeouts, so a code-keyed lookup on the
-// result never matches an ambiguous transport error.
-func larkErrorCode(err error) int {
-	code, _, _ := larkErrorCodeMsg(err)
-	return code
-}
-
-// larkErrorCodeMsg is larkErrorCode plus Lark's `msg` and whether err
-// carried a code at all. Classifiers that fall back to matching error
-// TEXT need the third result: "no code" and "code 0" must not both look
-// like a Lark verdict, or a gateway's HTML 502 would classify as one.
-func larkErrorCodeMsg(err error) (int, string, bool) {
-	var statusErr *larkAPIStatusError
-	if errors.As(err, &statusErr) {
-		return statusErr.Code, statusErr.Msg, statusErr.Code != 0
-	}
-	var apiErr *APIError
-	if errors.As(err, &apiErr) {
-		return apiErr.Code, apiErr.Msg, apiErr.Code != 0
-	}
-	return 0, "", false
+	return code == codeTokenExpired || code == codeTokenInvalid
 }
 
 // APIError is a structured Lark business error: the request reached
@@ -1298,20 +1200,17 @@ var threadReplyUnsupportedCodes = map[int]struct{}{
 	230111: {}, // cannot reply to a self-destructing message
 }
 
-// isThreadReplyUnsupported reports whether err carries a Lark business
-// code meaning the threaded reply cannot land on this target. Only such
-// errors are safe to retry at the chat level. Transport errors and other
-// business codes return false.
-//
-// The code is read through larkErrorCode, so it is found whether Lark
-// answered with a 2xx envelope or a non-2xx status — a definitive
-// "nothing was sent" verdict is equally definitive either way, and only
-// codes on the list get here. Errors with no Lark code (network failure,
-// timeout, a proxy's HTML 502) yield code 0, which is not on the list, so
-// ambiguous delivery still never triggers the fallback.
+// isThreadReplyUnsupported reports whether err is a Lark APIError whose
+// code means the threaded reply cannot land on this target. Only such
+// errors are safe to retry at the chat level. Transport errors and
+// other business codes return false.
 func isThreadReplyUnsupported(err error) bool {
-	_, ok := threadReplyUnsupportedCodes[larkErrorCode(err)]
-	return ok
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		_, ok := threadReplyUnsupportedCodes[apiErr.Code]
+		return ok
+	}
+	return false
 }
 
 func truncate(s string, n int) string {

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -71,18 +71,28 @@ const (
 	// transfers off the connector ACK path.
 	maxMessageResourceBytes = 100 << 20
 
-	// Lark's "invalid tenant_access_token" / "tenant_access_token
-	// expired" error codes. When we see either, drop the cached token
-	// so the next call refreshes from /tenant_access_token/internal.
-	// 99991663 = expired, 99991664 = invalid. Documented at:
-	// open.feishu.cn/document/server-docs/api-call-guide/server-error-codes.
-	codeTokenExpired = 99991663
-	codeTokenInvalid = 99991664
+	// Access-credential rejections. Seeing one means the token we
+	// presented is not usable, so drop the cached entry and re-mint from
+	// /tenant_access_token/internal. Both are from Lark's generic
+	// error-code table:
+	// open.feishu.cn/document/server-docs/api-call-guide/generic-error-code.
+	//
+	// 99991663 covers BOTH halves for the only credential this client
+	// mints — "tenant_access_token 已过期" and "凭证无效" share the one
+	// code — and is the code the wedged-cache bug reported in #7611 hit.
+	//
+	// 99991664 is app_access_token, which this client never mints. It
+	// stays in the class deliberately: it is unambiguously "the
+	// credential you presented was rejected", and if Lark ever answers it
+	// for a call we authenticated with a tenant token, re-minting is the
+	// only recovery. Being wrong costs one bounded refresh and one
+	// replay, while leaving it out would cost another wedged cache.
+	codeTenantTokenInvalid = 99991663
+	codeAppTokenInvalid    = 99991664
 
-	// codeNoAvailability means the bot cannot send private messages to the user
-	// because they are not in the bot's visible scope. In that case, the
-	// connector should keep the group-level reply path visible so users still get
-	// guidance.
+	// codeNoAvailability means the bot cannot send a private message to the
+	// user because they are outside the bot's visible scope. Keep the
+	// group-level reply path visible so users still get guidance.
 	codeNoAvailability = 230013
 )
 
@@ -267,6 +277,48 @@ func (c *httpAPIClient) invalidateToken(appID string) {
 	c.mu.Unlock()
 }
 
+// InvalidateTokenCache drops the cached tenant_access_token for an
+// app_id from outside the client. It exists for credential rotation:
+// re-registering a Bot issues a new app_secret, which makes Lark revoke
+// every token minted from the previous one, and the cache — keyed by
+// app_id, which does NOT change — would otherwise keep replaying a
+// token Lark now rejects.
+func (c *httpAPIClient) InvalidateTokenCache(appID string) {
+	c.invalidateToken(appID)
+}
+
+// doAuthedJSON performs one tenant_access_token-authenticated call. When
+// Lark rejects the token itself, it drops the cached entry, mints a
+// fresh token and replays the request exactly once.
+//
+// Replaying is safe for every caller here: Lark rejects a bad token
+// during authentication, before the request is processed, so nothing was
+// delivered and the retry cannot duplicate a message. Without it the
+// refresh would only help the NEXT call and the reply that triggered it
+// would still be lost.
+//
+// Only token errors are retried. Business codes, 5xx and network
+// failures are returned untouched — those are either definitive or
+// ambiguous about delivery, and neither is fixed by a new token.
+func (c *httpAPIClient) doAuthedJSON(ctx context.Context, creds InstallationCredentials, method, path string, body, out any) error {
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return err
+	}
+	err = c.doJSON(ctx, c.resolveBaseURL(creds), method, path, token, body, out)
+	if !isTokenError(larkErrorCode(err)) {
+		return err
+	}
+	c.cfg.Logger.Warn("lark http client: tenant_access_token rejected; refreshing and retrying once",
+		"app_id", creds.AppID, "path", path, "err", err)
+	c.invalidateToken(creds.AppID)
+	fresh, refreshErr := c.tenantAccessToken(ctx, creds)
+	if refreshErr != nil {
+		return fmt.Errorf("%w (token refresh failed: %v)", err, refreshErr)
+	}
+	return c.doJSON(ctx, c.resolveBaseURL(creds), method, path, fresh, body, out)
+}
+
 // outboundMessageRequest builds the (path, body) the three send methods
 // share. When target.IsSet() the message is routed through Lark's reply
 // endpoint (POST /im/v1/messages/{message_id}/reply) so it threads back
@@ -303,10 +355,6 @@ func (c *httpAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 	if p.CardJSON == "" {
 		return "", errors.New("lark http client: missing card json")
 	}
-	token, err := c.tenantAccessToken(ctx, p.InstallationID)
-	if err != nil {
-		return "", err
-	}
 	path, body := outboundMessageRequest(p.ChatID, "interactive", p.CardJSON, p.ReplyTarget)
 	var resp struct {
 		Code int    `json:"code"`
@@ -315,7 +363,7 @@ func (c *httpAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 			MessageID string `json:"message_id"`
 		} `json:"data"`
 	}
-	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: send interactive card: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.MessageID == "" {
@@ -340,10 +388,6 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 	if p.Text == "" {
 		return "", errors.New("lark http client: missing text")
 	}
-	token, err := c.tenantAccessToken(ctx, p.InstallationID)
-	if err != nil {
-		return "", err
-	}
 	// Lark's `text` msg_type expects content = JSON-encoded {"text": "..."}.
 	// json.Marshal handles the escape of newlines / quotes / unicode so
 	// the agent's reply round-trips intact.
@@ -359,7 +403,7 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 			MessageID string `json:"message_id"`
 		} `json:"data"`
 	}
-	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: send text message: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.MessageID == "" {
@@ -393,10 +437,6 @@ func (c *httpAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCard
 	if p.Markdown == "" {
 		return "", errors.New("lark http client: missing markdown body")
 	}
-	token, err := c.tenantAccessToken(ctx, p.InstallationID)
-	if err != nil {
-		return "", err
-	}
 	card := map[string]any{
 		"schema": "2.0",
 		"body": map[string]any{
@@ -422,7 +462,7 @@ func (c *httpAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCard
 			MessageID string `json:"message_id"`
 		} `json:"data"`
 	}
-	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: send markdown card: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.MessageID == "" {
@@ -444,17 +484,13 @@ func (c *httpAPIClient) PatchInteractiveCard(ctx context.Context, p PatchCardPar
 	if p.CardJSON == "" {
 		return errors.New("lark http client: missing card json")
 	}
-	token, err := c.tenantAccessToken(ctx, p.InstallationID)
-	if err != nil {
-		return err
-	}
 	body := map[string]string{"content": p.CardJSON}
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
 	}
 	path := "/open-apis/im/v1/messages/" + url.PathEscape(p.LarkCardMessageID)
-	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPatch, path, token, body, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPatch, path, body, &resp); err != nil {
 		return fmt.Errorf("lark http client: patch interactive card: %w", err)
 	}
 	if resp.Code != 0 {
@@ -481,10 +517,6 @@ func (c *httpAPIClient) SendBindingPromptCard(ctx context.Context, p BindingProm
 	if err != nil {
 		return fmt.Errorf("lark http client: render binding prompt: %w", err)
 	}
-	token, err := c.tenantAccessToken(ctx, p.InstallationID)
-	if err != nil {
-		return err
-	}
 	q := url.Values{}
 	q.Set("receive_id_type", "open_id")
 	body := map[string]string{
@@ -497,7 +529,7 @@ func (c *httpAPIClient) SendBindingPromptCard(ctx context.Context, p BindingProm
 		Msg  string `json:"msg"`
 	}
 	path := "/open-apis/im/v1/messages?" + q.Encode()
-	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
 		return fmt.Errorf("lark http client: send binding prompt: %w", err)
 	}
 	if resp.Code != 0 {
@@ -542,10 +574,6 @@ func (c *httpAPIClient) GetBotInfo(ctx context.Context, creds InstallationCreden
 	if creds.AppID == "" || creds.AppSecret == "" {
 		return BotInfo{}, errors.New("lark http client: missing app credentials for GetBotInfo")
 	}
-	token, err := c.tenantAccessToken(ctx, creds)
-	if err != nil {
-		return BotInfo{}, err
-	}
 	var botResp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
@@ -553,7 +581,7 @@ func (c *httpAPIClient) GetBotInfo(ctx context.Context, creds InstallationCreden
 			OpenID string `json:"open_id"`
 		} `json:"bot"`
 	}
-	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, "/open-apis/bot/v3/info", token, nil, &botResp); err != nil {
+	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, "/open-apis/bot/v3/info", nil, &botResp); err != nil {
 		return BotInfo{}, fmt.Errorf("lark http client: bot info: %w", err)
 	}
 	if botResp.Code != 0 {
@@ -570,7 +598,7 @@ func (c *httpAPIClient) GetBotInfo(ctx context.Context, creds InstallationCreden
 	// return the BotInfo with empty UnionID. Callers (Registration-
 	// Service.finishSuccess) accept the gap and persist what they
 	// have.
-	unionID, lookupErr := c.fetchBotUnionID(ctx, c.resolveBaseURL(creds), creds.AppID, token, botResp.Bot.OpenID)
+	unionID, lookupErr := c.fetchBotUnionID(ctx, creds, botResp.Bot.OpenID)
 	if lookupErr != nil {
 		c.cfg.Logger.Warn("lark http client: bot union_id lookup failed; continuing without it",
 			"app_id", creds.AppID,
@@ -598,10 +626,6 @@ func (c *httpAPIClient) GetMessage(ctx context.Context, creds InstallationCreden
 	if messageID == "" {
 		return nil, errors.New("lark http client: missing message_id")
 	}
-	token, err := c.tenantAccessToken(ctx, creds)
-	if err != nil {
-		return nil, err
-	}
 	q := url.Values{}
 	q.Set("user_id_type", "open_id")
 	path := "/open-apis/im/v1/messages/" + url.PathEscape(messageID) + "?" + q.Encode()
@@ -613,7 +637,7 @@ func (c *httpAPIClient) GetMessage(ctx context.Context, creds InstallationCreden
 			Items []larkRESTMessageItem `json:"items"`
 		} `json:"data"`
 	}
-	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, path, token, nil, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
 		return nil, fmt.Errorf("lark http client: get message: %w", err)
 	}
 	if resp.Code != 0 {
@@ -657,10 +681,6 @@ func (c *httpAPIClient) ListChatMessages(ctx context.Context, creds Installation
 	} else if size > larkListMessagesMaxPageSize {
 		size = larkListMessagesMaxPageSize
 	}
-	token, err := c.tenantAccessToken(ctx, creds)
-	if err != nil {
-		return nil, err
-	}
 	q := url.Values{}
 	if p.ThreadID != "" {
 		// Topic-scoped window: only this 话题's messages, so a @-mention
@@ -689,7 +709,7 @@ func (c *httpAPIClient) ListChatMessages(ctx context.Context, creds Installation
 			Items []larkRESTMessageItem `json:"items"`
 		} `json:"data"`
 	}
-	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, path, token, nil, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
 		return nil, fmt.Errorf("lark http client: list chat messages: %w", err)
 	}
 	if resp.Code != 0 {
@@ -739,10 +759,6 @@ func (c *httpAPIClient) DownloadMessageResourceStream(ctx context.Context, creds
 	if p.FileKey == "" {
 		return DownloadedResourceStream{}, errors.New("lark http client: missing file_key")
 	}
-	token, err := c.tenantAccessToken(ctx, creds)
-	if err != nil {
-		return DownloadedResourceStream{}, err
-	}
 	q := url.Values{}
 	if p.Type != "" {
 		q.Set("type", p.Type)
@@ -752,6 +768,28 @@ func (c *httpAPIClient) DownloadMessageResourceStream(ctx context.Context, creds
 		path += "?" + encoded
 	}
 
+	// Same refresh-and-retry contract as doAuthedJSON: Lark rejects a bad
+	// token before it serves any bytes, so replaying the GET once cannot
+	// produce a half-downloaded resource.
+	for attempt := 0; ; attempt++ {
+		token, err := c.tenantAccessToken(ctx, creds)
+		if err != nil {
+			return DownloadedResourceStream{}, err
+		}
+		stream, err := c.downloadMessageResourceStreamOnce(ctx, creds, path, token)
+		if err == nil {
+			return stream, nil
+		}
+		if attempt > 0 || !isTokenError(larkErrorCode(err)) {
+			return DownloadedResourceStream{}, err
+		}
+		c.cfg.Logger.Warn("lark http client: tenant_access_token rejected on resource download; refreshing and retrying once",
+			"app_id", creds.AppID, "err", err)
+		c.invalidateToken(creds.AppID)
+	}
+}
+
+func (c *httpAPIClient) downloadMessageResourceStreamOnce(ctx context.Context, creds InstallationCredentials, path, token string) (DownloadedResourceStream, error) {
 	downloadCtx := ctx
 	var cancel context.CancelFunc
 	if c.cfg.ResourceDownloadTimeout > 0 {
@@ -788,7 +826,13 @@ func (c *httpAPIClient) DownloadMessageResourceStream(ctx context.Context, creds
 		if readErr != nil {
 			return DownloadedResourceStream{}, readErr
 		}
-		return DownloadedResourceStream{}, fmt.Errorf("lark http client: download resource: http %d: %s", resp.StatusCode, truncate(string(rawBody), 512))
+		code, msg := parseLarkErrorBody(rawBody)
+		return DownloadedResourceStream{}, fmt.Errorf("lark http client: download resource: %w", &larkAPIStatusError{
+			StatusCode: resp.StatusCode,
+			Code:       code,
+			Msg:        msg,
+			Raw:        truncate(string(rawBody), 512),
+		})
 	}
 	contentType := resp.Header.Get("Content-Type")
 	if strings.Contains(strings.ToLower(contentType), "json") {
@@ -802,9 +846,8 @@ func (c *httpAPIClient) DownloadMessageResourceStream(ctx context.Context, creds
 			Msg  string `json:"msg"`
 		}
 		if err := json.Unmarshal(rawBody, &apiResp); err == nil && apiResp.Code != 0 {
-			if isTokenError(apiResp.Code) {
-				c.invalidateToken(creds.AppID)
-			}
+			// Token invalidation is the retry loop's job in the caller —
+			// it owns both this shape and the non-2xx one.
 			return DownloadedResourceStream{}, &APIError{Op: "download resource", Code: apiResp.Code, Msg: apiResp.Msg}
 		}
 		return DownloadedResourceStream{
@@ -910,10 +953,6 @@ func (c *httpAPIClient) AddMessageReaction(ctx context.Context, p AddReactionPar
 	if p.EmojiType == "" {
 		return "", errors.New("lark http client: missing emoji_type")
 	}
-	token, err := c.tenantAccessToken(ctx, p.InstallationID)
-	if err != nil {
-		return "", err
-	}
 	body := map[string]any{
 		"reaction_type": map[string]string{"emoji_type": p.EmojiType},
 	}
@@ -925,7 +964,7 @@ func (c *httpAPIClient) AddMessageReaction(ctx context.Context, p AddReactionPar
 			ReactionID string `json:"reaction_id"`
 		} `json:"data"`
 	}
-	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodPost, path, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: add message reaction: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.ReactionID == "" {
@@ -946,16 +985,12 @@ func (c *httpAPIClient) DeleteMessageReaction(ctx context.Context, p DeleteReact
 	if p.ReactionID == "" {
 		return errors.New("lark http client: missing reaction_id")
 	}
-	token, err := c.tenantAccessToken(ctx, p.InstallationID)
-	if err != nil {
-		return err
-	}
 	path := "/open-apis/im/v1/messages/" + url.PathEscape(p.MessageID) + "/reactions/" + url.PathEscape(p.ReactionID)
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
 	}
-	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodDelete, path, token, nil, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, p.InstallationID, http.MethodDelete, path, nil, &resp); err != nil {
 		return fmt.Errorf("lark http client: delete message reaction: %w", err)
 	}
 	if resp.Code != 0 {
@@ -981,10 +1016,6 @@ func (c *httpAPIClient) BatchGetUsers(ctx context.Context, creds InstallationCre
 	if len(openIDs) > larkBatchGetUsersMaxIDs {
 		openIDs = openIDs[:larkBatchGetUsersMaxIDs]
 	}
-	token, err := c.tenantAccessToken(ctx, creds)
-	if err != nil {
-		return nil, err
-	}
 	q := url.Values{}
 	q.Set("user_id_type", "open_id")
 	for _, id := range openIDs {
@@ -1004,7 +1035,7 @@ func (c *httpAPIClient) BatchGetUsers(ctx context.Context, creds InstallationCre
 			} `json:"items"`
 		} `json:"data"`
 	}
-	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, path, token, nil, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
 		return nil, fmt.Errorf("lark http client: batch get users: %w", err)
 	}
 	if resp.Code != 0 {
@@ -1081,7 +1112,7 @@ func (it larkRESTMessageItem) normalize() LarkMessage {
 // scope is restricted. Caller logs and continues; the decoder still
 // works in single-bot deployments where open_id-based matching is
 // unambiguous.
-func (c *httpAPIClient) fetchBotUnionID(ctx context.Context, baseURL, appID, token, openID string) (string, error) {
+func (c *httpAPIClient) fetchBotUnionID(ctx context.Context, creds InstallationCredentials, openID string) (string, error) {
 	if openID == "" {
 		return "", errors.New("empty open_id")
 	}
@@ -1097,7 +1128,7 @@ func (c *httpAPIClient) fetchBotUnionID(ctx context.Context, baseURL, appID, tok
 			} `json:"user"`
 		} `json:"data"`
 	}
-	if err := c.doJSON(ctx, baseURL, http.MethodGet, path, token, nil, &resp); err != nil {
+	if err := c.doAuthedJSON(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
 		return "", fmt.Errorf("contact users: %w", err)
 	}
 	if resp.Code != 0 {
@@ -1106,7 +1137,7 @@ func (c *httpAPIClient) fetchBotUnionID(ctx context.Context, baseURL, appID, tok
 		// the bearer would do nothing and a stale token would keep
 		// being reused on every retry until natural TTL expiry.
 		if isTokenError(resp.Code) {
-			c.invalidateToken(appID)
+			c.invalidateToken(creds.AppID)
 		}
 		return "", fmt.Errorf("contact users: code=%d msg=%q", resp.Code, resp.Msg)
 	}
@@ -1148,7 +1179,17 @@ func (c *httpAPIClient) doJSON(ctx context.Context, baseURL, method, path, token
 		return fmt.Errorf("read body: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(rawBody), 512))
+		// Lark still reports its business code in the body of a non-2xx
+		// reply, so parse it instead of collapsing the response into an
+		// opaque transport error. Everything that classifies by code —
+		// token invalidation above all — is unreachable otherwise.
+		code, msg := parseLarkErrorBody(rawBody)
+		return &larkAPIStatusError{
+			StatusCode: resp.StatusCode,
+			Code:       code,
+			Msg:        msg,
+			Raw:        truncate(string(rawBody), 512),
+		}
 	}
 	if out != nil && len(rawBody) > 0 {
 		if err := json.Unmarshal(rawBody, out); err != nil {
@@ -1158,8 +1199,70 @@ func (c *httpAPIClient) doJSON(ctx context.Context, baseURL, method, path, token
 	return nil
 }
 
+// parseLarkErrorBody best-effort extracts Lark's {code, msg} envelope
+// from an error body. A body that is not JSON at all (a proxy's HTML
+// error page, an empty 502) yields 0 / "" — no code, nothing to
+// classify — which keeps such failures on the plain-transport path.
+func parseLarkErrorBody(raw []byte) (int, string) {
+	var env struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return 0, ""
+	}
+	return env.Code, env.Msg
+}
+
 func isTokenError(code int) bool {
-	return code == codeTokenExpired || code == codeTokenInvalid
+	return code == codeTenantTokenInvalid || code == codeAppTokenInvalid
+}
+
+// larkAPIStatusError is a Lark reply that failed with a NON-2xx HTTP
+// status. It carries the business code Lark put in the body, because
+// Lark reports authentication failures that way: an invalid or expired
+// tenant_access_token comes back as HTTP 400 with {"code":99991663},
+// not as a 2xx envelope (#7611). A client that only reads the body of
+// 2xx replies can therefore never notice its cached token died, and
+// replays the dead token until the process restarts.
+//
+// Code is 0 when the body carried no parsable Lark envelope.
+type larkAPIStatusError struct {
+	StatusCode int
+	Code       int
+	Msg        string
+	Raw        string
+}
+
+func (e *larkAPIStatusError) Error() string {
+	// Preserve the historical wording — operators grep their logs for it.
+	return fmt.Sprintf("http %d: %s", e.StatusCode, e.Raw)
+}
+
+// larkErrorCode digs the Lark business code out of err, from either
+// shape that carries one: a non-2xx reply (larkAPIStatusError) or a 2xx
+// envelope a call site rejected (APIError). Returns 0 for anything else,
+// including network failures and timeouts, so a code-keyed lookup on the
+// result never matches an ambiguous transport error.
+func larkErrorCode(err error) int {
+	code, _, _ := larkErrorCodeMsg(err)
+	return code
+}
+
+// larkErrorCodeMsg is larkErrorCode plus Lark's `msg` and whether err
+// carried a code at all. Classifiers that fall back to matching error
+// TEXT need the third result: "no code" and "code 0" must not both look
+// like a Lark verdict, or a gateway's HTML 502 would classify as one.
+func larkErrorCodeMsg(err error) (int, string, bool) {
+	var statusErr *larkAPIStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.Code, statusErr.Msg, statusErr.Code != 0
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Code, apiErr.Msg, apiErr.Code != 0
+	}
+	return 0, "", false
 }
 
 // APIError is a structured Lark business error: the request reached
@@ -1200,17 +1303,20 @@ var threadReplyUnsupportedCodes = map[int]struct{}{
 	230111: {}, // cannot reply to a self-destructing message
 }
 
-// isThreadReplyUnsupported reports whether err is a Lark APIError whose
-// code means the threaded reply cannot land on this target. Only such
-// errors are safe to retry at the chat level. Transport errors and
-// other business codes return false.
+// isThreadReplyUnsupported reports whether err carries a Lark business
+// code meaning the threaded reply cannot land on this target. Only such
+// errors are safe to retry at the chat level. Transport errors and other
+// business codes return false.
+//
+// The code is read through larkErrorCode, so it is found whether Lark
+// answered with a 2xx envelope or a non-2xx status — a definitive
+// "nothing was sent" verdict is equally definitive either way, and only
+// codes on the list get here. Errors with no Lark code (network failure,
+// timeout, a proxy's HTML 502) yield code 0, which is not on the list, so
+// ambiguous delivery still never triggers the fallback.
 func isThreadReplyUnsupported(err error) bool {
-	var apiErr *APIError
-	if errors.As(err, &apiErr) {
-		_, ok := threadReplyUnsupportedCodes[apiErr.Code]
-		return ok
-	}
-	return false
+	_, ok := threadReplyUnsupportedCodes[larkErrorCode(err)]
+	return ok
 }
 
 func truncate(s string, n int) string {

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -999,7 +999,7 @@ func TestHTTPClient_SendInteractiveCard_TokenExpired_InvalidatesCache(t *testing
 		fake.sendN.Add(1)
 		n := sendCalls.Add(1)
 		if n == 1 {
-			writeJSON(w, map[string]any{"code": codeTokenExpired, "msg": "expired"})
+			writeJSON(w, map[string]any{"code": codeTenantTokenInvalid, "msg": "expired"})
 			return
 		}
 		writeJSON(w, map[string]any{"code": 0, "data": map[string]string{"message_id": "om_ok"}})

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -234,6 +234,13 @@ func testCreds() InstallationCredentials {
 	return InstallationCredentials{AppID: "cli_app_xx", AppSecret: "secret_xx"}
 }
 
+func TestHTTPClient_IsConfigured(t *testing.T) {
+	c := NewHTTPAPIClient(HTTPClientConfig{})
+	if !c.IsConfigured() {
+		t.Fatalf("real client must report IsConfigured()=true")
+	}
+}
+
 func TestHTTPClient_DownloadMessageResource(t *testing.T) {
 	fake := newLarkFake(t)
 	fake.stubToken("tok_resource", 7200)
@@ -426,6 +433,16 @@ func TestHTTPClient_DownloadMessageResourceBusinessError(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "234003") {
 		t.Fatalf("expected APIError with code, got %v", err)
+	}
+}
+
+// TestHTTPClient_StubReportsNotConfigured pins that the stub never
+// claims wired outbound — handlers gate install / management UI on
+// this signal.
+func TestHTTPClient_StubReportsNotConfigured(t *testing.T) {
+	s := NewStubAPIClient(nil)
+	if s.IsConfigured() {
+		t.Errorf("stub IsConfigured must be false")
 	}
 }
 
@@ -982,7 +999,7 @@ func TestHTTPClient_SendInteractiveCard_TokenExpired_InvalidatesCache(t *testing
 		fake.sendN.Add(1)
 		n := sendCalls.Add(1)
 		if n == 1 {
-			writeJSON(w, map[string]any{"code": codeTenantTokenInvalid, "msg": "expired"})
+			writeJSON(w, map[string]any{"code": codeTokenExpired, "msg": "expired"})
 			return
 		}
 		writeJSON(w, map[string]any{"code": 0, "data": map[string]string{"message_id": "om_ok"}})
@@ -1087,6 +1104,36 @@ func TestHTTPClient_SendBindingPromptCard_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(capturedBody["content"], "去绑定") {
 		t.Errorf("binding card should carry the localized CTA: %q", capturedBody["content"])
+	}
+}
+
+func TestHTTPClient_SendBindingPromptCard_NoAvailabilityReturnsAPIError(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok_bind_no_avail", 7200)
+
+	fake.mux.HandleFunc("/open-apis/im/v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		fake.bindN.Add(1)
+		writeJSON(w, map[string]any{"code": 230013, "msg": "Bot has NO availability to this user.", "data": map[string]any{}})
+	})
+
+	c := newTestClient(fake, time.Now)
+	err := c.SendBindingPromptCard(context.Background(), BindingPromptParams{
+		InstallationID: testCreds(),
+		OpenID:         OpenID("ou_user_1"),
+		BindURL:        "https://multica.test/lark/bind?token=abc",
+	})
+	if err == nil {
+		t.Fatal("expected SendBindingPromptCard to fail")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.Code != 230013 {
+		t.Fatalf("expected code=230013, got %d", apiErr.Code)
+	}
+	if apiErr.Msg != "Bot has NO availability to this user." {
+		t.Fatalf("unexpected msg: %q", apiErr.Msg)
 	}
 }
 

--- a/server/internal/integrations/lark/outcome_replier.go
+++ b/server/internal/integrations/lark/outcome_replier.go
@@ -52,7 +52,7 @@ type noopReplier struct {
 
 func (n *noopReplier) Reply(ctx context.Context, inst Installation, msg InboundMessage, res DispatchResult) {
 	switch res.Outcome {
-	case OutcomeNeedsBinding, OutcomeAgentOffline, OutcomeAgentArchived, OutcomeFreshPending, OutcomeChatStarted, OutcomeIssueUsage, OutcomeIssueConfirmation:
+	case OutcomeNeedsBinding, OutcomeAgentOffline, OutcomeAgentArchived, OutcomeFreshPending, OutcomeChatStarted, OutcomeIssueUsage:
 		n.log.Warn("lark outcome replier: outbound reply skipped (replier not wired)",
 			"outcome", string(res.Outcome),
 			"installation_id", uuidString(inst.ID),
@@ -190,15 +190,6 @@ func (r *LarkOutcomeReplier) Reply(ctx context.Context, inst Installation, msg I
 	case OutcomeChatStarted:
 		if err := r.sendChatNotice(ctx, inst, msg, chatStartedCopy); err != nil {
 			r.log.Warn("lark outcome replier: new-chat confirmation failed", "installation_id", uuidString(inst.ID), "chat_id", string(msg.ChatID), "err", err.Error())
-		}
-	case OutcomeIssueConfirmation:
-		copy := issueConfirmationCopy(res.IssueTitle)
-		if err := r.sendChatNotice(ctx, inst, msg, copy); err != nil {
-			r.log.Warn("lark outcome replier: issue confirmation reply failed",
-				"installation_id", uuidString(inst.ID),
-				"chat_id", string(msg.ChatID),
-				"err", err.Error(),
-			)
 		}
 	case OutcomeIssueUsage:
 		copy := issueUsageCopy
@@ -339,14 +330,6 @@ func issueCreatedText(res DispatchResult, appURL string) string {
 		return line
 	}
 	return line + "\n" + strings.TrimRight(appURL, "/") + "/issues/" + identifier
-}
-
-func issueConfirmationCopy(title string) string {
-	title = strings.TrimSpace(title)
-	if title == "" {
-		return "我已识别到一个任务草稿。回复「确认」创建，或回复「取消」放弃。"
-	}
-	return fmt.Sprintf("我准备创建任务：%s\n回复「确认」创建，或回复「取消」放弃。", title)
 }
 
 func issueDuplicateText(res DispatchResult, appURL string) string {

--- a/server/internal/integrations/lark/outcome_replier.go
+++ b/server/internal/integrations/lark/outcome_replier.go
@@ -52,7 +52,7 @@ type noopReplier struct {
 
 func (n *noopReplier) Reply(ctx context.Context, inst Installation, msg InboundMessage, res DispatchResult) {
 	switch res.Outcome {
-	case OutcomeNeedsBinding, OutcomeAgentOffline, OutcomeAgentArchived, OutcomeFreshPending, OutcomeChatStarted, OutcomeIssueUsage:
+	case OutcomeNeedsBinding, OutcomeAgentOffline, OutcomeAgentArchived, OutcomeFreshPending, OutcomeChatStarted, OutcomeIssueUsage, OutcomeIssueConfirmation:
 		n.log.Warn("lark outcome replier: outbound reply skipped (replier not wired)",
 			"outcome", string(res.Outcome),
 			"installation_id", uuidString(inst.ID),
@@ -156,7 +156,7 @@ func NewLarkOutcomeReplier(cfg OutcomeReplierConfig) OutcomeReplier {
 func (r *LarkOutcomeReplier) Reply(ctx context.Context, inst Installation, msg InboundMessage, res DispatchResult) {
 	switch res.Outcome {
 	case OutcomeNeedsBinding:
-		if err := r.sendBindingPrompt(ctx, inst, res); err != nil {
+		if err := r.sendBindingPrompt(ctx, inst, msg, res); err != nil {
 			r.log.Warn("lark outcome replier: binding prompt failed",
 				"installation_id", uuidString(inst.ID),
 				"open_id", string(res.SenderOpenID),
@@ -191,6 +191,15 @@ func (r *LarkOutcomeReplier) Reply(ctx context.Context, inst Installation, msg I
 		if err := r.sendChatNotice(ctx, inst, msg, chatStartedCopy); err != nil {
 			r.log.Warn("lark outcome replier: new-chat confirmation failed", "installation_id", uuidString(inst.ID), "chat_id", string(msg.ChatID), "err", err.Error())
 		}
+	case OutcomeIssueConfirmation:
+		copy := issueConfirmationCopy(res.IssueTitle)
+		if err := r.sendChatNotice(ctx, inst, msg, copy); err != nil {
+			r.log.Warn("lark outcome replier: issue confirmation reply failed",
+				"installation_id", uuidString(inst.ID),
+				"chat_id", string(msg.ChatID),
+				"err", err.Error(),
+			)
+		}
 	case OutcomeIssueUsage:
 		copy := issueUsageCopy
 		if res.IssueUsageHadMedia {
@@ -223,7 +232,7 @@ func (r *LarkOutcomeReplier) Reply(ctx context.Context, inst Installation, msg I
 	}
 }
 
-func (r *LarkOutcomeReplier) sendBindingPrompt(ctx context.Context, inst Installation, res DispatchResult) error {
+func (r *LarkOutcomeReplier) sendBindingPrompt(ctx context.Context, inst Installation, msg InboundMessage, res DispatchResult) error {
 	if res.SenderOpenID == "" {
 		return errors.New("missing sender open_id")
 	}
@@ -239,11 +248,31 @@ func (r *LarkOutcomeReplier) sendBindingPrompt(ctx context.Context, inst Install
 	if err != nil {
 		return err
 	}
-	return r.client.SendBindingPromptCard(ctx, BindingPromptParams{
+	if err := r.client.SendBindingPromptCard(ctx, BindingPromptParams{
 		InstallationID: creds,
 		OpenID:         res.SenderOpenID,
 		BindURL:        bindURL,
-	})
+	}); err != nil {
+		if isBindingPromptUnavailable(err) {
+			if err := r.sendChatNotice(ctx, inst, msg, bindingPromptUnavailableCopy); err != nil {
+				return fmt.Errorf("send binding prompt fallback failed: %w", err)
+			}
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func isBindingPromptUnavailable(err error) bool {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Code == codeNoAvailability
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "no availability") {
+		return true
+	}
+	return false
 }
 
 // sendIssueOutcome posts either the created confirmation or active-duplicate
@@ -310,6 +339,14 @@ func issueCreatedText(res DispatchResult, appURL string) string {
 		return line
 	}
 	return line + "\n" + strings.TrimRight(appURL, "/") + "/issues/" + identifier
+}
+
+func issueConfirmationCopy(title string) string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return "我已识别到一个任务草稿。回复「确认」创建，或回复「取消」放弃。"
+	}
+	return fmt.Sprintf("我准备创建任务：%s\n回复「确认」创建，或回复「取消」放弃。", title)
 }
 
 func issueDuplicateText(res DispatchResult, appURL string) string {
@@ -411,10 +448,11 @@ func renderNoticeCard(header, body string) (string, error) {
 // match the §4.6 design: an offline agent will run when the daemon
 // comes back; an archived agent needs operator action.
 const (
-	agentOfflineCopy        = "Agent 当前离线，消息已记录。下次 daemon 上线后会自动继续处理。"
-	agentArchivedCopy       = "这个 Agent 已被归档，无法继续处理消息。请联系工作区管理员恢复或重新绑定。"
-	freshPendingCopy        = "✅ 已准备从空上下文运行。你的下一条聊天消息仍会进入当前对话，但不会带上之前的上下文。"
-	chatStartedCopy         = "✅ 已新建 Multica 对话。你的下一条消息会进入该对话。"
-	issueUsageCopy          = "请填写任务标题，格式如下：\n\n`/issue <标题>`\n`[描述]`（可选）"
-	issueUsageWithMediaCopy = "请添加标题，并与图片或视频一起重新发送（*图片或视频可以位于命令之前或之后*）：\n\n`/issue <标题>`\n`[描述]`（可选）"
+	agentOfflineCopy             = "Agent 当前离线，消息已记录。下次 daemon 上线后会自动继续处理。"
+	agentArchivedCopy            = "这个 Agent 已被归档，无法继续处理消息。请联系工作区管理员恢复或重新绑定。"
+	freshPendingCopy             = "✅ 已准备从空上下文运行。你的下一条聊天消息仍会进入当前对话，但不会带上之前的上下文。"
+	chatStartedCopy              = "✅ 已新建 Multica 对话。你的下一条消息会进入该对话。"
+	issueUsageCopy               = "请填写任务标题，格式如下：\n\n`/issue <标题>`\n`[描述]`（可选）"
+	issueUsageWithMediaCopy      = "请添加标题，并与图片或视频一起重新发送（*图片或视频可以位于命令之前或之后*）：\n\n`/issue <标题>`\n`[描述]`（可选）"
+	bindingPromptUnavailableCopy = "你还未绑定 Multica 账户，绑定卡片未能发送到你的私聊。\n请先与 Bot 建立私信后重试，或联系管理员检查机器人在该用户侧的可见性。"
 )

--- a/server/internal/integrations/lark/outcome_replier.go
+++ b/server/internal/integrations/lark/outcome_replier.go
@@ -244,9 +244,9 @@ func (r *LarkOutcomeReplier) sendBindingPrompt(ctx context.Context, inst Install
 		OpenID:         res.SenderOpenID,
 		BindURL:        bindURL,
 	}); err != nil {
-		if isBindingPromptUnavailable(err) {
-			if err := r.sendChatNotice(ctx, inst, msg, bindingPromptUnavailableCopy); err != nil {
-				return fmt.Errorf("send binding prompt fallback failed: %w", err)
+		if msg.ChatType == ChatTypeGroup && isBindingPromptUnavailable(err) {
+			if fallbackErr := r.sendChatNotice(ctx, inst, msg, bindingPromptUnavailableCopy); fallbackErr != nil {
+				return fmt.Errorf("send binding prompt fallback failed after private prompt unavailable: %v: %w", err, fallbackErr)
 			}
 			return nil
 		}
@@ -256,14 +256,7 @@ func (r *LarkOutcomeReplier) sendBindingPrompt(ctx context.Context, inst Install
 }
 
 func isBindingPromptUnavailable(err error) bool {
-	var apiErr *APIError
-	if errors.As(err, &apiErr) {
-		return apiErr.Code == codeNoAvailability
-	}
-	if strings.Contains(strings.ToLower(err.Error()), "no availability") {
-		return true
-	}
-	return false
+	return larkErrorCode(err) == codeNoAvailability
 }
 
 // sendIssueOutcome posts either the created confirmation or active-duplicate
@@ -437,5 +430,5 @@ const (
 	chatStartedCopy              = "✅ 已新建 Multica 对话。你的下一条消息会进入该对话。"
 	issueUsageCopy               = "请填写任务标题，格式如下：\n\n`/issue <标题>`\n`[描述]`（可选）"
 	issueUsageWithMediaCopy      = "请添加标题，并与图片或视频一起重新发送（*图片或视频可以位于命令之前或之后*）：\n\n`/issue <标题>`\n`[描述]`（可选）"
-	bindingPromptUnavailableCopy = "你还未绑定 Multica 账户，绑定卡片未能发送到你的私聊。\n请先与 Bot 建立私信后重试，或联系管理员检查机器人在该用户侧的可见性。"
+	bindingPromptUnavailableCopy = "你还未绑定 Multica 账户，绑定卡片未能发送到你的私聊。\n请先打开机器人对话并发送一条消息，再回到群里重试；仍失败请联系管理员检查应用可用范围。"
 )

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -73,10 +73,10 @@ func (s *stubAPIClientWithRecorder) SendMarkdownCard(ctx context.Context, p Send
 func (s *stubAPIClientWithRecorder) SendBindingPromptCard(ctx context.Context, p BindingPromptParams) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.bindingCalls = append(s.bindingCalls, p)
 	if s.bindingErr != nil {
 		return s.bindingErr
 	}
-	s.bindingCalls = append(s.bindingCalls, p)
 	return nil
 }
 
@@ -357,6 +357,81 @@ func TestLarkOutcomeReplierUsesAppURLForWebLinks(t *testing.T) {
 	}
 	if !strings.Contains(stub.textOut[0].Text, "https://app.multica.test/issues/MUL-42") {
 		t.Fatalf("issue-created text should use AppURL; got %q", stub.textOut[0].Text)
+	}
+}
+
+func TestLarkOutcomeReplierNeedsBindingFallsBackToGroupNoticeWhenPrivateUnavailable(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	stub := &stubAPIClientWithRecorder{
+		configured: true,
+		bindingErr: &APIError{
+			Op:   "send binding prompt",
+			Code: codeNoAvailability,
+			Msg:  "Bot has NO availability to this user.",
+		},
+	}
+	rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+		APIClient:   stub,
+		BindingSvc:  fakeBindingMinter{raw: "token"},
+		Credentials: stubCredentialsResolver{secret: "s"},
+		Queries:     stubReplierQueries{},
+		AppURL:      "https://multica.test",
+		Logger:      log,
+	})
+
+	inst := Installation{AppID: "cli_x"}
+	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
+	inst.WorkspaceID = mustUUID("33333333-3333-3333-3333-333333333333")
+	rep.Reply(context.Background(), inst, InboundMessage{ChatID: "oc_chat", SenderOpenID: "ou_user"},
+		DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.bindingCalls) != 1 {
+		t.Fatalf("expected one binding prompt attempt, got %d", len(stub.bindingCalls))
+	}
+	if got := stub.bindingCalls[0].OpenID; got != "ou_user" {
+		t.Fatalf("binding prompt should target sender open_id; got %q", got)
+	}
+	if len(stub.interactiveOut) != 1 {
+		t.Fatalf("expected one fallback card, got %d", len(stub.interactiveOut))
+	}
+	if !strings.Contains(stub.interactiveOut[0].CardJSON, "绑定卡片未能发送到你的私聊") {
+		t.Fatalf("fallback card should contain private-send-unavailable guidance: %q", stub.interactiveOut[0].CardJSON)
+	}
+}
+
+func TestLarkOutcomeReplierNeedsBindingDoesNotFallbackForNonAvailabilityError(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	stub := &stubAPIClientWithRecorder{
+		configured: true,
+		bindingErr: &APIError{
+			Op:   "send binding prompt",
+			Code: 230002,
+			Msg:  "some other business error",
+		},
+	}
+	rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+		APIClient:   stub,
+		BindingSvc:  fakeBindingMinter{raw: "token"},
+		Credentials: stubCredentialsResolver{secret: "s"},
+		Queries:     stubReplierQueries{},
+		AppURL:      "https://multica.test",
+		Logger:      log,
+	})
+
+	rep.Reply(context.Background(), Installation{}, InboundMessage{ChatID: "oc_chat", SenderOpenID: "ou_user"},
+		DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.bindingCalls) != 1 {
+		t.Fatalf("expected one binding prompt attempt, got %d", len(stub.bindingCalls))
+	}
+	if len(stub.interactiveOut) != 0 {
+		t.Fatalf("did not expect fallback card on unrelated binding error, got %d", len(stub.interactiveOut))
 	}
 }
 

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -383,7 +383,7 @@ func TestLarkOutcomeReplierNeedsBindingFallsBackToGroupNoticeWhenPrivateUnavaila
 	inst := Installation{AppID: "cli_x"}
 	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
 	inst.WorkspaceID = mustUUID("33333333-3333-3333-3333-333333333333")
-	rep.Reply(context.Background(), inst, InboundMessage{ChatID: "oc_chat", SenderOpenID: "ou_user"},
+	rep.Reply(context.Background(), inst, InboundMessage{ChatID: "oc_chat", ChatType: ChatTypeGroup, SenderOpenID: "ou_user"},
 		DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
 
 	stub.mu.Lock()
@@ -397,8 +397,154 @@ func TestLarkOutcomeReplierNeedsBindingFallsBackToGroupNoticeWhenPrivateUnavaila
 	if len(stub.interactiveOut) != 1 {
 		t.Fatalf("expected one fallback card, got %d", len(stub.interactiveOut))
 	}
-	if !strings.Contains(stub.interactiveOut[0].CardJSON, "绑定卡片未能发送到你的私聊") {
+	if !strings.Contains(stub.interactiveOut[0].CardJSON, "请先打开机器人对话并发送一条消息，再回到群里重试") {
 		t.Fatalf("fallback card should contain private-send-unavailable guidance: %q", stub.interactiveOut[0].CardJSON)
+	}
+}
+
+func TestLarkOutcomeReplierNeedsBindingFallsBackForStatusErrorNoAvailabilityCode(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	stub := &stubAPIClientWithRecorder{
+		configured: true,
+		bindingErr: &larkAPIStatusError{
+			StatusCode: 400,
+			Code:       codeNoAvailability,
+			Msg:        "localized or otherwise arbitrary copy",
+			Raw:        `{"code":230013,"msg":"localized or otherwise arbitrary copy"}`,
+		},
+	}
+	inst := Installation{AppID: "cli_x"}
+	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
+	inst.WorkspaceID = mustUUID("33333333-3333-3333-3333-333333333333")
+	rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+		APIClient:   stub,
+		BindingSvc:  fakeBindingMinter{raw: "token"},
+		Credentials: stubCredentialsResolver{secret: "s"},
+		Queries:     stubReplierQueries{},
+		AppURL:      "https://multica.test",
+		Logger:      log,
+	})
+
+	rep.Reply(context.Background(), inst, InboundMessage{ChatID: "oc_chat", ChatType: ChatTypeGroup, SenderOpenID: "ou_user"},
+		DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.bindingCalls) != 1 {
+		t.Fatalf("expected one binding prompt attempt, got %d", len(stub.bindingCalls))
+	}
+	if len(stub.interactiveOut) != 1 {
+		t.Fatalf("expected one fallback card, got %d", len(stub.interactiveOut))
+	}
+}
+
+func TestLarkOutcomeReplierNeedsBindingDoesNotFallbackForUnstructuredNoAvailabilityText(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	stub := &stubAPIClientWithRecorder{
+		configured: true,
+		bindingErr: errors.New("proxy reported no availability while retrying"),
+	}
+	rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+		APIClient:   stub,
+		BindingSvc:  fakeBindingMinter{raw: "token"},
+		Credentials: stubCredentialsResolver{secret: "s"},
+		Queries:     stubReplierQueries{},
+		AppURL:      "https://multica.test",
+		Logger:      log,
+	})
+
+	rep.Reply(context.Background(), Installation{}, InboundMessage{ChatID: "oc_chat", ChatType: ChatTypeGroup, SenderOpenID: "ou_user"},
+		DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.bindingCalls) != 1 {
+		t.Fatalf("expected one binding prompt attempt, got %d", len(stub.bindingCalls))
+	}
+	if len(stub.interactiveOut) != 0 {
+		t.Fatalf("did not expect fallback card on unstructured error text, got %d", len(stub.interactiveOut))
+	}
+}
+
+func TestLarkOutcomeReplierNeedsBindingSuppressesFallbackOutsideGroupChats(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		chatType ChatType
+	}{
+		{name: "p2p", chatType: ChatTypeP2P},
+		{name: "unspecified", chatType: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			log := slog.New(slog.NewTextHandler(io.Discard, nil))
+			stub := &stubAPIClientWithRecorder{
+				configured: true,
+				bindingErr: &APIError{
+					Op:   "send binding prompt",
+					Code: codeNoAvailability,
+					Msg:  "Bot has no availability to this user.",
+				},
+			}
+			rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+				APIClient:   stub,
+				BindingSvc:  fakeBindingMinter{raw: "token"},
+				Credentials: stubCredentialsResolver{secret: "s"},
+				Queries:     stubReplierQueries{},
+				AppURL:      "https://multica.test",
+				Logger:      log,
+			})
+
+			rep.Reply(context.Background(), Installation{}, InboundMessage{ChatID: "oc_chat", ChatType: tc.chatType, SenderOpenID: "ou_user"},
+				DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
+
+			stub.mu.Lock()
+			defer stub.mu.Unlock()
+			if len(stub.bindingCalls) != 1 {
+				t.Fatalf("expected one binding prompt attempt, got %d", len(stub.bindingCalls))
+			}
+			if len(stub.interactiveOut) != 0 {
+				t.Fatalf("did not expect fallback card outside group chat, got %d", len(stub.interactiveOut))
+			}
+		})
+	}
+}
+
+func TestLarkOutcomeReplierNeedsBindingPreservesPromptAndFallbackErrors(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bindingErr := &APIError{Op: "send binding prompt", Code: codeNoAvailability, Msg: "private unavailable"}
+	fallbackErr := errors.New("fallback send failed")
+	stub := &stubAPIClientWithRecorder{
+		configured: true,
+		bindingErr: bindingErr,
+		sendErr:    fallbackErr,
+	}
+	inst := Installation{AppID: "cli_x"}
+	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
+	inst.WorkspaceID = mustUUID("33333333-3333-3333-3333-333333333333")
+	rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+		APIClient:   stub,
+		BindingSvc:  fakeBindingMinter{raw: "token"},
+		Credentials: stubCredentialsResolver{secret: "s"},
+		Queries:     stubReplierQueries{},
+		AppURL:      "https://multica.test",
+		Logger:      log,
+	})
+
+	err := rep.(*LarkOutcomeReplier).sendBindingPrompt(context.Background(), inst, InboundMessage{ChatID: "oc_chat", ChatType: ChatTypeGroup, SenderOpenID: "ou_user"},
+		DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
+	if err == nil {
+		t.Fatal("expected fallback failure")
+	}
+	if !strings.Contains(err.Error(), bindingErr.Error()) {
+		t.Fatalf("error should preserve original binding failure %q, got %q", bindingErr.Error(), err.Error())
+	}
+	if !errors.Is(err, fallbackErr) {
+		t.Fatalf("error should wrap fallback failure; got %v", err)
 	}
 }
 
@@ -422,7 +568,7 @@ func TestLarkOutcomeReplierNeedsBindingDoesNotFallbackForNonAvailabilityError(t 
 		Logger:      log,
 	})
 
-	rep.Reply(context.Background(), Installation{}, InboundMessage{ChatID: "oc_chat", SenderOpenID: "ou_user"},
+	rep.Reply(context.Background(), Installation{}, InboundMessage{ChatID: "oc_chat", ChatType: ChatTypeGroup, SenderOpenID: "ou_user"},
 		DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
 
 	stub.mu.Lock()


### PR DESCRIPTION
## What does this PR do?

When Lark users trigger a binding flow in group chat, if the bot cannot send the private binding card because the user has no chat availability (error 230013), the bot previously returned silently after @ mention with no feedback.

This PR makes that failure user-visible by sending a group fallback notice in this specific availability-only case, while preserving existing behavior for other errors.

## Related Issue

Closes #8062

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- server/internal/integrations/lark/http_client.go: return structured APIError with code for binding prompt failures.
- server/internal/integrations/lark/http_client_test.go: add regression test for 230013 mapping.
- server/internal/integrations/lark/outcome_replier.go: detect private-card unavailability and fallback to group notice for this case only.
- server/internal/integrations/lark/outcome_replier_test.go: add tests for fallback and non-fallback branches.

## How to Test

1. Run targeted Go tests under server/internal/integrations/lark.
2. Validate:
   - 230013 sending binding prompt -> private attempt + group fallback notice.
   - other API errors -> no fallback notice.

## Risks

- Only changes user-facing behavior for Lark binding failures; no schema/migration changes.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Implemented from issue reproduction + code-path audit, then added regression tests and tuned handling to isolate fallback condition.