### PR TITLE
MUL-7105: Route GitHub PR refresh lookups to replica

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -646,6 +646,7 @@ func main() {
 	// Reuse the handler's primary Queries handle so replica routing does not
 	// create a second wrapper around the same primary pool.
 	h.ReadSelector = dbreader.New(h.Queries, replicaQueries, readRecorder)
+	h.PRRefresh.SetReadSelector(h.ReadSelector)
 
 	// Reconciled race recoveries in the batched scheduler reuse the same
 	// daemon:register refresh the sync transition path publishes. Wired before

--- a/server/internal/dbreader/selector.go
+++ b/server/internal/dbreader/selector.go
@@ -30,6 +30,7 @@ type Business struct {
 var (
 	BusinessDashboard        = Business{label: "dashboard"}
 	BusinessDaemonWorkspaces = Business{label: "daemon_workspaces"}
+	BusinessGitHubPRRefresh  = Business{label: "github_pr_refresh"}
 	businessUnknown          = Business{label: "unknown"}
 )
 

--- a/server/internal/integrations/ghsnapshot/refresh.go
+++ b/server/internal/integrations/ghsnapshot/refresh.go
@@ -277,10 +277,13 @@ func (m *Manager) process(ctx context.Context, addr address) {
 		}
 	}
 
-	// Chase decision. Chase only while the snapshot is undecided AND we still
-	// have an open PR row on this head. If nothing applied (head advanced past
-	// this response, or the PR is gone), the webhook that moved the head has
-	// already enqueued the fresh head, so we stop here.
+	// Chase only while the snapshot is undecided AND a write proved that an
+	// open PR row still exists on this head. If the head advanced, its webhook
+	// owns the next refresh; if the row was removed, nothing remains to refresh.
+	// Replica lag can instead make rows empty; that omission is recovered by the
+	// bounded TTL sweep for an open/draft PR or by a later page-view refresh, so
+	// it must not start a chase without having observed current row state. A
+	// logged write failure is likewise left to those later triggers.
 	if anyApplied && anyOpenApplied && !snap.Decided() {
 		m.scheduleChase(addr)
 	} else {
@@ -290,6 +293,11 @@ func (m *Manager) process(ctx context.Context, addr address) {
 	}
 }
 
+// listGitHubPRRowsByAddress is eventual-consistency safe because the returned
+// IDs are only candidates for primary writes. Each write checks the current
+// head SHA on the primary, so replica lag can omit an update but cannot apply a
+// snapshot for an old head. The TTL sweep and page-view trigger recover omitted
+// rows.
 func (m *Manager) listGitHubPRRowsByAddress(ctx context.Context, params db.ListGitHubPRRowsByAddressParams) ([]db.ListGitHubPRRowsByAddressRow, error) {
 	return dbreader.Read(
 		ctx,

--- a/server/internal/integrations/ghsnapshot/refresh.go
+++ b/server/internal/integrations/ghsnapshot/refresh.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/dbreader"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -49,10 +50,11 @@ var (
 // PR linking, merge→Done, or any other existing behavior (acceptance
 // criterion 4).
 type Manager struct {
-	client    *Client
-	queries   *db.Queries
-	pool      TxBeginner
-	onApplied func(ctx context.Context, prID pgtype.UUID)
+	client       *Client
+	queries      *db.Queries
+	readSelector *dbreader.Selector
+	pool         TxBeginner
+	onApplied    func(ctx context.Context, prID pgtype.UUID)
 
 	concurrency   int
 	viewTTL       time.Duration
@@ -92,6 +94,7 @@ func NewManager(client *Client, queries *db.Queries, pool TxBeginner, onApplied 
 	return &Manager{
 		client:        client,
 		queries:       queries,
+		readSelector:  dbreader.NewPrimaryOnly(queries),
 		pool:          pool,
 		onApplied:     onApplied,
 		concurrency:   defaultConcurrency,
@@ -109,6 +112,15 @@ func NewManager(client *Client, queries *db.Queries, pool TxBeginner, onApplied 
 		trailing:      map[address]bool{},
 		attempts:      map[address]int{},
 		rateUntil:     map[int64]time.Time{},
+	}
+}
+
+// SetReadSelector opts the refresh worker into the API server's configured
+// replica routing. It must be called before Start; managers used by tests and
+// primary-only deployments retain the safe primary default from NewManager.
+func (m *Manager) SetReadSelector(selector *dbreader.Selector) {
+	if selector != nil {
+		m.readSelector = selector
 	}
 }
 
@@ -234,7 +246,7 @@ func (m *Manager) process(ctx context.Context, addr address) {
 		return
 	}
 
-	rows, err := m.queries.ListGitHubPRRowsByAddress(ctx, db.ListGitHubPRRowsByAddressParams{
+	rows, err := m.listGitHubPRRowsByAddress(ctx, db.ListGitHubPRRowsByAddressParams{
 		InstallationID: addr.InstallationID,
 		RepoOwner:      addr.Owner,
 		RepoName:       addr.Repo,
@@ -276,6 +288,18 @@ func (m *Manager) process(ctx context.Context, addr address) {
 		delete(m.attempts, addr)
 		m.mu.Unlock()
 	}
+}
+
+func (m *Manager) listGitHubPRRowsByAddress(ctx context.Context, params db.ListGitHubPRRowsByAddressParams) ([]db.ListGitHubPRRowsByAddressRow, error) {
+	return dbreader.Read(
+		ctx,
+		m.readSelector,
+		dbreader.BusinessGitHubPRRefresh,
+		dbreader.EventualConsistency,
+		func(ctx context.Context, queries *db.Queries) ([]db.ListGitHubPRRowsByAddressRow, error) {
+			return queries.ListGitHubPRRowsByAddress(ctx, params)
+		},
+	)
 }
 
 func (m *Manager) rateLimitPause(installationID int64) time.Duration {

--- a/server/internal/integrations/ghsnapshot/refresh_test.go
+++ b/server/internal/integrations/ghsnapshot/refresh_test.go
@@ -7,7 +7,39 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/multica-ai/multica/server/internal/dbreader"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
+
+type emptyRows struct{}
+
+func (*emptyRows) Close()                                       {}
+func (*emptyRows) Err() error                                   { return nil }
+func (*emptyRows) CommandTag() pgconn.CommandTag                { return pgconn.NewCommandTag("") }
+func (*emptyRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (*emptyRows) Next() bool                                   { return false }
+func (*emptyRows) Scan(...any) error                            { return nil }
+func (*emptyRows) Values() ([]any, error)                       { return nil, nil }
+func (*emptyRows) RawValues() [][]byte                          { return nil }
+func (*emptyRows) Conn() *pgx.Conn                              { return nil }
+
+type queryCountingDB struct {
+	queries int
+}
+
+func (*queryCountingDB) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.NewCommandTag(""), nil
+}
+
+func (d *queryCountingDB) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	d.queries++
+	return &emptyRows{}, nil
+}
+
+func (*queryCountingDB) QueryRow(context.Context, string, ...any) pgx.Row { return nil }
 
 func enabledClient(t *testing.T) *Client {
 	t.Helper()
@@ -16,6 +48,31 @@ func enabledClient(t *testing.T) *Client {
 		t.Fatal(err)
 	}
 	return &Client{appID: "1", privateKey: key, tokens: map[int64]cachedToken{}, now: time.Now}
+}
+
+func TestListGitHubPRRowsByAddressUsesConfiguredReplica(t *testing.T) {
+	primaryDB := &queryCountingDB{}
+	replicaDB := &queryCountingDB{}
+	primaryQueries := db.New(primaryDB)
+	replicaQueries := db.New(replicaDB)
+	m := NewManager(nil, primaryQueries, nil, nil)
+	m.SetReadSelector(dbreader.New(primaryQueries, replicaQueries, nil))
+
+	rows, err := m.listGitHubPRRowsByAddress(context.Background(), db.ListGitHubPRRowsByAddressParams{
+		InstallationID: 1,
+		RepoOwner:      "owner",
+		RepoName:       "repo",
+		PrNumber:       2,
+	})
+	if err != nil {
+		t.Fatalf("list rows: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("rows = %#v, want empty result", rows)
+	}
+	if primaryDB.queries != 0 || replicaDB.queries != 1 {
+		t.Fatalf("query calls: primary=%d replica=%d, want primary=0 replica=1", primaryDB.queries, replicaDB.queries)
+	}
 }
 
 // TestManagerDisabledNoOps is the clean-degradation guarantee (acceptance


### PR DESCRIPTION
## Summary

- route ListGitHubPRRowsByAddress through the API server read selector
- preserve primary-only defaults and automatic primary fallback when no healthy replica is available
- keep snapshot writes and the TTL sweep query on the primary
- add a regression test proving the lookup uses the configured replica

Closes MUL-7105

## Testing

- go test ./internal/integrations/ghsnapshot -run targeted-refresh-tests -count=1
- go test ./internal/dbreader -count=1
- go test ./cmd/server -run '^TestReplicaPool' -count=1
- go test ./internal/integrations/ghsnapshot ./internal/dbreader ./cmd/server -run '^$' -count=1
- go vet ./internal/integrations/ghsnapshot ./internal/dbreader ./cmd/server

The full local DB-backed suites remain unverified because this checkout's shared test database is behind current migrations (missing columns and stale fixture rows); the targeted tests and compile-only checks pass.