### PR TITLE
MUL-7092: fix(runtime): show configured Qwen models

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -265,10 +267,13 @@ func ListModels(ctx context.Context, providerType string, runtimeCmd Command) (C
 			return discoverCodebuddyModels(ctx, runtimeCmd)
 		})
 	case "qwen":
-		// Qwen Code has no account-independent headless model catalog. An
-		// empty list keeps the runtime default and manual model entry available
-		// without advertising a Token-Plan-specific model to other accounts.
-		return Catalog{Models: []Model{}}, nil
+		// Qwen Code keeps its account-scoped headless model catalog in the user
+		// settings file. Read only the model provider definitions instead of
+		// publishing a static Token-Plan-specific list that would be wrong for
+		// other accounts.
+		return cachedDiscovery(discoveryCacheKey(providerType, runtimeCmd), func() (Catalog, error) {
+			return discovered(discoverQwenModels(ctx, runtimeCmd))
+		})
 	case "qwenpaw":
 		// QwenPaw's model selection is unsupported (session/set_model
 		// persists to agent scope, not session scope), so there is no
@@ -651,6 +656,94 @@ func discoverTraecliModels(ctx context.Context, runtimeCmd Command) ([]Model, er
 		tmpdirPrefix: "multica-traecli-discovery-",
 		acpArgs:      []string{"acp", "serve", "--yolo"},
 	})
+}
+
+// discoverQwenModels reads Qwen Code's configured modelProviders without
+// loading its env block or invoking a model. Qwen's ACP catalog cannot be used
+// here: ACP exposes route IDs for provider disambiguation, while Multica's
+// Qwen backend executes headlessly with `qwen --model`, which accepts the
+// configured model ID.
+func discoverQwenModels(_ context.Context, _ Command) ([]Model, error) {
+	qwenHome := strings.TrimSpace(os.Getenv("QWEN_HOME"))
+	if qwenHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve Qwen home: %w", err)
+		}
+		qwenHome = filepath.Join(home, ".qwen")
+	}
+	return readQwenModels(filepath.Join(qwenHome, "settings.json"))
+}
+
+func readQwenModels(path string) ([]Model, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return []Model{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read Qwen settings: %w", err)
+	}
+
+	type configuredModel struct {
+		ID      string `json:"id"`
+		Name    string `json:"name"`
+		BaseURL string `json:"baseUrl"`
+	}
+	var settings struct {
+		ModelProviders map[string][]configuredModel `json:"modelProviders"`
+		Model          struct {
+			Name    string `json:"name"`
+			BaseURL string `json:"baseUrl"`
+		} `json:"model"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, fmt.Errorf("parse Qwen settings: %w", err)
+	}
+
+	providerIDs := make([]string, 0, len(settings.ModelProviders))
+	for providerID := range settings.ModelProviders {
+		providerIDs = append(providerIDs, providerID)
+	}
+	sort.Strings(providerIDs)
+
+	currentID := strings.TrimSpace(settings.Model.Name)
+	currentBaseURL := strings.TrimSpace(settings.Model.BaseURL)
+	models := make([]Model, 0)
+	modelIndex := make(map[string]int)
+	selectedIndex := -1
+	for _, providerID := range providerIDs {
+		for _, configured := range settings.ModelProviders[providerID] {
+			id := strings.TrimSpace(configured.ID)
+			if id == "" {
+				continue
+			}
+			label := strings.TrimSpace(configured.Name)
+			if label == "" {
+				label = id
+			}
+			candidate := Model{ID: id, Label: label, Provider: providerID}
+			matchesCurrent := id == currentID && (currentBaseURL == "" || strings.TrimSpace(configured.BaseURL) == currentBaseURL)
+			if index, exists := modelIndex[id]; exists {
+				// The headless --model flag cannot disambiguate two configured
+				// routes with the same ID. Prefer the currently selected route so
+				// the label describes what Qwen will actually use.
+				if matchesCurrent {
+					models[index] = candidate
+					selectedIndex = index
+				}
+				continue
+			}
+			modelIndex[id] = len(models)
+			models = append(models, candidate)
+			if matchesCurrent {
+				selectedIndex = len(models) - 1
+			}
+		}
+	}
+	if selectedIndex >= 0 {
+		models[selectedIndex].Default = true
+	}
+	return models, nil
 }
 
 // cursorStaticModels is a minimal fallback used when

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -42,17 +43,69 @@ func TestStaticModelCatalogsAreValid(t *testing.T) {
 	}
 }
 
-func TestListModelsQwenUsesRuntimeDefaultAndManualEntry(t *testing.T) {
-	// Qwen returns its manual-entry catalog without resolving or executing a CLI.
-	got, err := ListModels(context.Background(), "qwen", Command{Path: ""})
+func TestListModelsQwenDiscoversAccountCatalog(t *testing.T) {
+	qwenHome := t.TempDir()
+	t.Setenv("QWEN_HOME", qwenHome)
+	settings := `{
+  "env": {"SECRET_API_KEY": "must-not-be-read-as-a-model"},
+  "modelProviders": {
+    "openai": [
+      {"id":"deepseek-v4-flash","name":"[ModelStudio Standard] deepseek-v4-flash","baseUrl":"https://dashscope.example/v1"},
+      {"id":"qwen3.7-plus","name":"[ModelStudio Standard] qwen3.7-plus","baseUrl":"https://dashscope.example/v1"},
+      {"id":"deepseek-v4-flash","name":"[DeepSeek] deepseek-v4-flash","baseUrl":"https://deepseek.example"},
+      {"id":"z-ai/glm-4.5-air:free","name":"[OpenRouter] z-ai/glm-4.5-air:free","baseUrl":"https://openrouter.example/v1"}
+    ]
+  },
+  "model": {"name":"deepseek-v4-flash","baseUrl":"https://deepseek.example"}
+}`
+	if err := os.WriteFile(filepath.Join(qwenHome, "settings.json"), []byte(settings), 0o600); err != nil {
+		t.Fatalf("write Qwen settings: %v", err)
+	}
+
+	got, err := ListModels(context.Background(), "qwen", Command{Path: missingAgentExecutable(t, "qwen")})
+	if err != nil {
+		t.Fatalf("ListModels(qwen) error: %v", err)
+	}
+	if len(got.Models) != 3 {
+		t.Fatalf("ListModels(qwen) = %+v, want three account models", got)
+	}
+	if got.Fallback {
+		t.Error("Qwen configured catalog must be authoritative, not a fallback")
+	}
+	if got.Models[0].ID != "deepseek-v4-flash" || got.Models[0].Label != "[DeepSeek] deepseek-v4-flash" || !got.Models[0].Default {
+		t.Fatalf("first Qwen model = %+v, want deduplicated current DeepSeek route", got.Models[0])
+	}
+	if got.Models[1].ID != "qwen3.7-plus" || got.Models[1].Label != "[ModelStudio Standard] qwen3.7-plus" {
+		t.Fatalf("second Qwen model = %+v, want configured Qwen label", got.Models[1])
+	}
+	if got.Models[2].ID != "z-ai/glm-4.5-air:free" {
+		t.Fatalf("third Qwen model = %+v, want OpenRouter model", got.Models[2])
+	}
+}
+
+func TestListModelsQwenWithoutSettingsKeepsDefaultAndManualEntry(t *testing.T) {
+	t.Setenv("QWEN_HOME", t.TempDir())
+
+	got, err := ListModels(context.Background(), "qwen", Command{Path: missingAgentExecutable(t, "qwen")})
 	if err != nil {
 		t.Fatalf("ListModels(qwen) error: %v", err)
 	}
 	if len(got.Models) != 0 {
-		t.Fatalf("ListModels(qwen) = %+v, want no account-specific static catalog", got)
+		t.Fatalf("ListModels(qwen) = %+v, want empty catalog when settings are absent", got)
 	}
 	if got.Fallback {
-		t.Error("qwen's empty catalog is deliberate, not a discovery fallback")
+		t.Error("missing Qwen settings must preserve manual entry, not report a static fallback")
+	}
+}
+
+func TestReadQwenModelsRejectsMalformedSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"modelProviders":`), 0o600); err != nil {
+		t.Fatalf("write malformed Qwen settings: %v", err)
+	}
+
+	if _, err := readQwenModels(path); err == nil || !strings.Contains(err.Error(), "parse Qwen settings") {
+		t.Fatalf("readQwenModels error = %v, want parse Qwen settings error", err)
 	}
 }
 

--- a/server/pkg/agent/qwen_models_integration_test.go
+++ b/server/pkg/agent/qwen_models_integration_test.go
@@ -1,0 +1,35 @@
+//go:build agentintegration
+
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+// TestQwenRealModelCatalogSmoke verifies that the installed Qwen Code account
+// configuration exposes its selectable headless model IDs without reading or
+// logging credentials and without running a prompt.
+func TestQwenRealModelCatalogSmoke(t *testing.T) {
+	requireRealAgentSmoke(t)
+	models, err := discoverQwenModels(context.Background(), Command{})
+	if err != nil {
+		t.Fatalf("discover Qwen models: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("Qwen settings returned an empty model catalog")
+	}
+
+	defaultCount := 0
+	ids := make([]string, 0, len(models))
+	for _, model := range models {
+		ids = append(ids, model.ID)
+		if model.Default {
+			defaultCount++
+		}
+	}
+	if defaultCount != 1 {
+		t.Fatalf("Qwen configured default model count = %d, want 1", defaultCount)
+	}
+	t.Logf("Qwen model catalog OK: count=%d ids=%v", len(models), ids)
+}


### PR DESCRIPTION
## What does this PR do?

An online, authenticated Qwen Code runtime currently returns an empty model catalog, so agent settings show "No models available" even though Qwen's `/model` picker has configured models. This change reads the account's configured model IDs from Qwen's local `settings.json`, marks the active route as default, and preserves the existing Default/manual-entry behavior when no settings file exists.

The discovery path parses only `modelProviders` and the selected `model`. It does not expose Qwen's `env` block, invoke a model, or log credentials. ACP route IDs are deliberately not used because Multica launches Qwen headlessly with `qwen --model`, which accepts the configured model ID.

## Related Issue

Observed with Multica Desktop v0.4.40 and Qwen Code v0.23.0.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Discover Qwen models from `QWEN_HOME/settings.json` or `~/.qwen/settings.json`.
- Deduplicate identical model IDs and prefer the currently selected provider route for the label.
- Keep the catalog empty when settings are absent so Default and manual model entry remain available.
- Add unit, malformed-config, missing-config, and opt-in real-account smoke coverage.

## How to Test

1. Run `go test ./pkg/agent -run '^Test(ListModelsQwen|ReadQwenModels|ListModels)' -count=1 -v`.
2. Run `go test ./pkg/agent -run '^Test(NewReturnsQwenBackend|BuildQwenArgsKeepsProtocolManaged|BuildQwenArgsYoloAlwaysPresent|QwenCode020FixtureParses|QwenCode020ErrorFixturePreservesErrorMessage)$' -count=1 -v`.
3. With Qwen configured locally, run `$env:MULTICA_RUN_REAL_AGENT_SMOKE='1'; go test -tags=agentintegration ./pkg/agent -run '^TestQwenRealModelCatalogSmoke$' -count=1 -v`.
4. Run `go vet ./pkg/agent` and `go build -buildvcs=false ./...` from `server/`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: duplicate IDs configured against different base URLs cannot be disambiguated by Qwen's headless `--model` flag. The catalog therefore exposes each ID once and uses the active route's label when available.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Reproduced the empty catalog, traced Qwen selection through Multica and Qwen Code 0.23.0, rejected ACP-only route IDs as incompatible with headless execution, and implemented settings-based discovery with unit and opt-in real-account validation.

## Screenshots (optional)

The reported before-state shows an online Qwen runtime with an empty model picker. The runtime UI can be verified after this daemon change reaches a Desktop release.
