### PR TITLE
MUL-7085: fix(chat): publish cancellation events when archiving agents

### DIFF
--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -2429,9 +2429,9 @@ func (h *Handler) ArchiveAgent(w http.ResponseWriter, r *http.Request) {
 
 	// Cancel all pending/active tasks for this agent. The cancel and its
 	// delegated-failure settlement commit together — a settlement issued after
-	// the cancel committed could never be repaired. Per-task task:cancelled
-	// events are still skipped: the agent:archived event below already triggers
-	// a full active-tasks invalidation on every connected client.
+	// the cancel committed could never be repaired. Chat tasks publish
+	// task:cancelled after commit for chat lifecycle consumers; the aggregate
+	// agent:archived event below remains unchanged.
 	if cancelled, err := h.TaskService.CancelTasksForArchivedAgent(r.Context(), agent.ID); err != nil {
 		slog.Warn("cancel agent tasks on archive failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 	} else {

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -2432,10 +2432,8 @@ func (h *Handler) ArchiveAgent(w http.ResponseWriter, r *http.Request) {
 	// the cancel committed could never be repaired. Chat tasks publish
 	// task:cancelled after commit for chat lifecycle consumers; the aggregate
 	// agent:archived event below remains unchanged.
-	if cancelled, err := h.TaskService.CancelTasksForArchivedAgent(r.Context(), agent.ID); err != nil {
+	if _, err := h.TaskService.CancelTasksForArchivedAgent(r.Context(), agent.ID); err != nil {
 		slog.Warn("cancel agent tasks on archive failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
-	} else {
-		h.TaskService.CaptureCancelledTasks(r.Context(), cancelled)
 	}
 
 	wsID := uuidToString(archived.WorkspaceID)

--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -264,14 +264,12 @@ func (p *Patcher) SetTypingIndicatorManager(m *TypingIndicatorManager) {
 //     BroadcastCancelledTasks resolved each task's workspace through its
 //     chat_session, the same row its transaction had just deleted, and an
 //     event with no workspace is dropped before it reaches the bus. It now
-//     takes the workspace from its caller. Two holes are left, neither of
-//     them a missing subscription: archiving an agent stays silent by
-//     choice — agent:archived invalidates every client's task list
-//     instead — and no list refresh removes a Lark reaction; and an
-//     ending that arrives while the reaction is still being added clears
+//     takes the workspace from its caller. Archiving an agent also publishes
+//     task:cancelled for chat tasks after commit, clearing their reactions
+//     through this subscription. An ending during Add can still clear
 //     nothing, because Add records its state only after the Lark call
 //     returns, so the badge lands after the clear with nothing left to
-//     take it off. That second one predates task:cancelled — chat-done
+//     take it off. This race predates task:cancelled — chat-done
 //     and task-failed race the add the same way — and closing it needs a
 //     per-session generation the add can check when its call returns.
 //

--- a/server/internal/integrations/slack/typing_indicator.go
+++ b/server/internal/integrations/slack/typing_indicator.go
@@ -230,15 +230,10 @@ func (m *TypingIndicatorManager) apiForInstallation(ctx context.Context, id pgty
 // just deleted, and an event with no workspace is dropped before it reaches the
 // bus. It now takes the workspace from its caller.
 //
-// Two holes are left, and neither is a missing subscription.
+// Archiving an agent also publishes task:cancelled for its chat tasks after
+// commit, so these reactions are cleared through the same subscription.
 //
-// Archiving an agent cancels its tasks without broadcasting per row, on the
-// grounds that the agent:archived event already invalidates every client's task
-// list (handler/agent.go, ArchiveAgent). No client-side list refresh takes a
-// reaction off a Slack message, so archiving an agent mid-run leaves the 👀 in
-// place.
-//
-// And an ending that arrives while the reaction is still being added clears
+// An ending during Add can still clear
 // nothing: Add records its state only after the Slack call returns, so Clear
 // finds an empty map, and the reaction lands after it with nothing left to take
 // it off. The Router adds on a detached goroutine, so a cancelled or very fast

--- a/server/internal/integrations/slack/typing_indicator_archive_test.go
+++ b/server/internal/integrations/slack/typing_indicator_archive_test.go
@@ -1,0 +1,115 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/slack-go/slack"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// The task-state and transaction matrix lives in service/task_archive_cancel_test.go.
+// This regression follows one archive through the real bus subscriber and Slack
+// SDK, replacing only Slack's HTTP endpoint with a local server.
+func TestTypingIndicator_ArchiveRemovesSlackReaction(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	f := testutil.New(pool, "", "")
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	f.UserID = f.User(t, "Archive reaction test", "archive-reaction-"+suffix+"@example.test")
+	f.WorkspaceID = f.Workspace(t, "Archive reaction test", "archive-reaction-"+suffix)
+	f.Member(t, f.WorkspaceID, f.UserID, "owner")
+	runtimeID := f.Runtime(t, "Archive reaction test")
+	agentID := f.Agent(t, "Archive reaction test", runtimeID)
+	sessionID := f.ChatSession(t, agentID)
+	taskID := f.Task(t, agentID, testutil.Cols{
+		"chat_session_id": sessionID, "status": "running", "runtime_id": runtimeID,
+	})
+	installationID := f.Insert(t, "channel_installation", testutil.Cols{
+		"workspace_id": f.WorkspaceID, "agent_id": agentID, "channel_type": "slack",
+		"installer_user_id": f.UserID, "config": slackInstallConfigJSON(), "status": "active",
+	})
+	const channelID = "C_ARCHIVE_TEST"
+	ts := freshTS()
+	f.Insert(t, "channel_chat_session_binding", testutil.Cols{
+		"chat_session_id": sessionID, "installation_id": installationID, "channel_type": "slack",
+		"channel_chat_id": channelID, "chat_type": "group", "last_message_id": ts,
+	})
+	q := db.New(pool)
+	inst, err := q.GetChannelInstallation(ctx, db.GetChannelInstallationParams{
+		ID: util.MustParseUUID(installationID), ChannelType: "slack",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type reactionCall struct{ path, channel, timestamp, name string }
+	var mu sync.Mutex
+	var calls []reactionCall
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Error(err)
+		}
+		mu.Lock()
+		calls = append(calls, reactionCall{r.URL.Path, r.FormValue("channel"), r.FormValue("timestamp"), r.FormValue("name")})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(apiServer.Close)
+	manager := NewTypingIndicatorManager(q, nil, nil)
+	manager.newAPI = func(c credentials) reactionAPI {
+		return slack.New(c.BotToken, slack.OptionAPIURL(apiServer.URL+"/"), slack.OptionHTTPClient(apiServer.Client()))
+	}
+	bus := events.New()
+	manager.Register(bus)
+	manager.Add(ctx, inst, util.MustParseUUID(sessionID), channelID, ts)
+	mu.Lock()
+	added := append([]reactionCall(nil), calls...)
+	mu.Unlock()
+	if len(added) != 1 || added[0] != (reactionCall{"/reactions.add", channelID, ts, typingEmoji}) {
+		t.Fatalf("fixture must add the processing reaction through Slack HTTP: %+v", added)
+	}
+
+	// ArchiveAgent commits before the handler calls CancelTasksForArchivedAgent.
+	if _, err := q.ArchiveAgent(ctx, db.ArchiveAgentParams{
+		ID: util.MustParseUUID(agentID), ArchivedBy: util.MustParseUUID(f.UserID),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	svc := &service.TaskService{Queries: q, TxStarter: pool, Bus: bus}
+	if _, err := svc.CancelTasksForArchivedAgent(ctx, util.MustParseUUID(agentID)); err != nil {
+		t.Fatal(err)
+	}
+	var status string
+	f.QueryRow(t, "SELECT status FROM agent_task_queue WHERE id=$1", taskID).Scan(&status)
+	if status != "cancelled" {
+		t.Fatalf("task status = %q, want cancelled", status)
+	}
+	mu.Lock()
+	got := append([]reactionCall(nil), calls...)
+	mu.Unlock()
+	if len(got) != 2 || got[1] != (reactionCall{"/reactions.remove", channelID, ts, typingEmoji}) {
+		t.Fatalf("archived task is cancelled, but Slack must remove its processing reaction: %+v", got)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -5808,13 +5808,22 @@ func (s *TaskService) RecoverOrphanedTasksForRuntime(ctx context.Context, runtim
 // CancelTasksForArchivedAgent cancels every active task belonging to an agent
 // being archived and settles their recovery receipts in the same transaction.
 //
-// Unlike CancelTasksForAgent it emits no per-task task:cancelled event: the
-// agent:archived event the caller publishes already invalidates every client's
-// active-task view, so per-row events would be redundant noise.
+// After commit, chat tasks emit task:cancelled so existing consumers can clear
+// processing indicators, release streams, and refresh chat state. The caller
+// still publishes agent:archived; non-chat tasks keep their existing behavior.
 func (s *TaskService) CancelTasksForArchivedAgent(ctx context.Context, agentID pgtype.UUID) ([]db.AgentTaskQueue, error) {
-	return s.terminateTasksInTx(ctx, func(qtx *db.Queries) ([]db.AgentTaskQueue, error) {
+	cancelled, err := s.terminateTasksInTx(ctx, func(qtx *db.Queries) ([]db.AgentTaskQueue, error) {
 		return qtx.CancelAgentTasksByAgent(ctx, agentID)
 	})
+	if err != nil {
+		return nil, err
+	}
+	for _, task := range cancelled {
+		if task.ChatSessionID.Valid {
+			s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, task)
+		}
+	}
+	return cancelled, nil
 }
 
 func (s *TaskService) terminateTasksInTx(ctx context.Context, fail func(*db.Queries) ([]db.AgentTaskQueue, error)) ([]db.AgentTaskQueue, error) {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -5808,9 +5808,10 @@ func (s *TaskService) RecoverOrphanedTasksForRuntime(ctx context.Context, runtim
 // CancelTasksForArchivedAgent cancels every active task belonging to an agent
 // being archived and settles their recovery receipts in the same transaction.
 //
-// After commit, chat tasks emit task:cancelled so existing consumers can clear
-// processing indicators, release streams, and refresh chat state. The caller
-// still publishes agent:archived; non-chat tasks keep their existing behavior.
+// After commit, cancellation side effects are captured before chat tasks emit
+// task:cancelled so existing consumers can clear processing indicators, release
+// streams, and refresh chat state. The caller still publishes agent:archived;
+// non-chat tasks keep their existing behavior.
 func (s *TaskService) CancelTasksForArchivedAgent(ctx context.Context, agentID pgtype.UUID) ([]db.AgentTaskQueue, error) {
 	cancelled, err := s.terminateTasksInTx(ctx, func(qtx *db.Queries) ([]db.AgentTaskQueue, error) {
 		return qtx.CancelAgentTasksByAgent(ctx, agentID)
@@ -5818,6 +5819,7 @@ func (s *TaskService) CancelTasksForArchivedAgent(ctx context.Context, agentID p
 	if err != nil {
 		return nil, err
 	}
+	s.CaptureCancelledTasks(ctx, cancelled)
 	for _, task := range cancelled {
 		if task.ChatSessionID.Valid {
 			s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, task)

--- a/server/internal/service/task_archive_cancel_test.go
+++ b/server/internal/service/task_archive_cancel_test.go
@@ -1,0 +1,221 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+func newArchiveCancelFixture(t *testing.T) (*testutil.Fixture, string, string) {
+	t.Helper()
+	fx := testutil.New(newCancelFinalizePool(t), "", "")
+	suffix := time.Now().UnixNano()
+	fx.UserID = fx.User(t, "Archive cancellation", fmt.Sprintf("archive-cancel-%d@multica.test", suffix))
+	fx.WorkspaceID = fx.Workspace(t, "Archive cancellation", fmt.Sprintf("archive-cancel-%d", suffix))
+	fx.Member(t, fx.WorkspaceID, fx.UserID, "owner")
+	runtimeID := fx.Runtime(t, "Archive cancellation runtime")
+	agentID := fx.Agent(t, "Archived agent", runtimeID)
+	return fx, agentID, runtimeID
+}
+
+func TestCancelTasksForArchivedAgentPublishesCommittedChatCancellations(t *testing.T) {
+	ctx := context.Background()
+	fx, agentID, runtimeID := newArchiveCancelFixture(t)
+	chatByTask := make(map[string]string)
+	for _, status := range []string{"queued", "dispatched", "running", "waiting_local_directory", "deferred"} {
+		// No channel binding: the lifecycle notification applies to every chat.
+		chatID := fx.ChatSession(t, agentID)
+		taskID := fx.Task(t, agentID, testutil.Cols{
+			"chat_session_id": chatID,
+			"runtime_id":      runtimeID,
+			"status":          status,
+		})
+		chatByTask[taskID] = chatID
+	}
+	issueID := fx.Issue(t, "Issue task remains part of bulk cancellation")
+	issueTaskID := fx.Task(t, agentID, testutil.Cols{
+		"issue_id": issueID, "runtime_id": runtimeID, "status": "running",
+	})
+	unchanged := make(map[string]string)
+	for _, status := range []string{"completed", "failed", "cancelled"} {
+		unchanged[fx.Task(t, agentID, testutil.Cols{
+			"chat_session_id": fx.ChatSession(t, agentID),
+			"runtime_id":      runtimeID,
+			"status":          status,
+		})] = status
+	}
+	otherAgentID := fx.Agent(t, "Other agent", runtimeID)
+	unchanged[fx.Task(t, otherAgentID, testutil.Cols{
+		"chat_session_id": fx.ChatSession(t, otherAgentID),
+		"runtime_id":      runtimeID,
+		"status":          "running",
+	})] = "running"
+
+	// Hold a separate connection before cancellation starts, so the observer
+	// cannot reuse the transaction connection or see its uncommitted writes.
+	observer, err := fx.Pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire event observer: %v", err)
+	}
+	defer observer.Release()
+	bus := events.New()
+	seen := make(map[string]int)
+	bus.Subscribe(protocol.EventTaskCancelled, func(e events.Event) {
+		seen[e.TaskID]++
+		chatID, ok := chatByTask[e.TaskID]
+		if !ok {
+			t.Errorf("unexpected cancellation event for task %q", e.TaskID)
+			return
+		}
+		if e.WorkspaceID != fx.WorkspaceID || e.ChatSessionID != chatID || e.ActorType != "system" {
+			t.Errorf("task %s event scope = workspace %q chat %q actor %q", e.TaskID, e.WorkspaceID, e.ChatSessionID, e.ActorType)
+		}
+		payload, ok := e.Payload.(map[string]any)
+		if !ok {
+			t.Errorf("task %s payload type = %T, want map[string]any", e.TaskID, e.Payload)
+			return
+		}
+		for key, want := range map[string]any{
+			"task_id": e.TaskID, "agent_id": agentID, "chat_session_id": chatID,
+			"issue_id": "", "status": "cancelled",
+		} {
+			if got := payload[key]; got != want {
+				t.Errorf("task %s payload[%q] = %v, want %v", e.TaskID, key, got, want)
+			}
+		}
+		var status string
+		if err := observer.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, e.TaskID).Scan(&status); err != nil {
+			t.Errorf("read cancellation from event observer: %v", err)
+		} else if status != "cancelled" {
+			t.Errorf("task %s event arrived before cancellation committed: status = %q", e.TaskID, status)
+		}
+	})
+	svc := NewTaskService(db.New(fx.Pool), fx.Pool, nil, bus)
+	cancelled, err := svc.CancelTasksForArchivedAgent(ctx, util.MustParseUUID(agentID))
+	if err != nil {
+		t.Fatalf("cancel archived agent tasks: %v", err)
+	}
+	if len(cancelled) != len(chatByTask)+1 {
+		t.Errorf("cancelled rows = %d, want %d chat and issue tasks", len(cancelled), len(chatByTask)+1)
+	}
+	returned := make(map[string]int)
+	for _, task := range cancelled {
+		id := util.UUIDToString(task.ID)
+		returned[id]++
+		if _, ok := chatByTask[id]; !ok && id != issueTaskID {
+			t.Errorf("unexpected cancelled row %s", id)
+		}
+		if task.Status != "cancelled" {
+			t.Errorf("returned task %s status = %q, want cancelled", id, task.Status)
+		}
+	}
+	for taskID := range chatByTask {
+		if returned[taskID] != 1 || seen[taskID] != 1 {
+			t.Errorf("chat task %s: returned %d times, published %d times; want one each", taskID, returned[taskID], seen[taskID])
+		}
+	}
+	if returned[issueTaskID] != 1 || seen[issueTaskID] != 0 {
+		t.Errorf("issue task: returned %d times, published %d times; want one row and no task event", returned[issueTaskID], seen[issueTaskID])
+	}
+	if len(seen) != len(chatByTask) {
+		t.Errorf("distinct event tasks = %d, want %d", len(seen), len(chatByTask))
+	}
+	for taskID := range returned {
+		unchanged[taskID] = "cancelled"
+	}
+	for taskID, want := range unchanged {
+		var status string
+		if err := observer.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status); err != nil {
+			t.Fatalf("read task %s: %v", taskID, err)
+		}
+		if status != want {
+			t.Errorf("task %s persisted status = %q, want %q", taskID, status, want)
+		}
+	}
+
+	beforeRepeat := make(map[string]int, len(seen))
+	for taskID, count := range seen {
+		beforeRepeat[taskID] = count
+	}
+	cancelled, err = svc.CancelTasksForArchivedAgent(ctx, util.MustParseUUID(agentID))
+	if err != nil || len(cancelled) != 0 {
+		t.Fatalf("repeat cancellation: rows = %d, error = %v; want no rows and no error", len(cancelled), err)
+	}
+	if len(seen) != len(beforeRepeat) {
+		t.Error("repeat cancellation published events for additional tasks")
+	}
+	for taskID, count := range seen {
+		if count != beforeRepeat[taskID] {
+			t.Errorf("repeat cancellation published another event for task %s", taskID)
+		}
+	}
+}
+
+type archiveCancelRejectCommit struct {
+	pool             *pgxpool.Pool
+	taskID           string
+	err              error
+	statusBeforeFail string
+}
+
+func (s *archiveCancelRejectCommit) Begin(ctx context.Context) (pgx.Tx, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &archiveCancelRejectCommitTx{Tx: tx, starter: s}, nil
+}
+
+type archiveCancelRejectCommitTx struct {
+	pgx.Tx
+	starter *archiveCancelRejectCommit
+}
+
+func (tx *archiveCancelRejectCommitTx) Commit(ctx context.Context) error {
+	if err := tx.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, tx.starter.taskID).Scan(&tx.starter.statusBeforeFail); err != nil {
+		return err
+	}
+	if err := tx.Tx.Rollback(ctx); err != nil {
+		return err
+	}
+	return tx.starter.err
+}
+
+func TestCancelTasksForArchivedAgentCommitFailureDoesNotPublish(t *testing.T) {
+	ctx := context.Background()
+	fx, agentID, runtimeID := newArchiveCancelFixture(t)
+	taskID := fx.Task(t, agentID, testutil.Cols{
+		"chat_session_id": fx.ChatSession(t, agentID), "runtime_id": runtimeID, "status": "running",
+	})
+	injectedErr := errors.New("injected archive cancellation commit failure")
+	starter := &archiveCancelRejectCommit{pool: fx.Pool, taskID: taskID, err: injectedErr}
+	bus := events.New()
+	var published int
+	bus.Subscribe(protocol.EventTaskCancelled, func(events.Event) { published++ })
+	svc := NewTaskService(db.New(fx.Pool), starter, nil, bus)
+
+	cancelled, err := svc.CancelTasksForArchivedAgent(ctx, util.MustParseUUID(agentID))
+	if !errors.Is(err, injectedErr) || cancelled != nil {
+		t.Errorf("failed cancellation: rows = %v, error = %v; want nil rows and injected error", cancelled, err)
+	}
+	if starter.statusBeforeFail != "cancelled" {
+		t.Errorf("status inside failed transaction = %q, want cancelled", starter.statusBeforeFail)
+	}
+	var persistedStatus string
+	if err := fx.Pool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&persistedStatus); err != nil {
+		t.Fatalf("read rolled-back task: %v", err)
+	}
+	if persistedStatus != "running" || published != 0 {
+		t.Errorf("failed cancellation: persisted status = %q, published = %d; want running and no events", persistedStatus, published)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Archiving an agent cancels its chat tasks but skips `task:cancelled`, leaving existing chat lifecycle consumers uninformed. For example, Slack keeps an already-added processing reaction after the task is cancelled.

Publish the existing event for each chat task actually cancelled by archive, after the cancellation and recovery receipt settlement transaction commits. This repairs the producer shared by Slack/Lark cleanup, Telegram stream cleanup and web/desktop/mobile chat cancellation handlers. Non-chat tasks still receive no per-task archive event, and `agent:archived` remains unchanged.

The approach follows the existing cancellation contract: #6631 added the channel subscribers and identified archive's missing broadcast as a follow-up; #7820 established the atomic cancellation/settlement wrapper. Keeping that wrapper and reusing the existing event producer addresses the missing trigger without a new cancellation path or protocol.

Reported deployment: Not established (source-level report; verified with local automated tests).

Code applicability: Deployment-independent (Official App and self-host deployments running the affected backend version). The archive route and cancellation service have no deployment-mode gate. Which affected versions are currently deployed has not been verified.

## Related Issue

Closes #8072

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/service/task.go`: publish chat-only cancellation events after the existing transaction succeeds; propagate errors before any event is emitted.
- `server/internal/service/task_archive_cancel_test.go`: cover all five active statuses, committed state visible from another connection, event scope/payload, non-chat exclusion, terminal/other-agent preservation, repeat cancellation, and rollback without publication when commit fails.
- `server/internal/integrations/slack/typing_indicator_archive_test.go`: verify archive cancellation removes the reaction through the real service, bus subscriber and Slack SDK, using a local HTTP endpoint and a real database.
- Update the explanatory comments in `server/internal/handler/agent.go`, `server/internal/integrations/slack/typing_indicator.go` and `server/internal/integrations/lark/outbound.go`; their executable code is unchanged.

No API fields, event shapes, schema, migrations or client implementations change. Installed clients can use their existing `task:cancelled` handlers. WeCom retains its existing no-reply behavior on cancellation.

Risks and limits: delivery remains best-effort. The separate reaction Add/Clear race and restart recovery are not addressed. Existing synchronous channel subscribers can add latency proportional to the number of active chat sessions, with their existing per-event timeouts.

## How to Test

1. Set `DATABASE_URL` to a migrated local test database. From `server/`, run:

   ```sh
   ../scripts/go-test-with-agent-cli-guard.sh -- go test ./internal/service ./internal/integrations/slack -run 'TestCancelTasksForArchivedAgentPublishesCommittedChatCancellations|TestCancelTasksForArchivedAgentCommitFailureDoesNotPublish|TestTypingIndicator_ArchiveRemovesSlackReaction' -count=1 -v
   ```

   These are local automated backend tests, not a live deployment/UI reproduction. All three new tests passed without skips. The service test observes committed `cancelled` rows and one event per cancelled chat task; the Slack test observes the correct `/reactions.remove` request.

2. Regression proof: using Go's overlay to replace only `task.go` with the upstream implementation at `7a438bd5b8bf39afd54259a7eb0971390e50a8ef` makes the event-publication and Slack-removal tests fail for the missing events/removal. The commit-failure test still passes, protecting existing rollback behavior.

3. Also passed 17 targeted `-race` regressions across service, handler, Slack, Lark, Telegram and WeCom, including recovery settlement/rollback, agent archive/restore and adjacent chat deletion. `go vet` passed for those six packages, and `git diff --check` and formatting checks passed. These checks ran against the identical source before this commit; committing introduced no code changes.

Full repository checks, live channel-account replay, real deployment switching and multi-device UI E2E were not run. Local reaction verification uses a fake HTTP endpoint; hosted production behavior has not been checked.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

Documentation updates are the lifecycle comments listed above. There are no new runtimes, UI tabs or Chinese product copy. Screenshots are unavailable; the observable reaction change is covered by the HTTP regression rather than a live UI capture.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Reviewed the complete local change with alternating preflight and independent review passes, traced the intended contract through upstream history and consumers, ran database-backed regressions and old-implementation failure checks, and checked this issue/PR description against the full diff. The review required no additional code changes.

## Screenshots (optional)

Not provided; see the local reaction HTTP regression above.
