### PR TITLE
MUL-7055: extend search statement timeout to 5 seconds

### DIFF
--- a/server/internal/handler/search.go
+++ b/server/internal/handler/search.go
@@ -169,10 +169,10 @@ func runSearchQuery(
 }
 
 // isSearchStatementTimeout reports whether err is the canonical Postgres
-// query_canceled error (SQLSTATE 57014). Both `SET LOCAL statement_timeout`
-// firing and a client-side context cancellation surface as 57014 — the two
-// are indistinguishable from the client side, which is intentional in the
-// pgx layer.
+// query_canceled error (SQLSTATE 57014) produced when the transaction-local
+// statement timeout fires. A client-side context cancellation surfaces from
+// pgx as context.Canceled instead, so it is intentionally not classified as a
+// database statement timeout here.
 func isSearchStatementTimeout(err error) bool {
 	if err == nil {
 		return false

--- a/server/internal/handler/search.go
+++ b/server/internal/handler/search.go
@@ -25,15 +25,16 @@ import (
 // therefore still make either path slow enough that the frontend appears to
 // hang ("搜索卡死没有任何反应", MUL-4059).
 //
-// The 3 s cap leaves margin above the production-observed candidate-first
-// maximum (1.72 s in the MUL-7055 matrix) and is short enough that the
-// frontend's implicit request timeout (browser default, ~30 s) never kicks in.
-// On timeout the caller sees a 503 with a descriptive error rather than a
-// stalled connection — SearchIssues / SearchProjects map SQLSTATE 57014 to
-// http.StatusServiceUnavailable so the frontend can distinguish this from a
-// generic 500.
+// The 5 s cap leaves headroom above the production-observed candidate-first
+// maximum (1.79 s in the MUL-7055 matrix) while keeping a bounded database
+// safety fuse. Interactive web callers cancel superseded searches, and the
+// mobile API client has a 30 s request timeout, so this remains within the
+// first-party clients' request budgets. On timeout the caller sees a 503 with
+// a descriptive error rather than a stalled connection — SearchIssues /
+// SearchProjects map SQLSTATE 57014 to http.StatusServiceUnavailable so the
+// frontend can distinguish this from a generic 500.
 const (
-	searchStatementTimeout = 3 * time.Second
+	searchStatementTimeout = 5 * time.Second
 
 	searchWorkMemEnv       = "DATABASE_SEARCH_WORK_MEM_MB"
 	defaultSearchWorkMemMB = 64

--- a/server/internal/handler/search_timeout_test.go
+++ b/server/internal/handler/search_timeout_test.go
@@ -59,10 +59,16 @@ func TestParseSearchWorkMemMB(t *testing.T) {
 	}
 }
 
+func TestSearchStatementTimeoutDefault(t *testing.T) {
+	if got, want := searchStatementTimeout, 5*time.Second; got != want {
+		t.Fatalf("searchStatementTimeout = %s, want %s", got, want)
+	}
+}
+
 // TestRunSearchQuery_StatementTimeoutFires exercises the safety net end
 // to end against a live Postgres, proving that a deliberately hung
 // pg_sleep query is cut off by SET LOCAL statement_timeout (SQLSTATE
-// 57014) before the 3 s search cap could ever be reached. Skips
+// 57014) before the production search cap could ever be reached. Skips
 // gracefully if the database is not reachable — mirrors the pattern in
 // handler_test.go so CI without a DB stays green.
 func TestRunSearchQuery_StatementTimeoutFires(t *testing.T) {

--- a/server/internal/handler/search_timeout_test.go
+++ b/server/internal/handler/search_timeout_test.go
@@ -59,12 +59,6 @@ func TestParseSearchWorkMemMB(t *testing.T) {
 	}
 }
 
-func TestSearchStatementTimeoutDefault(t *testing.T) {
-	if got, want := searchStatementTimeout, 5*time.Second; got != want {
-		t.Fatalf("searchStatementTimeout = %s, want %s", got, want)
-	}
-}
-
 // TestRunSearchQuery_StatementTimeoutFires exercises the safety net end
 // to end against a live Postgres, proving that a deliberately hung
 // pg_sleep query is cut off by SET LOCAL statement_timeout (SQLSTATE


### PR DESCRIPTION
Closes MUL-7055

## Summary

- raise the transaction-local PostgreSQL timeout shared by issue and project search from 3 seconds to 5 seconds
- correct the timeout comments to reflect the actual web/mobile request budgets and distinguish client cancellation from PostgreSQL statement timeout
- keep the existing behavior-level timeout and error-classification coverage without adding a literal-value assertion

No new environment variable or deployment configuration is introduced.

## Production evidence

An independent read-only check on the MUL-7055 production benchmark workspace ran the four-term, zero-result query `2026 Weekly Sprint 36` through the merged candidate-first SQL five times in 1.66–1.80 seconds with no 3-second timeout. The legacy SQL timed out at 3 seconds and completed in 11.09 seconds only after its cap was raised. A 5-second cap therefore adds about 3.2 seconds of headroom over the slowest warm single-concurrency candidate-first sample while retaining a bounded database fuse.

## Validation

- `go test ./internal/handler -run 'Test(IsSearchStatementTimeout|RunSearchQuery_StatementTimeoutFires)$' -count=1 -v`
- `go vet ./internal/handler`
- `go build ./...`
- `git diff --check`

The full `go test ./internal/handler -count=1` run was also attempted locally, but this checkout's database is behind `main` and unrelated database-backed cases fail on missing columns such as `conversation_starters` and `durable_work_dir`. Independent review ran the full handler package against a freshly migrated PostgreSQL database successfully; CI also runs it against a clean database.

## Risk and rollback

Slow or overloaded searches may hold a database connection for up to two seconds longer before returning 503. The timeout remains transaction-local and bounded; rollback is a single commit revert.
