### PR TITLE
fix(pi): skip resuming sessions with missing recorded cwd

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1,11 +1,13 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"log/slog"
 	"math/rand"
 	"net"
@@ -6125,8 +6127,19 @@ func sameExistingDir(a, b string) bool {
 
 func gateResumeToReachableSession(task *Task, taskCtx *execenv.TaskContextForEnv, provider, envWorkDir string, sessionHomeReachable bool, taskLog *slog.Logger) bool {
 	var reachable bool
+	reason := "session_store_unreachable"
 	if providerUsesPiSessionFile(provider) {
 		reachable = piSessionFilePresent(task.PriorSessionID)
+		// Pi refuses to start when the recorded cwd of the session file it
+		// is given no longer exists (GH #8082), so a present file alone
+		// must not count as resumable. Pi-only: OMP shares the session-file
+		// plumbing but has no such recorded-cwd refusal evidence, and #7760
+		// keeps Pi-family resumes independent of workdir equality — only a
+		// confirmed-missing recorded cwd narrows the verdict here.
+		if reachable && provider == "pi" && piSessionRecordedCwdMissing(task.PriorSessionID) {
+			reachable = false
+			reason = "recorded_cwd_missing"
+		}
 	} else {
 		// Compare the directories, not the spelling. Reuse runs in the canonical
 		// path it validated and locked, which need not be character-identical to
@@ -6138,6 +6151,7 @@ func gateResumeToReachableSession(task *Task, taskCtx *execenv.TaskContextForEnv
 	if !reachable && task.PriorSessionID != "" {
 		taskLog.Info("dropping prior session: session store not reachable from this run",
 			"provider", provider,
+			"reason", reason,
 			"session_id", task.PriorSessionID,
 			"prior_workdir", task.PriorWorkDir,
 			"workdir", envWorkDir,
@@ -6173,6 +6187,51 @@ func piSessionFilePresent(sessionID string) bool {
 	}
 	info, err := os.Stat(sessionID)
 	return err == nil && info.Mode().IsRegular() && info.Size() > 0
+}
+
+// piSessionHeaderLimit caps how much of a Pi session file the resume gate
+// reads. It is a defensive read bound for this check, not Pi's official
+// header limit; anything larger is treated as undecidable, never as missing.
+const piSessionHeaderLimit = 64 * 1024
+
+// piSessionRecordedCwdMissing reports whether a Pi session file's recorded
+// working directory is confirmed absent (GH #8082). It answers only that:
+// true when the header's cwd is provably gone, false when it exists or when
+// the answer cannot be determined (unreadable file, oversized or malformed
+// header, missing/empty/non-string/relative cwd, non-session first line).
+// Undecidable stays resumable here so this check never invents new reasons
+// to discard a session beyond the one Pi itself refuses to start with.
+// The file is opened read-only and callers must preserve it; nothing here
+// creates, modifies, or recreates any path.
+func piSessionRecordedCwdMissing(sessionPath string) bool {
+	f, err := os.Open(sessionPath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	raw, err := io.ReadAll(io.LimitReader(f, piSessionHeaderLimit+1))
+	if err != nil || len(raw) > piSessionHeaderLimit {
+		return false
+	}
+	// The cwd lives in the first-line session header; the transcript body
+	// below it is never searched.
+	if i := bytes.IndexByte(raw, '\n'); i >= 0 {
+		raw = raw[:i]
+	}
+	raw = bytes.TrimSuffix(raw, []byte("\r"))
+	var header map[string]any
+	if err := json.Unmarshal(raw, &header); err != nil {
+		return false
+	}
+	if header["type"] != "session" {
+		return false
+	}
+	cwd, ok := header["cwd"].(string)
+	if !ok || cwd == "" || !filepath.IsAbs(cwd) {
+		return false
+	}
+	_, err = os.Stat(cwd)
+	return err != nil && os.IsNotExist(err)
 }
 
 // sessionHomeReachable reports whether a session recorded by a prior task on

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6243,7 +6243,15 @@ func piSessionRecordedCwdMissing(sessionPath string) bool {
 	}
 	line = bytes.TrimSuffix(line, []byte("\r"))
 	var header piSessionHeader
-	if err := json.NewDecoder(bytes.NewReader(line)).Decode(&header); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(line))
+	if err := dec.Decode(&header); err != nil {
+		return false
+	}
+	// The first line must be exactly one JSON value: a valid session
+	// prefix with trailing garbage is undecidable, never a drop reason.
+	// A second decode must hit EOF (trailing whitespace alone still
+	// yields EOF); anything else decoded means trailing non-whitespace.
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
 		return false
 	}
 	if header.Type != "session" {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6189,10 +6189,20 @@ func piSessionFilePresent(sessionID string) bool {
 	return err == nil && info.Mode().IsRegular() && info.Size() > 0
 }
 
-// piSessionHeaderLimit caps how much of a Pi session file the resume gate
-// reads. It is a defensive read bound for this check, not Pi's official
-// header limit; anything larger is treated as undecidable, never as missing.
+// piSessionHeaderLimit caps how much of a Pi session file's FIRST LINE the
+// resume gate reads. It is a defensive read bound for this check, not Pi's
+// official header limit; a first line beyond it is undecidable, never
+// missing. Bytes past the first newline are never read, so a long
+// transcript body cannot push a healthy header over the bound (GH #8082).
 const piSessionHeaderLimit = 64 * 1024
+
+// piSessionHeader carries only the fields the resume gate needs. Unknown
+// extra fields are ignored by the decoder; no constraints are placed on
+// version/id/timestamp shapes.
+type piSessionHeader struct {
+	Type string `json:"type"`
+	Cwd  string `json:"cwd"`
+}
 
 // piSessionRecordedCwdMissing reports whether a Pi session file's recorded
 // working directory is confirmed absent (GH #8082). It answers only that:
@@ -6209,28 +6219,42 @@ func piSessionRecordedCwdMissing(sessionPath string) bool {
 		return false
 	}
 	defer f.Close()
-	raw, err := io.ReadAll(io.LimitReader(f, piSessionHeaderLimit+1))
-	if err != nil || len(raw) > piSessionHeaderLimit {
+	// Bounded first-line read: stop at the newline so the transcript body
+	// is never consumed. Handles LF, CRLF, and a missing trailing newline.
+	var line []byte
+	one := make([]byte, 1)
+	for len(line) <= piSessionHeaderLimit {
+		n, rerr := f.Read(one)
+		if n > 0 {
+			if one[0] == '\n' {
+				break
+			}
+			line = append(line, one[0])
+		}
+		if rerr != nil {
+			if rerr == io.EOF {
+				break
+			}
+			return false
+		}
+	}
+	if len(line) > piSessionHeaderLimit {
 		return false
 	}
-	// The cwd lives in the first-line session header; the transcript body
-	// below it is never searched.
-	if i := bytes.IndexByte(raw, '\n'); i >= 0 {
-		raw = raw[:i]
-	}
-	raw = bytes.TrimSuffix(raw, []byte("\r"))
-	var header map[string]any
-	if err := json.Unmarshal(raw, &header); err != nil {
+	line = bytes.TrimSuffix(line, []byte("\r"))
+	var header piSessionHeader
+	if err := json.NewDecoder(bytes.NewReader(line)).Decode(&header); err != nil {
 		return false
 	}
-	if header["type"] != "session" {
+	if header.Type != "session" {
 		return false
 	}
-	cwd, ok := header["cwd"].(string)
-	if !ok || cwd == "" || !filepath.IsAbs(cwd) {
+	// A non-string cwd fails to decode into the struct as a type error,
+	// which Decode reports — same undecidable outcome as before.
+	if header.Cwd == "" || !filepath.IsAbs(header.Cwd) {
 		return false
 	}
-	_, err = os.Stat(cwd)
+	_, err = os.Stat(header.Cwd)
 	return err != nil && os.IsNotExist(err)
 }
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -6221,23 +6222,15 @@ func piSessionRecordedCwdMissing(sessionPath string) bool {
 	defer f.Close()
 	// Bounded first-line read: stop at the newline so the transcript body
 	// is never consumed. Handles LF, CRLF, and a missing trailing newline.
-	var line []byte
-	one := make([]byte, 1)
-	for len(line) <= piSessionHeaderLimit {
-		n, rerr := f.Read(one)
-		if n > 0 {
-			if one[0] == '\n' {
-				break
-			}
-			line = append(line, one[0])
-		}
-		if rerr != nil {
-			if rerr == io.EOF {
-				break
-			}
-			return false
-		}
+	// The buffered cap admits at most piSessionHeaderLimit content bytes
+	// plus the newline delimiter, so the delimiter itself never counts
+	// toward the bound: a first line of exactly the limit stays decidable,
+	// while limit+1 is undecidable however the line is terminated.
+	raw, rerr := bufio.NewReader(io.LimitReader(f, int64(piSessionHeaderLimit)+2)).ReadBytes('\n')
+	if rerr != nil && rerr != io.EOF {
+		return false
 	}
+	line := bytes.TrimSuffix(raw, []byte("\n"))
 	if len(line) > piSessionHeaderLimit {
 		return false
 	}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6193,17 +6193,10 @@ func piSessionFilePresent(sessionID string) bool {
 // piSessionHeaderLimit caps how much of a Pi session file's FIRST LINE the
 // resume gate reads. It is a defensive read bound for this check, not Pi's
 // official header limit; a first line beyond it is undecidable, never
-// missing. Bytes past the first newline are never read, so a long
-// transcript body cannot push a healthy header over the bound (GH #8082).
+// missing. Bytes past the first newline are never parsed or consulted, so
+// a long transcript body cannot push a healthy header over the bound
+// (GH #8082).
 const piSessionHeaderLimit = 64 * 1024
-
-// piSessionHeader carries only the fields the resume gate needs. Unknown
-// extra fields are ignored by the decoder; no constraints are placed on
-// version/id/timestamp shapes.
-type piSessionHeader struct {
-	Type string `json:"type"`
-	Cwd  string `json:"cwd"`
-}
 
 // piSessionRecordedCwdMissing reports whether a Pi session file's recorded
 // working directory is confirmed absent (GH #8082). It answers only that:
@@ -6220,12 +6213,16 @@ func piSessionRecordedCwdMissing(sessionPath string) bool {
 		return false
 	}
 	defer f.Close()
-	// Bounded first-line read: stop at the newline so the transcript body
-	// is never consumed. Handles LF, CRLF, and a missing trailing newline.
-	// The buffered cap admits at most piSessionHeaderLimit content bytes
-	// plus the newline delimiter, so the delimiter itself never counts
-	// toward the bound: a first line of exactly the limit stays decidable,
-	// while limit+1 is undecidable however the line is terminated.
+	// Bounded first-line read: only the first line is ever parsed or
+	// consulted, so the transcript body cannot affect the verdict.
+	// Handles LF, CRLF, and a missing trailing newline. The buffered
+	// reader may read ahead past the newline, but those bytes stay
+	// buffered and unused: reads from the file and memory use stay
+	// capped at piSessionHeaderLimit+2 regardless of file size. The +2
+	// slack admits piSessionHeaderLimit content bytes plus the newline
+	// delimiter, so the LF itself never counts toward the bound while a
+	// limit+1 first line still exceeds it however it is terminated; a
+	// capped read is length-checked below, never mistaken for clean EOF.
 	raw, rerr := bufio.NewReader(io.LimitReader(f, int64(piSessionHeaderLimit)+2)).ReadBytes('\n')
 	if rerr != nil && rerr != io.EOF {
 		return false
@@ -6235,9 +6232,15 @@ func piSessionRecordedCwdMissing(sessionPath string) bool {
 		return false
 	}
 	line = bytes.TrimSuffix(line, []byte("\r"))
-	var header piSessionHeader
+	// Exact-key header decode: only "type" and "cwd" decide (GH #8082).
+	// encoding/json struct matching is case-insensitive, so decode into
+	// a raw map and look the keys up exactly instead: an uppercase "CWD"
+	// neither overrides nor substitutes "cwd", and a duplicate "cwd"
+	// resolves to its last value. Extra fields stay ignored; the first
+	// line must still be exactly one JSON value.
+	var fields map[string]json.RawMessage
 	dec := json.NewDecoder(bytes.NewReader(line))
-	if err := dec.Decode(&header); err != nil {
+	if err := dec.Decode(&fields); err != nil {
 		return false
 	}
 	// The first line must be exactly one JSON value: a valid session
@@ -6247,15 +6250,31 @@ func piSessionRecordedCwdMissing(sessionPath string) bool {
 	if err := dec.Decode(&struct{}{}); err != io.EOF {
 		return false
 	}
-	if header.Type != "session" {
+	var typ string
+	if rawType, ok := fields["type"]; ok {
+		if err := json.Unmarshal(rawType, &typ); err != nil {
+			return false
+		}
+	}
+	if typ != "session" {
 		return false
 	}
-	// A non-string cwd fails to decode into the struct as a type error,
-	// which Decode reports — same undecidable outcome as before.
-	if header.Cwd == "" || !filepath.IsAbs(header.Cwd) {
+	// "cwd" is read by exact key only: an uppercase "CWD" never
+	// substitutes for it, and a duplicate "cwd" resolves to the last
+	// value the same way encoding/json does for repeated keys. A
+	// missing, null, or non-string cwd is undecidable, never a drop.
+	rawCwd, ok := fields["cwd"]
+	if !ok {
 		return false
 	}
-	_, err = os.Stat(header.Cwd)
+	var cwd string
+	if err := json.Unmarshal(rawCwd, &cwd); err != nil {
+		return false
+	}
+	if cwd == "" || !filepath.IsAbs(cwd) {
+		return false
+	}
+	_, err = os.Stat(cwd)
 	return err != nil && os.IsNotExist(err)
 }
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2162,6 +2162,386 @@ func TestGatePiResumeDropsUnusableSessionFile(t *testing.T) {
 	}
 }
 
+// writeGH8082Session writes a Pi session file whose first line is a session
+// header with the given extra fields, followed by a transcript body line so
+// tests prove only the header is consulted. Fixtures use json.Marshal, never
+// string concatenation.
+func writeGH8082Session(t *testing.T, path string, extra map[string]any, body string) {
+	t.Helper()
+	header := map[string]any{"type": "session"}
+	for k, v := range extra {
+		header[k] = v
+	}
+	raw, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal session header: %v", err)
+	}
+	if body == "" {
+		body = `{"type":"message","cwd decoy":"/nonexistent-decoy"}`
+	}
+	if err := os.WriteFile(path, append(append(raw, '\n'), body+"\n"...), 0o644); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+}
+
+// TestGH8082MissingRecordedCwdDropsPiResume is the core GH #8082 repro: the
+// session file exists but its recorded cwd was deleted, so the Pi resume
+// must be dropped via the existing fresh-session path. Fails on base with
+// reachable=true (file presence alone), passes with the helper wired in.
+func TestGH8082MissingRecordedCwdDropsPiResume(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	recorded := filepath.Join(base, "recorded-a")
+	if err := os.MkdirAll(recorded, 0o755); err != nil {
+		t.Fatalf("create recorded dir: %v", err)
+	}
+	envDir := filepath.Join(base, "fresh-b")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatalf("create env dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(envDir, "sentinel"), []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	sessionPath := filepath.Join(base, "pi-session.jsonl")
+	writeGH8082Session(t, sessionPath, map[string]any{"cwd": recorded}, "")
+	if err := os.RemoveAll(recorded); err != nil {
+		t.Fatalf("delete recorded dir: %v", err)
+	}
+	before, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("read session before gate: %v", err)
+	}
+
+	task := Task{PriorSessionID: sessionPath, PriorWorkDir: recorded}
+	taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+
+	reachable := gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default())
+
+	if reachable {
+		t.Fatal("reachable = true for a Pi session whose recorded cwd is gone")
+	}
+	if task.PriorSessionID != "" {
+		t.Fatalf("PriorSessionID = %q, want empty", task.PriorSessionID)
+	}
+	if taskCtx.PriorSessionResumed {
+		t.Fatal("PriorSessionResumed stayed true for a dropped Pi session")
+	}
+	if !taskCtx.PriorSessionResumeUnavailable || !task.PriorSessionResumeUnavailable {
+		t.Fatal("resume-unavailable notice missing on task or taskCtx")
+	}
+	if task.PriorWorkDir != recorded {
+		t.Fatalf("PriorWorkDir = %q, want %q (gate must not clear it)", task.PriorWorkDir, recorded)
+	}
+	if _, err := os.Stat(filepath.Join(envDir, "sentinel")); err != nil {
+		t.Fatalf("env workdir disturbed: %v", err)
+	}
+	after, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("read session after gate: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("session file was modified by the gate")
+	}
+	if _, err := os.Stat(recorded); !os.IsNotExist(err) {
+		t.Fatalf("recorded dir was recreated by the gate: %v", err)
+	}
+	// §6H boundary (unit-level): the gate output IS the backend input — runTask
+	// forwards task.PriorSessionID as ResumeSessionID (daemon.go runTask),
+	// and the Pi backend mints a new session path for --session when it is
+	// empty (pi.go: empty ResumeSessionID -> newPiSessionPath). The cleared
+	// PriorSessionID asserted above is therefore exactly what keeps the stale
+	// path S out of --session. Full fake-CLI invocation is out of scope for
+	// this narrow gate change; no new backend plumbing is added.
+}
+
+// TestGH8082CrossWorkdirResumePreserved guards PR #7760: different but
+// existing recorded cwd and env workdir must still resume.
+func TestGH8082CrossWorkdirResumePreserved(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	recorded := filepath.Join(base, "recorded-a")
+	envDir := filepath.Join(base, "fresh-b")
+	for _, dir := range []string{recorded, envDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+	sessionPath := filepath.Join(base, "pi-session.jsonl")
+	writeGH8082Session(t, sessionPath, map[string]any{"cwd": recorded}, "")
+
+	task := Task{PriorSessionID: sessionPath, PriorWorkDir: recorded}
+	taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+
+	reachable := gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default())
+
+	if !reachable {
+		t.Fatal("reachable = false for a Pi session whose recorded cwd still exists")
+	}
+	if task.PriorSessionID != sessionPath {
+		t.Fatalf("PriorSessionID = %q, want %q", task.PriorSessionID, sessionPath)
+	}
+	if !taskCtx.PriorSessionResumed {
+		t.Fatal("PriorSessionResumed was cleared for a healthy cross-workdir resume")
+	}
+	if taskCtx.PriorSessionResumeUnavailable || task.PriorSessionResumeUnavailable {
+		t.Fatal("healthy resume was reported unavailable")
+	}
+}
+
+// TestGH8082HeaderCwdNotPriorWorkDir proves the gate reads header.cwd, not
+// task.PriorWorkDir: an existing PriorWorkDir cannot rescue a session whose
+// recorded cwd is gone, and vice versa.
+func TestGH8082HeaderCwdNotPriorWorkDir(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	existing := filepath.Join(base, "existing-c")
+	envDir := filepath.Join(base, "fresh-b")
+	for _, dir := range []string{existing, envDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+	gone := filepath.Join(base, "deleted-a")
+
+	t.Run("existing PriorWorkDir does not rescue missing recorded cwd", func(t *testing.T) {
+		t.Parallel()
+		sessionPath := filepath.Join(base, "gone-session.jsonl")
+		writeGH8082Session(t, sessionPath, map[string]any{"cwd": gone}, "")
+		task := Task{PriorSessionID: sessionPath, PriorWorkDir: existing}
+		taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+		if gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default()) {
+			t.Fatal("reachable = true despite missing recorded cwd")
+		}
+		if task.PriorSessionID != "" {
+			t.Fatalf("PriorSessionID = %q, want empty", task.PriorSessionID)
+		}
+	})
+
+	t.Run("existing recorded cwd survives empty PriorWorkDir", func(t *testing.T) {
+		t.Parallel()
+		sessionPath := filepath.Join(base, "kept-session.jsonl")
+		writeGH8082Session(t, sessionPath, map[string]any{"cwd": existing}, "")
+		task := Task{PriorSessionID: sessionPath}
+		taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+		if !gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default()) {
+			t.Fatal("reachable = false despite existing recorded cwd")
+		}
+		if task.PriorSessionID != sessionPath {
+			t.Fatalf("PriorSessionID = %q, want %q", task.PriorSessionID, sessionPath)
+		}
+	})
+}
+
+// TestGH8082UndecidableHeaderStaysResumable: malformed or incomplete headers
+// must not become new drop reasons — only a confirmed-missing cwd narrows.
+func TestGH8082UndecidableHeaderStaysResumable(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]func(t *testing.T, path string){
+		"missing cwd": func(t *testing.T, path string) {
+			t.Helper()
+			writeGH8082Session(t, path, map[string]any{"version": 3}, "")
+		},
+		"empty cwd": func(t *testing.T, path string) {
+			t.Helper()
+			writeGH8082Session(t, path, map[string]any{"cwd": ""}, "")
+		},
+		"null cwd": func(t *testing.T, path string) {
+			t.Helper()
+			writeGH8082Session(t, path, map[string]any{"cwd": nil}, "")
+		},
+		"non-string cwd": func(t *testing.T, path string) {
+			t.Helper()
+			writeGH8082Session(t, path, map[string]any{"cwd": 42}, "")
+		},
+		"malformed JSON": func(t *testing.T, path string) {
+			t.Helper()
+			if err := os.WriteFile(path, []byte("not json at all\n"), 0o644); err != nil {
+					t.Fatalf("write malformed: %v", err)
+				}
+		},
+		"non-session first line": func(t *testing.T, path string) {
+			t.Helper()
+			if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+					t.Fatalf("write bare header: %v", err)
+				}
+		},
+		"relative cwd": func(t *testing.T, path string) {
+			t.Helper()
+			writeGH8082Session(t, path, map[string]any{"cwd": "some/relative/dir"}, "")
+		},
+		"oversize header": func(t *testing.T, path string) {
+			t.Helper()
+			pad := strings.Repeat("x", 64*1024+8) // piSessionHeaderLimit, inlined so this test compiles on base for RED
+			writeGH8082Session(t, path, map[string]any{"cwd": filepath.Join(t.TempDir(), "gone"), "pad": pad}, "")
+		},
+	}
+
+	for name, setup := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			base := t.TempDir()
+			envDir := filepath.Join(base, "workdir")
+			if err := os.MkdirAll(envDir, 0o755); err != nil {
+				t.Fatalf("create workdir: %v", err)
+				}
+			sessionPath := filepath.Join(base, "session.jsonl")
+			setup(t, sessionPath)
+			before, err := os.ReadFile(sessionPath)
+			if err != nil {
+					t.Fatalf("read before: %v", err)
+				}
+			task := Task{PriorSessionID: sessionPath, PriorWorkDir: envDir}
+			taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+			reachable := gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default())
+			if !reachable {
+				t.Fatalf("%s: undecidable header dropped a session", name)
+			}
+			if task.PriorSessionID != sessionPath {
+				t.Fatalf("%s: PriorSessionID changed to %q", name, task.PriorSessionID)
+			}
+			after, err := os.ReadFile(sessionPath)
+			if err != nil {
+					t.Fatalf("read after: %v", err)
+				}
+			if string(after) != string(before) {
+				t.Fatalf("%s: session file modified", name)
+			}
+		})
+	}
+}
+
+// TestGH8082HeaderFormatCompatibility is table-driven over line endings,
+// missing trailing newlines, unicode/space paths, and unknown header fields.
+func TestGH8082HeaderFormatCompatibility(t *testing.T) {
+	t.Parallel()
+
+	mkworld := func(t *testing.T) (recorded, envDir, base string) {
+		t.Helper()
+		base = t.TempDir()
+		recorded = filepath.Join(base, "work dir 한글")
+		envDir = filepath.Join(base, "fresh")
+		for _, dir := range []string{recorded, envDir} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("create %s: %v", dir, err)
+				}
+		}
+		return recorded, envDir, base
+	}
+	writeRaw := func(t *testing.T, path, line, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, append([]byte(line), body...), 0o644); err != nil {
+			t.Fatalf("write raw session: %v", err)
+			}
+	}
+	marshalHeader := func(t *testing.T, cwd string) string {
+		t.Helper()
+		raw, err := json.Marshal(map[string]any{
+				"type": "session", "version": 3, "id": "test-id",
+				"timestamp": "2026-09-06T00:00:00Z", "cwd": cwd,
+				"unknownFutureField": map[string]any{"nested": true},
+			})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+			}
+		return string(raw)
+	}
+
+	t.Run("existing cwd variants stay resumable", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct{ name, suffix, body string }{
+			{name: "LF", suffix: "\n", body: "{\"type\":\"message\"}\n"},
+			{name: "CRLF", suffix: "\r\n", body: "{\"type\":\"message\"}\r\n"},
+			{name: "no trailing newline", suffix: "", body: ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			recorded, envDir, base := mkworld(t)
+				sessionPath := filepath.Join(base, "s.jsonl")
+				writeRaw(t, sessionPath, marshalHeader(t, recorded)+tc.suffix, tc.body)
+				task := Task{PriorSessionID: sessionPath, PriorWorkDir: recorded}
+				taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+				if !gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default()) {
+					t.Fatalf("%s: existing recorded cwd dropped", tc.name)
+				}
+			})
+		}
+	})
+
+	t.Run("deleted cwd variants drop", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct{ name, suffix, body string }{
+			{name: "LF", suffix: "\n", body: "{\"type\":\"message\"}\n"},
+			{name: "CRLF", suffix: "\r\n", body: "{\"type\":\"message\"}\r\n"},
+			{name: "no trailing newline", suffix: "", body: ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			recorded, envDir, base := mkworld(t)
+				sessionPath := filepath.Join(base, "s.jsonl")
+				writeRaw(t, sessionPath, marshalHeader(t, recorded)+tc.suffix, tc.body)
+				if err := os.RemoveAll(recorded); err != nil {
+					t.Fatalf("delete recorded: %v", err)
+				}
+				task := Task{PriorSessionID: sessionPath, PriorWorkDir: recorded}
+				taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+				if gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default()) {
+					t.Fatalf("%s: deleted recorded cwd kept", tc.name)
+				}
+				if task.PriorSessionID != "" {
+					t.Fatalf("%s: PriorSessionID = %q, want empty", tc.name, task.PriorSessionID)
+				}
+			})
+		}
+	})
+}
+
+// TestGH8082OmpAndOtherProvidersUnaffected: the missing-cwd check is
+// Pi-only, so OMP keeps a deleted-cwd session reachable (prior behaviour)
+// and cwd-keyed providers are untouched.
+func TestGH8082OmpAndOtherProvidersUnaffected(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	recorded := filepath.Join(base, "recorded")
+	if err := os.MkdirAll(recorded, 0o755); err != nil {
+		t.Fatalf("create recorded: %v", err)
+	}
+	envDir := filepath.Join(base, "fresh")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatalf("create env: %v", err)
+	}
+	sessionPath := filepath.Join(base, "s.jsonl")
+	writeGH8082Session(t, sessionPath, map[string]any{"cwd": recorded}, "")
+	if err := os.RemoveAll(recorded); err != nil {
+		t.Fatalf("delete recorded: %v", err)
+	}
+
+	t.Run("omp keeps prior session-file behaviour", func(t *testing.T) {
+		t.Parallel()
+		task := Task{PriorSessionID: sessionPath, PriorWorkDir: recorded}
+		taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+		if !gateResumeToReachableSession(&task, &taskCtx, "omp", envDir, true, slog.Default()) {
+			t.Fatal("omp resume narrowed without recorded-cwd refusal evidence")
+		}
+		if task.PriorSessionID != sessionPath {
+			t.Fatalf("PriorSessionID = %q, want %q", task.PriorSessionID, sessionPath)
+		}
+	})
+
+	t.Run("claude still keys on workdir", func(t *testing.T) {
+		t.Parallel()
+		task := Task{PriorSessionID: "sess-1", PriorWorkDir: recorded}
+		taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+		if gateResumeToReachableSession(&task, &taskCtx, "claude", envDir, true, slog.Default()) {
+			t.Fatal("claude gate changed unexpectedly")
+		}
+	})
+}
+
 func TestSessionHomeReachable(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2247,21 +2247,24 @@ func TestGH8082MissingRecordedCwdDropsPiResume(t *testing.T) {
 		t.Fatalf("recorded dir was recreated by the gate: %v", err)
 	}
 	// §6H execution evidence lives in TestGH8082GateToBackendHandoff below:
-	// the cleared PriorSessionID feeds a real Pi backend Execute against a
-	// fake Pi CLI, which observes the fresh --session path and cwd.
+	// a stale-session task runs through production d.runTask against a
+	// fake Pi CLI, which observes the fresh --session path, cwd, and prompt.
 }
 
-// TestGH8082GateToBackendHandoff runs the §6H chain end to end at the
-// gate→backend boundary with production code throughout:
+// TestGH8082GateToBackendHandoff drives a stale-session task through the
+// production d.runTask glue end to end — no test-side gate call, no manual
+// ResumeSessionID injection:
 //
 //  1. stale session S with deleted recorded cwd A is prepared;
-//  2. the real gate drops the resume (PriorSessionID cleared, notice set);
-//  3. the cleared id is passed as ResumeSessionID into a real Pi backend
-//     Execute against a fake Pi CLI (OS-appropriate script) that records
-//     the argv it received and the cwd it ran in;
+//  2. the task enters production runTask with PriorSessionID=S; the in-run
+//     gate drops the resume, so the backend receives ResumeSessionID=""
+//     through the runTask→ExecOptions glue (daemon.go runTask);
+//  3. a fake Pi CLI (OS-appropriate script) records the argv, cwd, and
+//     stdin prompt it received, then emits one successful turn;
 //  4. the fake observes --session S2 (never the stale S), cwd B, and the
-//     backend returns SessionID S2 with a completed fake turn;
-//  5. BuildPrompt on the gated task still carries the continuity notice.
+//     runTask result carries SessionID S2;
+//  5. the stdin prompt the fake received carries the continuity notice, so
+//     the drop is disclosed in actual runTask output, not re-rendered here.
 //
 // A fake CLI success is a plumbing proof, not a real-Pi run: it shows the
 // stale path no longer reaches --session and the fresh path does.
@@ -2274,58 +2277,77 @@ func TestGH8082GateToBackendHandoff(t *testing.T) {
 	if err := os.MkdirAll(recorded, 0o755); err != nil {
 		t.Fatalf("create recorded dir: %v", err)
 	}
-	envDir := filepath.Join(base, "fresh-b")
-	if err := os.MkdirAll(envDir, 0o755); err != nil {
-		t.Fatalf("create env dir: %v", err)
-	}
 	sessionPath := filepath.Join(base, "pi-session.jsonl")
 	writeGH8082Session(t, sessionPath, map[string]any{"cwd": recorded}, "")
 	if err := os.RemoveAll(recorded); err != nil {
 		t.Fatalf("delete recorded dir: %v", err)
 	}
 
-	// Step 2: the production gate.
-	task := Task{PriorSessionID: sessionPath, PriorWorkDir: recorded}
-	taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
-	if gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default()) {
-		t.Fatal("reachable = true for a Pi session whose recorded cwd is gone")
-	}
-	if task.PriorSessionID != "" {
-		t.Fatalf("PriorSessionID = %q, want empty for the backend call", task.PriorSessionID)
-	}
-
-	// Step 3: fake Pi CLI recording argv and cwd. keep HOME/USERPROFILE
-	// inside temp so the backend's fresh session path cannot touch a real
-	// profile.
+	// Fake Pi CLI recording argv, cwd, and the stdin prompt. HOME/USERPROFILE
+	// stay inside temp so the fresh session path cannot touch a real profile.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	argvFile := filepath.Join(base, "observed-argv.txt")
 	cwdFile := filepath.Join(base, "observed-cwd.txt")
+	stdinFile := filepath.Join(base, "observed-stdin.txt")
 	t.Setenv("GH8082_OBSERVE_ARGV", argvFile)
 	t.Setenv("GH8082_OBSERVE_CWD", cwdFile)
-	execPath := writeGH8082FakePi(t, base)
+	t.Setenv("GH8082_OBSERVE_STDIN", stdinFile)
+	fakeBin := writeGH8082FakePi(t, base)
 
-	backend, err := agent.New("pi", agent.Config{ExecutablePath: execPath, Logger: slog.Default()})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := &Daemon{
+		client:         NewClient(srv.URL),
+		logger:         logger,
+		workspaces:     make(map[string]*workspaceState),
+		runtimeIndex:   map[string]Runtime{"rt-pi": {ID: "rt-pi", Provider: "pi"}},
+		activeEnvRoots: make(map[string]int),
+		resolvedPaths:  make(map[string]healedAgent),
+		agentVersions:  make(map[string]string),
+		cfg: Config{
+			WorkspacesRoot: t.TempDir(),
+			AgentTimeout:   60 * time.Second,
+			ServerBaseURL:  srv.URL,
+			Agents: map[string]AgentEntry{
+				"pi": {Path: fakeBin},
+			},
+		},
+	}
+	// PriorWorkDir names the deleted recorded dir: reuse refuses it and
+	// runTask prepares a fresh B, matching the real GH8082 shape.
+	task := Task{
+		ID:             "task-gh8082-handoff",
+		WorkspaceID:    "ws-gh8082",
+		RuntimeID:      "rt-pi",
+		IssueID:        "issue-gh8082",
+		AgentID:        "agent-gh8082",
+		AuthToken:      "mat_gh8082_handoff",
+		PriorSessionID: sessionPath,
+		PriorWorkDir:   recorded,
+		Agent: &AgentData{
+			ID:   "agent-gh8082",
+			Name: "gh8082-agent",
+		},
+	}
+
+	result, err := d.runTask(context.Background(), task, "pi", 0, logger)
 	if err != nil {
-		t.Fatalf("agent.New(pi): %v", err)
+		t.Fatalf("runTask: %v", err)
 	}
-	session, err := backend.Execute(t.Context(), "follow-up prompt", agent.ExecOptions{
-		Cwd:             envDir,
-		ResumeSessionID: task.PriorSessionID, // empty after the gate drop
-		Timeout:         60 * time.Second,
-	})
-	if err != nil {
-		t.Fatalf("backend Execute: %v", err)
-	}
-	for range session.Messages {
-	}
-	result, ok := <-session.Result
-	if !ok {
-		t.Fatal("result channel closed without a value")
-	}
-	if result.Status != "completed" {
+	if result.Status != "completed" || result.Comment != "done" {
 		t.Fatalf("result = %+v, want completed fake turn", result)
+	}
+	if result.SessionID == "" || result.SessionID == sessionPath {
+		t.Fatalf("SessionID = %q, want a fresh path, never the stale %q", result.SessionID, sessionPath)
+	}
+	if result.RetiredSessionID != "" {
+		t.Fatalf("RetiredSessionID = %q, want empty: the gate drops the resume before launch, no retry needed", result.RetiredSessionID)
 	}
 
 	// Step 4: what the fake CLI observed.
@@ -2355,24 +2377,30 @@ func TestGH8082GateToBackendHandoff(t *testing.T) {
 	if result.SessionID != observed {
 		t.Fatalf("SessionID = %q, want the observed fresh --session %q", result.SessionID, observed)
 	}
-	if strings.TrimSpace(strings.TrimPrefix(string(gotCwd), "\ufeff")) != envDir {
-		t.Fatalf("cli cwd = %q, want prepared workdir %q", strings.TrimSpace(string(gotCwd)), envDir)
+	if got, want := strings.TrimSpace(strings.TrimPrefix(string(gotCwd), "\ufeff")), result.WorkDir; got != want {
+		t.Fatalf("cli cwd = %q, want prepared workdir %q", got, want)
+	}
+	if result.WorkDir == recorded {
+		t.Fatalf("WorkDir = %q, want a fresh dir, never the deleted recorded %q", result.WorkDir, recorded)
 	}
 
-	// Step 5: the drop is still disclosed, not silently restarted.
-	if !taskCtx.PriorSessionResumeUnavailable || !task.PriorSessionResumeUnavailable {
-		t.Fatal("resume-unavailable notice missing on task or taskCtx")
+	// The drop is disclosed in the actual runTask prompt the fake received
+	// on stdin — not re-rendered here.
+	stdinRaw, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatalf("fake Pi never recorded stdin: %v", err)
 	}
-	if prompt := BuildPrompt(task, "pi"); !strings.Contains(prompt, sessionContinuityNoticeFor(task)) {
-		t.Fatal("BuildPrompt lost the continuity notice after the gate drop")
+	if !strings.Contains(string(stdinRaw), execenv.SessionContinuityNoticeIssue) {
+		t.Fatal("runTask prompt lost the continuity notice after the gate drop")
 	}
 }
 
 // writeGH8082FakePi installs an OS-appropriate fake Pi CLI: on Unix a shell
 // script, on Windows a pi.cmd + sibling pi.ps1 pair routed through the real
-// PowerShell invocation path. Both record argv and cwd to the files named by
-// GH8082_OBSERVE_ARGV / GH8082_OBSERVE_CWD, drain stdin, and emit one
-// successful turn. Returns the ExecutablePath for agent.New.
+// PowerShell invocation path. Both record argv, cwd, and the stdin prompt to
+// the files named by GH8082_OBSERVE_ARGV / GH8082_OBSERVE_CWD /
+// GH8082_OBSERVE_STDIN, then emit one successful turn. Returns the
+// ExecutablePath for the daemon's pi agent entry.
 func writeGH8082FakePi(t *testing.T, base string) string {
 	t.Helper()
 
@@ -2386,7 +2414,13 @@ func writeGH8082FakePi(t *testing.T, base string) string {
 		}
 		// events lines are already single-quoted; the JSON inside uses
 		// only double quotes, so no escaping is needed.
-		ps1 := "$null = $input\r\n" +
+		// Copy the raw stdin bytes, not text: the backend routes through a
+		// powershell -Command wrapper, under which script-scope $input does
+		// not see the piped prompt, and [Console]::In decodes through the
+		// console codepage, mangling non-ASCII (em-dash in the notice).
+		ps1 := "$stdinOut = [IO.File]::OpenWrite($env:GH8082_OBSERVE_STDIN)\r\n" +
+			"[Console]::OpenStandardInput().CopyTo($stdinOut)\r\n" +
+			"$stdinOut.Close()\r\n" +
 			"$args | Out-File -FilePath $env:GH8082_OBSERVE_ARGV -Encoding utf8\r\n" +
 			"(Get-Location).Path | Out-File -FilePath $env:GH8082_OBSERVE_CWD -Encoding utf8\r\n" +
 			strings.ReplaceAll(events, "\n", "\r\n") + "\r\n"
@@ -2397,9 +2431,9 @@ func writeGH8082FakePi(t *testing.T, base string) string {
 	}
 	fakeBin := filepath.Join(base, "pi")
 	script := "#!/bin/sh\n" +
+		"cat > \"${GH8082_OBSERVE_STDIN:-/dev/null}\"\n" +
 		"printf '%s\\n' \"$@\" > \"${GH8082_OBSERVE_ARGV}\"\n" +
 		"pwd > \"${GH8082_OBSERVE_CWD}\"\n" +
-		"cat > /dev/null\n" +
 		"printf '%s\\n' " + events + "\n"
 	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake pi: %v", err)

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2758,6 +2758,80 @@ func TestGH8082LongTranscriptStillDrops(t *testing.T) {
 	}
 }
 
+// TestGH8082HeaderLimitBoundary pins the off-by-one semantics of
+// piSessionHeaderLimit: the bound counts first-line header bytes only, the
+// newline delimiter itself never counts toward it. A first line of exactly
+// the limit stays decidable, while limit+1 is undecidable however the line
+// is terminated.
+func TestGH8082HeaderLimitBoundary(t *testing.T) {
+	t.Parallel()
+
+	// buildHeaderOfLen returns a valid session header JSON of exactly n
+	// bytes whose cwd is the (already deleted) gone path.
+	buildHeaderOfLen := func(t *testing.T, gone string, n int) []byte {
+		t.Helper()
+		base, err := json.Marshal(map[string]any{"type": "session", "cwd": gone})
+		if err != nil {
+			t.Fatalf("marshal base header: %v", err)
+		}
+		// New header: base minus "}" plus `,"pad":"<pad>"}`.
+		const padOverhead = len(`,"pad":""}`)
+		padLen := n - (len(base) - 1) - padOverhead
+		if padLen < 0 {
+			t.Fatalf("target length %d below minimal header length %d", n, len(base))
+		}
+		out := append(base[:len(base)-1], `,"pad":"`...)
+		out = append(out, strings.Repeat("x", padLen)...)
+		out = append(out, `"}`...)
+		if len(out) != n {
+			t.Fatalf("built header length = %d, want %d", len(out), n)
+		}
+		return out
+	}
+
+	cases := []struct {
+		name      string
+		lineLen   int
+		suffix    string
+		wantReach bool
+	}{
+		{name: "exact limit LF drops", lineLen: piSessionHeaderLimit, suffix: "\n", wantReach: false},
+		{name: "exact limit no newline drops", lineLen: piSessionHeaderLimit, suffix: "", wantReach: false},
+		{name: "limit+1 LF stays resumable", lineLen: piSessionHeaderLimit + 1, suffix: "\n", wantReach: true},
+		{name: "limit+1 no newline stays resumable", lineLen: piSessionHeaderLimit + 1, suffix: "", wantReach: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			base := t.TempDir()
+			gone := filepath.Join(base, "recorded")
+			if err := os.MkdirAll(gone, 0o755); err != nil {
+				t.Fatalf("create recorded: %v", err)
+			}
+		envDir := filepath.Join(base, "fresh")
+			if err := os.MkdirAll(envDir, 0o755); err != nil {
+				t.Fatalf("create env: %v", err)
+			}
+			if err := os.RemoveAll(gone); err != nil {
+				t.Fatalf("delete recorded: %v", err)
+			}
+			header := buildHeaderOfLen(t, gone, tc.lineLen)
+			sessionPath := filepath.Join(base, "s.jsonl")
+			content := append(append([]byte{}, header...), tc.suffix...)
+			if err := os.WriteFile(sessionPath, content, 0o644); err != nil {
+				t.Fatalf("write session: %v", err)
+			}
+			task := Task{PriorSessionID: sessionPath, PriorWorkDir: gone}
+			taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+			reachable := gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default())
+			if reachable != tc.wantReach {
+				t.Fatalf("reachable = %v, want %v (first-line len %d)", reachable, tc.wantReach, tc.lineLen)
+			}
+		})
+	}
+}
+
 // TestGH8082OmpAndOtherProvidersUnaffected: the missing-cwd check is
 // Pi-only, so OMP keeps a deleted-cwd session reachable (prior behaviour)
 // and cwd-keyed providers are untouched.

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2246,13 +2246,165 @@ func TestGH8082MissingRecordedCwdDropsPiResume(t *testing.T) {
 	if _, err := os.Stat(recorded); !os.IsNotExist(err) {
 		t.Fatalf("recorded dir was recreated by the gate: %v", err)
 	}
-	// §6H boundary (unit-level): the gate output IS the backend input — runTask
-	// forwards task.PriorSessionID as ResumeSessionID (daemon.go runTask),
-	// and the Pi backend mints a new session path for --session when it is
-	// empty (pi.go: empty ResumeSessionID -> newPiSessionPath). The cleared
-	// PriorSessionID asserted above is therefore exactly what keeps the stale
-	// path S out of --session. Full fake-CLI invocation is out of scope for
-	// this narrow gate change; no new backend plumbing is added.
+	// §6H execution evidence lives in TestGH8082GateToBackendHandoff below:
+	// the cleared PriorSessionID feeds a real Pi backend Execute against a
+	// fake Pi CLI, which observes the fresh --session path and cwd.
+}
+
+// TestGH8082GateToBackendHandoff runs the §6H chain end to end at the
+// gate→backend boundary with production code throughout:
+//
+//  1. stale session S with deleted recorded cwd A is prepared;
+//  2. the real gate drops the resume (PriorSessionID cleared, notice set);
+//  3. the cleared id is passed as ResumeSessionID into a real Pi backend
+//     Execute against a fake Pi CLI (OS-appropriate script) that records
+//     the argv it received and the cwd it ran in;
+//  4. the fake observes --session S2 (never the stale S), cwd B, and the
+//     backend returns SessionID S2 with a completed fake turn;
+//  5. BuildPrompt on the gated task still carries the continuity notice.
+//
+// A fake CLI success is a plumbing proof, not a real-Pi run: it shows the
+// stale path no longer reaches --session and the fresh path does.
+func TestGH8082GateToBackendHandoff(t *testing.T) {
+	// No t.Parallel: t.Setenv forbids it (HOME/USERPROFILE isolation plus
+	// fake-CLI observation files below).
+
+	base := t.TempDir()
+	recorded := filepath.Join(base, "recorded-a")
+	if err := os.MkdirAll(recorded, 0o755); err != nil {
+		t.Fatalf("create recorded dir: %v", err)
+	}
+	envDir := filepath.Join(base, "fresh-b")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatalf("create env dir: %v", err)
+	}
+	sessionPath := filepath.Join(base, "pi-session.jsonl")
+	writeGH8082Session(t, sessionPath, map[string]any{"cwd": recorded}, "")
+	if err := os.RemoveAll(recorded); err != nil {
+		t.Fatalf("delete recorded dir: %v", err)
+	}
+
+	// Step 2: the production gate.
+	task := Task{PriorSessionID: sessionPath, PriorWorkDir: recorded}
+	taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+	if gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default()) {
+		t.Fatal("reachable = true for a Pi session whose recorded cwd is gone")
+	}
+	if task.PriorSessionID != "" {
+		t.Fatalf("PriorSessionID = %q, want empty for the backend call", task.PriorSessionID)
+	}
+
+	// Step 3: fake Pi CLI recording argv and cwd. keep HOME/USERPROFILE
+	// inside temp so the backend's fresh session path cannot touch a real
+	// profile.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	argvFile := filepath.Join(base, "observed-argv.txt")
+	cwdFile := filepath.Join(base, "observed-cwd.txt")
+	t.Setenv("GH8082_OBSERVE_ARGV", argvFile)
+	t.Setenv("GH8082_OBSERVE_CWD", cwdFile)
+	execPath := writeGH8082FakePi(t, base)
+
+	backend, err := agent.New("pi", agent.Config{ExecutablePath: execPath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("agent.New(pi): %v", err)
+	}
+	session, err := backend.Execute(t.Context(), "follow-up prompt", agent.ExecOptions{
+		Cwd:             envDir,
+		ResumeSessionID: task.PriorSessionID, // empty after the gate drop
+		Timeout:         60 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("backend Execute: %v", err)
+	}
+	for range session.Messages {
+	}
+	result, ok := <-session.Result
+	if !ok {
+		t.Fatal("result channel closed without a value")
+	}
+	if result.Status != "completed" {
+		t.Fatalf("result = %+v, want completed fake turn", result)
+	}
+
+	// Step 4: what the fake CLI observed.
+	argvRaw, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatalf("fake Pi never recorded argv: %v; result=%+v", err, result)
+	}
+	gotCwd, err := os.ReadFile(cwdFile)
+	if err != nil {
+		t.Fatalf("fake Pi never recorded cwd: %v; result=%+v", err, result)
+	}
+	// Out-File -Encoding utf8 writes a BOM and CRLF line endings.
+	argv := strings.Split(strings.TrimPrefix(string(argvRaw), "\ufeff"), "\r\n")
+	sessionIdx := -1
+	for i, a := range argv {
+		if a == "--session" && i+1 < len(argv) {
+			sessionIdx = i + 1
+		}
+	}
+	if sessionIdx < 0 {
+		t.Fatalf("no --session in observed argv: %q", string(argvRaw))
+	}
+	observed := strings.TrimSpace(argv[sessionIdx])
+	if observed == "" || observed == sessionPath {
+		t.Fatalf("--session = %q, want a fresh path, never the stale %q", observed, sessionPath)
+	}
+	if result.SessionID != observed {
+		t.Fatalf("SessionID = %q, want the observed fresh --session %q", result.SessionID, observed)
+	}
+	if strings.TrimSpace(strings.TrimPrefix(string(gotCwd), "\ufeff")) != envDir {
+		t.Fatalf("cli cwd = %q, want prepared workdir %q", strings.TrimSpace(string(gotCwd)), envDir)
+	}
+
+	// Step 5: the drop is still disclosed, not silently restarted.
+	if !taskCtx.PriorSessionResumeUnavailable || !task.PriorSessionResumeUnavailable {
+		t.Fatal("resume-unavailable notice missing on task or taskCtx")
+	}
+	if prompt := BuildPrompt(task, "pi"); !strings.Contains(prompt, sessionContinuityNoticeFor(task)) {
+		t.Fatal("BuildPrompt lost the continuity notice after the gate drop")
+	}
+}
+
+// writeGH8082FakePi installs an OS-appropriate fake Pi CLI: on Unix a shell
+// script, on Windows a pi.cmd + sibling pi.ps1 pair routed through the real
+// PowerShell invocation path. Both record argv and cwd to the files named by
+// GH8082_OBSERVE_ARGV / GH8082_OBSERVE_CWD, drain stdin, and emit one
+// successful turn. Returns the ExecutablePath for agent.New.
+func writeGH8082FakePi(t *testing.T, base string) string {
+	t.Helper()
+
+	events := `'{"type":"agent_start"}'` + "\n" +
+		`'{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"done"}}'` + "\n" +
+		`'{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":1,"output":1}}}'`
+	if runtime.GOOS == "windows" {
+		cmdPath := filepath.Join(base, "pi.cmd")
+		if err := os.WriteFile(cmdPath, []byte("@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File \"%~dp0pi.ps1\" %*\r\n"), 0o644); err != nil {
+			t.Fatalf("write fake pi.cmd: %v", err)
+		}
+		// events lines are already single-quoted; the JSON inside uses
+		// only double quotes, so no escaping is needed.
+		ps1 := "$null = $input\r\n" +
+			"$args | Out-File -FilePath $env:GH8082_OBSERVE_ARGV -Encoding utf8\r\n" +
+			"(Get-Location).Path | Out-File -FilePath $env:GH8082_OBSERVE_CWD -Encoding utf8\r\n" +
+			strings.ReplaceAll(events, "\n", "\r\n") + "\r\n"
+		if err := os.WriteFile(filepath.Join(base, "pi.ps1"), []byte(ps1), 0o644); err != nil {
+			t.Fatalf("write fake pi.ps1: %v", err)
+		}
+		return cmdPath
+	}
+	fakeBin := filepath.Join(base, "pi")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > \"${GH8082_OBSERVE_ARGV}\"\n" +
+		"pwd > \"${GH8082_OBSERVE_CWD}\"\n" +
+		"cat > /dev/null\n" +
+		"printf '%s\\n' " + events + "\n"
+	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+	return fakeBin
 }
 
 // TestGH8082CrossWorkdirResumePreserved guards PR #7760: different but

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2363,6 +2363,20 @@ func TestGH8082UndecidableHeaderStaysResumable(t *testing.T) {
 					t.Fatalf("write malformed: %v", err)
 				}
 		},
+		"trailing garbage after session header": func(t *testing.T, path string) {
+			t.Helper()
+			// A valid session prefix with trailing non-whitespace is
+			// undecidable (not a drop reason), even when the parsed cwd
+			// is a deleted absolute path.
+			gone := filepath.Join(t.TempDir(), "deleted")
+			raw, err := json.Marshal(map[string]any{"type": "session", "cwd": gone})
+			if err != nil {
+				t.Fatalf("marshal header: %v", err)
+				}
+			if err := os.WriteFile(path, append(append(raw, ' ', '{', '}', ' '), '\n'), 0o644); err != nil {
+					t.Fatalf("write trailing-garbage header: %v", err)
+				}
+		},
 		"non-session first line": func(t *testing.T, path string) {
 			t.Helper()
 			if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2499,6 +2499,57 @@ func TestGH8082HeaderFormatCompatibility(t *testing.T) {
 	})
 }
 
+// TestGH8082LongTranscriptStillDrops: a healthy first-line header followed by
+// a body larger than the read bound must still drop when the recorded cwd is
+// gone. Guards the first-line-only reader: a whole-file bounded read would
+// misclassify this as oversized/undecidable and wrongly resume (GH #8082).
+func TestGH8082LongTranscriptStillDrops(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	recorded := filepath.Join(base, "recorded-a")
+	if err := os.MkdirAll(recorded, 0o755); err != nil {
+		t.Fatalf("create recorded: %v", err)
+	}
+	envDir := filepath.Join(base, "fresh-b")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatalf("create env: %v", err)
+	}
+	headerRaw, err := json.Marshal(map[string]any{"type": "session", "cwd": recorded})
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	// Body well past the 64KiB header bound, containing a decoy existing
+	// path that must never be consulted — only the header cwd counts.
+	body := strings.Repeat(`{"type":"message","text":"decoy `+envDir+`"}`+"\n", 4096)
+	sessionPath := filepath.Join(base, "long-session.jsonl")
+	if err := os.WriteFile(sessionPath, append(append(headerRaw, '\n'), body...), 0o644); err != nil {
+		t.Fatalf("write long session: %v", err)
+	}
+	info, err := os.Stat(sessionPath)
+	if err != nil || info.Size() <= 64*1024 {
+		t.Fatalf("fixture too small to prove bounded read: size=%v err=%v", info.Size(), err)
+	}
+	if err := os.RemoveAll(recorded); err != nil {
+		t.Fatalf("delete recorded: %v", err)
+	}
+
+	task := Task{PriorSessionID: sessionPath, PriorWorkDir: recorded}
+	taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+
+	reachable := gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default())
+
+	if reachable {
+		t.Fatal("reachable = true for a long-transcript session whose recorded cwd is gone")
+	}
+	if task.PriorSessionID != "" {
+		t.Fatalf("PriorSessionID = %q, want empty", task.PriorSessionID)
+	}
+	if !taskCtx.PriorSessionResumeUnavailable || !task.PriorSessionResumeUnavailable {
+		t.Fatal("resume-unavailable notice missing on task or taskCtx")
+	}
+}
+
 // TestGH8082OmpAndOtherProvidersUnaffected: the missing-cwd check is
 // Pi-only, so OMP keeps a deleted-cwd session reachable (prior behaviour)
 // and cwd-keyed providers are untouched.

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2359,8 +2359,11 @@ func TestGH8082GateToBackendHandoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fake Pi never recorded cwd: %v; result=%+v", err, result)
 	}
-	// Out-File -Encoding utf8 writes a BOM and CRLF line endings.
-	argv := strings.Split(strings.TrimPrefix(string(argvRaw), "\ufeff"), "\r\n")
+	// Windows Out-File -Encoding utf8 writes a BOM and CRLF line endings;
+	// the Unix fake writes plain LF. Normalize to LF before splitting so
+	// both parse (kept line-based, not Fields, to preserve paths with
+	// spaces).
+	argv := strings.Split(strings.ReplaceAll(strings.TrimPrefix(string(argvRaw), "\ufeff"), "\r\n", "\n"), "\n")
 	sessionIdx := -1
 	for i, a := range argv {
 		if a == "--session" && i+1 < len(argv) {
@@ -2430,11 +2433,16 @@ func writeGH8082FakePi(t *testing.T, base string) string {
 		return cmdPath
 	}
 	fakeBin := filepath.Join(base, "pi")
+	// Each event is its own printf argument: a bare newline-joined string
+	// would run the 2nd/3rd lines as shell commands (exit 127). The events
+	// are already single-quoted lines, so joining them with spaces yields
+	// three separate arguments (the JSON contains no single quotes).
+	shEvents := "printf '%s\\n' " + strings.ReplaceAll(events, "\n", " ")
 	script := "#!/bin/sh\n" +
 		"cat > \"${GH8082_OBSERVE_STDIN:-/dev/null}\"\n" +
 		"printf '%s\\n' \"$@\" > \"${GH8082_OBSERVE_ARGV}\"\n" +
 		"pwd > \"${GH8082_OBSERVE_CWD}\"\n" +
-		"printf '%s\\n' " + events + "\n"
+		shEvents + "\n"
 	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake pi: %v", err)
 	}

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2830,6 +2831,77 @@ func TestGH8082HeaderLimitBoundary(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGH8082HeaderExactKeyMatch: only the exact lowercase "cwd" key
+// decides (GH #8082). encoding/json struct matching is case-insensitive,
+// so an uppercase "CWD" must neither override nor substitute "cwd".
+func TestGH8082HeaderExactKeyMatch(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) (base, kept, gone, envDir string) {
+		t.Helper()
+		base = t.TempDir()
+		kept = filepath.Join(base, "kept")
+		gone = filepath.Join(base, "gone")
+		envDir = filepath.Join(base, "fresh")
+		for _, dir := range []string{kept, gone, envDir} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("create %s: %v", dir, err)
+			}
+		}
+		if err := os.RemoveAll(gone); err != nil {
+			t.Fatalf("delete gone: %v", err)
+		}
+		return base, kept, gone, envDir
+	}
+	writeLine := func(t *testing.T, path, line string) {
+		t.Helper()
+		if err := os.WriteFile(path, append([]byte(line), '\n'), 0o644); err != nil {
+			t.Fatalf("write session: %v", err)
+		}
+	}
+	check := func(t *testing.T, sessionPath, priorWorkDir, envDir string, wantReach bool, name string) {
+		t.Helper()
+		task := Task{PriorSessionID: sessionPath, PriorWorkDir: priorWorkDir}
+		taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+		reachable := gateResumeToReachableSession(&task, &taskCtx, "pi", envDir, true, slog.Default())
+		if reachable != wantReach {
+			t.Fatalf("%s: reachable = %v, want %v", name, reachable, wantReach)
+		}
+	}
+
+	t.Run("valid cwd with deleted CWD stays resumable", func(t *testing.T) {
+		t.Parallel()
+		base, kept, gone, envDir := setup(t)
+		sessionPath := filepath.Join(base, "s.jsonl")
+		writeLine(t, sessionPath, `{"type":"session","cwd":`+strconv.Quote(kept)+`,"CWD":`+strconv.Quote(gone)+`}`)
+		check(t, sessionPath, kept, envDir, true, "valid cwd + deleted CWD")
+	})
+
+	t.Run("deleted cwd with valid CWD drops", func(t *testing.T) {
+		t.Parallel()
+		base, kept, gone, envDir := setup(t)
+		sessionPath := filepath.Join(base, "s.jsonl")
+		writeLine(t, sessionPath, `{"type":"session","cwd":`+strconv.Quote(gone)+`,"CWD":`+strconv.Quote(kept)+`}`)
+		check(t, sessionPath, gone, envDir, false, "deleted cwd + valid CWD")
+	})
+
+	t.Run("CWD only stays resumable", func(t *testing.T) {
+		t.Parallel()
+		base, kept, _, envDir := setup(t)
+		sessionPath := filepath.Join(base, "s.jsonl")
+		writeLine(t, sessionPath, `{"type":"session","CWD":`+strconv.Quote(kept)+`}`)
+		check(t, sessionPath, kept, envDir, true, "CWD only")
+	})
+
+	t.Run("duplicate cwd ending in null stays resumable", func(t *testing.T) {
+		t.Parallel()
+		base, kept, gone, envDir := setup(t)
+		sessionPath := filepath.Join(base, "s.jsonl")
+		writeLine(t, sessionPath, `{"type":"session","cwd":`+strconv.Quote(gone)+`,"cwd":null}`)
+		check(t, sessionPath, kept, envDir, true, "duplicate cwd ending null")
+	})
 }
 
 // TestGH8082OmpAndOtherProvidersUnaffected: the missing-cwd check is


### PR DESCRIPTION
## What does this PR do?

When a Pi session file still exists but its recorded working directory (cwd
in the session header) has been deleted, Pi refuses to start with
`Stored session working directory does not exist`. The daemon previously
treated any present, non-empty session file as resumable, so it kept
handing the stale session path to Pi and hit the same failure on every
start.

This change adds a narrow, Pi-only pre-check: if the session file's
header records an absolute cwd that is confirmed missing (os.IsNotExist),
the gate marks the session unreachable and reuses the existing
fresh-session path. Normal cross-workdir resumes (PR #7760) are
preserved — only a confirmed-missing recorded cwd narrows the verdict.

The new helper reads only the first line of the session file (bounded to
64 KiB), so a long transcript body can never push a healthy header over
the limit. Malformed, empty, relative, or non-string cwd values, and
headers the decoder cannot fully parse, are treated as undecidable and
stay resumable — this check never invents new reasons to discard a
session beyond the one Pi itself refuses to start with.

## Related Issue

Addresses #8082 — startup recovery only.
The separate stderr-diagnostics request is not included.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/internal/daemon/daemon.go`: added
  `piSessionRecordedCwdMissing` helper that reads only the first line of
  the session file, decodes the `type`/`cwd` fields, and returns true
  only when the cwd is a confirmed-missing absolute path. Wired into
  `gateResumeToReachableSession` behind `provider == "pi"`. Added
  `reason: "recorded_cwd_missing"` to the existing "dropping prior
  session" log.
- `server/internal/daemon/daemon_test.go`: added `TestGH8082*`
  regression tests — core repro (A), cross-workdir preservation (B),
  header-cwd vs PriorWorkDir (C), undecidable-header tolerance (E),
  format compatibility (F), long-transcript bounded-read guard, and
  OMP/other-provider non-regression (G).
- `TestGH8082GateToBackendHandoff` additionally runs the real production
  `d.runTask(...)` with a fake Pi CLI (extended from the existing
  busy-retry fixture): it observes that the stale session `S` is not
  passed, that the CLI receives `--session <fresh S2>` with the prepared
  cwd, that stdin carries the continuity notice, and that the resulting
  `TaskResult.SessionID` equals the observed fresh session — closing the
  gate → `agent.ExecOptions` → Pi backend execution boundary end-to-end
  (no manual injection of `ResumeSessionID`).

## How to Test

```
cd server
go test ./internal/daemon/ -run 'TestGH8082|TestGatePiResume|TestGateResumeToReachableSession' -count=1 -v
go test ./pkg/agent/ -run 'Pi|Omp' -count=1
go vet ./internal/daemon/ ./pkg/agent/
git diff --check
```

Repro case: create a Pi session file whose header `cwd` points to a
directory, delete that directory, then run the gate with
provider="pi" — reachable is now false and the prior session ID is
cleared, so Pi mints a fresh session instead of refusing to start.

The `TestGH8082GateToBackendHandoff` test additionally drives the real
production `d.runTask(...)` with a fake Pi CLI and asserts the fresh
`--session` argument, the prepared working directory, the continuity
notice on stdin, and the returned `SessionID` — i.e. the full
execution handoff, not just the gate decision.

## Checklist

- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] If this change affects the UI, I have included before/after screenshots (N/A)
- [ ] I have updated relevant documentation to reflect my changes (N/A)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change (N/A)
- [ ] If this PR touches Chinese product copy, I checked it (N/A)

## Risk

- The check reads only the first line of the session file (bounded) and
  never modifies the session file, the current workdir, or GC/lock
  policy.
- Undecidable headers (malformed, empty/relative/non-string cwd, read
  limits) stay resumable — no new forced-reinit paths.
- A race where the recorded cwd is deleted right after the check is not
  addressed atomically (out of scope per issue spec).
- Verified at gate level plus the production `runTask` → Pi backend →
  fake CLI execution boundary (argv, cwd, stdin, returned SessionID).
  Real Pi CLI/model runs and the Unix fake-CLI path were not exercised
  on this Windows runtime (no credentials); `-race` was skipped locally
  (no gcc) and is left to CI.

## AI Disclosure

**AI tool used:** Multica Agent (worker-opencode implementation + Worker-codex
independent cross-validation over multiple review rounds).

**Prompt / approach:** Implemented per the issue spec (design §5, required
regression tests §6). Cross-validation found and fixed: a whole-file bounded
read misclassifying long transcripts, a permissive single-Decode accepting
trailing garbage after the header, and an initial §6H test that bypassed the
production `runTask` glue — the final regression runs the real `d.runTask(...)`
with a fake Pi CLI. Verification evidence: focused tests / go vet /
git diff --check all PASS; `-race` skipped locally (no gcc) but confirmed via
upstream CI (run 34013682159: backend-tests runs `scripts/test-go.sh --race`,
daemon package PASS; 14 SUCCESS / 1 SKIPPED / 0 failed).


