### PR TITLE
[MUL-7086] feat(auth): add workspace scope to personal access tokens

### DIFF
--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -554,11 +554,13 @@ export interface PersonalAccessToken {
   expires_at: string | null;
   last_used_at: string | null;
   created_at: string;
+  workspace_id?: string | null;
 }
 
 export interface CreatePersonalAccessTokenRequest {
   name: string;
   expires_in_days?: number;
+  workspace_id?: string;
 }
 
 export interface CreatePersonalAccessTokenResponse extends PersonalAccessToken {

--- a/server/internal/handler/personal_access_token.go
+++ b/server/internal/handler/personal_access_token.go
@@ -34,6 +34,7 @@ type PersonalAccessTokenResponse struct {
 	ExpiresAt  *string `json:"expires_at"`
 	LastUsedAt *string `json:"last_used_at"`
 	CreatedAt  string  `json:"created_at"`
+	WorkspaceID *string `json:"workspace_id,omitempty"`
 }
 
 type CreatePATResponse struct {
@@ -49,12 +50,14 @@ func patToResponse(pat db.PersonalAccessToken) PersonalAccessTokenResponse {
 		ExpiresAt:  timestampToPtr(pat.ExpiresAt),
 		LastUsedAt: timestampToPtr(pat.LastUsedAt),
 		CreatedAt:  timestampToString(pat.CreatedAt),
+		WorkspaceID: func() *string { if !pat.WorkspaceID.Valid { return nil }; v := uuidToString(pat.WorkspaceID); return &v }(),
 	}
 }
 
 type CreatePATRequest struct {
 	Name          string `json:"name"`
 	ExpiresInDays *int   `json:"expires_in_days"`
+	WorkspaceID   *string `json:"workspace_id,omitempty"`
 }
 
 func (h *Handler) CreatePersonalAccessToken(w http.ResponseWriter, r *http.Request) {
@@ -94,6 +97,7 @@ func (h *Handler) CreatePersonalAccessToken(w http.ResponseWriter, r *http.Reque
 
 	pat, err := h.Queries.CreatePersonalAccessToken(r.Context(), db.CreatePersonalAccessTokenParams{
 		UserID:      parseUUID(userID),
+		WorkspaceID: func() pgtype.UUID { if req.WorkspaceID == nil || *req.WorkspaceID == "" { return pgtype.UUID{} }; return parseUUID(*req.WorkspaceID) }(),
 		Name:        req.Name,
 		TokenHash:   auth.HashToken(rawToken),
 		TokenPrefix: prefix,

--- a/server/internal/handler/workspace_delete_manifest_test.go
+++ b/server/internal/handler/workspace_delete_manifest_test.go
@@ -93,7 +93,7 @@ var workspaceDeletionManifest = map[string]workspaceDeleteAction{
 	"agent_mcp_server":                   workspaceDelete,
 	"workspace_mcp_server":               workspaceDelete,
 	"notification_preference":            workspaceDelete,
-	"personal_access_token":              workspaceDeleteKeep,
+	"personal_access_token":              workspaceDelete,
 	"pinned_item":                        workspaceDelete,
 	"plugin_installation":                workspaceDelete,
 	"plugin_hook_schedule":               workspaceDelete,

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -203,6 +203,20 @@ func Auth(queries *db.Queries, patCache *auth.PATCache, cloudPAT *auth.CloudPATV
 				}
 
 				userID := uuidToString(pat.UserID)
+				// Workspace-scoped PATs are never valid outside their bound tenant.
+				// The workspace middleware runs later, so enforce the binding here
+				// against the request's explicit workspace selector as well.
+				if pat.WorkspaceID.Valid {
+					requested := r.Header.Get("X-Workspace-ID")
+					if requested == "" {
+						requested = r.URL.Query().Get("workspace_id")
+					}
+					if requested != "" && requested != uuidToString(pat.WorkspaceID) {
+						http.Error(w, `{"error":"token is not valid for this workspace"}`, http.StatusForbidden)
+						return
+					}
+					r.Header.Set("X-Workspace-ID", uuidToString(pat.WorkspaceID))
+				}
 				if rejectTemporarilyDisabledUser(w, r, userID, "", "pat") {
 					return
 				}
@@ -215,7 +229,12 @@ func Auth(queries *db.Queries, patCache *auth.PATCache, cloudPAT *auth.CloudPATV
 				if pat.ExpiresAt.Valid {
 					expiresAt = pat.ExpiresAt.Time
 				}
-				patCache.Set(r.Context(), hash, userID, auth.TTLForExpiry(time.Now(), expiresAt))
+				// Workspace-bound tokens carry more identity than the legacy
+				// user-only cache value; keep them on the DB path until the cache
+				// stores the complete token scope.
+				if !pat.WorkspaceID.Valid {
+					patCache.Set(r.Context(), hash, userID, auth.TTLForExpiry(time.Now(), expiresAt))
+				}
 
 				// Cache miss = TTL expired (or first use after revoke /
 				// process restart). Refresh last_used_at; subsequent hits

--- a/server/internal/middleware/daemon_auth.go
+++ b/server/internal/middleware/daemon_auth.go
@@ -215,6 +215,15 @@ func DaemonAuth(queries *db.Queries, patCache *auth.PATCache, daemonCache *auth.
 				}
 
 				userID := uuidToString(pat.UserID)
+				if pat.WorkspaceID.Valid {
+					requested := r.Header.Get("X-Workspace-ID")
+					if requested == "" { requested = r.URL.Query().Get("workspace_id") }
+					if requested != "" && requested != uuidToString(pat.WorkspaceID) {
+						writeError(w, http.StatusForbidden, "token is not valid for this workspace")
+						return
+					}
+					r.Header.Set("X-Workspace-ID", uuidToString(pat.WorkspaceID))
+				}
 				if rejectTemporarilyDisabledUser(w, r, userID, "", DaemonAuthPathPAT) {
 					return
 				}
@@ -224,7 +233,9 @@ func DaemonAuth(queries *db.Queries, patCache *auth.PATCache, daemonCache *auth.
 				if pat.ExpiresAt.Valid {
 					expiresAt = pat.ExpiresAt.Time
 				}
-				patCache.Set(r.Context(), hash, userID, auth.TTLForExpiry(time.Now(), expiresAt))
+				if !pat.WorkspaceID.Valid {
+					patCache.Set(r.Context(), hash, userID, auth.TTLForExpiry(time.Now(), expiresAt))
+				}
 
 				// Cache miss = first request in this TTL window. Refresh
 				// last_used_at; subsequent hits skip the write entirely.

--- a/server/migrations/451_personal_access_token_workspace_id.down.sql
+++ b/server/migrations/451_personal_access_token_workspace_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_pat_workspace;
+ALTER TABLE personal_access_token DROP COLUMN IF EXISTS workspace_id;

--- a/server/migrations/451_personal_access_token_workspace_id.up.sql
+++ b/server/migrations/451_personal_access_token_workspace_id.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE personal_access_token ADD COLUMN workspace_id UUID REFERENCES workspace(id) ON DELETE CASCADE;
+CREATE INDEX idx_pat_workspace ON personal_access_token(workspace_id, revoked) WHERE workspace_id IS NOT NULL;

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -1038,6 +1038,7 @@ type PersonalAccessToken struct {
 	LastUsedAt  pgtype.Timestamptz `json:"last_used_at"`
 	Revoked     bool               `json:"revoked"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
 }
 
 type PinnedItem struct {

--- a/server/pkg/db/generated/personal_access_token.sql.go
+++ b/server/pkg/db/generated/personal_access_token.sql.go
@@ -12,13 +12,14 @@ import (
 )
 
 const createPersonalAccessToken = `-- name: CreatePersonalAccessToken :one
-INSERT INTO personal_access_token (user_id, name, token_hash, token_prefix, expires_at)
-VALUES ($1, $2, $3, $4, $5)
-RETURNING id, user_id, name, token_hash, token_prefix, expires_at, last_used_at, revoked, created_at
+INSERT INTO personal_access_token (user_id, workspace_id, name, token_hash, token_prefix, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id, user_id, name, token_hash, token_prefix, expires_at, last_used_at, revoked, created_at, workspace_id
 `
 
 type CreatePersonalAccessTokenParams struct {
 	UserID      pgtype.UUID        `json:"user_id"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
 	Name        string             `json:"name"`
 	TokenHash   string             `json:"token_hash"`
 	TokenPrefix string             `json:"token_prefix"`
@@ -28,6 +29,7 @@ type CreatePersonalAccessTokenParams struct {
 func (q *Queries) CreatePersonalAccessToken(ctx context.Context, arg CreatePersonalAccessTokenParams) (PersonalAccessToken, error) {
 	row := q.db.QueryRow(ctx, createPersonalAccessToken,
 		arg.UserID,
+		arg.WorkspaceID,
 		arg.Name,
 		arg.TokenHash,
 		arg.TokenPrefix,
@@ -44,6 +46,7 @@ func (q *Queries) CreatePersonalAccessToken(ctx context.Context, arg CreatePerso
 		&i.LastUsedAt,
 		&i.Revoked,
 		&i.CreatedAt,
+		&i.WorkspaceID,
 	)
 	return i, err
 }
@@ -84,7 +87,7 @@ func (q *Queries) ExtendPersonalAccessTokenExpiry(ctx context.Context, arg Exten
 }
 
 const getPersonalAccessTokenByHash = `-- name: GetPersonalAccessTokenByHash :one
-SELECT id, user_id, name, token_hash, token_prefix, expires_at, last_used_at, revoked, created_at FROM personal_access_token
+SELECT id, user_id, name, token_hash, token_prefix, expires_at, last_used_at, revoked, created_at, workspace_id FROM personal_access_token
 WHERE token_hash = $1
   AND revoked = FALSE
   AND (expires_at IS NULL OR expires_at > now())
@@ -103,12 +106,13 @@ func (q *Queries) GetPersonalAccessTokenByHash(ctx context.Context, tokenHash st
 		&i.LastUsedAt,
 		&i.Revoked,
 		&i.CreatedAt,
+		&i.WorkspaceID,
 	)
 	return i, err
 }
 
 const listPersonalAccessTokensByUser = `-- name: ListPersonalAccessTokensByUser :many
-SELECT id, user_id, name, token_hash, token_prefix, expires_at, last_used_at, revoked, created_at FROM personal_access_token
+SELECT id, user_id, name, token_hash, token_prefix, expires_at, last_used_at, revoked, created_at, workspace_id FROM personal_access_token
 WHERE user_id = $1
   AND revoked = FALSE
 ORDER BY created_at DESC
@@ -133,6 +137,7 @@ func (q *Queries) ListPersonalAccessTokensByUser(ctx context.Context, userID pgt
 			&i.LastUsedAt,
 			&i.Revoked,
 			&i.CreatedAt,
+			&i.WorkspaceID,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/personal_access_token.sql
+++ b/server/pkg/db/queries/personal_access_token.sql
@@ -1,6 +1,6 @@
 -- name: CreatePersonalAccessToken :one
-INSERT INTO personal_access_token (user_id, name, token_hash, token_prefix, expires_at)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO personal_access_token (user_id, workspace_id, name, token_hash, token_prefix, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING *;
 
 -- name: GetPersonalAccessTokenByHash :one


### PR DESCRIPTION
## Summary

Personal access tokens are currently account-scoped, which makes it impossible to issue a least-privilege token for one workspace. This change adds an optional workspace binding while preserving existing account-level tokens.

## Changes

- Add nullable `workspace_id` to `personal_access_token` with an index and rollback migration.
- Accept and return `workspace_id` when creating/listing tokens.
- Reject workspace-bound tokens when a request selects a different workspace.
- Keep workspace-bound tokens off the legacy user-only auth cache.
- Add the field to generated SQLC models and shared API types.

## Compatibility

Existing tokens with `workspace_id = NULL` retain current account-level behavior. New workspace-bound tokens are enforced server-side and the bound workspace is propagated to downstream workspace resolution.

## Validation

`go test ./internal/handler ./internal/middleware`
