### PR TITLE
MUL-7077: fix(inbox): narrow default list width to 280px

### DIFF
--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -878,7 +878,7 @@ export function InboxPage() {
   if (viewLoading) {
     return (
       <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
-        <ResizablePanel id="list" defaultSize={320} minSize={240} maxSize={480} groupResizeBehavior="preserve-pixel-size">
+        <ResizablePanel id="list" defaultSize={280} minSize={240} maxSize={480} groupResizeBehavior="preserve-pixel-size">
           <div className="flex flex-col border-r h-full">
             <div className={cn("flex h-12 shrink-0 items-center border-b", PAGE_GUTTER)}>
               <Skeleton className="h-5 w-16" />
@@ -909,7 +909,7 @@ export function InboxPage() {
 
   return (
     <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
-      <ResizablePanel id="list" defaultSize={320} minSize={240} maxSize={480} groupResizeBehavior="preserve-pixel-size">
+      <ResizablePanel id="list" defaultSize={280} minSize={240} maxSize={480} groupResizeBehavior="preserve-pixel-size">
       <div className="flex flex-col border-r h-full">
         {listPanel}
       </div>


### PR DESCRIPTION
Inbox's 320px default list takes roughly a third of the content area at the default 1280px desktop window width. Reduce it to 280px in both the loading and loaded layouts, giving the detail pane 40px more space on Web and Desktop.

Keep the 240–480px resize bounds and existing saved layouts. Saved splits contain only percentages, so they cannot reliably distinguish an old default from a user's preferred width; this change applies when no saved layout exists.

Validation: InboxPage suite passed (39 tests); git diff --check passed. The preceding investigation measured the 280px split in a 1280×800 browser viewport. No new visual check was performed in this change.

Closes MUL-7077
