### PR TITLE
fix(claude): preserve results and keep native loops running (MUL-7087)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -8749,7 +8749,8 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 
 	var toolCount atomic.Int32
 	// lastActivityAt records (as unix nanos) when the drain loop most
-	// recently received a message from the backend. The idle watchdog
+	// recently received a message from the backend, or the end of a confirmed
+	// native scheduled wait, whichever is later. The idle watchdog
 	// reads this to decide whether the agent has gone silent for too long.
 	// Initialise to the start so a backend that never emits a single
 	// message also trips the watchdog.
@@ -8844,6 +8845,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		}()
 
 		var sessionPinned atomic.Bool
+		var waitingUntil time.Time
 		for {
 			select {
 			case msg, ok := <-session.Messages:
@@ -8855,7 +8857,14 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 				// gone silent — stamping before processing makes sure a
 				// slow downstream call (mu.Lock contention, batch resize)
 				// can't be misattributed to backend silence.
-				lastActivityAt.Store(time.Now().UnixNano())
+				activityAt := time.Now()
+				if msg.Type == agent.MessageStatus {
+					waitingUntil = msg.WaitingUntil
+				}
+				if waitingUntil.After(activityAt) {
+					activityAt = waitingUntil
+				}
+				lastActivityAt.Store(activityAt.UnixNano())
 				switch msg.Type {
 				case agent.MessageStatus:
 					// Persist the session/work_dir as soon as the backend

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -8748,10 +8748,10 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	defer drainCancel()
 
 	var toolCount atomic.Int32
-	// lastActivityAt records (as unix nanos) when the drain loop most
-	// recently received a message from the backend, or the end of a confirmed
-	// native scheduled wait, whichever is later. The idle watchdog
-	// reads this to decide whether the agent has gone silent for too long.
+	// lastActivityAt records (as unix nanos) when the drain loop most recently
+	// received a message from the backend. Confirmed native scheduled waits live
+	// only in Session.Liveness; Message.WaitingUntil is a display field and must
+	// not become a second, uncleared watchdog-control source.
 	// Initialise to the start so a backend that never emits a single
 	// message also trips the watchdog.
 	var lastActivityAt atomic.Int64
@@ -8845,7 +8845,6 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		}()
 
 		var sessionPinned atomic.Bool
-		var waitingUntil time.Time
 		for {
 			select {
 			case msg, ok := <-session.Messages:
@@ -8858,12 +8857,6 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 				// slow downstream call (mu.Lock contention, batch resize)
 				// can't be misattributed to backend silence.
 				activityAt := time.Now()
-				if msg.Type == agent.MessageStatus {
-					waitingUntil = msg.WaitingUntil
-				}
-				if waitingUntil.After(activityAt) {
-					activityAt = waitingUntil
-				}
 				lastActivityAt.Store(activityAt.UnixNano())
 				switch msg.Type {
 				case agent.MessageStatus:

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -8777,7 +8777,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	var idleWatchdogThreshold atomic.Int64
 	idleWatchdogThreshold.Store(int64(idleWindow))
 	if idleWindow > 0 {
-		go d.runIdleWatchdog(agentCtx, idleWindow, d.cfg.AgentToolWatchdog, &lastActivityAt, &inFlightTools, &idleWatchdogFired, &idleWatchdogThreshold, agentCancel, session.Messages, taskLog)
+		go d.runIdleWatchdog(agentCtx, idleWindow, d.cfg.AgentToolWatchdog, &lastActivityAt, &inFlightTools, &idleWatchdogFired, &idleWatchdogThreshold, agentCancel, session.Messages, session.Liveness, taskLog)
 	}
 
 	// drainFinished closes after the drain goroutine has flushed the last
@@ -9122,7 +9122,7 @@ func idleWatchdogTickInterval(window time.Duration) time.Duration {
 //
 // Polling rate comes from idleWatchdogTickInterval, so a run is force-stopped
 // somewhere between its budget and budget + tick, never earlier.
-func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow time.Duration, lastActivityAt *atomic.Int64, inFlightTools *atomic.Int32, fired *atomic.Bool, firedThreshold *atomic.Int64, cancel context.CancelFunc, messages <-chan agent.Message, taskLog *slog.Logger) {
+func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow time.Duration, lastActivityAt *atomic.Int64, inFlightTools *atomic.Int32, fired *atomic.Bool, firedThreshold *atomic.Int64, cancel context.CancelFunc, messages <-chan agent.Message, liveness *agent.SessionLiveness, taskLog *slog.Logger) {
 	ticker := time.NewTicker(idleWatchdogTickInterval(window))
 	defer ticker.Stop()
 	for {
@@ -9143,6 +9143,9 @@ func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow ti
 				threshold = toolWindow
 			}
 			last := time.Unix(0, lastActivityAt.Load())
+			if waitingUntil := liveness.WaitingUntil(); waitingUntil.After(last) {
+				last = waitingUntil
+			}
 			idleFor := time.Since(last)
 			if idleFor < threshold {
 				continue

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -3323,11 +3323,20 @@ func TestExecuteAndDrain_ContextCancelled_ReportsCancelled(t *testing.T) {
 // idle watchdog is the only thing that ends this otherwise-forever-silent run.
 type idleWatchdogBackend struct {
 	emitOne bool // when true, emit one message before going silent; when false, never emit anything
+	waitFor time.Duration
+	resume  bool
 }
 
 func (b idleWatchdogBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
-	msgCh := make(chan agent.Message, 1)
+	msgCh := make(chan agent.Message, 3)
 	resCh := make(chan agent.Result)
+	if b.waitFor > 0 {
+		msgCh <- agent.Message{Type: agent.MessageStatus, Status: "waiting", WaitingUntil: time.Now().Add(b.waitFor)}
+		msgCh <- agent.Message{Type: agent.MessageLog, Content: "still waiting"}
+		if b.resume {
+			msgCh <- agent.Message{Type: agent.MessageStatus, Status: "running"}
+		}
+	}
 	if b.emitOne {
 		msgCh <- agent.Message{Type: agent.MessageText, Content: "hello"}
 	}
@@ -5710,5 +5719,50 @@ func TestHermesProfileChainCoversLaunchPrefix(t *testing.T) {
 	}
 	if strings.Join(strippedCustom, "\x00") != "--yolo" {
 		t.Errorf("custom = %v, want only the selector removed", strippedCustom)
+	}
+}
+
+// Confirmed scheduled silence gets a finite extension. Incidental log output
+// preserves it, while a running transition restores ordinary hang detection.
+func TestExecuteAndDrain_IdleWatchdog_NativeScheduledWait(t *testing.T) {
+	for _, resume := range []bool{false, true} {
+		t.Run(fmt.Sprintf("resume=%t", resume), func(t *testing.T) {
+			t.Parallel()
+			d := newTestDaemon(t)
+			d.cfg.AgentIdleWatchdog = 50 * time.Millisecond
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			start := time.Now()
+			result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{waitFor: 300 * time.Millisecond, resume: resume}, "p", agent.ExecOptions{}, slog.Default(), "native-wait", "", new(atomic.Int32))
+			if err != nil || result.Status != "idle_watchdog" {
+				t.Fatalf("result=%+v error=%v", result, err)
+			}
+			elapsed := time.Since(start)
+			if !resume && elapsed < 300*time.Millisecond {
+				t.Fatalf("scheduled wait killed early after %s", elapsed)
+			}
+			if resume && elapsed > 250*time.Millisecond {
+				t.Fatalf("running turn retained scheduled idle exemption: %s", elapsed)
+			}
+		})
+	}
+}
+
+func TestExecuteAndDrain_NativeScheduledWaitCanCancel(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	d.cfg.AgentIdleWatchdog = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{waitFor: time.Hour}, "p", agent.ExecOptions{}, slog.Default(), "native-wait-cancel", "", new(atomic.Int32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status == "idle_watchdog" {
+		t.Fatalf("cancel was attributed to idle watchdog: %+v", result)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("native wait blocked context cancellation")
 	}
 }

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -3322,19 +3322,31 @@ func TestExecuteAndDrain_ContextCancelled_ReportsCancelled(t *testing.T) {
 // cap (opts.Timeout = 0) the drain loop imposes no deadline of its own, so the
 // idle watchdog is the only thing that ends this otherwise-forever-silent run.
 type idleWatchdogBackend struct {
-	emitOne bool // when true, emit one message before going silent; when false, never emit anything
-	waitFor time.Duration
-	resume  bool
+	emitOne           bool // when true, emit one message before going silent; when false, never emit anything
+	waitFor           time.Duration
+	resume            bool
+	dropRunningStatus bool
 }
 
 func (b idleWatchdogBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
-	msgCh := make(chan agent.Message, 3)
+	capacity := 3
+	if b.dropRunningStatus {
+		capacity = 2
+	}
+	msgCh := make(chan agent.Message, capacity)
 	resCh := make(chan agent.Result)
+	liveness := &agent.SessionLiveness{}
 	if b.waitFor > 0 {
-		msgCh <- agent.Message{Type: agent.MessageStatus, Status: "waiting", WaitingUntil: time.Now().Add(b.waitFor)}
+		waitingUntil := time.Now().Add(b.waitFor)
+		liveness.SetWaitingUntil(waitingUntil)
+		msgCh <- agent.Message{Type: agent.MessageStatus, Status: "waiting", WaitingUntil: waitingUntil}
 		msgCh <- agent.Message{Type: agent.MessageLog, Content: "still waiting"}
 		if b.resume {
-			msgCh <- agent.Message{Type: agent.MessageStatus, Status: "running"}
+			liveness.ClearWaitingUntil()
+			select {
+			case msgCh <- agent.Message{Type: agent.MessageStatus, Status: "running"}:
+			default:
+			}
 		}
 	}
 	if b.emitOne {
@@ -3342,7 +3354,7 @@ func (b idleWatchdogBackend) Execute(_ context.Context, _ string, _ agent.ExecOp
 	}
 	// Deliberately do NOT close msgCh and never write to resCh — this models
 	// a backend whose subprocess is hung and will never naturally complete.
-	return &agent.Session{Messages: msgCh, Result: resCh}, nil
+	return &agent.Session{Messages: msgCh, Result: resCh, Liveness: liveness}, nil
 }
 
 // TestIdleWatchdogTickInterval pins the ceiling, which is the reason the helper
@@ -5745,6 +5757,26 @@ func TestExecuteAndDrain_IdleWatchdog_NativeScheduledWait(t *testing.T) {
 				t.Fatalf("running turn retained scheduled idle exemption: %s", elapsed)
 			}
 		})
+	}
+}
+
+func TestExecuteAndDrain_IdleWatchdog_LivenessClearSurvivesDroppedRunningStatus(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t)
+	d.cfg.AgentIdleWatchdog = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	start := time.Now()
+	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{
+		waitFor:           300 * time.Millisecond,
+		resume:            true,
+		dropRunningStatus: true,
+	}, "p", agent.ExecOptions{}, slog.Default(), "native-wait-dropped-running", "", new(atomic.Int32))
+	if err != nil || result.Status != "idle_watchdog" {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("dropped running display retained stale scheduled exemption: %s", elapsed)
 	}
 }
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -172,6 +172,9 @@ type Message struct {
 	Status    string         // agent status string (Status)
 	Level     string         // log level (Log)
 	SessionID string         // backend session id (Status), for early resume-pointer pinning
+	// WaitingUntil defers the idle watchdog during a confirmed native scheduled
+	// wait. The normal idle budget resumes at this time; hard timeouts still apply.
+	WaitingUntil time.Time
 }
 
 // TokenUsage tracks token consumption for a single model.

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -153,21 +153,24 @@ type Session struct {
 	Liveness *SessionLiveness
 }
 
-// SessionLiveness exposes read-only backend liveness state to the daemon. A
-// future WaitingUntil means the backend has positively confirmed a native
-// scheduled wait; zero restores the ordinary idle watchdog immediately.
+// SessionLiveness carries backend-owned watchdog state to the daemon. A future
+// WaitingUntil means the backend has positively confirmed a native scheduled
+// wait; zero restores the ordinary idle watchdog immediately. Backends publish
+// transitions with SetWaitingUntil and ClearWaitingUntil; consumers only read.
 type SessionLiveness struct {
 	waitingUntilNanos atomic.Int64
 }
 
-func (s *SessionLiveness) setWaitingUntil(until time.Time) {
+// SetWaitingUntil publishes a confirmed native-wait deadline.
+func (s *SessionLiveness) SetWaitingUntil(until time.Time) {
 	if s == nil {
 		return
 	}
 	s.waitingUntilNanos.Store(until.UnixNano())
 }
 
-func (s *SessionLiveness) clearWaitingUntil() {
+// ClearWaitingUntil restores the ordinary idle watchdog immediately.
+func (s *SessionLiveness) ClearWaitingUntil() {
 	if s != nil {
 		s.waitingUntilNanos.Store(0)
 	}

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -146,6 +147,42 @@ type Session struct {
 	Messages <-chan Message
 	// Result receives exactly one value — the final outcome — then closes.
 	Result <-chan Result
+	// Liveness carries backend-owned watchdog state independently of Messages,
+	// which callers are allowed not to consume. It is nil for backends that do
+	// not need to defer the ordinary idle deadline.
+	Liveness *SessionLiveness
+}
+
+// SessionLiveness exposes read-only backend liveness state to the daemon. A
+// future WaitingUntil means the backend has positively confirmed a native
+// scheduled wait; zero restores the ordinary idle watchdog immediately.
+type SessionLiveness struct {
+	waitingUntilNanos atomic.Int64
+}
+
+func (s *SessionLiveness) setWaitingUntil(until time.Time) {
+	if s == nil {
+		return
+	}
+	s.waitingUntilNanos.Store(until.UnixNano())
+}
+
+func (s *SessionLiveness) clearWaitingUntil() {
+	if s != nil {
+		s.waitingUntilNanos.Store(0)
+	}
+}
+
+// WaitingUntil returns the current confirmed native-wait deadline.
+func (s *SessionLiveness) WaitingUntil() time.Time {
+	if s == nil {
+		return time.Time{}
+	}
+	nanos := s.waitingUntilNanos.Load()
+	if nanos == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, nanos)
 }
 
 // MessageType identifies the kind of Message.
@@ -172,8 +209,9 @@ type Message struct {
 	Status    string         // agent status string (Status)
 	Level     string         // log level (Log)
 	SessionID string         // backend session id (Status), for early resume-pointer pinning
-	// WaitingUntil defers the idle watchdog during a confirmed native scheduled
-	// wait. The normal idle budget resumes at this time; hard timeouts still apply.
+	// WaitingUntil presents a confirmed native scheduled wait to message
+	// consumers. Watchdog control uses Session.Liveness so this optional stream
+	// can fill or remain unread without blocking the backend.
 	WaitingUntil time.Time
 }
 

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -171,6 +171,8 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		var sessionID string
 		sawAsyncLaunch := false
 		usage := make(map[string]TokenUsage)
+		var schedules claudeSchedules
+		waitingForWakeup := false
 		eventCount := 0
 		invalidEventCount := 0
 		assistantEventCount := 0
@@ -209,6 +211,23 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			_ = stdout.Close()
 		}()
 
+		beginScheduledTurn := func() {
+			if !waitingForWakeup {
+				return
+			}
+			// Retain the completed result throughout the scheduled wait. Reset
+			// only once a new main-thread turn starts, so EOF during the wait
+			// succeeds but an incomplete subsequent turn still fails.
+			waitingForWakeup = false
+			schedules.beginTurn(time.Now())
+			sawResult = false
+			finalResultText = ""
+			lastAssistantText = ""
+			resultIsError = false
+			terminalReasonError = ""
+			trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
+		}
+
 		scanner := newAgentStreamScanner(stdout)
 
 		for scanner.Scan() {
@@ -226,6 +245,10 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 			switch msg.Type {
 			case "assistant":
+				if msg.ParentToolUseID == "" {
+					beginScheduledTurn()
+				}
+				schedules.observe(msg, time.Now())
 				assistantEventCount++
 				turn := b.handleAssistant(msg, msgCh, usage)
 				toolUseCount += turn.toolUses
@@ -234,14 +257,23 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				}
 				lastAssistantText = turn.resolveFallback(lastAssistantText)
 			case "user":
+				schedules.observe(msg, time.Now())
 				if b.handleUser(msg, msgCh) {
 					sawAsyncLaunch = true
 				}
 			case "system":
+				if msg.Subtype == "init" && msg.ParentToolUseID == "" {
+					beginScheduledTurn()
+				}
 				if msg.SessionID != "" {
 					sessionID = msg.SessionID
 				}
-				trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
+				status := Message{Type: MessageStatus, Status: "running", SessionID: sessionID}
+				if waitingForWakeup {
+					status.Status = "waiting"
+					status.WaitingUntil, _ = schedules.waitingUntil()
+				}
+				trySend(msgCh, status)
 			case "result":
 				sawResult = true
 				finalResultText = msg.ResultText
@@ -252,9 +284,17 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					// The terminal usage snapshot replaces assistant-event totals.
 					usage = resultUsage
 				}
-				// A result completes this headless turn, including after a successful
-				// ScheduleWakeup. The CLI may exit without another result; retain
-				// the output and session ID so a separate task can resume it.
+				if until, pending := schedules.waitingUntil(); pending && !resultIsError && terminalReasonError == "" && !sawAsyncLaunch {
+					waitingForWakeup = true
+					b.cfg.Logger.Info("claude awaiting native scheduled wakeup", "session_id", sessionID, "waiting_until", until)
+					// This transition controls the daemon's watchdog, so unlike
+					// display-only events it must survive a full output buffer.
+					select {
+					case msgCh <- Message{Type: MessageStatus, Status: "waiting", SessionID: sessionID, WaitingUntil: until}:
+					case <-runCtx.Done():
+					}
+					continue
+				}
 				closeStdin()
 			case "log":
 				if msg.Log != nil {
@@ -541,11 +581,13 @@ func claudeMapHasAsyncLaunchStatus(value map[string]any) bool {
 // ── Claude SDK JSON types ──
 
 type claudeSDKMessage struct {
-	Type      string          `json:"type"`
-	Message   json.RawMessage `json:"message,omitempty"`
-	Subtype   string          `json:"subtype,omitempty"`
-	SessionID string          `json:"session_id,omitempty"`
-	Model     string          `json:"model,omitempty"`
+	ParentToolUseID string          `json:"parent_tool_use_id,omitempty"`
+	ToolUseResult   json.RawMessage `json:"tool_use_result,omitempty"`
+	Type            string          `json:"type"`
+	Message         json.RawMessage `json:"message,omitempty"`
+	Subtype         string          `json:"subtype,omitempty"`
+	SessionID       string          `json:"session_id,omitempty"`
+	Model           string          `json:"model,omitempty"`
 
 	// result fields
 	ResultText string `json:"result,omitempty"`
@@ -671,6 +713,7 @@ func claudeUsageHasTokens(input, output, cacheRead, cacheWrite int64) bool {
 }
 
 type claudeContentBlock struct {
+	IsError   bool            `json:"is_error,omitempty"`
 	Type      string          `json:"type"`
 	Text      string          `json:"text,omitempty"`
 	ID        string          `json:"id,omitempty"`

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -171,8 +171,6 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		var sessionID string
 		sawAsyncLaunch := false
 		usage := make(map[string]TokenUsage)
-		pendingWakeupCalls := make(map[string]claudeWakeupDirective)
-		keepAliveAfterResult := false
 		eventCount := 0
 		invalidEventCount := 0
 		assistantEventCount := 0
@@ -235,15 +233,9 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					unreadableAssistantCount++
 				}
 				lastAssistantText = turn.resolveFallback(lastAssistantText)
-				for callID, directive := range claudeScheduleWakeupCalls(msg) {
-					pendingWakeupCalls[callID] = directive
-				}
 			case "user":
 				if b.handleUser(msg, msgCh) {
 					sawAsyncLaunch = true
-				}
-				if directive, ok := claudeCompletedWakeupDirective(msg, pendingWakeupCalls); ok {
-					keepAliveAfterResult = directive == claudeWakeupArm
 				}
 			case "system":
 				if msg.SessionID != "" {
@@ -257,30 +249,12 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				terminalReasonError = claudeTerminalReasonFailure(msg.TerminalReason, msg.ResultText)
 				sessionID = msg.SessionID
 				if resultUsage := claudeResultUsage(msg, opts.Model); len(resultUsage) > 0 {
-					// Claude Code reports modelUsage as a cumulative snapshot for
-					// the lifetime of this stream-json process. Keep the newest
-					// snapshot instead of summing snapshots across scheduled ticks.
+					// The terminal usage snapshot replaces assistant-event totals.
 					usage = resultUsage
 				}
-				if keepAliveAfterResult && !resultIsError && terminalReasonError == "" {
-					// Claude Code's dynamic /loop emits an ordinary result at the end
-					// of every tick, then waits for its in-process ScheduleWakeup timer.
-					// Closing stdin here destroys that timer and every persistent
-					// Monitor even though the tool just reported a successful wakeup.
-					// Keep the stream-json session alive for exactly one more tick; the
-					// next tick must re-arm ScheduleWakeup or the next result closes it.
-					b.cfg.Logger.Info("claude scheduled loop armed; keeping stream-json session open",
-						"session_id", sessionID,
-					)
-					keepAliveAfterResult = false
-					sawResult = false
-					resultIsError = false
-					finalResultText = ""
-					terminalReasonError = ""
-					lastAssistantText = ""
-					continue
-				}
-				keepAliveAfterResult = false
+				// A result completes this headless turn, including after a successful
+				// ScheduleWakeup. The CLI may exit without another result; retain
+				// the output and session ID so a separate task can resume it.
 				closeStdin()
 			case "log":
 				if msg.Log != nil {
@@ -704,72 +678,6 @@ type claudeContentBlock struct {
 	Input     json.RawMessage `json:"input,omitempty"`
 	ToolUseID string          `json:"tool_use_id,omitempty"`
 	Content   json.RawMessage `json:"content,omitempty"`
-	IsError   bool            `json:"is_error,omitempty"`
-}
-
-type claudeWakeupDirective uint8
-
-const (
-	claudeWakeupNone claudeWakeupDirective = iota
-	claudeWakeupArm
-	claudeWakeupStop
-)
-
-// claudeScheduleWakeupCalls records the intent of ScheduleWakeup tool calls by
-// call id. The intent is not applied until the corresponding tool_result says
-// the harness accepted it; otherwise a rejected tool call could keep a
-// headless Claude process waiting forever with no wakeup pending.
-func claudeScheduleWakeupCalls(msg claudeSDKMessage) map[string]claudeWakeupDirective {
-	var content claudeMessageContent
-	if err := json.Unmarshal(msg.Message, &content); err != nil {
-		return nil
-	}
-
-	calls := make(map[string]claudeWakeupDirective)
-	for _, block := range content.Content {
-		if block.Type != "tool_use" || block.Name != "ScheduleWakeup" || block.ID == "" {
-			continue
-		}
-		directive := claudeWakeupArm
-		var input struct {
-			Stop bool `json:"stop"`
-		}
-		if len(block.Input) > 0 && json.Unmarshal(block.Input, &input) == nil && input.Stop {
-			directive = claudeWakeupStop
-		}
-		calls[block.ID] = directive
-	}
-	return calls
-}
-
-// claudeCompletedWakeupDirective returns the last successfully completed
-// ScheduleWakeup directive in a user tool-result event. Claude normally emits
-// one result per event, but preserving wire order makes the behavior explicit
-// if a future CLI batches them.
-func claudeCompletedWakeupDirective(msg claudeSDKMessage, pending map[string]claudeWakeupDirective) (claudeWakeupDirective, bool) {
-	var content claudeMessageContent
-	if err := json.Unmarshal(msg.Message, &content); err != nil {
-		return claudeWakeupNone, false
-	}
-
-	directive := claudeWakeupNone
-	found := false
-	for _, block := range content.Content {
-		if block.Type != "tool_result" {
-			continue
-		}
-		pendingDirective, ok := pending[block.ToolUseID]
-		if !ok {
-			continue
-		}
-		delete(pending, block.ToolUseID)
-		if block.IsError {
-			continue
-		}
-		directive = pendingDirective
-		found = true
-	}
-	return directive, found
 }
 
 type claudeControlRequestPayload struct {

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -171,7 +171,6 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		var sessionID string
 		sawAsyncLaunch := false
 		usage := make(map[string]TokenUsage)
-		turnUsage := make(map[string]TokenUsage)
 		pendingWakeupCalls := make(map[string]claudeWakeupDirective)
 		keepAliveAfterResult := false
 		eventCount := 0
@@ -230,7 +229,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			switch msg.Type {
 			case "assistant":
 				assistantEventCount++
-				turn := b.handleAssistant(msg, msgCh, turnUsage)
+				turn := b.handleAssistant(msg, msgCh, usage)
 				toolUseCount += turn.toolUses
 				if !turn.understood {
 					unreadableAssistantCount++
@@ -258,10 +257,11 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				terminalReasonError = claudeTerminalReasonFailure(msg.TerminalReason, msg.ResultText)
 				sessionID = msg.SessionID
 				if resultUsage := claudeResultUsage(msg, opts.Model); len(resultUsage) > 0 {
-					turnUsage = resultUsage
+					// Claude Code reports modelUsage as a cumulative snapshot for
+					// the lifetime of this stream-json process. Keep the newest
+					// snapshot instead of summing snapshots across scheduled ticks.
+					usage = resultUsage
 				}
-				mergeClaudeUsage(usage, turnUsage)
-				turnUsage = make(map[string]TokenUsage)
 				if keepAliveAfterResult && !resultIsError && terminalReasonError == "" {
 					// Claude Code's dynamic /loop emits an ordinary result at the end
 					// of every tick, then waits for its in-process ScheduleWakeup timer.
@@ -303,7 +303,6 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 
 		closeStdin()
-		mergeClaudeUsage(usage, turnUsage)
 
 		// Wait for process exit, then release the cancellation handler.
 		exitErr := cmd.Wait()
@@ -771,17 +770,6 @@ func claudeCompletedWakeupDirective(msg claudeSDKMessage, pending map[string]cla
 		found = true
 	}
 	return directive, found
-}
-
-func mergeClaudeUsage(dst, src map[string]TokenUsage) {
-	for model, incoming := range src {
-		current := dst[model]
-		current.InputTokens += incoming.InputTokens
-		current.OutputTokens += incoming.OutputTokens
-		current.CacheReadTokens += incoming.CacheReadTokens
-		current.CacheWriteTokens += incoming.CacheWriteTokens
-		dst[model] = current
-	}
 }
 
 type claudeControlRequestPayload struct {

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -171,6 +171,9 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		var sessionID string
 		sawAsyncLaunch := false
 		usage := make(map[string]TokenUsage)
+		turnUsage := make(map[string]TokenUsage)
+		pendingWakeupCalls := make(map[string]claudeWakeupDirective)
+		keepAliveAfterResult := false
 		eventCount := 0
 		invalidEventCount := 0
 		assistantEventCount := 0
@@ -227,15 +230,21 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			switch msg.Type {
 			case "assistant":
 				assistantEventCount++
-				turn := b.handleAssistant(msg, msgCh, usage)
+				turn := b.handleAssistant(msg, msgCh, turnUsage)
 				toolUseCount += turn.toolUses
 				if !turn.understood {
 					unreadableAssistantCount++
 				}
 				lastAssistantText = turn.resolveFallback(lastAssistantText)
+				for callID, directive := range claudeScheduleWakeupCalls(msg) {
+					pendingWakeupCalls[callID] = directive
+				}
 			case "user":
 				if b.handleUser(msg, msgCh) {
 					sawAsyncLaunch = true
+				}
+				if directive, ok := claudeCompletedWakeupDirective(msg, pendingWakeupCalls); ok {
+					keepAliveAfterResult = directive == claudeWakeupArm
 				}
 			case "system":
 				if msg.SessionID != "" {
@@ -249,8 +258,29 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				terminalReasonError = claudeTerminalReasonFailure(msg.TerminalReason, msg.ResultText)
 				sessionID = msg.SessionID
 				if resultUsage := claudeResultUsage(msg, opts.Model); len(resultUsage) > 0 {
-					usage = resultUsage
+					turnUsage = resultUsage
 				}
+				mergeClaudeUsage(usage, turnUsage)
+				turnUsage = make(map[string]TokenUsage)
+				if keepAliveAfterResult && !resultIsError && terminalReasonError == "" {
+					// Claude Code's dynamic /loop emits an ordinary result at the end
+					// of every tick, then waits for its in-process ScheduleWakeup timer.
+					// Closing stdin here destroys that timer and every persistent
+					// Monitor even though the tool just reported a successful wakeup.
+					// Keep the stream-json session alive for exactly one more tick; the
+					// next tick must re-arm ScheduleWakeup or the next result closes it.
+					b.cfg.Logger.Info("claude scheduled loop armed; keeping stream-json session open",
+						"session_id", sessionID,
+					)
+					keepAliveAfterResult = false
+					sawResult = false
+					resultIsError = false
+					finalResultText = ""
+					terminalReasonError = ""
+					lastAssistantText = ""
+					continue
+				}
+				keepAliveAfterResult = false
 				closeStdin()
 			case "log":
 				if msg.Log != nil {
@@ -273,6 +303,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 
 		closeStdin()
+		mergeClaudeUsage(usage, turnUsage)
 
 		// Wait for process exit, then release the cancellation handler.
 		exitErr := cmd.Wait()
@@ -674,6 +705,83 @@ type claudeContentBlock struct {
 	Input     json.RawMessage `json:"input,omitempty"`
 	ToolUseID string          `json:"tool_use_id,omitempty"`
 	Content   json.RawMessage `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+}
+
+type claudeWakeupDirective uint8
+
+const (
+	claudeWakeupNone claudeWakeupDirective = iota
+	claudeWakeupArm
+	claudeWakeupStop
+)
+
+// claudeScheduleWakeupCalls records the intent of ScheduleWakeup tool calls by
+// call id. The intent is not applied until the corresponding tool_result says
+// the harness accepted it; otherwise a rejected tool call could keep a
+// headless Claude process waiting forever with no wakeup pending.
+func claudeScheduleWakeupCalls(msg claudeSDKMessage) map[string]claudeWakeupDirective {
+	var content claudeMessageContent
+	if err := json.Unmarshal(msg.Message, &content); err != nil {
+		return nil
+	}
+
+	calls := make(map[string]claudeWakeupDirective)
+	for _, block := range content.Content {
+		if block.Type != "tool_use" || block.Name != "ScheduleWakeup" || block.ID == "" {
+			continue
+		}
+		directive := claudeWakeupArm
+		var input struct {
+			Stop bool `json:"stop"`
+		}
+		if len(block.Input) > 0 && json.Unmarshal(block.Input, &input) == nil && input.Stop {
+			directive = claudeWakeupStop
+		}
+		calls[block.ID] = directive
+	}
+	return calls
+}
+
+// claudeCompletedWakeupDirective returns the last successfully completed
+// ScheduleWakeup directive in a user tool-result event. Claude normally emits
+// one result per event, but preserving wire order makes the behavior explicit
+// if a future CLI batches them.
+func claudeCompletedWakeupDirective(msg claudeSDKMessage, pending map[string]claudeWakeupDirective) (claudeWakeupDirective, bool) {
+	var content claudeMessageContent
+	if err := json.Unmarshal(msg.Message, &content); err != nil {
+		return claudeWakeupNone, false
+	}
+
+	directive := claudeWakeupNone
+	found := false
+	for _, block := range content.Content {
+		if block.Type != "tool_result" {
+			continue
+		}
+		pendingDirective, ok := pending[block.ToolUseID]
+		if !ok {
+			continue
+		}
+		delete(pending, block.ToolUseID)
+		if block.IsError {
+			continue
+		}
+		directive = pendingDirective
+		found = true
+	}
+	return directive, found
+}
+
+func mergeClaudeUsage(dst, src map[string]TokenUsage) {
+	for model, incoming := range src {
+		current := dst[model]
+		current.InputTokens += incoming.InputTokens
+		current.OutputTokens += incoming.OutputTokens
+		current.CacheReadTokens += incoming.CacheReadTokens
+		current.CacheWriteTokens += incoming.CacheWriteTokens
+		dst[model] = current
+	}
 }
 
 type claudeControlRequestPayload struct {

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -126,6 +126,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
+	liveness := &SessionLiveness{}
 
 	// procDone closes once cmd.Wait() returns, letting the cancellation handler
 	// skip a process that already exited and avoid signalling a dead/reused pid.
@@ -216,9 +217,10 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				return
 			}
 			// Retain the completed result throughout the scheduled wait. Reset
-			// only once a new main-thread turn starts, so EOF during the wait
-			// succeeds but an incomplete subsequent turn still fails.
+			// only once a new main-thread turn starts, so an incomplete subsequent
+			// turn cannot be masked by the previous checkpoint.
 			waitingForWakeup = false
+			liveness.clearWaitingUntil()
 			schedules.beginTurn(time.Now())
 			sawResult = false
 			finalResultText = ""
@@ -286,13 +288,9 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				}
 				if until, pending := schedules.waitingUntil(); pending && !resultIsError && terminalReasonError == "" && !sawAsyncLaunch {
 					waitingForWakeup = true
+					liveness.setWaitingUntil(until)
 					b.cfg.Logger.Info("claude awaiting native scheduled wakeup", "session_id", sessionID, "waiting_until", until)
-					// This transition controls the daemon's watchdog, so unlike
-					// display-only events it must survive a full output buffer.
-					select {
-					case msgCh <- Message{Type: MessageStatus, Status: "waiting", SessionID: sessionID, WaitingUntil: until}:
-					case <-runCtx.Done():
-					}
+					trySend(msgCh, Message{Type: MessageStatus, Status: "waiting", SessionID: sessionID, WaitingUntil: until})
 					continue
 				}
 				closeStdin()
@@ -334,6 +332,8 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		completionGuardError := ""
 		if sawAsyncLaunch {
 			completionGuardError = "claude launched an async background task; Multica-managed runs require foreground execution"
+		} else if waitingForWakeup {
+			completionGuardError = "claude exited before the confirmed scheduled wakeup; the native loop can no longer continue"
 		}
 		finalStatus, finalOutput, finalError := finalizeStreamResult(
 			"claude",
@@ -404,7 +404,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 	}()
 
-	return &Session{Messages: msgCh, Result: resCh}, nil
+	return &Session{Messages: msgCh, Result: resCh, Liveness: liveness}, nil
 }
 
 func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message, usage map[string]TokenUsage) assistantTurn {

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -212,7 +212,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			_ = stdout.Close()
 		}()
 
-		beginScheduledTurn := func() {
+		beginScheduledTurn := func(scheduledCronFire bool) {
 			if !waitingForWakeup {
 				return
 			}
@@ -220,8 +220,8 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			// only once a new main-thread turn starts, so an incomplete subsequent
 			// turn cannot be masked by the previous checkpoint.
 			waitingForWakeup = false
-			liveness.clearWaitingUntil()
-			schedules.beginTurn(time.Now())
+			liveness.ClearWaitingUntil()
+			schedules.beginTurn(time.Now(), scheduledCronFire)
 			sawResult = false
 			finalResultText = ""
 			lastAssistantText = ""
@@ -248,7 +248,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			switch msg.Type {
 			case "assistant":
 				if msg.ParentToolUseID == "" {
-					beginScheduledTurn()
+					beginScheduledTurn(false)
 				}
 				schedules.observe(msg, time.Now())
 				assistantEventCount++
@@ -264,8 +264,13 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					sawAsyncLaunch = true
 				}
 			case "system":
-				if msg.Subtype == "init" && msg.ParentToolUseID == "" {
-					beginScheduledTurn()
+				if msg.ParentToolUseID == "" {
+					switch msg.Subtype {
+					case "scheduled_task_fire":
+						beginScheduledTurn(true)
+					case "init":
+						beginScheduledTurn(false)
+					}
 				}
 				if msg.SessionID != "" {
 					sessionID = msg.SessionID
@@ -288,7 +293,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				}
 				if until, pending := schedules.waitingUntil(); pending && !resultIsError && terminalReasonError == "" && !sawAsyncLaunch {
 					waitingForWakeup = true
-					liveness.setWaitingUntil(until)
+					liveness.SetWaitingUntil(until)
 					b.cfg.Logger.Info("claude awaiting native scheduled wakeup", "session_id", sessionID, "waiting_until", until)
 					trySend(msgCh, Message{Type: MessageStatus, Status: "waiting", SessionID: sessionID, WaitingUntil: until})
 					continue

--- a/server/pkg/agent/claude_deadlock_test.go
+++ b/server/pkg/agent/claude_deadlock_test.go
@@ -43,6 +43,9 @@ func TestMain(m *testing.M) {
 	case "async_launched_tool_result":
 		runFakeClaudeAsyncLaunchedToolResult()
 		os.Exit(0)
+	case "scheduled_loop":
+		runFakeClaudeScheduledLoop()
+		os.Exit(0)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown CLAUDE_FAKE_MODE: %q\n", mode)
 		os.Exit(2)
@@ -153,6 +156,48 @@ func runFakeClaudeAsyncLaunchedToolResult() {
 	fmt.Println(`{"type":"system","session_id":"sess-async-launched"}`)
 	fmt.Println(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call-async","content":{"status":"async_launched","message":"background task launched"}}]}}`)
 	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-async-launched","result":"parent turn completed early"}`)
+}
+
+// runFakeClaudeScheduledLoop reproduces Claude Code's dynamic /loop protocol:
+// a successful ScheduleWakeup ends the current tick with a normal result, the
+// process stays idle until the timer fires, and a later tick stops the loop and
+// emits the terminal result. Reading stdin concurrently lets the fake fail
+// immediately if Multica closes it after the intermediate result.
+func runFakeClaudeScheduledLoop() {
+	reader := bufio.NewReader(os.Stdin)
+	if _, err := reader.ReadString('\n'); err != nil {
+		fmt.Fprintf(os.Stderr, "read prompt: %v\n", err)
+		os.Exit(51)
+	}
+
+	fmt.Println(`{"type":"system","session_id":"sess-loop"}`)
+	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"claude-test","content":[{"type":"tool_use","id":"call-arm","name":"ScheduleWakeup","input":{"delaySeconds":60,"prompt":"repeat"}}]}}`)
+	fmt.Println(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call-arm","content":"Next wakeup scheduled"}]}}`)
+	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-loop","result":"first tick","modelUsage":{"claude-test":{"inputTokens":10,"outputTokens":1}}}`)
+
+	eof := make(chan error, 1)
+	go func() {
+		_, err := reader.ReadByte()
+		eof <- err
+	}()
+	select {
+	case err := <-eof:
+		fmt.Fprintf(os.Stderr, "stdin closed before scheduled wakeup: %v\n", err)
+		os.Exit(52)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"claude-test","content":[{"type":"tool_use","id":"call-stop","name":"ScheduleWakeup","input":{"stop":true}}]}}`)
+	fmt.Println(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call-stop","content":"Loop stopped"}]}}`)
+	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"claude-test","content":[{"type":"text","text":"second tick finished"}]}}`)
+	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-loop","result":"second tick finished","modelUsage":{"claude-test":{"inputTokens":20,"outputTokens":2}}}`)
+
+	select {
+	case <-eof:
+	case <-time.After(2 * time.Second):
+		fmt.Fprintln(os.Stderr, "stdin stayed open after ScheduleWakeup stop")
+		os.Exit(53)
+	}
 }
 
 // TestClaudeExecuteDoesNotDeadlockOnStartupStdoutBurst verifies that the
@@ -357,5 +402,57 @@ func TestClaudeExecuteFailsLoudlyOnAsyncLaunchedToolResult(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for result — claude backend did not fail async_launched tool result")
+	}
+}
+
+func TestClaudeExecuteKeepsScheduledLoopAliveAcrossResults(t *testing.T) {
+	t.Parallel()
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	backend, err := New("claude", Config{
+		ExecutablePath: self,
+		Env:            map[string]string{"CLAUDE_FAKE_MODE": "scheduled_loop", "IS_SANDBOX": "1"},
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new claude backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "/loop 1m continue", ExecOptions{Timeout: 8 * time.Second})
+	if err != nil {
+		t.Fatalf("execute returned error: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Output != "second tick finished" {
+			t.Fatalf("expected the terminal loop tick, got %q", result.Output)
+		}
+		if result.SessionID != "sess-loop" {
+			t.Fatalf("expected session id sess-loop, got %q", result.SessionID)
+		}
+		wantUsage := TokenUsage{InputTokens: 30, OutputTokens: 3}
+		if got := result.Usage["claude-test"]; got != wantUsage {
+			t.Fatalf("loop usage = %+v, want %+v", got, wantUsage)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for scheduled loop — Claude stdin was not managed across result events")
 	}
 }

--- a/server/pkg/agent/claude_deadlock_test.go
+++ b/server/pkg/agent/claude_deadlock_test.go
@@ -47,6 +47,9 @@ func TestMain(m *testing.M) {
 	case "scheduled_wakeup_exit", "scheduled_wakeup_eof", "scheduled_wakeup_no_result":
 		runFakeClaudeScheduledWakeup(mode)
 		os.Exit(0)
+	case "native_loop", "native_loop_exit", "native_loop_incomplete", "native_loop_init_incomplete", "native_loop_cancel", "native_cron":
+		runFakeClaudeNativeLoop(mode)
+		os.Exit(0)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown CLAUDE_FAKE_MODE: %q\n", mode)
 		os.Exit(2)

--- a/server/pkg/agent/claude_deadlock_test.go
+++ b/server/pkg/agent/claude_deadlock_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -43,8 +44,8 @@ func TestMain(m *testing.M) {
 	case "async_launched_tool_result":
 		runFakeClaudeAsyncLaunchedToolResult()
 		os.Exit(0)
-	case "scheduled_loop":
-		runFakeClaudeScheduledLoop()
+	case "scheduled_wakeup_exit", "scheduled_wakeup_eof", "scheduled_wakeup_no_result":
+		runFakeClaudeScheduledWakeup(mode)
 		os.Exit(0)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown CLAUDE_FAKE_MODE: %q\n", mode)
@@ -158,47 +159,32 @@ func runFakeClaudeAsyncLaunchedToolResult() {
 	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-async-launched","result":"parent turn completed early"}`)
 }
 
-// runFakeClaudeScheduledLoop reproduces Claude Code's dynamic /loop protocol:
-// a successful ScheduleWakeup ends the current tick with a normal result, the
-// process stays idle until the timer fires, and a later tick stops the loop and
-// emits the terminal result. Reading stdin concurrently lets the fake fail
-// immediately if Multica closes it after the intermediate result.
-func runFakeClaudeScheduledLoop() {
+// runFakeClaudeScheduledWakeup reproduces a headless turn that arms a wakeup
+// and then exits. A successful tool result does not promise another CLI turn.
+func runFakeClaudeScheduledWakeup(mode string) {
 	reader := bufio.NewReader(os.Stdin)
 	if _, err := reader.ReadString('\n'); err != nil {
 		fmt.Fprintf(os.Stderr, "read prompt: %v\n", err)
 		os.Exit(51)
 	}
 
-	fmt.Println(`{"type":"system","session_id":"sess-loop"}`)
-	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"claude-test","content":[{"type":"tool_use","id":"call-arm","name":"ScheduleWakeup","input":{"delaySeconds":60,"prompt":"repeat"}}]}}`)
+	fmt.Fprintln(os.Stderr, `[claude-code:unrecognized_model] {"model":"k3-256k","query_source":"sdk"}`)
+	fmt.Println(`{"type":"system","session_id":"sess-wakeup"}`)
+	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"k3-256k","content":[{"type":"tool_use","id":"call-arm","name":"ScheduleWakeup","input":{"delaySeconds":1400,"prompt":"repeat"}}]}}`)
 	fmt.Println(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call-arm","content":"Next wakeup scheduled"}]}}`)
-	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-loop","result":"first tick","modelUsage":{"claude-test":{"inputTokens":10,"outputTokens":1}}}`)
-
-	eof := make(chan error, 1)
-	go func() {
-		_, err := reader.ReadByte()
-		eof <- err
-	}()
-	select {
-	case err := <-eof:
-		fmt.Fprintf(os.Stderr, "stdin closed before scheduled wakeup: %v\n", err)
-		os.Exit(52)
-	case <-time.After(100 * time.Millisecond):
+	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"k3-256k","content":[{"type":"text","text":"assistant fallback"}],"usage":{"input_tokens":4,"output_tokens":1}}}`)
+	if mode == "scheduled_wakeup_no_result" {
+		return
 	}
+	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-wakeup","result":"current turn finished","modelUsage":{"k3-256k":{"inputTokens":10,"outputTokens":2,"cacheReadInputTokens":3,"cacheCreationInputTokens":4}}}`)
 
-	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"claude-test","content":[{"type":"tool_use","id":"call-stop","name":"ScheduleWakeup","input":{"stop":true}}]}}`)
-	fmt.Println(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call-stop","content":"Loop stopped"}]}}`)
-	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"claude-test","content":[{"type":"text","text":"second tick finished"}]}}`)
-	// modelUsage is cumulative for the lifetime of the stream-json process:
-	// this snapshot already includes the first tick's 10 input / 1 output.
-	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-loop","result":"second tick finished","modelUsage":{"claude-test":{"inputTokens":30,"outputTokens":3}}}`)
-
-	select {
-	case <-eof:
-	case <-time.After(2 * time.Second):
-		fmt.Fprintln(os.Stderr, "stdin stayed open after ScheduleWakeup stop")
-		os.Exit(53)
+	if mode == "scheduled_wakeup_eof" {
+		// Also enforce the turn boundary for a child that waits for stdin EOF.
+		// Merely retaining sawResult while keeping stdin open would still hang.
+		if _, err := reader.ReadByte(); err != io.EOF {
+			fmt.Fprintf(os.Stderr, "expected stdin EOF after result, got %v\n", err)
+			os.Exit(52)
+		}
 	}
 }
 
@@ -407,7 +393,7 @@ func TestClaudeExecuteFailsLoudlyOnAsyncLaunchedToolResult(t *testing.T) {
 	}
 }
 
-func TestClaudeExecuteKeepsScheduledLoopAliveAcrossResults(t *testing.T) {
+func TestClaudeExecuteScheduledWakeupPreservesTerminalResult(t *testing.T) {
 	t.Parallel()
 
 	self, err := os.Executable()
@@ -415,46 +401,52 @@ func TestClaudeExecuteKeepsScheduledLoopAliveAcrossResults(t *testing.T) {
 		t.Fatalf("os.Executable: %v", err)
 	}
 
-	backend, err := New("claude", Config{
-		ExecutablePath: self,
-		Env:            map[string]string{"CLAUDE_FAKE_MODE": "scheduled_loop", "IS_SANDBOX": "1"},
-		Logger:         slog.Default(),
-	})
-	if err != nil {
-		t.Fatalf("new claude backend: %v", err)
-	}
+	for _, mode := range []string{"scheduled_wakeup_exit", "scheduled_wakeup_eof", "scheduled_wakeup_no_result"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			backend, err := New("claude", Config{
+				ExecutablePath: self,
+				Env:            map[string]string{"CLAUDE_FAKE_MODE": mode, "IS_SANDBOX": "1"},
+				Logger:         slog.Default(),
+			})
+			if err != nil {
+				t.Fatalf("new claude backend: %v", err)
+			}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	session, err := backend.Execute(ctx, "/loop 1m continue", ExecOptions{Timeout: 8 * time.Second})
-	if err != nil {
-		t.Fatalf("execute returned error: %v", err)
-	}
-	go func() {
-		for range session.Messages {
-		}
-	}()
-
-	select {
-	case result, ok := <-session.Result:
-		if !ok {
-			t.Fatal("result channel closed without a value")
-		}
-		if result.Status != "completed" {
-			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
-		}
-		if result.Output != "second tick finished" {
-			t.Fatalf("expected the terminal loop tick, got %q", result.Output)
-		}
-		if result.SessionID != "sess-loop" {
-			t.Fatalf("expected session id sess-loop, got %q", result.SessionID)
-		}
-		wantUsage := TokenUsage{InputTokens: 30, OutputTokens: 3}
-		if got := result.Usage["claude-test"]; got != wantUsage {
-			t.Fatalf("loop usage = %+v, want %+v", got, wantUsage)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timeout waiting for scheduled loop — Claude stdin was not managed across result events")
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			session, err := backend.Execute(ctx, "/loop continue", ExecOptions{Model: "k3-256k", Timeout: 3 * time.Second})
+			if err != nil {
+				t.Fatalf("execute returned error: %v", err)
+			}
+			for range session.Messages {
+			}
+			result, ok := <-session.Result
+			if !ok {
+				t.Fatal("result channel closed without a value")
+			}
+			if result.SessionID != "sess-wakeup" {
+				t.Fatalf("expected resumable session id sess-wakeup, got %q", result.SessionID)
+			}
+			if mode == "scheduled_wakeup_no_result" {
+				if result.Status != "failed" || !strings.Contains(result.Error, "stream ended without terminal result") {
+					t.Fatalf("expected missing terminal result failure, got status=%q error=%q", result.Status, result.Error)
+				}
+				if !strings.Contains(result.Error, "[claude-code:unrecognized_model]") {
+					t.Fatalf("expected stderr preserved for a real failure, got %q", result.Error)
+				}
+				return
+			}
+			if result.Status != "completed" || result.Error != "" {
+				t.Fatalf("expected successful completion despite stderr warning, got status=%q error=%q", result.Status, result.Error)
+			}
+			if result.Output != "current turn finished" {
+				t.Fatalf("expected terminal result text, got %q", result.Output)
+			}
+			wantUsage := TokenUsage{InputTokens: 10, OutputTokens: 2, CacheReadTokens: 3, CacheWriteTokens: 4}
+			if got := result.Usage["k3-256k"]; got != wantUsage {
+				t.Fatalf("result usage = %+v, want %+v", got, wantUsage)
+			}
+		})
 	}
 }

--- a/server/pkg/agent/claude_deadlock_test.go
+++ b/server/pkg/agent/claude_deadlock_test.go
@@ -190,7 +190,9 @@ func runFakeClaudeScheduledLoop() {
 	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"claude-test","content":[{"type":"tool_use","id":"call-stop","name":"ScheduleWakeup","input":{"stop":true}}]}}`)
 	fmt.Println(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call-stop","content":"Loop stopped"}]}}`)
 	fmt.Println(`{"type":"assistant","message":{"role":"assistant","model":"claude-test","content":[{"type":"text","text":"second tick finished"}]}}`)
-	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-loop","result":"second tick finished","modelUsage":{"claude-test":{"inputTokens":20,"outputTokens":2}}}`)
+	// modelUsage is cumulative for the lifetime of the stream-json process:
+	// this snapshot already includes the first tick's 10 input / 1 output.
+	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-loop","result":"second tick finished","modelUsage":{"claude-test":{"inputTokens":30,"outputTokens":3}}}`)
 
 	select {
 	case <-eof:

--- a/server/pkg/agent/claude_deadlock_test.go
+++ b/server/pkg/agent/claude_deadlock_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 	case "scheduled_wakeup_exit", "scheduled_wakeup_eof", "scheduled_wakeup_no_result":
 		runFakeClaudeScheduledWakeup(mode)
 		os.Exit(0)
-	case "native_loop", "native_loop_exit", "native_loop_incomplete", "native_loop_init_incomplete", "native_loop_cancel", "native_cron":
+	case "native_loop", "native_loop_exit", "native_loop_buffer_full_exit", "native_loop_incomplete", "native_loop_init_incomplete", "native_loop_cancel", "native_cron":
 		runFakeClaudeNativeLoop(mode)
 		os.Exit(0)
 	default:

--- a/server/pkg/agent/claude_loop_integration_test.go
+++ b/server/pkg/agent/claude_loop_integration_test.go
@@ -1,0 +1,184 @@
+//go:build agentintegration
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Exercises the installed CLI's /loop expansion and timers through Execute.
+// Only the Messages API is mocked; no authenticated model account is used.
+func TestClaudeNativeLoopIntegration(t *testing.T) {
+	if os.Getenv("MULTICA_RUN_REAL_AGENT_SMOKE") != "1" {
+		t.Skip("set MULTICA_RUN_REAL_AGENT_SMOKE=1 to run the installed Claude CLI against a local mock API")
+	}
+	executable := os.Getenv("MULTICA_CLAUDE_EXECUTABLE")
+	if executable == "" {
+		executable = "claude"
+	}
+	executable, err := exec.LookPath(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, kind := range []string{"dynamic", "cron"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			config := filepath.Join(root, "config")
+			if err := os.Mkdir(config, 0700); err != nil {
+				t.Fatal(err)
+			}
+			cached := fmt.Sprintf(`{"cachedGrowthBookFeatures":{"tengu_kairos_loop_dynamic":true,"tengu_kairos_loop_prompt":true,"tengu_kairos_cron":true},"cachedGrowthBookFeaturesAt":%d}`, time.Now().UnixMilli())
+			if err := os.WriteFile(filepath.Join(config, ".claude.json"), []byte(cached), 0600); err != nil {
+				t.Fatal(err)
+			}
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.Contains(r.URL.Path, "/messages") {
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprint(w, `{}`)
+					return
+				}
+				var req struct {
+					Model    string          `json:"model"`
+					Stream   bool            `json:"stream"`
+					Messages json.RawMessage `json:"messages"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Error(err)
+					http.Error(w, "bad request", 400)
+					return
+				}
+				n := calls.Add(1)
+				var block map[string]any
+				switch n {
+				case 1:
+					name, input := "ScheduleWakeup", map[string]any{"delaySeconds": 60, "reason": "bounded native loop smoke test", "prompt": "Stop the loop and say second tick finished.", "noop": false}
+					if kind == "cron" {
+						name = "CronCreate"
+						input = map[string]any{"cron": "* * * * *", "recurring": true, "prompt": "Delete this cron and say second tick finished."}
+					}
+					block = map[string]any{"type": "tool_use", "id": "call-arm", "name": name, "input": input}
+				case 3:
+					name, input := "ScheduleWakeup", map[string]any{"stop": true}
+					if kind == "cron" {
+						match := regexp.MustCompile(`Scheduled recurring job ([a-z0-9]+)`).FindSubmatch(req.Messages)
+						if len(match) != 2 {
+							t.Error("native CronCreate receipt missing from conversation")
+							http.Error(w, "missing cron", 500)
+							return
+						}
+						name = "CronDelete"
+						input = map[string]any{"id": string(match[1])}
+					}
+					block = map[string]any{"type": "tool_use", "id": "call-stop", "name": name, "input": input}
+				default:
+					value := "first tick finished"
+					if n > 2 {
+						value = "second tick finished"
+					}
+					block = map[string]any{"type": "text", "text": value}
+				}
+				stop := "end_turn"
+				if block["type"] == "tool_use" {
+					stop = "tool_use"
+				}
+				message := map[string]any{"id": fmt.Sprintf("msg-%d", n), "type": "message", "role": "assistant", "model": req.Model, "content": []any{block}, "stop_reason": stop, "stop_sequence": nil, "usage": map[string]int{"input_tokens": 10, "output_tokens": 5}}
+				if !req.Stream {
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(message)
+					return
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				emit := func(event string, data map[string]any) {
+					data["type"] = event
+					b, _ := json.Marshal(data)
+					fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, b)
+					w.(http.Flusher).Flush()
+				}
+				message["content"] = []any{}
+				message["stop_reason"] = nil
+				message["usage"] = map[string]int{"input_tokens": 10, "output_tokens": 0}
+				emit("message_start", map[string]any{"message": message})
+				start, delta := map[string]any{"type": "text", "text": ""}, map[string]any{"type": "text_delta", "text": block["text"]}
+				if stop == "tool_use" {
+					b, _ := json.Marshal(block["input"])
+					start = map[string]any{"type": "tool_use", "id": block["id"], "name": block["name"], "input": map[string]any{}}
+					delta = map[string]any{"type": "input_json_delta", "partial_json": string(b)}
+				}
+				emit("content_block_start", map[string]any{"index": 0, "content_block": start})
+				emit("content_block_delta", map[string]any{"index": 0, "delta": delta})
+				emit("content_block_stop", map[string]any{"index": 0})
+				emit("message_delta", map[string]any{"delta": map[string]any{"stop_reason": stop, "stop_sequence": nil}, "usage": map[string]int{"output_tokens": 5}})
+				emit("message_stop", map[string]any{})
+			}))
+			defer server.Close()
+			// Override inherited credentials and feature opt-outs in this subprocess.
+			// The isolated config and dummy key never use the developer's account.
+			env := map[string]string{}
+			for _, item := range os.Environ() {
+				key, _, _ := strings.Cut(item, "=")
+				if strings.HasPrefix(key, "ANTHROPIC_") || strings.HasPrefix(key, "CLAUDE_") {
+					env[key] = ""
+				}
+			}
+			for _, key := range []string{"DISABLE_TELEMETRY", "DO_NOT_TRACK", "DISABLE_ERROR_REPORTING"} {
+				env[key] = ""
+			}
+			env["ANTHROPIC_BASE_URL"] = server.URL
+			env["ANTHROPIC_API_KEY"] = "local-test-key"
+			env["CLAUDE_CONFIG_DIR"] = config
+			env["IS_SANDBOX"] = "1"
+			backend, err := New("claude", Config{ExecutablePath: executable, Env: env, Logger: slog.Default()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
+			defer cancel()
+			prompt := "/loop Run the bounded native loop smoke check and stop after the second tick."
+			if kind == "cron" {
+				prompt = "/loop 1m Run the bounded native loop smoke check and delete the cron after the second tick."
+			}
+			start := time.Now()
+			session, err := backend.Execute(ctx, prompt, ExecOptions{Cwd: root, Model: "claude-sonnet-4-6", Timeout: 145 * time.Second, ThinkingLevel: "low", McpConfig: json.RawMessage(`{"mcpServers":{}}`), CustomArgs: []string{"--strict-mcp-config", "--setting-sources", ""}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			waited := false
+			sessionID := ""
+			for msg := range session.Messages {
+				if msg.SessionID != "" {
+					if sessionID != "" && sessionID != msg.SessionID {
+						t.Error("native loop changed session")
+					}
+					sessionID = msg.SessionID
+				}
+				if !msg.WaitingUntil.IsZero() {
+					waited = true
+					t.Logf("native wait until %s", msg.WaitingUntil)
+				}
+			}
+			result := <-session.Result
+			if !waited || calls.Load() != 4 || result.Status != "completed" || result.Output != "second tick finished" {
+				t.Fatalf("waited=%v requests=%d result=%+v", waited, calls.Load(), result)
+			}
+			if kind == "dynamic" && time.Since(start) < time.Minute {
+				t.Fatal("second turn did not wait for the native timer")
+			}
+			t.Logf("native %s completed two turns and stopped in %s; session=%s", kind, time.Since(start), sessionID)
+		})
+	}
+}

--- a/server/pkg/agent/claude_schedule.go
+++ b/server/pkg/agent/claude_schedule.go
@@ -1,0 +1,134 @@
+package agent
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// claudeSchedules observes native scheduling receipts. Claude owns the timers,
+// prompt expansion and dispatch; this only decides when its stdin may close.
+// A successful tool_result alone is insufficient: disabled/expired dynamic
+// loops return a non-error result with scheduledFor=0.
+type claudeSchedules struct {
+	calls  map[string]claudeContentBlock
+	wakeup time.Time
+	crons  map[string]claudeCron
+}
+
+type claudeCron struct {
+	schedule  cron.Schedule
+	next      time.Time
+	expires   time.Time
+	recurring bool
+}
+
+func (s *claudeSchedules) observe(msg claudeSDKMessage, now time.Time) {
+	if msg.ParentToolUseID != "" {
+		return
+	}
+	var content claudeMessageContent
+	if json.Unmarshal(msg.Message, &content) != nil {
+		return
+	}
+	for _, block := range content.Content {
+		if msg.Type == "assistant" && block.Type == "tool_use" && block.ID != "" {
+			switch block.Name {
+			case "ScheduleWakeup", "CronCreate", "CronDelete":
+				if s.calls == nil {
+					s.calls = make(map[string]claudeContentBlock)
+				}
+				s.calls[block.ID] = block
+			}
+		}
+		if msg.Type != "user" || block.Type != "tool_result" {
+			continue
+		}
+		call, ok := s.calls[block.ToolUseID]
+		if !ok {
+			continue
+		}
+		delete(s.calls, block.ToolUseID)
+		if block.IsError {
+			continue
+		}
+		switch call.Name {
+		case "ScheduleWakeup":
+			var receipt struct {
+				ScheduledFor int64 `json:"scheduledFor"`
+				Stopped      bool  `json:"stopped"`
+			}
+			if json.Unmarshal(msg.ToolUseResult, &receipt) != nil {
+				continue
+			}
+			if receipt.Stopped {
+				s.wakeup = time.Time{}
+			} else if receipt.ScheduledFor > 0 {
+				s.wakeup = time.UnixMilli(receipt.ScheduledFor)
+			}
+		case "CronCreate":
+			var receipt struct {
+				ID        string `json:"id"`
+				Recurring bool   `json:"recurring"`
+			}
+			var input struct {
+				Cron string `json:"cron"`
+			}
+			if json.Unmarshal(msg.ToolUseResult, &receipt) != nil || receipt.ID == "" || json.Unmarshal(call.Input, &input) != nil {
+				continue
+			}
+			schedule, err := cron.ParseStandard(input.Cron)
+			if err != nil {
+				continue
+			}
+			if s.crons == nil {
+				s.crons = make(map[string]claudeCron)
+			}
+			s.crons[receipt.ID] = claudeCron{schedule: schedule, next: schedule.Next(now), expires: now.Add(7 * 24 * time.Hour), recurring: receipt.Recurring}
+		case "CronDelete":
+			var receipt struct {
+				ID string `json:"id"`
+			}
+			if json.Unmarshal(msg.ToolUseResult, &receipt) != nil {
+				continue
+			}
+			delete(s.crons, receipt.ID)
+		}
+	}
+}
+
+// A main-thread response after a due time consumes that scheduled fire. Early
+// responses (for example a task notification) leave future wakeups intact.
+func (s *claudeSchedules) beginTurn(now time.Time) {
+	if !s.wakeup.After(now) {
+		s.wakeup = time.Time{}
+	}
+	for id, entry := range s.crons {
+		if entry.expires.Before(now) || !entry.recurring && !entry.next.After(now) {
+			delete(s.crons, id)
+			continue
+		}
+		if !entry.next.After(now) {
+			entry.next = entry.schedule.Next(now)
+			s.crons[id] = entry
+		}
+	}
+}
+
+func (s *claudeSchedules) waitingUntil() (time.Time, bool) {
+	until := s.wakeup
+	for _, entry := range s.crons {
+		// Claude jitters recurring fires by up to half an interval, capped at
+		// 30 minutes. After that boundary the daemon's normal idle budget applies.
+		next := entry.next
+		if entry.recurring {
+			jitter := min(entry.schedule.Next(next).Sub(next)/2, 30*time.Minute)
+			next = next.Add(jitter)
+		}
+		if until.IsZero() || next.Before(until) {
+			until = next
+		}
+	}
+	return until, !until.IsZero()
+}

--- a/server/pkg/agent/claude_schedule.go
+++ b/server/pkg/agent/claude_schedule.go
@@ -92,7 +92,11 @@ func (s *claudeSchedules) observe(msg claudeSDKMessage, now time.Time) {
 			if s.crons == nil {
 				s.crons = make(map[string]claudeCron)
 			}
-			s.crons[receipt.ID] = claudeCron{schedule: schedule, next: schedule.Next(now), expires: now.Add(7 * 24 * time.Hour), recurring: receipt.Recurring}
+			entry := claudeCron{schedule: schedule, next: schedule.Next(now), recurring: receipt.Recurring}
+			if receipt.Recurring {
+				entry.expires = now.Add(7 * 24 * time.Hour)
+			}
+			s.crons[receipt.ID] = entry
 		case "CronDelete":
 			var receipt struct {
 				ID string `json:"id"`
@@ -105,14 +109,17 @@ func (s *claudeSchedules) observe(msg claudeSDKMessage, now time.Time) {
 	}
 }
 
-// A main-thread response after a due time consumes that scheduled fire. Early
-// responses (for example a task notification) leave future wakeups intact.
-func (s *claudeSchedules) beginTurn(now time.Time) {
+// A main-thread response after a due time consumes that scheduled fire. Claude
+// emits scheduled_task_fire for cron-driven turns; that marker permits the
+// documented 90-second early window for one-shots at :00/:30. Other early
+// responses (for example an unrelated task notification) leave them intact.
+func (s *claudeSchedules) beginTurn(now time.Time, scheduledCronFire bool) {
 	if !s.wakeup.After(now) {
 		s.wakeup = time.Time{}
 	}
 	for id, entry := range s.crons {
-		if entry.expires.Before(now) || !entry.recurring && !entry.next.After(now) {
+		if (entry.recurring && entry.expires.Before(now)) ||
+			(!entry.recurring && claudeOneShotFired(entry.next, now, scheduledCronFire)) {
 			delete(s.crons, id)
 			continue
 		}
@@ -121,6 +128,16 @@ func (s *claudeSchedules) beginTurn(now time.Time) {
 			s.crons[id] = entry
 		}
 	}
+}
+
+func claudeOneShotFired(next, now time.Time, scheduledCronFire bool) bool {
+	if !next.After(now) {
+		return true
+	}
+	if !scheduledCronFire || next.Minute() != 0 && next.Minute() != 30 {
+		return false
+	}
+	return !now.Before(next.Add(-90 * time.Second))
 }
 
 func (s *claudeSchedules) waitingUntil() (time.Time, bool) {
@@ -133,7 +150,7 @@ func (s *claudeSchedules) waitingUntil() (time.Time, bool) {
 			jitter := min(entry.schedule.Next(next).Sub(next)/2, 30*time.Minute)
 			next = next.Add(jitter)
 		}
-		if entry.expires.Before(next) {
+		if entry.recurring && entry.expires.Before(next) {
 			next = entry.expires
 		}
 		if until.IsZero() || next.Before(until) {

--- a/server/pkg/agent/claude_schedule.go
+++ b/server/pkg/agent/claude_schedule.go
@@ -2,6 +2,9 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -78,7 +81,11 @@ func (s *claudeSchedules) observe(msg claudeSDKMessage, now time.Time) {
 			if json.Unmarshal(msg.ToolUseResult, &receipt) != nil || receipt.ID == "" || json.Unmarshal(call.Input, &input) != nil {
 				continue
 			}
-			schedule, err := cron.ParseStandard(input.Cron)
+			cronExpression, err := normalizeClaudeCron(input.Cron)
+			if err != nil {
+				continue
+			}
+			schedule, err := cron.ParseStandard(cronExpression)
 			if err != nil {
 				continue
 			}
@@ -126,9 +133,77 @@ func (s *claudeSchedules) waitingUntil() (time.Time, bool) {
 			jitter := min(entry.schedule.Next(next).Sub(next)/2, 30*time.Minute)
 			next = next.Add(jitter)
 		}
+		if entry.expires.Before(next) {
+			next = entry.expires
+		}
 		if until.IsZero() || next.Before(until) {
 			until = next
 		}
 	}
 	return until, !until.IsZero()
+}
+
+// normalizeClaudeCron converts Claude's Sunday value 7 into robfig/cron's
+// equivalent 0. Claude accepts both values, including 7 inside lists and
+// ascending numeric ranges; robfig's standard five-field parser accepts only
+// 0-6. Other fields and expressions pass through unchanged for the parser to
+// validate.
+func normalizeClaudeCron(expression string) (string, error) {
+	fields := strings.Fields(expression)
+	if len(fields) != 5 {
+		return "", fmt.Errorf("claude cron: expected 5 fields, got %d", len(fields))
+	}
+
+	parts := strings.Split(fields[4], ",")
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		values, changed, err := normalizeClaudeSundayPart(part)
+		if err != nil {
+			return "", err
+		}
+		if changed {
+			normalized = append(normalized, values...)
+		} else {
+			normalized = append(normalized, part)
+		}
+	}
+	fields[4] = strings.Join(normalized, ",")
+	return strings.Join(fields, " "), nil
+}
+
+func normalizeClaudeSundayPart(part string) ([]string, bool, error) {
+	if part == "7" {
+		return []string{"0"}, true, nil
+	}
+
+	rangePart, stepPart, hasStep := strings.Cut(part, "/")
+	startText, endText, hasRange := strings.Cut(rangePart, "-")
+	if !hasRange || endText != "7" {
+		return nil, false, nil
+	}
+	start, err := strconv.Atoi(startText)
+	if err != nil || start < 0 || start > 7 {
+		return nil, false, nil
+	}
+	step := 1
+	if hasStep {
+		step, err = strconv.Atoi(stepPart)
+		if err != nil || step <= 0 {
+			return nil, false, fmt.Errorf("claude cron: invalid weekday step %q", stepPart)
+		}
+	}
+
+	values := make([]string, 0, 8-start)
+	seen := make(map[int]bool, 8-start)
+	for day := start; day <= 7; day += step {
+		normalizedDay := day
+		if day == 7 {
+			normalizedDay = 0
+		}
+		if !seen[normalizedDay] {
+			values = append(values, strconv.Itoa(normalizedDay))
+			seen[normalizedDay] = true
+		}
+	}
+	return values, true, nil
 }

--- a/server/pkg/agent/claude_schedule_test.go
+++ b/server/pkg/agent/claude_schedule_test.go
@@ -1,0 +1,185 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func scheduleEvent(typ, content, receipt string) claudeSDKMessage {
+	return claudeSDKMessage{Type: typ, Message: json.RawMessage(`{"content":[` + content + `]}`), ToolUseResult: json.RawMessage(receipt)}
+}
+
+func TestClaudeSchedulesRequireNativeReceipt(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name, receipt       string
+		failed, child, want bool
+	}{
+		{name: "confirmed", receipt: fmt.Sprintf(`{"scheduledFor":%d}`, now.Add(time.Hour).UnixMilli()), want: true},
+		{name: "text only", receipt: ""},
+		{name: "disabled", receipt: `{"scheduledFor":0}`},
+		{name: "failed", receipt: fmt.Sprintf(`{"scheduledFor":%d}`, now.Add(time.Hour).UnixMilli()), failed: true},
+		{name: "subagent", receipt: fmt.Sprintf(`{"scheduledFor":%d}`, now.Add(time.Hour).UnixMilli()), child: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var s claudeSchedules
+			call := scheduleEvent("assistant", `{"type":"tool_use","id":"arm","name":"ScheduleWakeup","input":{}}`, "")
+			result := scheduleEvent("user", fmt.Sprintf(`{"type":"tool_result","tool_use_id":"arm","is_error":%t,"content":"scheduled"}`, tc.failed), tc.receipt)
+			if tc.child {
+				call.ParentToolUseID = "child"
+				result.ParentToolUseID = "child"
+			}
+			s.observe(call, now)
+			s.observe(result, now)
+			if _, got := s.waitingUntil(); got != tc.want {
+				t.Fatalf("waiting=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaudeSchedulesConsumeAndCancel(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	var s claudeSchedules
+	s.observe(scheduleEvent("assistant", `{"type":"tool_use","id":"arm","name":"ScheduleWakeup","input":{}}`, ""), now)
+	s.observe(scheduleEvent("user", `{"type":"tool_result","tool_use_id":"arm"}`, fmt.Sprintf(`{"scheduledFor":%d}`, now.Add(time.Minute).UnixMilli())), now)
+	s.beginTurn(now.Add(time.Second))
+	if _, ok := s.waitingUntil(); !ok {
+		t.Fatal("early notification consumed future wakeup")
+	}
+	s.beginTurn(now.Add(time.Minute))
+	if _, ok := s.waitingUntil(); ok {
+		t.Fatal("fired one-shot wakeup retained")
+	}
+	s.observe(scheduleEvent("assistant", `{"type":"tool_use","id":"cron","name":"CronCreate","input":{"cron":"* * * * *"}}`, ""), now)
+	s.observe(scheduleEvent("user", `{"type":"tool_result","tool_use_id":"cron"}`, `{"id":"job","recurring":true}`), now)
+	s.beginTurn(now.Add(time.Minute))
+	if due, ok := s.waitingUntil(); !ok || !due.After(now.Add(time.Minute)) {
+		t.Fatalf("recurring cron lost after first fire: %v %v", due, ok)
+	}
+	s.observe(scheduleEvent("assistant", `{"type":"tool_use","id":"stop","name":"CronDelete","input":{"id":"job"}}`, ""), now)
+	s.observe(scheduleEvent("user", `{"type":"tool_result","tool_use_id":"stop","is_error":true}`, `"failed"`), now)
+	if _, ok := s.waitingUntil(); !ok {
+		t.Fatal("failed deletion removed cron")
+	}
+	s.observe(scheduleEvent("assistant", `{"type":"tool_use","id":"stop2","name":"CronDelete","input":{"id":"job"}}`, ""), now)
+	s.observe(scheduleEvent("user", `{"type":"tool_result","tool_use_id":"stop2"}`, `{"id":"job"}`), now)
+	if _, ok := s.waitingUntil(); ok {
+		t.Fatal("successful deletion retained cron")
+	}
+}
+
+// The fake owns its timer, just like native Claude. EOF before the second turn
+// cancels it, reproducing the adapter's former close-stdin-on-first-result bug.
+func runFakeClaudeNativeLoop(mode string) {
+	reader := bufio.NewReader(os.Stdin)
+	if _, err := reader.ReadString('\n'); err != nil {
+		os.Exit(61)
+	}
+	fmt.Println(`{"type":"system","session_id":"native-session"}`)
+	tool, input, receipt := "ScheduleWakeup", `{"delaySeconds":60}`, fmt.Sprintf(`{"scheduledFor":%d}`, time.Now().Add(80*time.Millisecond).UnixMilli())
+	if mode == "native_cron" {
+		tool = "CronCreate"
+		input = `{"cron":"* * * * *","recurring":true}`
+		receipt = `{"id":"job","recurring":true}`
+	}
+	fmt.Printf("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"arm\",\"name\":%q,\"input\":%s}]}}\n", tool, input)
+	fmt.Printf("{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"arm\",\"content\":\"scheduled\"}]},\"tool_use_result\":%s}\n", receipt)
+	fmt.Println(`{"type":"result","session_id":"native-session","result":"first turn","modelUsage":{"k3-256k":{"inputTokens":10,"outputTokens":2}}}`)
+	if mode == "native_loop_exit" {
+		return
+	}
+	eof := make(chan struct{})
+	go func() { _, _ = io.Copy(io.Discard, reader); close(eof) }()
+	if mode == "native_loop_cancel" {
+		<-eof
+		return
+	}
+	select {
+	case <-eof:
+		return
+	case <-time.After(100 * time.Millisecond):
+	}
+	fmt.Println(`{"type":"system","subtype":"init","session_id":"native-session"}`)
+	if mode == "native_loop_init_incomplete" {
+		return
+	}
+	fmt.Println(`{"type":"assistant","message":{"content":[{"type":"text","text":"second turn"}],"model":"k3-256k","usage":{"input_tokens":5,"output_tokens":1}}}`)
+	if mode == "native_loop_incomplete" {
+		return
+	}
+	tool, input, receipt = "ScheduleWakeup", `{"stop":true}`, `{"scheduledFor":0,"stopped":true}`
+	if mode == "native_cron" {
+		tool = "CronDelete"
+		input = `{"id":"job"}`
+		receipt = `{"id":"job"}`
+	}
+	fmt.Printf("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"stop\",\"name\":%q,\"input\":%s}]}}\n", tool, input)
+	fmt.Printf("{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"stop\"}]},\"tool_use_result\":%s}\n", receipt)
+	fmt.Println(`{"type":"result","session_id":"native-session","result":"second turn","modelUsage":{"k3-256k":{"inputTokens":20,"outputTokens":4}}}`)
+	<-eof
+}
+
+func TestClaudeExecuteNativeLoop(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []string{"native_loop", "native_cron", "native_loop_exit", "native_loop_incomplete", "native_loop_init_incomplete", "native_loop_cancel"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			backend, err := New("claude", Config{ExecutablePath: self, Env: map[string]string{"CLAUDE_FAKE_MODE": mode, "IS_SANDBOX": "1"}, Logger: slog.Default()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			session, err := backend.Execute(ctx, "/loop check", ExecOptions{Model: "k3-256k", Timeout: 3 * time.Second})
+			if err != nil {
+				t.Fatal(err)
+			}
+			waited := false
+			for msg := range session.Messages {
+				if msg.Type == MessageStatus && !msg.WaitingUntil.IsZero() {
+					waited = true
+					if mode == "native_loop_cancel" {
+						cancel()
+					}
+				}
+			}
+			result := <-session.Result
+			if !waited {
+				t.Fatal("no confirmed waiting status")
+			}
+			if result.SessionID != "native-session" {
+				t.Fatalf("session lost: %+v", result)
+			}
+			switch mode {
+			case "native_loop_cancel":
+				if result.Status != "aborted" {
+					t.Fatalf("cancelled wait: %+v", result)
+				}
+			case "native_loop_incomplete", "native_loop_init_incomplete":
+				if result.Status != "failed" || !strings.Contains(result.Error, "without terminal result") {
+					t.Fatalf("incomplete new turn masked by previous result: %+v", result)
+				}
+			case "native_loop_exit":
+				if result.Status != "completed" || result.Output != "first turn" {
+					t.Fatalf("completed checkpoint lost at EOF: %+v", result)
+				}
+			default:
+				if result.Status != "completed" || result.Output != "second turn" || result.Usage["k3-256k"].InputTokens != 20 {
+					t.Fatalf("second turn/stop/cumulative usage: %+v", result)
+				}
+			}
+		})
+	}
+}

--- a/server/pkg/agent/claude_schedule_test.go
+++ b/server/pkg/agent/claude_schedule_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/robfig/cron/v3"
 )
 
 func scheduleEvent(typ, content, receipt string) claudeSDKMessage {
@@ -77,6 +79,46 @@ func TestClaudeSchedulesConsumeAndCancel(t *testing.T) {
 	}
 }
 
+func TestNormalizeClaudeCronSunday(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		expression string
+		want       string
+	}{
+		{name: "literal", expression: "0 9 * * 7", want: "0 9 * * 0"},
+		{name: "list", expression: "0 9 * * 1,3,7", want: "0 9 * * 1,3,0"},
+		{name: "range", expression: "0 9 * * 5-7", want: "0 9 * * 5,6,0"},
+		{name: "stepped range", expression: "0 9 * * 5-7/2", want: "0 9 * * 5,0"},
+		{name: "robfig range unchanged", expression: "0 9 * * 0-6", want: "0 9 * * 0-6"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeClaudeCron(tc.expression)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeClaudeCron(%q) = %q, want %q", tc.expression, got, tc.want)
+			}
+			if _, err := cron.ParseStandard(got); err != nil {
+				t.Fatalf("normalized expression is not parseable: %v", err)
+			}
+		})
+	}
+}
+
+func TestClaudeSchedulesCapWaitAtSevenDayExpiry(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	var s claudeSchedules
+	s.observe(scheduleEvent("assistant", `{"type":"tool_use","id":"cron","name":"CronCreate","input":{"cron":"0 0 1 1 *"}}`, ""), now)
+	s.observe(scheduleEvent("user", `{"type":"tool_result","tool_use_id":"cron"}`, `{"id":"yearly","recurring":true}`), now)
+
+	got, ok := s.waitingUntil()
+	want := now.Add(7 * 24 * time.Hour)
+	if !ok || !got.Equal(want) {
+		t.Fatalf("waitingUntil() = %v, %v, want seven-day expiry %v", got, ok, want)
+	}
+}
+
 // The fake owns its timer, just like native Claude. EOF before the second turn
 // cancels it, reproducing the adapter's former close-stdin-on-first-result bug.
 func runFakeClaudeNativeLoop(mode string) {
@@ -85,6 +127,11 @@ func runFakeClaudeNativeLoop(mode string) {
 		os.Exit(61)
 	}
 	fmt.Println(`{"type":"system","session_id":"native-session"}`)
+	if mode == "native_loop_buffer_full_exit" {
+		for i := 0; i < 300; i++ {
+			fmt.Printf("{\"type\":\"log\",\"log\":{\"level\":\"info\",\"message\":\"buffer-%d\"}}\n", i)
+		}
+	}
 	tool, input, receipt := "ScheduleWakeup", `{"delaySeconds":60}`, fmt.Sprintf(`{"scheduledFor":%d}`, time.Now().Add(80*time.Millisecond).UnixMilli())
 	if mode == "native_cron" {
 		tool = "CronCreate"
@@ -94,7 +141,7 @@ func runFakeClaudeNativeLoop(mode string) {
 	fmt.Printf("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"arm\",\"name\":%q,\"input\":%s}]}}\n", tool, input)
 	fmt.Printf("{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"arm\",\"content\":\"scheduled\"}]},\"tool_use_result\":%s}\n", receipt)
 	fmt.Println(`{"type":"result","session_id":"native-session","result":"first turn","modelUsage":{"k3-256k":{"inputTokens":10,"outputTokens":2}}}`)
-	if mode == "native_loop_exit" {
+	if mode == "native_loop_exit" || mode == "native_loop_buffer_full_exit" {
 		return
 	}
 	eof := make(chan struct{})
@@ -172,8 +219,8 @@ func TestClaudeExecuteNativeLoop(t *testing.T) {
 					t.Fatalf("incomplete new turn masked by previous result: %+v", result)
 				}
 			case "native_loop_exit":
-				if result.Status != "completed" || result.Output != "first turn" {
-					t.Fatalf("completed checkpoint lost at EOF: %+v", result)
+				if result.Status != "failed" || !strings.Contains(result.Error, "before the confirmed scheduled wakeup") {
+					t.Fatalf("lost native loop reported as success: %+v", result)
 				}
 			default:
 				if result.Status != "completed" || result.Output != "second turn" || result.Usage["k3-256k"].InputTokens != 20 {
@@ -181,5 +228,31 @@ func TestClaudeExecuteNativeLoop(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestClaudeExecuteScheduledWaitDoesNotDependOnMessageConsumer(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := New("claude", Config{ExecutablePath: self, Env: map[string]string{"CLAUDE_FAKE_MODE": "native_loop_buffer_full_exit", "IS_SANDBOX": "1"}, Logger: slog.Default()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "/loop check", ExecOptions{Model: "k3-256k", Timeout: 2 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case result := <-session.Result:
+		if result.Status != "failed" || !strings.Contains(result.Error, "before the confirmed scheduled wakeup") {
+			t.Fatalf("unexpected result after unread full message buffer: %+v", result)
+		}
+	case <-ctx.Done():
+		t.Fatal("result blocked behind the optional Messages consumer")
 	}
 }

--- a/server/pkg/agent/claude_schedule_test.go
+++ b/server/pkg/agent/claude_schedule_test.go
@@ -53,17 +53,17 @@ func TestClaudeSchedulesConsumeAndCancel(t *testing.T) {
 	var s claudeSchedules
 	s.observe(scheduleEvent("assistant", `{"type":"tool_use","id":"arm","name":"ScheduleWakeup","input":{}}`, ""), now)
 	s.observe(scheduleEvent("user", `{"type":"tool_result","tool_use_id":"arm"}`, fmt.Sprintf(`{"scheduledFor":%d}`, now.Add(time.Minute).UnixMilli())), now)
-	s.beginTurn(now.Add(time.Second))
+	s.beginTurn(now.Add(time.Second), false)
 	if _, ok := s.waitingUntil(); !ok {
 		t.Fatal("early notification consumed future wakeup")
 	}
-	s.beginTurn(now.Add(time.Minute))
+	s.beginTurn(now.Add(time.Minute), false)
 	if _, ok := s.waitingUntil(); ok {
 		t.Fatal("fired one-shot wakeup retained")
 	}
 	s.observe(scheduleEvent("assistant", `{"type":"tool_use","id":"cron","name":"CronCreate","input":{"cron":"* * * * *"}}`, ""), now)
 	s.observe(scheduleEvent("user", `{"type":"tool_result","tool_use_id":"cron"}`, `{"id":"job","recurring":true}`), now)
-	s.beginTurn(now.Add(time.Minute))
+	s.beginTurn(now.Add(time.Minute), false)
 	if due, ok := s.waitingUntil(); !ok || !due.After(now.Add(time.Minute)) {
 		t.Fatalf("recurring cron lost after first fire: %v %v", due, ok)
 	}
@@ -116,6 +116,37 @@ func TestClaudeSchedulesCapWaitAtSevenDayExpiry(t *testing.T) {
 	want := now.Add(7 * 24 * time.Hour)
 	if !ok || !got.Equal(want) {
 		t.Fatalf("waitingUntil() = %v, %v, want seven-day expiry %v", got, ok, want)
+	}
+}
+
+func TestClaudeSchedulesOneShotDoesNotExpireAfterSevenDays(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	var s claudeSchedules
+	s.observe(scheduleEvent("assistant", `{"type":"tool_use","id":"cron","name":"CronCreate","input":{"cron":"0 0 1 10 *"}}`, ""), now)
+	s.observe(scheduleEvent("user", `{"type":"tool_result","tool_use_id":"cron"}`, `{"id":"october","recurring":false}`), now)
+	s.beginTurn(now.Add(8*24*time.Hour), false)
+
+	got, ok := s.waitingUntil()
+	want := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+	if !ok || !got.Equal(want) {
+		t.Fatalf("waitingUntil() = %v, %v, want one-shot fire %v", got, ok, want)
+	}
+}
+
+func TestClaudeSchedulesEarlyOneShotRequiresScheduledFireMarker(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	var s claudeSchedules
+	s.observe(scheduleEvent("assistant", `{"type":"tool_use","id":"cron","name":"CronCreate","input":{"cron":"0 13 5 9 *"}}`, ""), now)
+	s.observe(scheduleEvent("user", `{"type":"tool_result","tool_use_id":"cron"}`, `{"id":"one-shot","recurring":false}`), now)
+
+	early := time.Date(2026, 9, 5, 12, 58, 31, 0, time.UTC)
+	s.beginTurn(early, false)
+	if _, ok := s.waitingUntil(); !ok {
+		t.Fatal("unrelated pre-due notification consumed one-shot")
+	}
+	s.beginTurn(early, true)
+	if _, ok := s.waitingUntil(); ok {
+		t.Fatal("scheduled_task_fire did not consume one-shot within its 90-second early window")
 	}
 }
 

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -126,56 +126,6 @@ func TestClaudeHandleUserToolResult(t *testing.T) {
 	}
 }
 
-func TestClaudeScheduleWakeupRequiresSuccessfulToolResult(t *testing.T) {
-	t.Parallel()
-
-	arm := claudeSDKMessage{Message: mustMarshal(t, claudeMessageContent{
-		Content: []claudeContentBlock{{
-			Type:  "tool_use",
-			ID:    "call-arm",
-			Name:  "ScheduleWakeup",
-			Input: mustMarshal(t, map[string]any{"delaySeconds": 60}),
-		}},
-	})}
-	pending := claudeScheduleWakeupCalls(arm)
-	if pending["call-arm"] != claudeWakeupArm {
-		t.Fatalf("arm directive = %v, want %v", pending["call-arm"], claudeWakeupArm)
-	}
-
-	failed := claudeSDKMessage{Message: mustMarshal(t, claudeMessageContent{
-		Content: []claudeContentBlock{{
-			Type:      "tool_result",
-			ToolUseID: "call-arm",
-			IsError:   true,
-		}},
-	})}
-	if directive, ok := claudeCompletedWakeupDirective(failed, pending); ok {
-		t.Fatalf("failed wakeup unexpectedly completed with directive %v", directive)
-	}
-	if _, ok := pending["call-arm"]; ok {
-		t.Fatal("failed wakeup call was not removed from pending set")
-	}
-
-	stop := claudeSDKMessage{Message: mustMarshal(t, claudeMessageContent{
-		Content: []claudeContentBlock{{
-			Type:  "tool_use",
-			ID:    "call-stop",
-			Name:  "ScheduleWakeup",
-			Input: mustMarshal(t, map[string]any{"stop": true}),
-		}},
-	})}
-	pending = claudeScheduleWakeupCalls(stop)
-	succeeded := claudeSDKMessage{Message: mustMarshal(t, claudeMessageContent{
-		Content: []claudeContentBlock{{
-			Type:      "tool_result",
-			ToolUseID: "call-stop",
-		}},
-	})}
-	if directive, ok := claudeCompletedWakeupDirective(succeeded, pending); !ok || directive != claudeWakeupStop {
-		t.Fatalf("successful stop = (%v, %v), want (%v, true)", directive, ok, claudeWakeupStop)
-	}
-}
-
 func TestClaudeHandleControlRequestAutoApproves(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -126,6 +126,56 @@ func TestClaudeHandleUserToolResult(t *testing.T) {
 	}
 }
 
+func TestClaudeScheduleWakeupRequiresSuccessfulToolResult(t *testing.T) {
+	t.Parallel()
+
+	arm := claudeSDKMessage{Message: mustMarshal(t, claudeMessageContent{
+		Content: []claudeContentBlock{{
+			Type:  "tool_use",
+			ID:    "call-arm",
+			Name:  "ScheduleWakeup",
+			Input: mustMarshal(t, map[string]any{"delaySeconds": 60}),
+		}},
+	})}
+	pending := claudeScheduleWakeupCalls(arm)
+	if pending["call-arm"] != claudeWakeupArm {
+		t.Fatalf("arm directive = %v, want %v", pending["call-arm"], claudeWakeupArm)
+	}
+
+	failed := claudeSDKMessage{Message: mustMarshal(t, claudeMessageContent{
+		Content: []claudeContentBlock{{
+			Type:      "tool_result",
+			ToolUseID: "call-arm",
+			IsError:   true,
+		}},
+	})}
+	if directive, ok := claudeCompletedWakeupDirective(failed, pending); ok {
+		t.Fatalf("failed wakeup unexpectedly completed with directive %v", directive)
+	}
+	if _, ok := pending["call-arm"]; ok {
+		t.Fatal("failed wakeup call was not removed from pending set")
+	}
+
+	stop := claudeSDKMessage{Message: mustMarshal(t, claudeMessageContent{
+		Content: []claudeContentBlock{{
+			Type:  "tool_use",
+			ID:    "call-stop",
+			Name:  "ScheduleWakeup",
+			Input: mustMarshal(t, map[string]any{"stop": true}),
+		}},
+	})}
+	pending = claudeScheduleWakeupCalls(stop)
+	succeeded := claudeSDKMessage{Message: mustMarshal(t, claudeMessageContent{
+		Content: []claudeContentBlock{{
+			Type:      "tool_result",
+			ToolUseID: "call-stop",
+		}},
+	})}
+	if directive, ok := claudeCompletedWakeupDirective(succeeded, pending); !ok || directive != claudeWakeupStop {
+		t.Fatalf("successful stop = (%v, %v), want (%v, true)", directive, ok, claudeWakeupStop)
+	}
+}
+
 func TestClaudeHandleControlRequestAutoApproves(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Reported failure

A native Claude `/loop` run failed with:

```text
claude stream ended without terminal result; claude stderr: [claude-code:unrecognized_model] {"model":"k3-256k","query_source":"sdk"}
```

The incident logs identify the regression:

| Log time | What happened |
| --- | --- |
| 22:18:13 | `ScheduleWakeup` reported success for a wakeup requested 1,400 seconds later. |
| 22:18:28 | Claude produced a complete answer and a normal terminal `result`. Multica then cleared `sawResult` and the final text while waiting for another iteration. |
| 22:18:33 | The CLI exited with `exit_code=0`, without a second result. Multica finalized with no retained terminal result, losing the answer and reporting the error above. |

The custom-model warning also appeared in successful runs, so it did not establish the cause of this failure. The decisive evidence was the valid result followed by a clean exit.

A follow-up correction retained the answer but always closed stdin after the first result. That prevented native scheduling from reaching its next iteration. The adapter needed to distinguish a completed iteration, a scheduled wait, and the start of a subsequent turn.

## Code changes

- **Native scheduling receipts — `server/pkg/agent/claude_schedule.go`:** track main-thread `ScheduleWakeup` and `CronCreate` calls together with their structured results. Require a positive `scheduledFor` or an accepted cron receipt; a non-error tool result alone is insufficient because disabled scheduling can return `scheduledFor: 0`. Failed, text-only and subagent receipts do not arm a wait. Native stop and cron-deletion receipts clear the corresponding schedules.
- **Stream lifetime — `server/pkg/agent/claude.go`:** keep stdin open while a confirmed schedule remains, allowing Claude to own timer dispatch and session reuse. Close input after ordinary completion, terminal failure, or removal of the remaining schedule.
- **Result and usage handling — `claude.go`:** retain the completed answer throughout the wait, resetting terminal state only when the next main-thread turn starts. Clean EOF while waiting preserves the answer; a subsequent turn that starts but never returns a terminal result still fails. Terminal usage snapshots replace accumulated totals to avoid double-counting across iterations.
- **Daemon liveness — `server/pkg/agent/agent.go` and `server/internal/daemon/daemon.go`:** carry the expected wakeup time in `Message.WaitingUntil`. The idle watchdog allows silence until that time, then applies its ordinary idle budget. Incidental logs preserve the scheduled wait; a running transition restores normal hang detection immediately. Cancellation and hard task deadlines still apply.

## Why Codex `/goal` worked while Claude `/loop` failed

| | Codex `/goal` | Claude `/loop` |
| --- | --- | --- |
| Continuation policy | Work across turns toward an objective and a verifiable stopping condition. | Run another iteration when a scheduled wakeup becomes due. |
| Typical use | Finish a migration and validate the result. | Check CI repeatedly and address failures. |
| Cadence | Driven by progress toward the objective. | Fixed cron interval or a delay Claude selects each iteration. |
| Multica integration | `codex app-server --listen stdio://`, with its own notification/turn handling. | `claude -p` with stream-json input/output and per-iteration results. |

The working Codex path never executed the faulty Claude-specific reset/close logic. This was an adapter lifecycle bug, rather than evidence that Claude cannot remain active. The transport difference alone does not guarantee correct continuation; each backend must respect its runtime's completion boundaries.

Official references: [Codex goal workflow](https://learn.chatgpt.com/use-cases/follow-goals) and [Claude native scheduling](https://code.claude.com/docs/en/scheduled-tasks).

## Verification

- Full `pkg/agent` and `internal/daemon` suites and `go vet` passed on both the PR branch and the maintained personal branch.
- Regression and focused race tests cover confirmed/invalid scheduling receipts, two-turn execution, stop, cancellation, clean EOF during a wait, and incomplete subsequent turns. Daemon tests check the scheduled idle extension, restoration of ordinary hang detection, and cancellation.
- The opt-in integration test runs **real Claude Code 2.1.246 against a local mock Messages API**. Dynamic `/loop` and fixed `/loop 1m` each enter a second iteration in the same process/session, then stop through `ScheduleWakeup(stop: true)` and `CronDelete`, respectively. Native CLI expansion, timers, tool execution and stream handling are exercised; model responses are mocked and no authenticated model account is used.
- Real-CLI execution requires the `agentintegration` build tag and `MULTICA_RUN_REAL_AGENT_SMOKE=1` before executable lookup. `MULTICA_CLAUDE_EXECUTABLE` optionally selects the binary.

Coverage establishes the confirmed dynamic-wakeup and cron paths during an active execution; it does not establish compatibility with every Claude background mechanism or CLI version. Native scheduling availability remains controlled by Claude Code.

The implementation is mirrored to `mameikagou/multica`'s `local/native-context-chat-handoff` branch at `bcc74f93ed`, and a clean Linux amd64 daemon build was produced from that commit. That build step did not restart the running daemon.
