### PR TITLE
MUL-7097: WS-4963 fix(autopilot): alert on skipped schedule streaks

### DIFF
--- a/server/cmd/server/autopilot_failure_monitor.go
+++ b/server/cmd/server/autopilot_failure_monitor.go
@@ -23,8 +23,8 @@ import (
 
 // failureMonitorConfig is the tunable knob set for the autopilot failure
 // monitor. Defaults match the proposal in MUL-1336 §6 action item #2:
-// pause autopilots whose recent run history is dominated by failures and that
-// have run enough times that the failure rate is statistically meaningful.
+// pause autopilots whose recent run history is dominated by unsuccessful
+// terminal runs, plus a low-volume guard for consecutive schedule skips.
 //
 // All values can be overridden via env vars (see envFailureMonitorConfig).
 // Setting Interval <= 0 disables the monitor entirely.
@@ -33,6 +33,7 @@ type failureMonitorConfig struct {
 	Lookback     time.Duration
 	MinRuns      int64
 	FailRatio    float64
+	SkipStreak   int64
 	StartupDelay time.Duration
 }
 
@@ -42,6 +43,7 @@ func defaultFailureMonitorConfig() failureMonitorConfig {
 		Lookback:     7 * 24 * time.Hour,
 		MinRuns:      50,
 		FailRatio:    0.9,
+		SkipStreak:   2,
 		StartupDelay: 1 * time.Minute,
 	}
 }
@@ -57,13 +59,16 @@ func envFailureMonitorConfig() failureMonitorConfig {
 	if v, ok := envFloatInUnitInterval("AUTOPILOT_FAIL_MONITOR_FAIL_RATIO"); ok {
 		cfg.FailRatio = v
 	}
+	if v, ok := envInt64Positive("AUTOPILOT_FAIL_MONITOR_SKIP_STREAK"); ok {
+		cfg.SkipStreak = v
+	}
 	return cfg
 }
 
 // runAutopilotFailureMonitor periodically pauses autopilots whose recent run
-// history exceeds the configured failure threshold. This stops runaway
-// scheduled autopilots from burning tasks/tokens on a hot loop (e.g. the
-// `Registro de ls cada 5 min` case in MUL-1336: 1,475 / 1,476 runs failed
+// history exceeds the configured failure threshold or skip-streak threshold.
+// This stops runaway scheduled autopilots from burning tasks/tokens on a hot
+// loop (e.g. the `Registro de ls cada 5 min` case in MUL-1336: 1,475 / 1,476 runs failed
 // over 7 days, still firing every 5 min). The monitor leaves a
 // `severity=attention` inbox notification for the autopilot's creator (or the
 // agent's owner if the autopilot was created by an agent) so somebody human
@@ -82,6 +87,7 @@ func runAutopilotFailureMonitor(ctx context.Context, queries *db.Queries, bus *e
 		"lookback", cfg.Lookback.String(),
 		"min_runs", cfg.MinRuns,
 		"fail_ratio", cfg.FailRatio,
+		"skip_streak", cfg.SkipStreak,
 	)
 
 	// Stagger startup so we don't all-or-nothing hit the DB the moment the
@@ -120,6 +126,7 @@ func tickAutopilotFailureMonitor(ctx context.Context, queries *db.Queries, bus *
 		db.SelectAutopilotsExceedingFailureThresholdParams{
 			MinRuns:            cfg.MinRuns,
 			FailRatioThreshold: cfg.FailRatio,
+			SkipStreak:         cfg.SkipStreak,
 			Since:              pgtype.Timestamptz{Time: since, Valid: true},
 		},
 	)
@@ -134,7 +141,11 @@ func tickAutopilotFailureMonitor(ctx context.Context, queries *db.Queries, bus *
 	slog.Info("autopilot failure monitor: candidates", "count", len(candidates))
 
 	for _, c := range candidates {
-		paused, err := queries.SystemPauseAutopilot(ctx, c.ID)
+		reason := autopilotPauseReason(c, cfg)
+		paused, err := queries.SystemPauseAutopilot(ctx, db.SystemPauseAutopilotParams{
+			ID:          c.ID,
+			PauseReason: pgtype.Text{String: reason, Valid: true},
+		})
 		if err != nil {
 			// pgx returns ErrNoRows when the WHERE status='active' clause
 			// matched zero rows — i.e. another caller (manual UI action,
@@ -160,9 +171,12 @@ func tickAutopilotFailureMonitor(ctx context.Context, queries *db.Queries, bus *
 				"autopilot_id", util.UUIDToString(paused.ID), "error", verr)
 		}
 
+		unsuccessfulRuns := c.FailedRuns + c.SkippedRuns
+		unsuccessfulPct := 100.0
 		failPct := 100.0
 		if c.TotalRuns > 0 {
-			failPct = math.Round(float64(c.FailedRuns)/float64(c.TotalRuns)*1000) / 10 // one decimal place
+			unsuccessfulPct = math.Round(float64(unsuccessfulRuns)/float64(c.TotalRuns)*1000) / 10 // one decimal place
+			failPct = math.Round(float64(c.FailedRuns)/float64(c.TotalRuns)*1000) / 10
 		}
 
 		slog.Info(
@@ -171,11 +185,14 @@ func tickAutopilotFailureMonitor(ctx context.Context, queries *db.Queries, bus *
 			"workspace_id", util.UUIDToString(c.WorkspaceID),
 			"title", c.Title,
 			"failed_runs", c.FailedRuns,
+			"skipped_runs", c.SkippedRuns,
 			"total_runs", c.TotalRuns,
 			"fail_pct", failPct,
+			"unsuccessful_pct", unsuccessfulPct,
+			"reason", reason,
 		)
 
-		emitAutopilotPausedNotifications(ctx, queries, bus, paused, c, cfg, failPct)
+		emitAutopilotPausedNotifications(ctx, queries, bus, paused, c, cfg, reason, unsuccessfulPct)
 
 		// Fan out the status change so any open UI updates the autopilot row.
 		workspaceID := util.UUIDToString(paused.WorkspaceID)
@@ -185,10 +202,22 @@ func tickAutopilotFailureMonitor(ctx context.Context, queries *db.Queries, bus *
 			ActorType:   "system",
 			Payload: map[string]any{
 				"autopilot": autopilotEventPayload(paused),
-				"reason":    "auto_paused_high_failure_rate",
+				"reason":    reason,
 			},
 		})
 	}
+}
+
+const (
+	autopilotPauseReasonFailureRate = "auto_paused_high_failure_rate"
+	autopilotPauseReasonSkipStreak  = "auto_paused_consecutive_skips"
+)
+
+func autopilotPauseReason(c db.SelectAutopilotsExceedingFailureThresholdRow, cfg failureMonitorConfig) string {
+	if c.RecentNaturalRuns >= cfg.SkipStreak && c.RecentSkippedRuns == c.RecentNaturalRuns {
+		return autopilotPauseReasonSkipStreak
+	}
+	return autopilotPauseReasonFailureRate
 }
 
 // emitAutopilotPausedNotifications creates one inbox_item per relevant
@@ -210,7 +239,8 @@ func emitAutopilotPausedNotifications(
 	autopilot db.Autopilot,
 	candidate db.SelectAutopilotsExceedingFailureThresholdRow,
 	cfg failureMonitorConfig,
-	failPct float64,
+	reason string,
+	unsuccessfulPct float64,
 ) {
 	recipients := resolveAutopilotPausedRecipients(ctx, queries, autopilot)
 	if len(recipients) == 0 {
@@ -218,20 +248,34 @@ func emitAutopilotPausedNotifications(
 	}
 
 	title := fmt.Sprintf("Autopilot paused: %s", autopilot.Title)
-	body := fmt.Sprintf(
-		"Auto-paused after %d of %d runs failed (%.1f%%) in the last %s. Investigate the failures, fix the root cause, then re-enable from the autopilot page.",
-		candidate.FailedRuns, candidate.TotalRuns, failPct, formatLookback(cfg.Lookback),
-	)
+	unsuccessfulRuns := candidate.FailedRuns + candidate.SkippedRuns
+	body := ""
+	if reason == autopilotPauseReasonSkipStreak {
+		body = fmt.Sprintf(
+			"Auto-paused after the latest %d natural schedule runs were skipped. Skipped runs are treated as failures; investigate the recorded skip reason, fix it, then re-enable from the autopilot page.",
+			candidate.RecentSkippedRuns,
+		)
+	} else {
+		body = fmt.Sprintf(
+			"Auto-paused after %d of %d runs failed or were skipped (%.1f%%) in the last %s. Investigate the failures or skips, fix the root cause, then re-enable from the autopilot page.",
+			unsuccessfulRuns, candidate.TotalRuns, unsuccessfulPct, formatLookback(cfg.Lookback),
+		)
+	}
 	details, _ := json.Marshal(map[string]any{
-		"autopilot_id":         util.UUIDToString(autopilot.ID),
-		"autopilot_title":      autopilot.Title,
-		"failed_runs":          candidate.FailedRuns,
-		"total_runs":           candidate.TotalRuns,
-		"fail_pct":             failPct,
-		"lookback_seconds":     int64(cfg.Lookback.Seconds()),
-		"threshold_min_runs":   cfg.MinRuns,
-		"threshold_fail_ratio": cfg.FailRatio,
-		"reason":               "auto_paused_high_failure_rate",
+		"autopilot_id":          util.UUIDToString(autopilot.ID),
+		"autopilot_title":       autopilot.Title,
+		"failed_runs":           candidate.FailedRuns,
+		"skipped_runs":          candidate.SkippedRuns,
+		"total_runs":            candidate.TotalRuns,
+		"fail_pct":              failurePercent(candidate.FailedRuns, candidate.TotalRuns),
+		"unsuccessful_pct":      unsuccessfulPct,
+		"recent_natural_runs":   candidate.RecentNaturalRuns,
+		"recent_skipped_runs":   candidate.RecentSkippedRuns,
+		"skip_streak_threshold": cfg.SkipStreak,
+		"lookback_seconds":      int64(cfg.Lookback.Seconds()),
+		"threshold_min_runs":    cfg.MinRuns,
+		"threshold_fail_ratio":  cfg.FailRatio,
+		"reason":                reason,
 	})
 
 	workspaceID := util.UUIDToString(autopilot.WorkspaceID)
@@ -277,6 +321,13 @@ func emitAutopilotPausedNotifications(
 			Payload:     map[string]any{"item": inboxItemToResponse(item)},
 		})
 	}
+}
+
+func failurePercent(part, total int64) float64 {
+	if total <= 0 {
+		return 100
+	}
+	return math.Round(float64(part)/float64(total)*1000) / 10
 }
 
 func resolveAutopilotPausedRecipients(

--- a/server/cmd/server/autopilot_failure_monitor_test.go
+++ b/server/cmd/server/autopilot_failure_monitor_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -76,6 +78,23 @@ func seedAutopilotRuns(t *testing.T, autopilotID pgtype.UUID, total, failed int,
 	}
 }
 
+func seedAutopilotRun(t *testing.T, autopilotID pgtype.UUID, status string, runAt time.Time) {
+	seedAutopilotRunWithSource(t, autopilotID, "schedule", status, runAt)
+}
+
+func seedAutopilotRunWithSource(t *testing.T, autopilotID pgtype.UUID, source, status string, runAt time.Time) {
+	t.Helper()
+	fixture := testutil.New(testPool, testWorkspaceID, testUserID)
+	fixture.Insert(t, "autopilot_run", testutil.Cols{
+		"autopilot_id": util.UUIDToString(autopilotID),
+		"source":       source,
+		"status":       status,
+		"created_at":   runAt,
+		"triggered_at": runAt,
+		"completed_at": runAt,
+	})
+}
+
 func reloadAutopilotStatus(t *testing.T, queries *db.Queries, id pgtype.UUID) string {
 	t.Helper()
 	ap, err := queries.GetAutopilot(context.Background(), id)
@@ -90,10 +109,11 @@ func TestAutopilotFailureMonitor_PausesOffenderAndNotifiesCreator(t *testing.T) 
 	bus := events.New()
 
 	cfg := failureMonitorConfig{
-		Interval:  time.Hour,
-		Lookback:  7 * 24 * time.Hour,
-		MinRuns:   10,
-		FailRatio: 0.9,
+		Interval:   time.Hour,
+		Lookback:   7 * 24 * time.Hour,
+		MinRuns:    10,
+		FailRatio:  0.9,
+		SkipStreak: 2,
 	}
 
 	agentID := pickFixtureAgent(t)
@@ -165,10 +185,11 @@ func TestAutopilotFailureMonitor_LeavesAlreadyPausedAlone(t *testing.T) {
 	queries := db.New(testPool)
 	bus := events.New()
 	cfg := failureMonitorConfig{
-		Interval:  time.Hour,
-		Lookback:  7 * 24 * time.Hour,
-		MinRuns:   10,
-		FailRatio: 0.9,
+		Interval:   time.Hour,
+		Lookback:   7 * 24 * time.Hour,
+		MinRuns:    10,
+		FailRatio:  0.9,
+		SkipStreak: 2,
 	}
 
 	agentID := pickFixtureAgent(t)
@@ -197,10 +218,11 @@ func TestAutopilotFailureMonitor_AgentCreatorRoutesToOwner(t *testing.T) {
 	queries := db.New(testPool)
 	bus := events.New()
 	cfg := failureMonitorConfig{
-		Interval:  time.Hour,
-		Lookback:  7 * 24 * time.Hour,
-		MinRuns:   10,
-		FailRatio: 0.9,
+		Interval:   time.Hour,
+		Lookback:   7 * 24 * time.Hour,
+		MinRuns:    10,
+		FailRatio:  0.9,
+		SkipStreak: 2,
 	}
 
 	agentID := pickFixtureAgent(t)
@@ -234,10 +256,11 @@ func TestAutopilotFailureMonitor_FormerCreatorFallsBackToWorkspaceManagers(t *te
 	queries := db.New(testPool)
 	bus := events.New()
 	cfg := failureMonitorConfig{
-		Interval:  time.Hour,
-		Lookback:  7 * 24 * time.Hour,
-		MinRuns:   10,
-		FailRatio: 0.9,
+		Interval:   time.Hour,
+		Lookback:   7 * 24 * time.Hour,
+		MinRuns:    10,
+		FailRatio:  0.9,
+		SkipStreak: 2,
 	}
 	agentID := pickFixtureAgent(t)
 	autopilot := seedAutopilot(
@@ -275,10 +298,11 @@ func TestAutopilotFailureMonitor_BelowThresholdNoOp(t *testing.T) {
 	queries := db.New(testPool)
 	bus := events.New()
 	cfg := failureMonitorConfig{
-		Interval:  time.Hour,
-		Lookback:  7 * 24 * time.Hour,
-		MinRuns:   10,
-		FailRatio: 0.9,
+		Interval:   time.Hour,
+		Lookback:   7 * 24 * time.Hour,
+		MinRuns:    10,
+		FailRatio:  0.9,
+		SkipStreak: 2,
 	}
 
 	agentID := pickFixtureAgent(t)
@@ -298,5 +322,128 @@ func TestAutopilotFailureMonitor_BelowThresholdNoOp(t *testing.T) {
 	}
 	if len(inboxEvents) != 0 {
 		t.Fatalf("expected no inbox events, got %d", len(inboxEvents))
+	}
+}
+
+func TestAutopilotFailureMonitor_ConsecutiveNaturalSkipsPauseAndRecoveryClearsCandidate(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	cfg := failureMonitorConfig{
+		Interval:   time.Hour,
+		Lookback:   7 * 24 * time.Hour,
+		MinRuns:    50, // The two-run schedule streak, not the rate threshold, must fire.
+		FailRatio:  0.9,
+		SkipStreak: 2,
+	}
+
+	agentID := pickFixtureAgent(t)
+	streak := seedAutopilot(t, queries, "Failure monitor: consecutive skipped schedules", "member", parseUUID(testUserID), agentID)
+	recovered := seedAutopilot(t, queries, "Failure monitor: recovered schedule", "member", parseUUID(testUserID), agentID)
+	now := time.Now()
+	seedAutopilotRun(t, streak.ID, "skipped", now.Add(-2*time.Minute))
+	seedAutopilotRunWithSource(t, streak.ID, "manual", "completed", now.Add(-90*time.Second))
+	seedAutopilotRun(t, streak.ID, "skipped", now.Add(-1*time.Minute))
+	seedAutopilotRun(t, recovered.ID, "skipped", now.Add(-2*time.Minute))
+	seedAutopilotRun(t, recovered.ID, "completed", now.Add(-1*time.Minute))
+
+	candidates, err := queries.SelectAutopilotsExceedingFailureThreshold(context.Background(), db.SelectAutopilotsExceedingFailureThresholdParams{
+		MinRuns:            cfg.MinRuns,
+		FailRatioThreshold: cfg.FailRatio,
+		SkipStreak:         cfg.SkipStreak,
+		Since:              pgtype.Timestamptz{Time: now.Add(-cfg.Lookback), Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("select failure candidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != streak.ID {
+		t.Fatalf("candidates = %#v, want only the consecutive-skip autopilot %s", candidates, util.UUIDToString(streak.ID))
+	}
+	if got := autopilotPauseReason(candidates[0], cfg); got != autopilotPauseReasonSkipStreak {
+		t.Fatalf("pause reason = %q, want %q", got, autopilotPauseReasonSkipStreak)
+	}
+
+	var inboxEvents []events.Event
+	bus.Subscribe(protocol.EventInboxNew, func(e events.Event) {
+		inboxEvents = append(inboxEvents, e)
+	})
+	tickAutopilotFailureMonitor(context.Background(), queries, bus, cfg)
+
+	paused, err := queries.GetAutopilot(context.Background(), streak.ID)
+	if err != nil {
+		t.Fatalf("reload paused autopilot: %v", err)
+	}
+	if paused.Status != "paused" || paused.PauseReason.String != autopilotPauseReasonSkipStreak {
+		t.Fatalf("paused autopilot = status %q, pause_reason %q; want paused/%q", paused.Status, paused.PauseReason.String, autopilotPauseReasonSkipStreak)
+	}
+	if len(inboxEvents) != 1 {
+		t.Fatalf("inbox events = %d, want 1", len(inboxEvents))
+	}
+	item := inboxEvents[0].Payload.(map[string]any)["item"].(map[string]any)
+	var details map[string]any
+	if err := json.Unmarshal(item["details"].(json.RawMessage), &details); err != nil {
+		t.Fatalf("decode notification details: %v", err)
+	}
+	if got := details["reason"]; got != autopilotPauseReasonSkipStreak {
+		t.Fatalf("notification reason = %v, want %q", got, autopilotPauseReasonSkipStreak)
+	}
+	if got := reloadAutopilotStatus(t, queries, recovered.ID); got != "active" {
+		t.Fatalf("completed natural run must clear the skip-streak candidate; status = %q", got)
+	}
+
+	fixture := testutil.New(testPool, testWorkspaceID, testUserID)
+	fixture.Exec(t, `UPDATE autopilot SET status = 'active', pause_reason = NULL WHERE id = $1`, util.UUIDToString(streak.ID))
+	seedAutopilotRun(t, streak.ID, "completed", now)
+	tickAutopilotFailureMonitor(context.Background(), queries, bus, cfg)
+
+	restored, err := queries.GetAutopilot(context.Background(), streak.ID)
+	if err != nil {
+		t.Fatalf("reload restored autopilot: %v", err)
+	}
+	if restored.Status != "active" || restored.PauseReason.Valid {
+		t.Fatalf("restored autopilot = status %q, pause_reason %q; want active with no alert", restored.Status, restored.PauseReason.String)
+	}
+	if len(inboxEvents) != 1 {
+		t.Fatalf("recovery emitted another inbox event; got %d total, want the original 1", len(inboxEvents))
+	}
+}
+
+func TestAutopilotFailureMonitor_SkipsCarryFailureRateWeight(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	cfg := failureMonitorConfig{
+		Interval:   time.Hour,
+		Lookback:   7 * 24 * time.Hour,
+		MinRuns:    10,
+		FailRatio:  0.9,
+		SkipStreak: 2,
+	}
+
+	agentID := pickFixtureAgent(t)
+	autopilot := seedAutopilot(t, queries, "Failure monitor: skip has failure weight", "member", parseUUID(testUserID), agentID)
+	now := time.Now()
+	for i := 0; i < 8; i++ {
+		seedAutopilotRun(t, autopilot.ID, "failed", now.Add(time.Duration(i-10)*time.Minute))
+	}
+	seedAutopilotRun(t, autopilot.ID, "skipped", now.Add(-2*time.Minute))
+	seedAutopilotRun(t, autopilot.ID, "completed", now.Add(-1*time.Minute))
+
+	var updateEvents []events.Event
+	bus.Subscribe(protocol.EventAutopilotUpdated, func(e events.Event) {
+		updateEvents = append(updateEvents, e)
+	})
+	tickAutopilotFailureMonitor(context.Background(), queries, bus, cfg)
+
+	paused, err := queries.GetAutopilot(context.Background(), autopilot.ID)
+	if err != nil {
+		t.Fatalf("reload paused autopilot: %v", err)
+	}
+	if paused.Status != "paused" || paused.PauseReason.String != autopilotPauseReasonFailureRate {
+		t.Fatalf("paused autopilot = status %q, pause_reason %q; want paused/%q", paused.Status, paused.PauseReason.String, autopilotPauseReasonFailureRate)
+	}
+	if len(updateEvents) != 1 {
+		t.Fatalf("update events = %d, want 1", len(updateEvents))
+	}
+	if got := updateEvents[0].Payload.(map[string]any)["reason"]; got != autopilotPauseReasonFailureRate {
+		t.Fatalf("update reason = %v, want %q", got, autopilotPauseReasonFailureRate)
 	}
 }

--- a/server/internal/service/builtin_skills/multica-platform/references/autopilots.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/autopilots.md
@@ -75,6 +75,20 @@ keeps write/execute but cannot re-grant or revoke peers. `get` stamps two
 per-caller booleans — `can_write` and the narrower `can_manage_access` — read
 those rather than inferring from role.
 
+## Failure monitoring
+
+The server auto-pauses an active autopilot when either of these guards fires:
+
+- failed and skipped terminal runs together exceed the configured failure-rate
+  threshold; skipped work carries the same weight as failed work;
+- the latest two natural schedule runs are both skipped, independent of the
+  minimum sample size used by the rate threshold.
+
+Manual, webhook, and API runs do not break or manufacture the natural schedule
+streak. A later completed natural schedule run breaks it. The paused autopilot's
+`pause_reason` distinguishes `auto_paused_high_failure_rate` from
+`auto_paused_consecutive_skips`, and the owner receives an inbox notification.
+
 ## Side effects
 
 These mutate durable state or start work: `create`, `update`, `delete`, trigger

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -1847,57 +1847,98 @@ const selectAutopilotsExceedingFailureThreshold = `-- name: SelectAutopilotsExce
 
 WITH stats AS (
     SELECT autopilot_id,
-           count(*) FILTER (WHERE status IN ('completed', 'failed')) AS total,
-           count(*) FILTER (WHERE status = 'failed') AS failed
+           count(*) FILTER (WHERE status IN ('completed', 'failed', 'skipped')) AS total,
+           count(*) FILTER (WHERE status = 'failed') AS failed,
+           count(*) FILTER (WHERE status = 'skipped') AS skipped
     FROM autopilot_run
-    WHERE created_at >= $3::timestamptz
+    WHERE created_at >= $4::timestamptz
+    GROUP BY autopilot_id
+), recent_natural_runs AS (
+    SELECT autopilot_id,
+           status,
+           row_number() OVER (
+               PARTITION BY autopilot_id
+               ORDER BY COALESCE(planned_at, triggered_at, created_at) DESC, id DESC
+           ) AS position
+    FROM autopilot_run
+    WHERE created_at >= $4::timestamptz
+      AND source = 'schedule'
+), natural_streaks AS (
+    SELECT autopilot_id,
+           count(*) FILTER (WHERE position <= $3::bigint) AS recent_natural_runs,
+           count(*) FILTER (
+               WHERE position <= $3::bigint
+                 AND status = 'skipped'
+           ) AS recent_skipped_runs
+    FROM recent_natural_runs
     GROUP BY autopilot_id
 )
 SELECT a.id, a.workspace_id, a.title, a.assignee_id,
        a.created_by_type, a.created_by_id,
        s.total::bigint  AS total_runs,
-       s.failed::bigint AS failed_runs
+       s.failed::bigint AS failed_runs,
+       s.skipped::bigint AS skipped_runs,
+       COALESCE(ns.recent_natural_runs, 0)::bigint AS recent_natural_runs,
+       COALESCE(ns.recent_skipped_runs, 0)::bigint AS recent_skipped_runs
 FROM autopilot a
 JOIN stats s ON s.autopilot_id = a.id
+LEFT JOIN natural_streaks ns ON ns.autopilot_id = a.id
 WHERE a.status = 'active'
-  AND s.total >= $1::bigint
-  AND s.failed::float8 / NULLIF(s.total, 0)::float8 >= $2::float8
-ORDER BY s.failed DESC, a.id ASC
+  AND (
+      (
+          s.total >= $1::bigint
+          AND (s.failed + s.skipped)::float8 / NULLIF(s.total, 0)::float8
+              >= $2::float8
+      )
+      OR (
+          COALESCE(ns.recent_natural_runs, 0) >= $3::bigint
+          AND ns.recent_skipped_runs = ns.recent_natural_runs
+      )
+  )
+ORDER BY (s.failed + s.skipped) DESC, a.id ASC
 `
 
 type SelectAutopilotsExceedingFailureThresholdParams struct {
 	MinRuns            int64              `json:"min_runs"`
 	FailRatioThreshold float64            `json:"fail_ratio_threshold"`
+	SkipStreak         int64              `json:"skip_streak"`
 	Since              pgtype.Timestamptz `json:"since"`
 }
 
 type SelectAutopilotsExceedingFailureThresholdRow struct {
-	ID            pgtype.UUID `json:"id"`
-	WorkspaceID   pgtype.UUID `json:"workspace_id"`
-	Title         string      `json:"title"`
-	AssigneeID    pgtype.UUID `json:"assignee_id"`
-	CreatedByType string      `json:"created_by_type"`
-	CreatedByID   pgtype.UUID `json:"created_by_id"`
-	TotalRuns     int64       `json:"total_runs"`
-	FailedRuns    int64       `json:"failed_runs"`
+	ID                pgtype.UUID `json:"id"`
+	WorkspaceID       pgtype.UUID `json:"workspace_id"`
+	Title             string      `json:"title"`
+	AssigneeID        pgtype.UUID `json:"assignee_id"`
+	CreatedByType     string      `json:"created_by_type"`
+	CreatedByID       pgtype.UUID `json:"created_by_id"`
+	TotalRuns         int64       `json:"total_runs"`
+	FailedRuns        int64       `json:"failed_runs"`
+	SkippedRuns       int64       `json:"skipped_runs"`
+	RecentNaturalRuns int64       `json:"recent_natural_runs"`
+	RecentSkippedRuns int64       `json:"recent_skipped_runs"`
 }
 
 // =====================
 // Failure-rate auto-pause
 // =====================
-// Find active autopilots whose recent run failure rate exceeds the threshold.
-// Counts only "real" terminal runs (completed | failed). 'skipped' is
-// excluded from BOTH numerator and denominator: an admission-skipped run
-// (e.g. assignee runtime offline at dispatch time, MUL-1899) is neither a
-// success nor a failure, so it must not dilute the failure ratio (which
-// would let a 100%-failing autopilot mask itself behind a wall of skips)
-// nor inflate it. issue_created/running are still excluded so in-flight
-// work isn't penalised.
-// Used by the failure monitor to auto-pause sustained-failure autopilots
-// (the canonical example from MUL-1336 was an autopilot scheduled every 5 min
-// that 100% failed for days, burning ~1.5k useless tasks per week).
+// Find active autopilots whose real terminal runs exceed the failure threshold,
+// or whose latest natural schedule rounds form a skipped streak. A skipped
+// admission is still an unsuccessful scheduled obligation: it must count with
+// a failed run instead of providing a loophole that hides a dead autopilot.
+// In-flight rows remain excluded from the rate and break a natural-run streak.
+//
+// The streak is deliberately schedule-only. Manual, webhook, and API runs are
+// not natural rounds, so they must neither mask nor manufacture this alert.
+// Used by the failure monitor to pause both a hot failure loop and a silently
+// skipped automation before it can disappear behind an apparently active rule.
 func (q *Queries) SelectAutopilotsExceedingFailureThreshold(ctx context.Context, arg SelectAutopilotsExceedingFailureThresholdParams) ([]SelectAutopilotsExceedingFailureThresholdRow, error) {
-	rows, err := q.db.Query(ctx, selectAutopilotsExceedingFailureThreshold, arg.MinRuns, arg.FailRatioThreshold, arg.Since)
+	rows, err := q.db.Query(ctx, selectAutopilotsExceedingFailureThreshold,
+		arg.MinRuns,
+		arg.FailRatioThreshold,
+		arg.SkipStreak,
+		arg.Since,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1914,6 +1955,9 @@ func (q *Queries) SelectAutopilotsExceedingFailureThreshold(ctx context.Context,
 			&i.CreatedByID,
 			&i.TotalRuns,
 			&i.FailedRuns,
+			&i.SkippedRuns,
+			&i.RecentNaturalRuns,
+			&i.RecentSkippedRuns,
 		); err != nil {
 			return nil, err
 		}
@@ -2066,17 +2110,22 @@ func (q *Queries) SetAutopilotTriggerWebhookToken(ctx context.Context, arg SetAu
 
 const systemPauseAutopilot = `-- name: SystemPauseAutopilot :one
 UPDATE autopilot
-SET status = 'paused', pause_reason = NULL, updated_at = now()
+SET status = 'paused', pause_reason = $2, updated_at = now()
 WHERE id = $1 AND status = 'active'
 RETURNING id, workspace_id, title, description, assignee_id, status, execution_mode, issue_title_template, created_by_type, created_by_id, last_run_at, created_at, updated_at, assignee_type, project_id, pause_reason
 `
 
-// Atomically pauses an autopilot only if it is currently active. Returns no
-// rows when the autopilot was already paused/archived (or another worker
-// raced first), letting the caller treat that as a benign no-op rather than
-// an error.
-func (q *Queries) SystemPauseAutopilot(ctx context.Context, id pgtype.UUID) (Autopilot, error) {
-	row := q.db.QueryRow(ctx, systemPauseAutopilot, id)
+type SystemPauseAutopilotParams struct {
+	ID          pgtype.UUID `json:"id"`
+	PauseReason pgtype.Text `json:"pause_reason"`
+}
+
+// Atomically pauses an autopilot only if it is currently active, retaining the
+// machine-readable reason so the active/paused dashboard state is actionable.
+// Returns no rows when the autopilot was already paused/archived (or another
+// worker raced first), letting the caller treat that as a benign no-op.
+func (q *Queries) SystemPauseAutopilot(ctx context.Context, arg SystemPauseAutopilotParams) (Autopilot, error) {
+	row := q.db.QueryRow(ctx, systemPauseAutopilot, arg.ID, arg.PauseReason)
 	var i Autopilot
 	err := row.Scan(
 		&i.ID,

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -674,43 +674,75 @@ SELECT * FROM updated_runs;
 -- =====================
 
 -- name: SelectAutopilotsExceedingFailureThreshold :many
--- Find active autopilots whose recent run failure rate exceeds the threshold.
--- Counts only "real" terminal runs (completed | failed). 'skipped' is
--- excluded from BOTH numerator and denominator: an admission-skipped run
--- (e.g. assignee runtime offline at dispatch time, MUL-1899) is neither a
--- success nor a failure, so it must not dilute the failure ratio (which
--- would let a 100%-failing autopilot mask itself behind a wall of skips)
--- nor inflate it. issue_created/running are still excluded so in-flight
--- work isn't penalised.
--- Used by the failure monitor to auto-pause sustained-failure autopilots
--- (the canonical example from MUL-1336 was an autopilot scheduled every 5 min
--- that 100% failed for days, burning ~1.5k useless tasks per week).
+-- Find active autopilots whose real terminal runs exceed the failure threshold,
+-- or whose latest natural schedule rounds form a skipped streak. A skipped
+-- admission is still an unsuccessful scheduled obligation: it must count with
+-- a failed run instead of providing a loophole that hides a dead autopilot.
+-- In-flight rows remain excluded from the rate and break a natural-run streak.
+--
+-- The streak is deliberately schedule-only. Manual, webhook, and API runs are
+-- not natural rounds, so they must neither mask nor manufacture this alert.
+-- Used by the failure monitor to pause both a hot failure loop and a silently
+-- skipped automation before it can disappear behind an apparently active rule.
 WITH stats AS (
     SELECT autopilot_id,
-           count(*) FILTER (WHERE status IN ('completed', 'failed')) AS total,
-           count(*) FILTER (WHERE status = 'failed') AS failed
+           count(*) FILTER (WHERE status IN ('completed', 'failed', 'skipped')) AS total,
+           count(*) FILTER (WHERE status = 'failed') AS failed,
+           count(*) FILTER (WHERE status = 'skipped') AS skipped
     FROM autopilot_run
     WHERE created_at >= sqlc.arg('since')::timestamptz
+    GROUP BY autopilot_id
+), recent_natural_runs AS (
+    SELECT autopilot_id,
+           status,
+           row_number() OVER (
+               PARTITION BY autopilot_id
+               ORDER BY COALESCE(planned_at, triggered_at, created_at) DESC, id DESC
+           ) AS position
+    FROM autopilot_run
+    WHERE created_at >= sqlc.arg('since')::timestamptz
+      AND source = 'schedule'
+), natural_streaks AS (
+    SELECT autopilot_id,
+           count(*) FILTER (WHERE position <= sqlc.arg('skip_streak')::bigint) AS recent_natural_runs,
+           count(*) FILTER (
+               WHERE position <= sqlc.arg('skip_streak')::bigint
+                 AND status = 'skipped'
+           ) AS recent_skipped_runs
+    FROM recent_natural_runs
     GROUP BY autopilot_id
 )
 SELECT a.id, a.workspace_id, a.title, a.assignee_id,
        a.created_by_type, a.created_by_id,
        s.total::bigint  AS total_runs,
-       s.failed::bigint AS failed_runs
+       s.failed::bigint AS failed_runs,
+       s.skipped::bigint AS skipped_runs,
+       COALESCE(ns.recent_natural_runs, 0)::bigint AS recent_natural_runs,
+       COALESCE(ns.recent_skipped_runs, 0)::bigint AS recent_skipped_runs
 FROM autopilot a
 JOIN stats s ON s.autopilot_id = a.id
+LEFT JOIN natural_streaks ns ON ns.autopilot_id = a.id
 WHERE a.status = 'active'
-  AND s.total >= sqlc.arg('min_runs')::bigint
-  AND s.failed::float8 / NULLIF(s.total, 0)::float8 >= sqlc.arg('fail_ratio_threshold')::float8
-ORDER BY s.failed DESC, a.id ASC;
+  AND (
+      (
+          s.total >= sqlc.arg('min_runs')::bigint
+          AND (s.failed + s.skipped)::float8 / NULLIF(s.total, 0)::float8
+              >= sqlc.arg('fail_ratio_threshold')::float8
+      )
+      OR (
+          COALESCE(ns.recent_natural_runs, 0) >= sqlc.arg('skip_streak')::bigint
+          AND ns.recent_skipped_runs = ns.recent_natural_runs
+      )
+  )
+ORDER BY (s.failed + s.skipped) DESC, a.id ASC;
 
 -- name: SystemPauseAutopilot :one
--- Atomically pauses an autopilot only if it is currently active. Returns no
--- rows when the autopilot was already paused/archived (or another worker
--- raced first), letting the caller treat that as a benign no-op rather than
--- an error.
+-- Atomically pauses an autopilot only if it is currently active, retaining the
+-- machine-readable reason so the active/paused dashboard state is actionable.
+-- Returns no rows when the autopilot was already paused/archived (or another
+-- worker raced first), letting the caller treat that as a benign no-op.
 UPDATE autopilot
-SET status = 'paused', pause_reason = NULL, updated_at = now()
+SET status = 'paused', pause_reason = sqlc.arg('pause_reason'), updated_at = now()
 WHERE id = $1 AND status = 'active'
 RETURNING *;
 


### PR DESCRIPTION
## Summary

- count `skipped` autopilot runs as unsuccessful alongside `failed`
- auto-pause after two consecutive natural scheduled skips, independent of the rate-monitor sample floor
- keep manual/webhook/API runs from manufacturing or masking the natural schedule streak
- persist a machine-readable pause reason and include skip metrics in owner notifications
- document the failure-monitor contract in the built-in Multica platform skill

## Verification

- `go test -race ./cmd/server -run 'TestAutopilotFailureMonitor_(ConsecutiveNaturalSkipsPauseAndRecoveryClearsCandidate|SkipsCarryFailureRateWeight)$' -count=1`
- `go test ./cmd/server ./internal/service ./internal/handler`
- `go vet ./cmd/server ./internal/service ./internal/handler`
- `make sqlc`
- `git diff --check`

Full-suite note: a broader race run reached an unrelated timing-boundary failure in `daemon_batch_claim_test.go` (`5067ms`, expected `1..5000ms`). The targeted PostgreSQL-backed race tests pass.

Tracks WS-4963.
