### PR TITLE
fix(pi): reject incomplete terminal event streams

### DIFF
--- a/server/internal/daemon/pi_busy_retry_unix_test.go
+++ b/server/internal/daemon/pi_busy_retry_unix_test.go
@@ -44,7 +44,8 @@ func TestRunTaskPiBusyRetryDoesNotRetireHealthySession(t *testing.T) {
 cat > /dev/null
 printf '%s\n' '{"type":"agent_start"}'
 printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"done"}}'
-printf '%s\n' '{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":1,"output":1}}}'
+printf '%s\n' '{"type":"turn_end","message":{"role":"assistant","stopReason":"stop","model":"test","usage":{"input":1,"output":1}}}'
+printf '%s\n' '{"type":"agent_end"}'
 `
 	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake pi: %v", err)

--- a/server/pkg/agent/omp_test.go
+++ b/server/pkg/agent/omp_test.go
@@ -88,7 +88,8 @@ func TestOmpExecuteDefaultsToOmpBinary(t *testing.T) {
 	script := "#!/bin/sh\n" +
 		"cat > /dev/null\n" +
 		"printf '%s\\n' '{\"type\":\"agent_start\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"turn_end\",\"message\":{\"role\":\"assistant\",\"model\":\"test\",\"usage\":{\"input\":1,\"output\":1}}}'\n" +
+		"printf '%s\\n' '{\"type\":\"turn_end\",\"message\":{\"role\":\"assistant\",\"stopReason\":\"stop\",\"model\":\"test\",\"usage\":{\"input\":1,\"output\":1}}}'\n" +
+		"printf '%s\\n' '{\"type\":\"agent_end\"}'\n" +
 		"exit 0\n"
 	writeTestExecutable(t, fakePath, []byte(script))
 
@@ -178,7 +179,8 @@ func TestOmpExecuteCompletesFromEventStream(t *testing.T) {
 		`{"type":"agent_start"}`,
 		`{"type":"turn_start"}`,
 		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello from omp"}}`,
-		`{"type":"turn_end","message":{"role":"assistant","model":"omp-test","usage":{"input":10,"output":5}}}`,
+		`{"type":"turn_end","message":{"role":"assistant","stopReason":"stop","model":"omp-test","usage":{"input":10,"output":5}}}`,
+		`{"type":"agent_end"}`,
 	}
 	fakePath := filepath.Join(t.TempDir(), "omp")
 	writeTestExecutable(t, fakePath, []byte(piEventStreamScript(events)))

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -312,6 +312,8 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		finalStatus := "completed"
 		var finalError string
 		var lastTurnError string
+		var lastStopReason string
+		var turnEnded, agentEnded bool
 		usage := make(map[string]TokenUsage)
 
 		// Pi message_update events can be large (they embed the full message
@@ -331,12 +333,16 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 
 			switch evt.Type {
 			case "agent_start":
+				turnEnded, agentEnded = false, false
+				lastStopReason = ""
 				trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
 
 			case "turn_start":
 				output.Reset()
 				textBuffer.Reset()
 				lastTurnError = ""
+				lastStopReason = ""
+				turnEnded, agentEnded = false, false
 
 			case "message_update":
 				if evt.AssistantMessageEvent == nil {
@@ -374,10 +380,13 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 				})
 
 			case "turn_end":
+				turnEnded, agentEnded = false, false
 				msg := decodePiMessage(evt.Message)
-				if msg == nil {
+				if msg == nil || msg.Role != "assistant" {
 					continue
 				}
+				turnEnded = true
+				lastStopReason = msg.StopReason
 				if msg.Usage != nil {
 					model := msg.Model
 					if model == "" {
@@ -404,6 +413,15 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 					}
 				}
 
+			case "agent_end":
+				// A turn can finish before Pi retries or runs another tool turn.
+				// Only the last completed loop is terminal evidence at process EOF.
+				agentEnded = turnEnded && !evt.WillRetry
+
+			case "auto_retry_start":
+				turnEnded, agentEnded = false, false
+				lastStopReason = ""
+
 			case "error":
 				errText := decodePiString(evt.Message)
 				trySend(msgCh, Message{Type: MessageError, Content: errText})
@@ -423,6 +441,13 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 				}
 			}
 		}
+		streamErr := scanner.Err()
+		streamFailed := streamErr != nil && runCtx.Err() == nil
+		if streamFailed {
+			// Once stdout cannot be consumed, the child may block writing to it.
+			// Cancel this owned process tree before waiting for its exit.
+			cancel()
+		}
 		if d := flushPiTextBuffer(&textBuffer); d != "" {
 			output.WriteString(d)
 			trySend(msgCh, Message{Type: MessageText, Content: d})
@@ -436,7 +461,10 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		// child exited has returned by now. The writer sends exactly once.
 		writeErr := <-writeErrCh
 
-		if runCtx.Err() == context.DeadlineExceeded {
+		if streamFailed {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("%s stream read failed: %v", label, streamErr)
+		} else if runCtx.Err() == context.DeadlineExceeded {
 			finalStatus = "timeout"
 			finalError = fmt.Sprintf("%s timed out after %s", label, timeout)
 		} else if runCtx.Err() == context.Canceled {
@@ -469,7 +497,26 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 			finalError = lastTurnError
 		}
 
-		b.cfg.Logger.Info(label+" finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+		if finalStatus == "completed" {
+			switch {
+			case lastStopReason == "length":
+				finalStatus = "failed"
+				finalError = label + " ended at its output token limit"
+			case lastStopReason == "aborted":
+				finalStatus = "aborted"
+				finalError = label + " aborted the turn"
+			case !turnEnded || !agentEnded:
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("%s stream ended without terminal events (turn_end=%t, agent_end=%t, stop_reason=%q)", label, turnEnded, agentEnded, lastStopReason)
+			case lastStopReason != "stop" && lastStopReason != "toolUse":
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("%s ended with unsupported stop reason %q", label, lastStopReason)
+			}
+		}
+
+		b.cfg.Logger.Info(label+" finished", "pid", cmd.Process.Pid, "status", finalStatus,
+			"duration", duration.Round(time.Millisecond).String(),
+			"stop_reason", lastStopReason, "turn_end", turnEnded, "agent_end", agentEnded)
 
 		// Publish the terminal result only after the transcript is available to
 		// a follow-up run. The result channel is buffered, so relying on a defer
@@ -511,6 +558,9 @@ func piSessionBusyResult(label, sessionPath string) *Session {
 // demand by the switch arms.
 type piStreamEvent struct {
 	Type string `json:"type"`
+
+	// agent_end can precede an automatic retry rather than process completion.
+	WillRetry bool `json:"willRetry,omitempty"`
 
 	// message_update
 	AssistantMessageEvent *piAssistantMessageEvent `json:"assistantMessageEvent,omitempty"`

--- a/server/pkg/agent/pi_stdin_unix_test.go
+++ b/server/pkg/agent/pi_stdin_unix_test.go
@@ -30,7 +30,8 @@ cat > %[2]q
 printf '%%s\n' '{"type":"agent_start"}'
 printf '%%s\n' '{"type":"turn_start"}'
 printf '%%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"ok"}}'
-printf '%%s\n' '{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}'
+printf '%%s\n' '{"type":"turn_end","message":{"role":"assistant","stopReason":"stop","model":"test","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}'
+printf '%%s\n' '{"type":"agent_end"}'
 `, argvPath, stdinPath)
 
 	fakePath := filepath.Join(dir, "pi")
@@ -115,7 +116,8 @@ func TestPiExecuteLargePromptDoesNotDeadlock(t *testing.T) {
 yes '{"type":"noise","pad":"0123456789012345678901234567890123456789"}' | head -n 8000
 cat > %[1]q
 printf '%%s\n' '{"type":"agent_start"}'
-printf '%%s\n' '{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}'
+printf '%%s\n' '{"type":"turn_end","message":{"role":"assistant","stopReason":"stop","model":"test","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}'
+printf '%%s\n' '{"type":"agent_end"}'
 `, stdinPath)
 	fakePath := filepath.Join(dir, "pi")
 	writeTestExecutable(t, fakePath, []byte(script))

--- a/server/pkg/agent/pi_stdin_windows_test.go
+++ b/server/pkg/agent/pi_stdin_windows_test.go
@@ -57,7 +57,8 @@ func TestPiShimHelperProcess(t *testing.T) {
 	}
 
 	fmt.Println(`{"type":"agent_start"}`)
-	fmt.Println(`{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}`)
+	fmt.Println(`{"type":"turn_end","message":{"role":"assistant","stopReason":"stop","model":"test","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}`)
+	fmt.Println(`{"type":"agent_end"}`)
 	os.Exit(0)
 }
 

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -11,6 +12,92 @@ import (
 	"testing"
 	"time"
 )
+
+// Re-execute the test binary as a fake Pi on every OS, without a provider CLI.
+func TestPiEventStreamHelperProcess(t *testing.T) {
+	path := os.Getenv("MULTICA_PI_EVENT_STREAM_FIXTURE")
+	if path == "" {
+		t.Skip("subprocess fixture")
+	}
+	if _, err := io.Copy(io.Discard, os.Stdin); err != nil {
+		os.Exit(1)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		os.Exit(1)
+	}
+	_, err = io.Copy(os.Stdout, f)
+	_ = f.Close()
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func TestPiExecuteRequiresTerminalEvidence(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const start = "{\"type\":\"agent_start\"}\n{\"type\":\"turn_start\"}\n"
+	const progress = "{\"type\":\"message_update\",\"assistantMessageEvent\":{\"type\":\"text_delta\",\"delta\":\"Checking the remaining conditions.\"}}\n"
+	const end = "{\"type\":\"agent_end\",\"willRetry\":false}\n"
+	turn := func(reason string) string {
+		return fmt.Sprintf("{\"type\":\"turn_end\",\"message\":{\"role\":\"assistant\",\"model\":\"fixture\",\"stopReason\":%q,\"errorMessage\":\"provider error\"}}\n", reason)
+	}
+	for _, provider := range []string{"pi", "omp"} {
+		t.Run(provider, func(t *testing.T) {
+			for _, tc := range []struct{ name, events, status, errorText, output string }{
+				{"normal_stop", start + progress + turn("stop") + end, "completed", "", "Checking the remaining conditions."},
+				{"tool_only_stop", start + turn("toolUse") + end, "completed", "", ""},
+				{"empty_stream", "", "failed", "terminal", ""},
+				{"missing_turn_end", start + progress + end, "failed", "terminal", "Checking the remaining conditions."},
+				{"missing_agent_end", start + progress + turn("stop"), "failed", "terminal", "Checking the remaining conditions."},
+				{"truncated_json", start + progress + "{\"type\":\"turn_end\",\"message\":", "failed", "terminal", "Checking the remaining conditions."},
+				{"length_limit", start + progress + turn("length") + end, "failed", "output token limit", "Checking the remaining conditions."},
+				{"aborted", start + turn("aborted") + end, "aborted", "aborted", ""},
+				{"unknown_reason", start + turn("unexpected") + end, "failed", "stop reason", ""},
+				{"missing_reason", start + turn("") + end, "failed", "stop reason", ""},
+				{"provider_error", start + turn("error") + end, "failed", "provider error", ""},
+				{"retry_succeeds", start + turn("error") + "{\"type\":\"agent_end\",\"willRetry\":true}\n{\"type\":\"auto_retry_start\"}\n" + start + progress + turn("stop") + end + "{\"type\":\"auto_retry_end\",\"success\":true}\n", "completed", "", "Checking the remaining conditions."},
+				{"length_continues", start + turn("length") + "{\"type\":\"turn_start\"}\n" + progress + turn("stop") + end, "completed", "", "Checking the remaining conditions."},
+				{"later_turn_incomplete", start + turn("stop") + end + "{\"type\":\"turn_start\"}\n" + progress, "failed", "terminal", "Checking the remaining conditions."},
+				{"later_end_incomplete", start + turn("stop") + end + turn("stop"), "failed", "terminal", ""},
+				{"retry_pending", start + turn("stop") + "{\"type\":\"agent_end\",\"willRetry\":true}\n", "failed", "terminal", ""},
+				{"oversized_frame", start + progress + strings.Repeat("x", agentStreamMaxLineBytes+1) + "\n", "failed", "stream read failed", "Checking the remaining conditions."},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					dir := t.TempDir()
+					fixture := filepath.Join(dir, "events.jsonl")
+					if err := os.WriteFile(fixture, []byte(tc.events), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					backend, err := ResolveBackend(provider, Config{
+						ExecutablePath: executable,
+						LaunchPrefix:   []string{"-test.run=^TestPiEventStreamHelperProcess$", "--"},
+						Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+						Env:            map[string]string{"MULTICA_PI_EVENT_STREAM_FIXTURE": fixture},
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					session, err := backend.Execute(t.Context(), "fixture prompt", ExecOptions{
+						Cwd: dir, ResumeSessionID: filepath.Join(dir, "session.jsonl"), Timeout: 10 * time.Second,
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					for range session.Messages {
+					}
+					result := <-session.Result
+					if result.Status != tc.status || result.Output != tc.output || !strings.Contains(result.Error, tc.errorText) || (tc.errorText == "" && result.Error != "") {
+						t.Fatalf("status=%q error=%q output=%q; want %q, error containing %q, output %q", result.Status, result.Error, result.Output, tc.status, tc.errorText, tc.output)
+					}
+				})
+			}
+		})
+	}
+}
 
 func TestBuildPiArgsNoToolAllowlist(t *testing.T) {
 	// Extension tools registered via Pi's registerTool() must not be
@@ -234,7 +321,8 @@ func TestPiExecuteAttachesStdinPipe(t *testing.T) {
 		"  fifo|*pipe*)\n" +
 		"    if [ \"$payload\" = 'prompt-over-stdin' ]; then\n" +
 		"      printf '%s\\n' '{\"type\":\"agent_start\"}'\n" +
-		"      printf '%s\\n' '{\"type\":\"turn_end\",\"message\":{\"role\":\"assistant\",\"model\":\"test\",\"usage\":{\"input\":1,\"output\":1,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":2}}}'\n" +
+		"      printf '%s\\n' '{\"type\":\"turn_end\",\"message\":{\"role\":\"assistant\",\"stopReason\":\"stop\",\"model\":\"test\",\"usage\":{\"input\":1,\"output\":1,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":2}}}'\n" +
+		"      printf '%s\\n' '{\"type\":\"agent_end\"}'\n" +
 		"      exit 0\n" +
 		"    fi\n" +
 		"    ;;\n" +
@@ -327,12 +415,13 @@ func TestPiExecuteRetainsOnlyLastTurnOutput(t *testing.T) {
 		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"intermediate"}}`,
 		`{"type":"tool_execution_start","toolCallId":"call_1","toolName":"bash","args":{"command":"echo hi"}}`,
 		`{"type":"tool_execution_end","toolCallId":"call_1","toolName":"bash","result":{"content":[{"type":"text","text":"hi"}]},"isError":false}`,
-		`{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":1,"output":1}}}`,
+		`{"type":"turn_end","message":{"role":"assistant","stopReason":"toolUse","model":"test","usage":{"input":1,"output":1}}}`,
 		`{"type":"turn_start"}`,
 		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"final"}}`,
 		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":" "}}`,
 		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"answer"}}`,
-		`{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":2,"output":2}}}`,
+		`{"type":"turn_end","message":{"role":"assistant","stopReason":"stop","model":"test","usage":{"input":2,"output":2}}}`,
+		`{"type":"agent_end"}`,
 	}
 	fakePath := filepath.Join(t.TempDir(), "pi")
 	writeTestExecutable(t, fakePath, []byte(piEventStreamScript(events)))
@@ -430,7 +519,8 @@ func TestPiExecuteSucceedsWhenRetryFollowsTurnError(t *testing.T) {
 		`{"type":"agent_start"}`,
 		`{"type":"turn_start"}`,
 		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"recovered"}}`,
-		`{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":2,"output":2}}}`,
+		`{"type":"turn_end","message":{"role":"assistant","stopReason":"stop","model":"test","usage":{"input":2,"output":2}}}`,
+		`{"type":"agent_end"}`,
 	}
 	fakePath := filepath.Join(t.TempDir(), "pi")
 	writeTestExecutable(t, fakePath, []byte(piEventStreamScript(events)))


### PR DESCRIPTION
## What does this PR do?

Pi and OMP can currently exit with code 0 after an incomplete JSON stream and still be reported as `completed`. A stream containing only a progress message, or a final `stopReason=length`, reproduces this without calling a real provider.

Require a final assistant `turn_end` and subsequent non-retrying `agent_end` before accepting successful process exit. Preserve normal `stop`, tool-only `toolUse`, and successful recovery after an earlier failed or truncated turn.

The check belongs in `piBackend.Execute`, which both runtimes share. The [Pi event loop](https://github.com/earendil-works/pi/blob/v0.84.4/packages/agent/src/agent-loop.ts) distinguishes a finished turn from a finished agent loop; process exit alone does not provide that evidence.

## Related Issue

Related runtime area: #8085 handles missing recorded working directories during session resume. This PR is independent and changes completion classification after execution.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `server/pkg/agent/pi.go`: track the last turn's stop reason and terminal events, invalidate earlier completion evidence when another turn or retry starts, and retain those fields in the completion log.
- Report final token-limit stops, aborted turns, and unsupported stop reasons accurately. Treat scanner errors as failures and cancel the owned process before waiting, so an unreadable stdout stream cannot leave the child blocked writing to it.
- Add 34 subprocess cases across Pi and OMP using the Go test executable as a fake runtime. Update existing successful fixtures to include the terminal events emitted by the real protocol.

Risk and scope: older wrappers that omit terminal events will now fail instead of reporting success. This validates the runtime protocol, not task semantics: a model that emits a normal `stop` after only a progress sentence still completes. No automatic continuation or retry policy is added.

## How to Test

From `server/`:

```sh
go test ./pkg/agent -run 'Pi|Omp' -count=1
go vet ./pkg/agent ./internal/daemon
```

Both passed locally on Windows amd64 with Go 1.26.7. The regression test failed on the original implementation before the fix. Coverage includes missing events, truncated JSON, oversized frames, stop reasons, tool-only completion, successful retries, and incomplete later turns.

Linux amd64 test binaries for both packages also compiled with `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -c`; Linux tests were not executed locally. `gofmt` and `git diff --check` passed. Real-provider smoke tests were not run.

## Checklist

- [x] Included the problem, relevant execution path, and rationale for the shared fix
- [x] Ran applicable local tests and added regression coverage
- [x] Documented risks and unverified scope
- UI, translations, and runtime registration documentation: not applicable

## AI Disclosure

**AI tool used:** Codex in Multica.

**Prompt / approach:** Investigate premature completion reports, reproduce the protocol gap with a fake runtime, inspect Pi and OMP event sources, implement the shared backend fix, and verify normal completion and retry behavior before opening a Draft PR.
