### PR TITLE
MUL-7096: WS-4954 fix(daemon): share per-run Codex temporary caches

### DIFF
--- a/server/internal/daemon/artifact_matcher.go
+++ b/server/internal/daemon/artifact_matcher.go
@@ -62,6 +62,26 @@ func (m artifactMatcher) matchDirectory(absRoot, path string, entry os.DirEntry)
 	return "", false
 }
 
+// matchExactPath reports only an exact daemon-managed path. It is used for a
+// linked leaf: basename patterns must never remove links, while an exact cache
+// link created by the daemon can be safely unlinked without touching its
+// target.
+func (m artifactMatcher) matchExactPath(absRoot, path, name string) (string, bool) {
+	if _, ok := m.exactLeafNames[name]; !ok {
+		return "", false
+	}
+	rel, err := filepath.Rel(absRoot, path)
+	if err != nil {
+		return "", false
+	}
+	rel, ok := safeRelativePath(rel)
+	if !ok {
+		return "", false
+	}
+	label, ok := m.exactPaths[rel]
+	return label, ok
+}
+
 func (m artifactMatcher) managedSubpaths() []string {
 	out := make([]string, 0, len(m.exactPaths))
 	for rel := range m.exactPaths {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5498,6 +5498,24 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		}
 	}
 
+	// Stamp completion metadata for every run whose environment was prepared,
+	// including raw runner errors and server-side cancellation. Without this,
+	// those early-return paths have no CompletedAt signal and their regenerable
+	// Codex caches wait for the much longer orphan policy instead of the normal
+	// artifact sweeper.
+	if result.EnvRoot != "" {
+		if meta, ok := gcMetaForTask(task); ok {
+			// In-place local_directory runs retain their env root for forensic
+			// access. Worktree runs are disposable and deliberately excluded.
+			if assignment, _ := localDirectoryAssignmentForTask(task, d.cfg.DaemonID); assignment != nil && !assignment.UsesWorktree() {
+				meta.LocalDirectory = true
+			}
+			if metaErr := execenv.WriteGCMeta(result.EnvRoot, meta, taskLog); metaErr != nil {
+				taskLog.Warn("write gc meta failed (non-fatal)", "error", metaErr)
+			}
+		}
+	}
+
 	// Check if we were cancelled by the polling goroutine.
 	select {
 	case <-cancelledByPoll:
@@ -5575,35 +5593,6 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	}
 
 	d.reportTaskResult(ctx, task.ID, result, taskLog)
-
-	// Write GC metadata after the task finishes so the periodic GC loop
-	// can look up the parent record (issue / chat session / autopilot run /
-	// task itself for quick-create) later. Written last so that a mid-task
-	// crash leaves the directory as an orphan (cleaned up by GCOrphanTTL).
-	if result.EnvRoot != "" {
-		if meta, ok := gcMetaForTask(task); ok {
-			// A local_directory project_resource matched this daemon
-			// means the agent ran in the user's own tree. Stamp the
-			// meta so the GC loop never tries to RemoveAll envRoot's
-			// sibling workdir (which is the user's path) or the envRoot
-			// itself (we want output/ and logs/ to linger for forensic
-			// access).
-			//
-			// Worktree mode is excluded: its workdir is a disposable
-			// worktree INSIDE envRoot, already removed by Finalize, and
-			// the deliverable lives on as a branch in the user's repo.
-			// Stamping it would hand every worktree task a permanently
-			// exempt env root, so the directory would accumulate one env
-			// root per task forever — the exact cost the exemption was
-			// meant to trade away for a user's own files.
-			if assignment, _ := localDirectoryAssignmentForTask(task, d.cfg.DaemonID); assignment != nil && !assignment.UsesWorktree() {
-				meta.LocalDirectory = true
-			}
-			if err := execenv.WriteGCMeta(result.EnvRoot, meta, taskLog); err != nil {
-				taskLog.Warn("write gc meta failed (non-fatal)", "error", err)
-			}
-		}
-	}
 }
 
 // worktreePreservedError marks a task error that must survive the cancel path:
@@ -7683,6 +7672,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			}
 		}
 	}
+	// Once an execution environment exists, always return its root even when a
+	// later launch/configuration step fails. handleTask uses this private field
+	// to write completion metadata so the GC can reclaim daemon-owned caches
+	// from failed runs; terminal API callbacks do not expose EnvRoot.
+	defer func() {
+		if taskResult.EnvRoot == "" {
+			taskResult.EnvRoot = env.RootDir
+		}
+	}()
 	// Belt-and-suspenders: also mark whatever root we ended up with, in case
 	// future changes diverge from ResolveRootDir.
 	if env.RootDir != resolvedRoot && env.RootDir != "" {

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -4516,6 +4516,55 @@ func TestHandleTask_BareErrorReportsFailureWithCancelledParent(t *testing.T) {
 	}
 }
 
+func TestHandleTask_BareErrorWritesGCCompletionMetadata(t *testing.T) {
+	t.Parallel()
+
+	workspacesRoot := t.TempDir()
+	workspaceID := "ws-failed-gc-meta"
+	taskID := "task-failed-gc-meta"
+	envRoot := execenv.PredictRootDir(execenv.RootDirParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    workspaceID,
+		TaskID:         taskID,
+	})
+	if err := os.MkdirAll(envRoot, 0o755); err != nil {
+		t.Fatalf("create failed task env root: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{
+		client:             NewClient(srv.URL),
+		logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		runtimeIndex:       map[string]Runtime{"rt-1": {ID: "rt-1", Provider: "codex"}},
+		activeEnvRoots:     make(map[string]int),
+		cancelPollInterval: time.Hour,
+		cfg:                Config{WorkspacesRoot: workspacesRoot},
+	}
+	d.runner = taskRunnerFunc(func(context.Context, Task, string, int, *slog.Logger) (TaskResult, error) {
+		return TaskResult{EnvRoot: envRoot}, errors.New("agent process crashed")
+	})
+
+	d.handleTask(context.Background(), Task{
+		ID:          taskID,
+		WorkspaceID: workspaceID,
+		RuntimeID:   "rt-1",
+		IssueID:     "issue-failed-gc-meta",
+		Agent:       &AgentData{Name: "test-agent"},
+	}, 0)
+
+	meta, err := execenv.ReadGCMeta(envRoot)
+	if err != nil {
+		t.Fatalf("read failed-run GC metadata: %v", err)
+	}
+	if meta.IssueID != "issue-failed-gc-meta" || meta.CompletedAt.IsZero() {
+		t.Fatalf("failed-run GC metadata = %+v", meta)
+	}
+}
+
 // TestHandleTask_UntrackedRuntimeFailsBackForRetry covers the window between a
 // batch claim leaving with a runtime ID and the claimed task arriving here.
 //

--- a/server/internal/daemon/diskusage_test.go
+++ b/server/internal/daemon/diskusage_test.go
@@ -321,8 +321,8 @@ func TestScanDiskUsage_ManagedCodexSandboxIsExactAndDeduplicated(t *testing.T) {
 	if got := report.Tasks[0].ArtifactSizeBytes; got != 300 {
 		t.Fatalf("artifact_size_bytes=%d, want exact managed 300", got)
 	}
-	if got := strings.Join(report.ManagedArtifactSubpaths, ","); got != "codex-home/.sandbox-bin" {
-		t.Fatalf("managed artifact paths=%q, want codex-home/.sandbox-bin", got)
+	if got := strings.Join(report.ManagedArtifactSubpaths, ","); got != "codex-home/.sandbox-bin,codex-home/.tmp" {
+		t.Fatalf("managed artifact paths=%q, want codex-home/.sandbox-bin,codex-home/.tmp", got)
 	}
 
 	report, err = ScanDiskUsage(root, []string{".sandbox-bin"})
@@ -547,8 +547,8 @@ func TestScanDiskUsageRoots_SumsAcrossRoots(t *testing.T) {
 	if agg.TotalWorkspaceCount != 2 {
 		t.Fatalf("TotalWorkspaceCount = %d, want 2", agg.TotalWorkspaceCount)
 	}
-	if got := strings.Join(agg.ManagedArtifactSubpaths, ","); got != "codex-home/.sandbox-bin" {
-		t.Fatalf("managed artifact paths=%q, want codex-home/.sandbox-bin", got)
+	if got := strings.Join(agg.ManagedArtifactSubpaths, ","); got != "codex-home/.sandbox-bin,codex-home/.tmp" {
+		t.Fatalf("managed artifact paths=%q, want codex-home/.sandbox-bin,codex-home/.tmp", got)
 	}
 }
 

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -269,6 +269,18 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		}
 	}
 
+	// Codex's plugin startup sync materialises Git marketplace checkouts and
+	// the curated plugin repository under .tmp. Leaving that directory absent
+	// in a per-task home makes every task clone the same hundreds of MiB again.
+	// Share the whole directory, rather than only its large children, so Codex's
+	// adjacent lock and revision files coordinate concurrent task/Desktop syncs.
+	if err := exposeSharedCodexCacheDir(
+		filepath.Join(sharedHome, ".tmp"),
+		filepath.Join(codexHome, ".tmp"),
+	); err != nil {
+		logger.Warn("execenv: codex-home temporary cache exposure failed", "error", err)
+	}
+
 	if err := exposeSharedCodexPluginCache(codexHome, sharedHome); err != nil {
 		logger.Warn("execenv: codex-home plugin cache exposure failed", "error", err)
 	}
@@ -1233,31 +1245,46 @@ func resolveCodexConfigPath(configPath, sharedHome, key string) (string, error) 
 func exposeSharedCodexPluginCache(codexHome, sharedHome string) error {
 	src := filepath.Join(sharedHome, "plugins", "cache")
 	dst := filepath.Join(codexHome, "plugins", "cache")
+	return exposeSharedCodexCacheDir(src, dst)
+}
+
+// exposeSharedCodexCacheDir makes one daemon-created cache path resolve to the
+// user's shared Codex cache. Cache state is intentionally shared; config,
+// sessions, skills, and other task state remain isolated elsewhere in the
+// per-task CODEX_HOME.
+//
+// A reused home may still contain a regular directory produced by an older
+// daemon. Remove that duplicate before linking. When dst is already a link,
+// remove only the link itself — never follow it into the shared Codex home.
+func exposeSharedCodexCacheDir(src, dst string) error {
 	if err := os.MkdirAll(src, 0o755); err != nil {
-		return fmt.Errorf("create shared plugin cache dir: %w", err)
+		return fmt.Errorf("create shared cache dir %s: %w", src, err)
 	}
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("create codex plugin dir: %w", err)
+		return fmt.Errorf("create codex cache parent %s: %w", filepath.Dir(dst), err)
 	}
 
 	if fi, err := os.Lstat(dst); err == nil {
-		isLink := fi.Mode()&os.ModeSymlink != 0
+		// Go reports Windows directory junctions as ModeDir|ModeIrregular.
+		isLink := fi.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0
 		if isLink {
 			if target, readlinkErr := os.Readlink(dst); readlinkErr == nil && target == src {
 				return nil
 			}
 			if err := os.Remove(dst); err != nil {
-				return fmt.Errorf("remove stale plugin cache link: %w", err)
+				return fmt.Errorf("remove stale cache link %s: %w", dst, err)
 			}
 		} else {
 			if err := os.RemoveAll(dst); err != nil {
-				return fmt.Errorf("remove stale plugin cache path: %w", err)
+				return fmt.Errorf("remove stale cache path %s: %w", dst, err)
 			}
 		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect cache path %s: %w", dst, err)
 	}
 
 	if err := createDirLink(src, dst); err != nil {
-		return fmt.Errorf("expose shared plugin cache: %w", err)
+		return fmt.Errorf("link shared cache %s to %s: %w", src, dst, err)
 	}
 	return nil
 }

--- a/server/internal/daemon/execenv/codex_tmp_real_integration_test.go
+++ b/server/internal/daemon/execenv/codex_tmp_real_integration_test.go
@@ -1,0 +1,153 @@
+//go:build agentintegration
+
+package execenv
+
+import (
+	"context"
+	"io/fs"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCodexSharedTemporaryCacheRealTask verifies the real Codex CLI can start
+// with the daemon's shared .tmp layout and does not replace the task link with
+// a private marketplace/plugin clone. It is opt-in because it uses the user's
+// authenticated Codex account and may consume quota.
+func TestCodexSharedTemporaryCacheRealTask(t *testing.T) {
+	if os.Getenv("MULTICA_RUN_REAL_AGENT_SMOKE") != "1" {
+		t.Skip("set MULTICA_RUN_REAL_AGENT_SMOKE=1 to allow real Codex CLI and account access")
+	}
+	if testing.Short() {
+		t.Skip("skipping real-binary smoke test in -short mode")
+	}
+
+	bin, err := exec.LookPath("codex")
+	if err != nil {
+		t.Skip("codex not on PATH; skipping real-binary smoke test")
+	}
+	sharedHome := strings.TrimSpace(os.Getenv("MULTICA_REAL_CODEX_HOME"))
+	if sharedHome == "" {
+		userHome, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			t.Fatalf("resolve user home: %v", homeErr)
+		}
+		sharedHome = filepath.Join(userHome, ".codex")
+	}
+	sharedHome, err = filepath.Abs(sharedHome)
+	if err != nil {
+		t.Fatalf("resolve shared Codex home: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	environment, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "00000000-0000-4000-8000-000000000011",
+		TaskID:         "00000000-0000-4000-8000-000000000012",
+		AgentName:      "codex-real-cache-smoke",
+		Provider:       "codex",
+		Task: TaskContextForEnv{
+			IssueID: "codex-real-cache-smoke",
+		},
+	}, slog.Default())
+	if err != nil {
+		t.Fatalf("prepare daemon-equivalent Codex environment: %v", err)
+	}
+	defer environment.Cleanup(true)
+
+	taskTmp := filepath.Join(environment.CodexHome, ".tmp")
+	sharedTmp := filepath.Join(sharedHome, ".tmp")
+	assertSameCodexTemporaryCache(t, taskTmp, sharedTmp)
+	before := localBytesWithoutLinks(t, environment.CodexHome)
+
+	lastMessage := filepath.Join(t.TempDir(), "last-message.txt")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin,
+		"exec",
+		"--ephemeral",
+		"--skip-git-repo-check",
+		"--sandbox", "read-only",
+		"--output-last-message", lastMessage,
+		"Reply with exactly: MULTICA_CODEX_TMP_OK",
+	)
+	cmd.Dir = environment.WorkDir
+	for _, entry := range os.Environ() {
+		if !strings.HasPrefix(entry, "CODEX_HOME=") {
+			cmd.Env = append(cmd.Env, entry)
+		}
+	}
+	cmd.Env = append(cmd.Env, "CODEX_HOME="+environment.CodexHome)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("real Codex task failed: %v\n%s", err, output)
+	}
+	message, err := os.ReadFile(lastMessage)
+	if err != nil {
+		t.Fatalf("read real Codex final message: %v", err)
+	}
+	if strings.TrimSpace(string(message)) != "MULTICA_CODEX_TMP_OK" {
+		t.Fatalf("real Codex final message = %q", message)
+	}
+
+	assertSameCodexTemporaryCache(t, taskTmp, sharedTmp)
+	after := localBytesWithoutLinks(t, environment.CodexHome)
+	t.Logf("real Codex cache smoke passed; task-local CODEX_HOME bytes before=%d after=%d", before, after)
+}
+
+func assertSameCodexTemporaryCache(t *testing.T, taskTmp, sharedTmp string) {
+	t.Helper()
+	info, err := os.Lstat(taskTmp)
+	if err != nil {
+		t.Fatalf("stat task .tmp: %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("task .tmp is not a symlink: mode=%v", info.Mode())
+	}
+	taskInfo, err := os.Stat(taskTmp)
+	if err != nil {
+		t.Fatalf("resolve task .tmp: %v", err)
+	}
+	sharedInfo, err := os.Stat(sharedTmp)
+	if err != nil {
+		t.Fatalf("stat shared .tmp: %v", err)
+	}
+	if !os.SameFile(taskInfo, sharedInfo) {
+		t.Fatal("task .tmp no longer resolves to the shared Codex cache")
+	}
+}
+
+func localBytesWithoutLinks(t *testing.T, root string) int64 {
+	t.Helper()
+	var total int64
+	if err := filepath.WalkDir(root, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type()&(os.ModeSymlink|os.ModeIrregular) != 0 {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			total += info.Size()
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("measure task-local Codex home: %v", err)
+	}
+	return total
+}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2715,12 +2715,18 @@ func TestPrepareCodexHomeSeedsFromShared(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sharedPluginCache, "superpowers", "SKILL.md"), []byte("Use superpowers."), 0o644); err != nil {
 		t.Fatalf("write shared plugin skill: %v", err)
 	}
-	sharedMarketplace := filepath.Join(sharedHome, ".tmp", "marketplaces", "test-marketplace")
-	if err := os.MkdirAll(sharedMarketplace, 0o755); err != nil {
-		t.Fatalf("create shared marketplace cache: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sharedMarketplace, "manifest.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
-		t.Fatalf("write shared marketplace manifest: %v", err)
+	for _, rel := range []string{
+		filepath.Join("marketplaces", "test-marketplace"),
+		filepath.Join("bundled-marketplaces", "openai-bundled"),
+		filepath.Join("plugins", "curated"),
+	} {
+		cacheDir := filepath.Join(sharedHome, ".tmp", rel)
+		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+			t.Fatalf("create shared temporary cache %s: %v", rel, err)
+		}
+		if err := os.WriteFile(filepath.Join(cacheDir, "marker"), []byte(rel), 0o644); err != nil {
+			t.Fatalf("write shared temporary cache marker %s: %v", rel, err)
+		}
 	}
 
 	// Point CODEX_HOME to our fake shared home.
@@ -2822,11 +2828,41 @@ func TestPrepareCodexHomeSeedsFromShared(t *testing.T) {
 		t.Errorf("plugin cache skill content = %q", data)
 	}
 
-	// Marketplace checkouts contain executable plugin code and must not be
-	// linked into a task home where one task could mutate another task's state.
-	marketplacePath := filepath.Join(codexHome, ".tmp", "marketplaces")
-	if _, err := os.Lstat(marketplacePath); !os.IsNotExist(err) {
-		t.Fatalf("shared marketplace cache exposed in task home: %v", err)
+	// Codex's complete temporary plugin cache is shared. Linking the root also
+	// shares the adjacent sync lock/revision files, preventing concurrent tasks
+	// from mutating one checkout under independent per-task locks.
+	tmpPath := filepath.Join(codexHome, ".tmp")
+	sharedTmpPath := filepath.Join(sharedHome, ".tmp")
+	tmpInfo, err := os.Lstat(tmpPath)
+	if err != nil {
+		t.Fatalf("temporary plugin cache not exposed: %v", err)
+	}
+	if runtime.GOOS != "windows" && tmpInfo.Mode()&os.ModeSymlink == 0 {
+		t.Error("temporary plugin cache should be a symlink")
+	}
+	for _, rel := range []string{
+		filepath.Join("marketplaces", "test-marketplace"),
+		filepath.Join("bundled-marketplaces", "openai-bundled"),
+		filepath.Join("plugins", "curated"),
+	} {
+		data, err := os.ReadFile(filepath.Join(tmpPath, rel, "marker"))
+		if err != nil {
+			t.Fatalf("temporary cache %s not visible through task home: %v", rel, err)
+		}
+		if string(data) != rel {
+			t.Errorf("temporary cache %s marker = %q", rel, data)
+		}
+	}
+	sharedInfo, err := os.Stat(sharedTmpPath)
+	if err != nil {
+		t.Fatalf("stat shared temporary cache: %v", err)
+	}
+	taskInfo, err := os.Stat(tmpPath)
+	if err != nil {
+		t.Fatalf("stat task temporary cache: %v", err)
+	}
+	if !os.SameFile(sharedInfo, taskInfo) {
+		t.Error("task temporary cache does not resolve to the shared cache")
 	}
 }
 
@@ -3388,7 +3424,7 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 	}
 
 	// Directory should contain task-local sessions, the model-cache config
-	// binding, and auto-generated config.toml.
+	// binding, auto-generated config.toml, and shared cache links.
 	entries, err := os.ReadDir(codexHome)
 	if err != nil {
 		t.Fatalf("failed to read codex-home: %v", err)
@@ -3406,11 +3442,14 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 	if !entryNames["plugins"] {
 		t.Error("expected plugins directory for plugin cache exposure")
 	}
+	if !entryNames[".tmp"] {
+		t.Error("expected .tmp directory link for temporary plugin cache exposure")
+	}
 	if !entryNames[codexModelsCacheBindingFile] {
 		t.Error("expected models cache config binding")
 	}
 	for name := range entryNames {
-		if name != "sessions" && name != "config.toml" && name != "plugins" && name != codexModelsCacheBindingFile {
+		if name != "sessions" && name != "config.toml" && name != "plugins" && name != ".tmp" && name != codexModelsCacheBindingFile {
 			t.Errorf("unexpected entry: %s", name)
 		}
 	}
@@ -3429,6 +3468,44 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(codexHome, "plugins", "cache")); err != nil {
 		t.Fatalf("missing shared plugin cache exposure should still be tolerated and created: %v", err)
+	}
+}
+
+// A home created by an older daemon may already contain a full task-local
+// .tmp clone. Preparing it again must replace the duplicate with the shared
+// cache rather than preserving hundreds of MiB indefinitely.
+func TestPrepareCodexHomeReplacesTaskLocalTemporaryCacheOnReuse(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	sharedMarker := filepath.Join(sharedHome, ".tmp", "marketplaces", "shared")
+	if err := os.MkdirAll(filepath.Dir(sharedMarker), 0o755); err != nil {
+		t.Fatalf("create shared marketplace cache: %v", err)
+	}
+	if err := os.WriteFile(sharedMarker, []byte("shared"), 0o644); err != nil {
+		t.Fatalf("write shared marker: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	staleMarker := filepath.Join(codexHome, ".tmp", "marketplaces", "stale-task-copy")
+	if err := os.MkdirAll(filepath.Dir(staleMarker), 0o755); err != nil {
+		t.Fatalf("create stale task cache: %v", err)
+	}
+	if err := os.WriteFile(staleMarker, []byte("duplicate"), 0o644); err != nil {
+		t.Fatalf("write stale task marker: %v", err)
+	}
+
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("prepareCodexHome failed: %v", err)
+	}
+	if _, err := os.Stat(staleMarker); !os.IsNotExist(err) {
+		t.Fatalf("stale task-local cache survived reuse: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(codexHome, ".tmp", "marketplaces", "shared")); err != nil {
+		t.Fatalf("shared cache is not exposed after reuse: %v", err)
+	} else if string(data) != "shared" {
+		t.Fatalf("shared cache marker = %q, want shared", data)
 	}
 }
 
@@ -4393,6 +4470,13 @@ func TestReuseRestoresCodexPluginCache(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sharedPluginCache, "superpowers", "SKILL.md"), []byte("Use superpowers."), 0o644); err != nil {
 		t.Fatalf("write shared plugin skill: %v", err)
 	}
+	sharedTmpMarker := filepath.Join(sharedHome, ".tmp", "marketplaces", "shared-marker")
+	if err := os.MkdirAll(filepath.Dir(sharedTmpMarker), 0o755); err != nil {
+		t.Fatalf("create shared temporary cache: %v", err)
+	}
+	if err := os.WriteFile(sharedTmpMarker, []byte("shared"), 0o644); err != nil {
+		t.Fatalf("write shared temporary cache marker: %v", err)
+	}
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	workspacesRoot := t.TempDir()
@@ -4412,6 +4496,9 @@ func TestReuseRestoresCodexPluginCache(t *testing.T) {
 	if err := os.RemoveAll(filepath.Join(env.CodexHome, "plugins")); err != nil {
 		t.Fatalf("remove codex plugins dir: %v", err)
 	}
+	if err := os.RemoveAll(filepath.Join(env.CodexHome, ".tmp")); err != nil {
+		t.Fatalf("remove codex temporary cache link: %v", err)
+	}
 
 	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-plugin-test"}}, testLogger())
 	if reused == nil {
@@ -4424,6 +4511,11 @@ func TestReuseRestoresCodexPluginCache(t *testing.T) {
 	}
 	if string(data) != "Use superpowers." {
 		t.Errorf("reused plugin cache skill content = %q", data)
+	}
+	if data, err := os.ReadFile(filepath.Join(reused.CodexHome, ".tmp", "marketplaces", "shared-marker")); err != nil {
+		t.Fatalf("reused codex temporary cache not restored: %v", err)
+	} else if string(data) != "shared" {
+		t.Errorf("reused temporary cache marker = %q", data)
 	}
 }
 

--- a/server/internal/daemon/execenv/reclaimable.go
+++ b/server/internal/daemon/execenv/reclaimable.go
@@ -5,6 +5,7 @@ import "path/filepath"
 const (
 	codexHomeDirName       = "codex-home"
 	codexSandboxBinDirName = ".sandbox-bin"
+	codexTemporaryDirName  = ".tmp"
 )
 
 // ManagedReclaimableArtifactSubpaths returns daemon-owned, regenerable
@@ -12,5 +13,8 @@ const (
 // relative paths rather than basenames: a repository may legitimately contain
 // a directory with the same leaf name.
 func ManagedReclaimableArtifactSubpaths() []string {
-	return []string{filepath.Join(codexHomeDirName, codexSandboxBinDirName)}
+	return []string{
+		filepath.Join(codexHomeDirName, codexSandboxBinDirName),
+		filepath.Join(codexHomeDirName, codexTemporaryDirName),
+	}
 }

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -433,7 +433,8 @@ func (d *Daemon) shouldCleanTaskDir(ctx context.Context, taskDir string) gcActio
 // the parent record, and shouldCleanTaskDirForKind is what answers it. Whether
 // the daemon's *own regenerable cache* may be reclaimed is not a per-kind
 // question at all — codex-home/.sandbox-bin is a ~285 MiB copy of the Codex
-// binary that the next run re-provisions on demand, whoever the parent is.
+// binary and codex-home/.tmp may be a legacy per-task copy of plugin caches.
+// The next run re-provisions either on demand, whoever the parent is.
 // Wiring that reclaim into the issue path alone (#5654) left every other kind
 // holding the cache indefinitely; for chat that is genuinely unbounded, since a
 // session stays "active" with no time limit and Desktop's chat is the main
@@ -716,9 +717,11 @@ func (d *Daemon) gcDecisionChat(ctx context.Context, taskDir string, meta *exece
 		//
 		// This protects the session's own data, not the daemon's regenerable
 		// caches. shouldCleanTaskDir layers applyManagedArtifactFallback on top
-		// of this skip, so a session idle past GCArtifactTTL gives back
-		// codex-home/.sandbox-bin and the next message re-provisions it. That
-		// costs a ~285 MiB Codex bootstrap on resume and is the same trade-off
+		// of this skip, so a session idle past GCArtifactTTL gives back the
+		// task-local codex-home/.sandbox-bin and .tmp link. The next message
+		// re-provisions both; only .sandbox-bin incurs the ~285 MiB Codex
+		// bootstrap cost because .tmp resolves back to the shared cache. This is
+		// the same trade-off
 		// gcDecisionIssueResult already makes for a completed task whose issue
 		// is still open — without it an active session pins the cache forever
 		// (#6782).
@@ -917,9 +920,10 @@ const linkedDirModes = os.ModeSymlink | os.ModeIrregular
 //   - patterns are basename-only; entries with a path separator are dropped.
 //   - .git subtrees are never descended into, so the agent's git history stays
 //     intact even if a pattern would otherwise match.
-//   - linked directories are skipped entirely — neither the link nor its
-//     target is touched, so a malicious or stale link can't redirect the GC
-//     outside the workdir. See linkedDirModes for what counts as a link.
+//   - linked directories are never followed. An exact daemon-managed leaf may
+//     be unlinked directly; all linked parents and basename-only matches stay
+//     untouched, so a malicious link can't redirect the GC outside the workdir.
+//     See linkedDirModes for what counts as a link.
 //   - every removal target is verified to live inside taskDir, so a tampered
 //     .gc_meta.json can't trick the daemon into deleting outside its sandbox.
 func (d *Daemon) cleanTaskArtifacts(taskDir string, patterns []string) (removed int, bytes int64, perPattern map[string]int) {
@@ -955,7 +959,7 @@ func (d *Daemon) cleanManagedTaskArtifacts(taskDir string) (removed int, bytes i
 			continue
 		}
 		size := dirSize(target)
-		if rmErr := os.RemoveAll(target); rmErr != nil {
+		if rmErr := removeManagedArtifact(target); rmErr != nil {
 			d.logger.Warn("gc: artifact remove failed", "path", target, "error", rmErr)
 			continue
 		}
@@ -967,6 +971,21 @@ func (d *Daemon) cleanManagedTaskArtifacts(taskDir string) (removed int, bytes i
 	return
 }
 
+// removeManagedArtifact removes a regular managed directory recursively, but
+// unlinks a symlink or Windows junction leaf directly. The latter is how a new
+// task exposes the user's shared Codex .tmp cache; unlinking it must never
+// descend into or mutate the shared target.
+func removeManagedArtifact(target string) error {
+	info, err := os.Lstat(target)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&linkedDirModes != 0 {
+		return os.Remove(target)
+	}
+	return os.RemoveAll(target)
+}
+
 // managedArtifactTarget resolves one managed relative subpath under absRoot to
 // an absolute path that is safe to remove, reporting false when there is
 // nothing to reclaim.
@@ -975,15 +994,17 @@ func (d *Daemon) cleanManagedTaskArtifacts(taskDir string) (removed int, bytes i
 // junctions: the per-task codex-home links the user's real skills, Codex
 // session store and plugin cache into itself, so following one would put
 // RemoveAll inside the user's home. Addressing the path directly means every
-// component between absRoot and the leaf has to be re-checked, not just the
-// leaf. See linkedDirModes.
+// parent component has to be a real directory. The exact leaf may itself be a
+// link created by the daemon; callers unlink that leaf without following it.
+// See linkedDirModes.
 //
 // Containment needs no separate check: safeRelativePath has already rejected
 // absolute paths and anything that escapes upward, and filepath.Clean leaves no
 // interior "..", so joining the components one at a time cannot leave absRoot.
 func managedArtifactTarget(absRoot, rel string) (string, bool) {
 	current := absRoot
-	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+	parts := strings.Split(rel, string(filepath.Separator))
+	for i, part := range parts {
 		current = filepath.Join(current, part)
 		info, err := os.Lstat(current)
 		if err != nil {
@@ -991,7 +1012,10 @@ func managedArtifactTarget(absRoot, rel string) (string, bool) {
 			// "nothing for this cycle to do".
 			return "", false
 		}
-		if info.Mode()&linkedDirModes != 0 || !info.IsDir() {
+		if info.Mode()&linkedDirModes != 0 {
+			return current, i == len(parts)-1
+		}
+		if !info.IsDir() {
 			return "", false
 		}
 	}
@@ -1037,21 +1061,35 @@ func (d *Daemon) cleanTaskArtifactsMatching(taskDir string, matcher artifactMatc
 		if path == absRoot {
 			return nil
 		}
+		// Refuse to follow linked directories. WalkDir reports them as type Dir
+		// on some platforms; lstat to be sure. An exact daemon-managed leaf is
+		// safe to unlink directly, but basename patterns never remove links and
+		// a linked parent is always left alone.
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return nil
+		}
+		if info.Mode()&linkedDirModes != 0 {
+			if pattern, ok := matcher.matchExactPath(absRoot, path, entry.Name()); ok {
+				if rmErr := os.Remove(path); rmErr != nil {
+					d.logger.Warn("gc: artifact link remove failed", "path", path, "error", rmErr)
+				} else {
+					removed++
+					perPattern[pattern]++
+					d.logger.Info("gc: artifact link removed", "path", path, "bytes", 0)
+				}
+			}
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
 		if !entry.IsDir() {
 			return nil
 		}
 		// Never descend into .git — preserves agent commits even if a pattern
 		// like "objects" would otherwise match.
 		if entry.Name() == ".git" {
-			return filepath.SkipDir
-		}
-		// Refuse to follow linked directories. WalkDir reports them as type
-		// Dir on some platforms; lstat to be sure.
-		info, statErr := os.Lstat(path)
-		if statErr != nil {
-			return nil
-		}
-		if info.Mode()&linkedDirModes != 0 {
 			return filepath.SkipDir
 		}
 		pattern, ok := matcher.matchDirectory(absRoot, path, entry)

--- a/server/internal/daemon/gc_junction_windows_test.go
+++ b/server/internal/daemon/gc_junction_windows_test.go
@@ -86,3 +86,33 @@ func TestTaskSize_DoesNotCountDirectoryJunction(t *testing.T) {
 		t.Errorf("artifacts = %d, want 0", artifacts)
 	}
 }
+
+func TestManagedArtifact_RemovesTemporaryCacheJunctionOnly(t *testing.T) {
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := t.TempDir()
+	sharedTmp := t.TempDir()
+	keep := filepath.Join(sharedTmp, "marketplaces", "keep")
+	if err := os.MkdirAll(filepath.Dir(keep), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keep, []byte("shared content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(taskDir, "codex-home", ".tmp")
+	createJunction(t, sharedTmp, linkPath)
+
+	removed, bytes, perPattern := d.cleanManagedTaskArtifacts(taskDir)
+	if removed != 1 || bytes != 0 {
+		t.Fatalf("removed=%d bytes=%d, want 1/0", removed, bytes)
+	}
+	if got := perPattern[managedArtifactPatternPrefix+"codex-home/.tmp"]; got != 1 {
+		t.Fatalf("temporary cache pattern count = %d, want 1", got)
+	}
+	if _, err := os.Lstat(linkPath); !os.IsNotExist(err) {
+		t.Fatalf("task temporary cache junction survived: %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Fatalf("shared temporary cache target was touched: %v", err)
+	}
+}

--- a/server/internal/daemon/gc_managed_artifact_test.go
+++ b/server/internal/daemon/gc_managed_artifact_test.go
@@ -13,15 +13,16 @@ import (
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
 
-// The managed Codex cache (codex-home/.sandbox-bin, a ~285 MiB copy of the
-// Codex binary) used to be reclaimed only on the issue decision path. Every
-// other kind held it for as long as its parent record said "keep the
-// directory" — unbounded for a chat session, which stays "active" with no time
-// limit. See #6782, and #5654 for the original issue-path fix.
+// The managed Codex caches (codex-home/.sandbox-bin, a ~285 MiB copy of the
+// Codex binary, and codex-home/.tmp plugin caches) are reclaimed independently
+// from task work products. Every task kind must eventually give them back even
+// when its parent record keeps the directory.
 //
 // sandboxBinRel is the exact managed subpath, spelled out here so a change to
 // ManagedReclaimableArtifactSubpaths has to face these tests.
 const sandboxBinRel = "codex-home/.sandbox-bin"
+
+const codexTmpRel = "codex-home/.tmp"
 
 // chatGCMux serves a chat gc-check that reports the given status.
 func chatGCMux(chatID, status string) *http.ServeMux {
@@ -68,6 +69,7 @@ func TestManagedArtifact_IdleActiveChatReclaimsSandboxBin(t *testing.T) {
 	}
 	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws", "idle-chat", meta)
 	writeFile(t, filepath.Join(taskDir, sandboxBinRel, "codex"), 4096)
+	writeFile(t, filepath.Join(taskDir, codexTmpRel, "marketplaces", "plugin"), 2048)
 	// Everything below must survive: session data, the audit trail, and a
 	// user-owned directory that merely shares the managed basename.
 	writeFile(t, filepath.Join(taskDir, "logs/run.log"), 32)
@@ -83,6 +85,7 @@ func TestManagedArtifact_IdleActiveChatReclaimsSandboxBin(t *testing.T) {
 	d.applyGCAction(taskDir, action, stats)
 
 	assertGone(t, taskDir, sandboxBinRel)
+	assertGone(t, taskDir, codexTmpRel)
 	assertKept(t, taskDir,
 		"logs/run.log",
 		"output/result.md",
@@ -90,11 +93,14 @@ func TestManagedArtifact_IdleActiveChatReclaimsSandboxBin(t *testing.T) {
 		"workdir/repo/.sandbox-bin/user-owned",
 		".gc_meta.json",
 	)
-	if stats.artifactRemoved != 1 {
-		t.Fatalf("artifact_removed = %d, want 1", stats.artifactRemoved)
+	if stats.artifactRemoved != 2 {
+		t.Fatalf("artifact_removed = %d, want 2", stats.artifactRemoved)
 	}
 	if got := stats.byPattern[managedArtifactPatternPrefix+sandboxBinRel]; got != 1 {
 		t.Fatalf("managed pattern count = %d, want 1", got)
+	}
+	if got := stats.byPattern[managedArtifactPatternPrefix+codexTmpRel]; got != 1 {
+		t.Fatalf("temporary cache pattern count = %d, want 1", got)
 	}
 }
 
@@ -303,19 +309,19 @@ func TestManagedArtifact_SecondCycleIsANoOp(t *testing.T) {
 	}
 }
 
-// The direct-path removal replaced a tree walk that refused to descend through
-// symlinks and junctions. It has to refuse at every component, not just the
-// leaf — codex-home links the user's real ~/.codex content into itself.
+// Direct removal may unlink an exact managed leaf, but it must refuse a linked
+// parent. Neither case may follow the link into the user's real ~/.codex.
 func TestManagedArtifact_DirectRemovalDoesNotFollowLinks(t *testing.T) {
 	t.Parallel()
 	d := newGCTestDaemon(t, http.NewServeMux())
 
 	for _, tc := range []struct {
-		name     string
-		linkPath string
+		name        string
+		linkPath    string
+		wantRemoved int
 	}{
-		{name: "leaf", linkPath: sandboxBinRel},
-		{name: "parent", linkPath: "codex-home"},
+		{name: "leaf", linkPath: sandboxBinRel, wantRemoved: 1},
+		{name: "parent", linkPath: "codex-home", wantRemoved: 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			taskDir := t.TempDir()
@@ -337,8 +343,8 @@ func TestManagedArtifact_DirectRemovalDoesNotFollowLinks(t *testing.T) {
 			}
 
 			removed, bytes, _ := d.cleanManagedTaskArtifacts(taskDir)
-			if removed != 0 || bytes != 0 {
-				t.Fatalf("removed=%d bytes=%d, want 0 through a link", removed, bytes)
+			if removed != tc.wantRemoved || bytes != 0 {
+				t.Fatalf("removed=%d bytes=%d, want %d/0", removed, bytes, tc.wantRemoved)
 			}
 			for _, keep := range []string{keepFile, userSandboxBin} {
 				if _, err := os.Stat(keep); err != nil {
@@ -346,6 +352,39 @@ func TestManagedArtifact_DirectRemovalDoesNotFollowLinks(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// A new task's codex-home/.tmp is a link to the user's shared cache. GC must
+// remove only that task-local link, leaving every shared cache byte intact.
+func TestManagedArtifact_ReclaimsTaskTemporaryCacheLinkOnly(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := t.TempDir()
+	sharedTmp := t.TempDir()
+	sharedMarker := filepath.Join(sharedTmp, "marketplaces", "keep")
+	writeFile(t, sharedMarker, 4096)
+
+	linkPath := filepath.Join(taskDir, filepath.FromSlash(codexTmpRel))
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(sharedTmp, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	removed, bytes, perPattern := d.cleanManagedTaskArtifacts(taskDir)
+	if removed != 1 || bytes != 0 {
+		t.Fatalf("removed=%d bytes=%d, want 1/0 for a cache link", removed, bytes)
+	}
+	if got := perPattern[managedArtifactPatternPrefix+codexTmpRel]; got != 1 {
+		t.Fatalf("temporary cache pattern count = %d, want 1", got)
+	}
+	if _, err := os.Lstat(linkPath); !os.IsNotExist(err) {
+		t.Fatalf("task temporary cache link survived: %v", err)
+	}
+	if _, err := os.Stat(sharedMarker); err != nil {
+		t.Fatalf("shared temporary cache target was touched: %v", err)
 	}
 }
 

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1528,11 +1528,12 @@ func TestCleanTaskArtifacts_ManagedPathDoesNotFollowSymlinks(t *testing.T) {
 	d := newGCTestDaemon(t, http.NewServeMux())
 
 	for _, tc := range []struct {
-		name     string
-		linkPath string
+		name        string
+		linkPath    string
+		wantRemoved int
 	}{
-		{name: "leaf", linkPath: "codex-home/.sandbox-bin"},
-		{name: "parent", linkPath: "codex-home"},
+		{name: "exact managed leaf is unlinked", linkPath: "codex-home/.sandbox-bin", wantRemoved: 1},
+		{name: "linked parent is preserved", linkPath: "codex-home", wantRemoved: 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			taskDir := t.TempDir()
@@ -1548,8 +1549,8 @@ func TestCleanTaskArtifacts_ManagedPathDoesNotFollowSymlinks(t *testing.T) {
 			}
 
 			removed, _, _ := d.cleanTaskArtifacts(taskDir, nil)
-			if removed != 0 {
-				t.Fatalf("removed=%d, want 0 for symlinked managed path", removed)
+			if removed != tc.wantRemoved {
+				t.Fatalf("removed=%d, want %d for symlinked managed path", removed, tc.wantRemoved)
 			}
 			if _, err := os.Stat(keepFile); err != nil {
 				t.Fatalf("symlink target was touched: %v", err)
@@ -2383,7 +2384,8 @@ func TestShouldCleanTaskDir_ChatHardDeletedFreshMtime(t *testing.T) {
 //
 // #6782 narrowed this from "the GC does nothing" to "the GC never removes the
 // directory": a session idle past GCArtifactTTL now gives back the regenerable
-// codex-home/.sandbox-bin cache, which the next message re-provisions. The
+// codex-home/.sandbox-bin cache and shared-cache .tmp link, which the next
+// message re-provisions. The
 // acceptance criterion is unchanged — the session's own data survives — so
 // this asserts the surviving contents rather than the bare action value.
 // TestManagedArtifact_IdleActiveChatReclaimsSandboxBin covers the carve-out.

--- a/server/internal/daemon/workdir_race_test.go
+++ b/server/internal/daemon/workdir_race_test.go
@@ -146,8 +146,15 @@ func TestRunTask_StartTaskCalledAfterWorkdirOnDisk(t *testing.T) {
 	}
 
 	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
-	// The Run() failure is expected; we only assert the pre-Run ordering.
-	_, _ = d.runTask(context.Background(), task, "claude", 0, taskLog)
+	// The Run() failure is expected. Its result must still retain EnvRoot so
+	// handleTask can stamp GC completion metadata for the failed run.
+	result, runErr := d.runTask(context.Background(), task, "claude", 0, taskLog)
+	if runErr == nil {
+		t.Fatal("runTask unexpectedly succeeded with a missing agent binary")
+	}
+	if result.EnvRoot != expectedEnvRoot {
+		t.Fatalf("failed run EnvRoot = %q, want %q for GC", result.EnvRoot, expectedEnvRoot)
+	}
 
 	if !startCalled.Load() {
 		t.Fatal("runTask did not call /start — Fix A's StartTask placement is missing")
@@ -778,10 +785,11 @@ func TestRunTask_PrepareTimeoutStopsLeaseDuringBlockedStartTask(t *testing.T) {
 // neither isActiveEnvRoot nor a .gc_meta.json file — falling through to
 // orphanByMTime, gated only by the 72h GCOrphanTTL.
 //
-// This test fakes the inner guard's lifecycle (mark + deferred unmark),
-// then asserts that at the moment /complete is hit (i.e. between runner.run
-// returning and WriteGCMeta running), isActiveEnvRoot(envRoot) is still
-// true thanks to the outer guard handleTask installs.
+// This test fakes the inner guard's lifecycle (mark + deferred unmark), then
+// asserts that at the moment /complete is hit, isActiveEnvRoot(envRoot) is
+// still true thanks to the outer guard handleTask installs. Completion metadata
+// is now stamped before this callback, but the root must remain reserved until
+// all terminal reporting is finished.
 func TestHandleTask_KeepsEnvRootActiveAcrossCompletion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- expose the user's whole shared Codex `.tmp` cache through each per-task `CODEX_HOME` before Codex starts, so marketplace/plugin sync reuses one checkout and one set of lock/revision files
- register `codex-home/.tmp` as an exact daemon-managed artifact; GC unlinks only the task-side symlink/junction and never follows it into the shared cache
- preserve the environment root and stamp GC completion metadata on failed/cancelled runs, allowing their managed artifacts to follow the normal sweeper lifecycle
- cover fresh prepare, reused legacy homes, GC walking/direct cleanup, failed-run metadata, real Codex startup, and Windows junction safety

## Verification

- `go test ./internal/daemon/... -count=1`
- `GOOS=windows GOARCH=amd64 go test ./internal/daemon/... -run '^$' -exec=true -count=1`
- real Codex integration smoke passed twice with Codex CLI `0.153.4`; the latest run returned exactly `MULTICA_CODEX_TMP_OK` and kept `.tmp` linked throughout

Machine evidence from the latest smoke:

- legacy active task, intentionally left untouched: `codex-home` 338 MiB, including task-local `.tmp` 316 MiB
- new linked-cache task: task-local `CODEX_HOME` 1,184,688 bytes before Codex launch and 2,141,091 bytes after launch
- immediate `df -k` available space: 7,638,536 KiB before, 7,645,056 KiB after
- shared `~/.codex/.tmp` remained intact (728 MiB total; marketplaces 552 MiB, bundled marketplaces 84 MiB, plugins 88 MiB)

## Operational note

No existing in-progress workspace copies were removed or modified, the shared cache was not cleaned, and this branch has not been deployed to a daemon or any production path.

Tracks WS-4954.
