### PR TITLE
MUL-7107 fix(agents): put agent detail on one leading edge

### DIFF
--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -56,8 +56,9 @@ import {
   DropdownMenuTrigger,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { cn } from "@multica/ui/lib/utils";
 import { AppLink, useNavigation } from "../../navigation";
-import { PageHeader } from "../../layout/page-header";
+import { PAGE_GUTTER, PageHeader } from "../../layout/page-header";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { AgentPresenceIndicator } from "./agent-presence-indicator";
 import { VisibilityBadge } from "./visibility-badge";
@@ -357,7 +358,7 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
       />
 
       {!canEdit.allowed && (
-        <div className="px-6 pt-3">
+        <div className={cn(PAGE_GUTTER, "pt-3")}>
           <CapabilityBanner
             reason={canEdit.reason}
             resource="agent"
@@ -367,7 +368,12 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
       )}
 
       {isArchived && (
-        <div className="flex shrink-0 items-center gap-2 border-b bg-muted/50 px-6 py-2 text-caption text-muted-foreground">
+        <div
+          className={cn(
+            "flex shrink-0 items-center gap-2 border-b bg-muted/50 py-2 text-caption text-muted-foreground",
+            PAGE_GUTTER,
+          )}
+        >
           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
           <span className="flex-1">
             {t(($) => $.detail.archived_banner)}
@@ -386,7 +392,12 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
       )}
 
       {!isArchived && !runtimeBound && (
-        <div className="flex shrink-0 items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-6 py-2 text-caption text-amber-900 dark:text-amber-100">
+        <div
+          className={cn(
+            "flex shrink-0 items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 py-2 text-caption text-amber-900 dark:text-amber-100",
+            PAGE_GUTTER,
+          )}
+        >
           <Server className="h-3.5 w-3.5 shrink-0" />
           <span className="flex-1">
             {t(($) => $.detail.runtime_required_banner)}
@@ -500,106 +511,106 @@ function DetailHeader({
   const hasMoreActions = !!onArchive;
 
   return (
-    <header className="shrink-0 border-b bg-background px-4 pb-5 pt-3 sm:px-6">
-      <div className="mx-auto max-w-[1440px]">
-        <div className="flex min-w-0 items-center gap-1.5 text-caption text-muted-foreground">
-          <AppLink
-            href={backHref}
-            className="rounded-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            {t(($) => $.page.title)}
-          </AppLink>
-          <span aria-hidden="true">/</span>
-          <span className="truncate text-foreground">{agent.name}</span>
-        </div>
+    <header
+      className={cn("shrink-0 border-b bg-background pb-5 pt-3", PAGE_GUTTER)}
+    >
+      <div className="flex min-w-0 items-center gap-1.5 text-caption text-muted-foreground">
+        <AppLink
+          href={backHref}
+          className="rounded-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {t(($) => $.page.title)}
+        </AppLink>
+        <span aria-hidden="true">/</span>
+        <span className="truncate text-foreground">{agent.name}</span>
+      </div>
 
-        <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="flex min-w-0 items-start gap-4">
-            <ActorAvatar
-              actorType="agent"
-              actorId={agent.id}
-              size="2xl"
-              profileLink={false}
-              className="ring-1 ring-border"
-            />
-            <div className="min-w-0 pt-0.5">
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
-                <h1 className="min-w-0 text-balance text-title-lg font-semibold tracking-tight sm:text-display-sm">
-                  {agent.name}
-                </h1>
-                <AgentPresenceIndicator detail={presence} />
-              </div>
-              <ExpandableDescription>
-                {agent.description ||
-                  t(($) => $.inspector.no_description_placeholder)}
-              </ExpandableDescription>
-              <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-caption text-muted-foreground">
-                <span className="inline-flex min-w-0 items-center gap-1.5">
-                  <Bot className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                  <span className="truncate">{agent.model || t(($) => $.pickers.model_default)}</span>
+      <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex min-w-0 items-start gap-4">
+          <ActorAvatar
+            actorType="agent"
+            actorId={agent.id}
+            size="2xl"
+            profileLink={false}
+            className="ring-1 ring-border"
+          />
+          <div className="min-w-0 pt-0.5">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+              <h1 className="min-w-0 text-balance text-title-lg font-semibold tracking-tight sm:text-display-sm">
+                {agent.name}
+              </h1>
+              <AgentPresenceIndicator detail={presence} />
+            </div>
+            <ExpandableDescription>
+              {agent.description ||
+                t(($) => $.inspector.no_description_placeholder)}
+            </ExpandableDescription>
+            <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-caption text-muted-foreground">
+              <span className="inline-flex min-w-0 items-center gap-1.5">
+                <Bot className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <span className="truncate">{agent.model || t(($) => $.pickers.model_default)}</span>
+              </span>
+              <span className="inline-flex min-w-0 items-center gap-1.5">
+                <Server className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <span className="truncate">
+                  {runtime
+                    ? runtimeDisplayLabel(runtime)
+                    : t(($) => $.pickers.runtime_none)}
                 </span>
-                <span className="inline-flex min-w-0 items-center gap-1.5">
-                  <Server className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                  <span className="truncate">
-                    {runtime
-                      ? runtimeDisplayLabel(runtime)
-                      : t(($) => $.pickers.runtime_none)}
-                  </span>
-                </span>
-                <VisibilityBadge value={agent.visibility} />
-                <span className="inline-flex items-center gap-1.5">
-                  <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
-                  {t(($) => $.detail.updated, { when: timeAgo(agent.updated_at) })}
-                </span>
-              </div>
+              </span>
+              <VisibilityBadge value={agent.visibility} />
+              <span className="inline-flex items-center gap-1.5">
+                <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+                {t(($) => $.detail.updated, { when: timeAgo(agent.updated_at) })}
+              </span>
             </div>
           </div>
+        </div>
 
-          <div className="flex shrink-0 items-center gap-2 self-end lg:self-start">
-            {!isArchived && (
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={dmPending}
-                // An anchor never matches `:disabled`, so the base variant's
-                // `disabled:` rules never fire here — Base UI's data-disabled
-                // is what carries the dimmed, inert look.
-                className="data-disabled:pointer-events-none data-disabled:opacity-50"
-                render={<AppLink href={dmHref} onClick={onDm} />}
-                nativeButton={false}
+        <div className="flex shrink-0 items-center gap-2 self-end lg:self-start">
+          {!isArchived && (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={dmPending}
+              // An anchor never matches `:disabled`, so the base variant's
+              // `disabled:` rules never fire here — Base UI's data-disabled
+              // is what carries the dimmed, inert look.
+              className="data-disabled:pointer-events-none data-disabled:opacity-50"
+              render={<AppLink href={dmHref} onClick={onDm} />}
+              nativeButton={false}
+            >
+              <MessageSquare className="h-4 w-4" aria-hidden="true" />
+              {t(($) => $.detail.dm)}
+            </Button>
+          )}
+          {!isArchived && canAssign && (
+            <Button type="button" size="sm" onClick={onAssign}>
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              {t(($) => $.detail.assign_work)}
+            </Button>
+          )}
+          {!isArchived && canArchive && hasMoreActions ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={<Button variant="ghost" size="icon-sm" />}
+                aria-label={t(($) => $.detail.more_actions_aria)}
               >
-                <MessageSquare className="h-4 w-4" aria-hidden="true" />
-                {t(($) => $.detail.dm)}
-              </Button>
-            )}
-            {!isArchived && canAssign && (
-              <Button type="button" size="sm" onClick={onAssign}>
-                <Plus className="h-4 w-4" aria-hidden="true" />
-                {t(($) => $.detail.assign_work)}
-              </Button>
-            )}
-            {!isArchived && canArchive && hasMoreActions ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={<Button variant="ghost" size="icon-sm" />}
-                  aria-label={t(($) => $.detail.more_actions_aria)}
-                >
-                  <MoreHorizontal
-                    className="h-4 w-4 text-muted-foreground"
-                    aria-hidden="true"
-                  />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-auto">
-                  {onArchive && (
-                    <DropdownMenuItem variant="destructive" onClick={onArchive}>
-                      <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-                      {t(($) => $.detail.more_archive)}
-                    </DropdownMenuItem>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : null}
-          </div>
+                <MoreHorizontal
+                  className="h-4 w-4 text-muted-foreground"
+                  aria-hidden="true"
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-auto">
+                {onArchive && (
+                  <DropdownMenuItem variant="destructive" onClick={onArchive}>
+                    <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                    {t(($) => $.detail.more_archive)}
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
         </div>
       </div>
     </header>
@@ -623,7 +634,7 @@ function BackHeader({ paths, title }: { paths: string; title: string }) {
 function DetailLoadingSkeleton() {
   return (
     <div className="flex flex-1 min-h-0 flex-col">
-      <div className="shrink-0 border-b px-6 pb-5 pt-3">
+      <div className={cn("shrink-0 border-b pb-5 pt-3", PAGE_GUTTER)}>
         <Skeleton className="h-4 w-48" />
         <div className="mt-4 flex items-start gap-4">
           <Skeleton className="h-14 w-14 rounded-full" />
@@ -634,7 +645,7 @@ function DetailLoadingSkeleton() {
           </div>
         </div>
       </div>
-      <div className="flex flex-1 flex-col p-6">
+      <div className={cn("flex flex-1 flex-col py-6", PAGE_GUTTER)}>
         <Skeleton className="h-9 w-96" />
         <div className="mt-6 grid flex-1 gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
           <div className="space-y-5">

--- a/packages/views/agents/components/agent-overview-pane.test.tsx
+++ b/packages/views/agents/components/agent-overview-pane.test.tsx
@@ -11,6 +11,7 @@ import {
   NavigationProvider,
   type NavigationAdapter,
 } from "../../navigation";
+import { PAGE_GUTTER } from "../../layout/page-header";
 
 const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
 
@@ -276,5 +277,48 @@ describe("AgentOverviewPane Environment tab visibility", () => {
     expect(
       screen.queryByRole("tab", { name: /^Environment$/i }),
     ).not.toBeInTheDocument();
+  });
+});
+
+// MUL-7107: the header, the tab bar and every panel share one leading edge.
+// The regression these guard against is a centred width cap: `mx-auto` plus a
+// `max-w-*` moves an element's edge as the viewport grows, so chrome on a
+// centred rail and a panel on the page gutter agreed at 1440px and drifted
+// hundreds of pixels apart above it. A cap must be anchored, never centred.
+describe("AgentOverviewPane horizontal alignment", () => {
+  const centredCap = (root: HTMLElement) =>
+    Array.from(root.querySelectorAll<HTMLElement>(".mx-auto")).filter((el) =>
+      Array.from(el.classList).some((c) => c.startsWith("max-w-")),
+    );
+
+  it("puts the tab bar on the shared page gutter, not a centred rail", () => {
+    const { container } = renderPane([makeRuntime("claude")]);
+    const tablist = container.querySelector('[role="tablist"]');
+
+    expect(tablist).toHaveClass(PAGE_GUTTER);
+    expect(centredCap(container as HTMLElement)).toEqual([]);
+  });
+
+  it("starts the Overview panel on that same gutter", () => {
+    const { container } = renderPane([makeRuntime("claude")]);
+    const tablist = container.querySelector('[role="tablist"]');
+    const panel = tablist?.nextElementSibling?.firstElementChild;
+
+    expect(panel).toHaveClass(PAGE_GUTTER);
+    expect(panel).not.toHaveClass("mx-auto");
+  });
+
+  it.each([
+    ["Capabilities", openCapabilities],
+    ["Settings", openSettings],
+  ])("starts the %s nav rail on that same gutter", (_name, open) => {
+    const { container } = renderPane([makeRuntime("claude")]);
+    open();
+
+    // The rail is the leftmost thing in these panels, so it — not the content
+    // pane behind it — is what has to line up with the tabs above.
+    const rail = container.querySelector("aside");
+    expect(rail).toHaveClass(PAGE_GUTTER);
+    expect(centredCap(container as HTMLElement)).toEqual([]);
   });
 });

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -27,6 +27,7 @@ import {
   AlertDialogTitle,
 } from "@multica/ui/components/ui/alert-dialog";
 import { cn } from "@multica/ui/lib/utils";
+import { PAGE_GUTTER } from "../../layout/page-header";
 import { ActivityTab } from "./tabs/activity-tab";
 import { InstructionsTab } from "./tabs/instructions-tab";
 import { SkillsTab } from "./tabs/skills-tab";
@@ -327,11 +328,11 @@ export function AgentOverviewPane({
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
       <div
-        className="shrink-0 overflow-x-auto border-b px-4 sm:px-6"
+        className={cn("shrink-0 overflow-x-auto border-b", PAGE_GUTTER)}
         role="tablist"
         aria-label={t(($) => $.tabs.page_navigation_aria)}
       >
-        <div className="mx-auto flex max-w-[1440px] items-center gap-6">
+        <div className="flex items-center gap-6">
           {TOP_TABS.map((tab) => (
             <button
               key={tab.id}
@@ -352,7 +353,16 @@ export function AgentOverviewPane({
         </div>
       </div>
 
-      {/* Overview/Work scroll as one page. Sidebar views split scrolling on
+      {/* One leading edge for the whole page: the header, the tab bar and
+          every panel start at PAGE_GUTTER (MUL-7107). The chrome used to sit
+          on a centred `max-w-[1440px]` rail while the panels did not, so above
+          ~1730px the tabs walked right and left the content behind them.
+
+          A panel caps its width by anchoring, never by centring — a centred cap
+          drifts away from that edge as the window grows. Lists stay full-bleed
+          (an issue table wants the width); reading and form content takes a cap.
+
+          Overview/Work scroll as one page. Sidebar views split scrolling on
           md+ (nav rail pinned, content pane scrolls) like settings-page.tsx;
           below md the rail is a horizontal strip and the page scrolls whole. */}
       <div
@@ -362,7 +372,12 @@ export function AgentOverviewPane({
         )}
       >
         {effectiveView === "overview" && (
-          <div className="mx-auto max-w-[1440px] p-4 sm:p-6">
+          <div
+            className={cn(
+              "w-full max-w-[1440px] py-4 sm:py-6",
+              PAGE_GUTTER,
+            )}
+          >
             <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
               <ActivityTab agent={agent} showPerformance={false} />
               <AgentOverviewSummary
@@ -384,7 +399,12 @@ export function AgentOverviewPane({
           <div className="flex min-h-full flex-col md:h-full md:flex-row">
             {/* Content-surface color, no shell tint — same rule as the settings
                 nav: in-card panels must not break the desktop tab merge (MUL-4439). */}
-            <aside className="shrink-0 overflow-x-auto border-b border-surface-border p-2 md:w-52 md:overflow-y-auto md:border-b-0 md:border-r md:p-4">
+            <aside
+              className={cn(
+                "shrink-0 overflow-x-auto border-b border-surface-border py-2 md:w-52 md:overflow-y-auto md:border-b-0 md:border-r md:py-4",
+                PAGE_GUTTER,
+              )}
+            >
               <div
                 className="flex w-max min-w-full items-center gap-1 md:w-full md:flex-col md:items-stretch"
                 role="tablist"
@@ -415,7 +435,7 @@ export function AgentOverviewPane({
             </aside>
 
             <section className="min-w-0 flex-1 md:overflow-y-auto">
-              <div className="mx-auto w-full max-w-3xl p-4 sm:p-6 md:p-8">
+              <div className="w-full max-w-3xl p-4 sm:p-6 md:p-8">
                 <header>
                   <h2 className="text-title-sm font-medium text-balance">
                     {t(($) => $.tabs[activeSecondaryTab.labelKey])}

--- a/packages/views/common/actor-issues-panel.test.tsx
+++ b/packages/views/common/actor-issues-panel.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../locales/en/common.json";
+import enIssues from "../locales/en/issues.json";
+import { ActorIssuesPanel } from "./actor-issues-panel";
+
+// The gutter is overridden with a sentinel rather than compared against the
+// real constant. `PAGE_GUTTER` is `px-4` today, so asserting the real value
+// would pass just as happily against a hand-spelled `px-4` — the very thing
+// this guards. Only a component that reads the constant picks the sentinel up.
+const SENTINEL_GUTTER = "px-[13px]";
+vi.mock("../layout/page-header", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../layout/page-header")>()),
+  PAGE_GUTTER: "px-[13px]",
+}));
+
+// MUL-7107: this toolbar is the leading edge the agent detail tab bar has to
+// line up with, but it lives here rather than in the pane, and the pane's own
+// suite mocks this component out. Without an assertion here the shared gutter
+// is unasserted anywhere, which is how the toolbar came to spell its own
+// `px-4` and stayed aligned only by coincidence.
+//
+// IssueSurface is stubbed down to its renderHeader slot so the real
+// ActorIssuesHeader renders without the query/api layer; the toolbar's own
+// heavy children are stubbed for the same reason.
+vi.mock("../issues/surface/issue-surface", () => ({
+  IssueSurface: ({
+    renderHeader,
+  }: {
+    renderHeader?: (ctx: { controller: unknown }) => React.ReactNode;
+  }) => (
+    <div>
+      {renderHeader?.({
+        controller: {
+          surfaceIssues: [],
+          isRefreshing: false,
+          facetCountsExact: true,
+          tableFacetCounts: undefined,
+          setActiveTableFacet: vi.fn(),
+        },
+      })}
+    </div>
+  ),
+}));
+vi.mock("../issues/components/issues-header", () => ({
+  IssueDisplayControls: () => <div>display-controls</div>,
+  ViewRefreshIndicator: () => <div>refresh-indicator</div>,
+}));
+vi.mock("../issues/components/filter-chips-bar", () => ({
+  FilterChipsBar: () => <div>filter-chips-bar</div>,
+}));
+
+const TEST_RESOURCES = { en: { common: enCommon, issues: enIssues } };
+
+describe("ActorIssuesPanel toolbar alignment", () => {
+  it("reads the shared page gutter instead of spelling its own", () => {
+    const { container } = render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <ActorIssuesPanel actorType="agent" actorId="agent-1" />
+      </I18nProvider>,
+    );
+
+    const toolbar = container.querySelector("div.border-b");
+    expect(toolbar).toBeTruthy();
+    expect(toolbar).toHaveClass(SENTINEL_GUTTER);
+  });
+});

--- a/packages/views/common/actor-issues-panel.tsx
+++ b/packages/views/common/actor-issues-panel.tsx
@@ -13,6 +13,7 @@ import {
   type ActorIssuesScope,
 } from "@multica/core/issues/stores/actor-issues-view-store";
 import { Button } from "@multica/ui/components/ui/button";
+import { cn } from "@multica/ui/lib/utils";
 import { Input } from "@multica/ui/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@multica/ui/components/ui/tooltip";
 import {
@@ -22,6 +23,7 @@ import {
 import { FilterChipsBar } from "../issues/components/filter-chips-bar";
 import { IssueSurface } from "../issues/surface/issue-surface";
 import { useT } from "../i18n";
+import { PAGE_GUTTER } from "../layout/page-header";
 
 export type TaskActorType = "member" | "agent";
 
@@ -52,7 +54,12 @@ function ActorIssuesHeader({
 
   return (
     <>
-    <div className="flex h-12 shrink-0 items-center justify-between gap-3 border-b px-4">
+    <div
+      className={cn(
+        "flex h-12 shrink-0 items-center justify-between gap-3 border-b",
+        PAGE_GUTTER,
+      )}
+    >
       <div className="flex items-center gap-3">
         <div className="relative">
           <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />


### PR DESCRIPTION
## Problem

The agent detail header and tab bar sat on a centred `mx-auto max-w-[1440px]` rail while the panels under them did not. Below ~1490px of content width the rail is wider than the viewport, so nothing moves; above it the rail starts shrinking inward and the tabs walk right, away from everything they label.

Measured on the real page (Playwright, offsets relative to the content region's leading edge):

| viewport | tabs | Work toolbar | Settings sub-nav |
|---|---|---|---|
| 768–1728px | 24px | 16px | 16px |
| 2200px | **248px** | 16px | 16px |

So the tabs were 8px off their own content at every width from `sm` up, and 232px off at 2200px. The Settings form was worse in the other direction: `mx-auto max-w-3xl` centred it in the space left beside its nav rail, so it drifted right as the window grew, leaving ~470px of dead space between the nav and the form.

## Approach

Drop the rail from the chrome rather than extending it to the panels.

Every issue list in the product — Issues, My Issues, project detail, member detail — is full-bleed on `PAGE_GUTTER`, and member detail is the Work tab's structural twin (same header + `ActorIssuesPanel`, no rail). The gutter is the edge the rest of the product already agrees on. Moving the panels onto the rail instead would have put a 1440px cap on an issue table that has one nowhere else, and pushed the settings nav 232px right of the identical nav in workspace settings.

`max-w-[1440px]` appears 10 times in 4 files and is not a global convention; no tab panel anywhere used it except this page's Overview.

## Changes

- **`agent-detail-page.tsx`** — the header reads `PAGE_GUTTER` instead of `px-4 sm:px-6` + rail; the wrapper `div` the rail lived in is gone. The three banners and the loading skeleton move off their own bare `px-6` onto the same constant.
- **`agent-overview-pane.tsx`** — the tab bar reads `PAGE_GUTTER`. Overview keeps `max-w-[1440px]` but anchored rather than centred. The Capabilities/Settings nav rail reads `PAGE_GUTTER`; its content pane drops `mx-auto` so it left-aligns behind the rail.

Panels keep their own width discipline, but the rule is now **a cap is anchored, never centred** — a centred cap is exactly the drift this fixes. Lists stay full-bleed; reading and form content takes a cap.

## Side effects worth knowing

This also moves the page's gutter from 24px to 16px at `sm` and up. That is a convergence, not a regression: `PAGE_GUTTER` is `px-4`, and Issues/Inbox/Chat all use it through `PageHeader`, so navigating from Issues into an agent detail page previously shifted the title 8px. Two smaller pre-existing edges are folded in for the same reason — Overview was 24px off (it put the gutter inside the rail while the chrome put it outside), and the banners/skeleton were on a third edge, so the title jumped when the page loaded or a banner appeared.

## Verification

- `pnpm typecheck` — 9/9 packages.
- `pnpm lint --filter=@multica/views` — 0 errors (26 pre-existing warnings in billing/runtimes).
- `pnpm vitest run packages/views/agents packages/views/layout` — 60 files, 503 tests.
- 4 new regression tests in `agent-overview-pane.test.tsx`. Their core assertion is that no element in the pane combines `mx-auto` with a `max-w-*` cap, because that combination is the drift mechanism. Confirmed all 4 fail against the pre-fix files, so they are not permanently green.
- Leading edges measured in a browser at 390 / 768 / 1024 / 1280 / 1440 / 1728 / 2200px before and after. After: the tabs, the Overview content, the Work toolbar and the Capabilities/Settings nav all sit at 16px at every width. At 390px the secondary nav moves 8px → 16px (it was on `p-2`) and now matches the tabs; nothing else changes below `sm`.

## Not included

`skill-detail-page.tsx` has the identical defect — rail on the chrome, neither panel following it — and is deliberately left for a separate change.
