### PR TITLE
MUL-7107 fix(views): put detail pages on one shared rail

### DIFF
--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -369,43 +369,43 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
 
       {isArchived && (
         <div className="shrink-0 border-b bg-muted/50 py-2 text-caption text-muted-foreground">
-        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-center gap-2")}>
-          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-          <span className="flex-1">
-            {t(($) => $.detail.archived_banner)}
-          </span>
-          {canEdit.allowed && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-6 text-caption"
-              onClick={() => handleRestore(agent.id)}
-            >
-              {t(($) => $.detail.restore)}
-            </Button>
-          )}
-        </div>
+          <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-center gap-2")}>
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            <span className="flex-1">
+              {t(($) => $.detail.archived_banner)}
+            </span>
+            {canEdit.allowed && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-6 text-caption"
+                onClick={() => handleRestore(agent.id)}
+              >
+                {t(($) => $.detail.restore)}
+              </Button>
+            )}
+          </div>
         </div>
       )}
 
       {!isArchived && !runtimeBound && (
         <div className="shrink-0 border-b border-amber-500/30 bg-amber-500/10 py-2 text-caption text-amber-900 dark:text-amber-100">
-        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-center gap-2")}>
-          <Server className="h-3.5 w-3.5 shrink-0" />
-          <span className="flex-1">
-            {t(($) => $.detail.runtime_required_banner)}
-          </span>
-          {canEdit.allowed && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-6 border-amber-500/40 bg-background/70 text-caption"
-              onClick={() => setTabNavIntent("general")}
-            >
-              {t(($) => $.detail.bind_runtime)}
-            </Button>
-          )}
-        </div>
+          <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-center gap-2")}>
+            <Server className="h-3.5 w-3.5 shrink-0" />
+            <span className="flex-1">
+              {t(($) => $.detail.runtime_required_banner)}
+            </span>
+            {canEdit.allowed && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-6 border-amber-500/40 bg-background/70 text-caption"
+                onClick={() => setTabNavIntent("general")}
+              >
+                {t(($) => $.detail.bind_runtime)}
+              </Button>
+            )}
+          </div>
         </div>
       )}
 
@@ -509,105 +509,105 @@ function DetailHeader({
       className="shrink-0 border-b bg-background pb-5 pt-3"
     >
       <div className={cn(PAGE_RAIL, PAGE_GUTTER)}>
-      <div className="flex min-w-0 items-center gap-1.5 text-caption text-muted-foreground">
-        <AppLink
-          href={backHref}
-          className="rounded-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          {t(($) => $.page.title)}
-        </AppLink>
-        <span aria-hidden="true">/</span>
-        <span className="truncate text-foreground">{agent.name}</span>
-      </div>
+        <div className="flex min-w-0 items-center gap-1.5 text-caption text-muted-foreground">
+          <AppLink
+            href={backHref}
+            className="rounded-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t(($) => $.page.title)}
+          </AppLink>
+          <span aria-hidden="true">/</span>
+          <span className="truncate text-foreground">{agent.name}</span>
+        </div>
 
-      <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex min-w-0 items-start gap-4">
-          <ActorAvatar
-            actorType="agent"
-            actorId={agent.id}
-            size="2xl"
-            profileLink={false}
-            className="ring-1 ring-border"
-          />
-          <div className="min-w-0 pt-0.5">
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
-              <h1 className="min-w-0 text-balance text-title-lg font-semibold tracking-tight sm:text-display-sm">
-                {agent.name}
-              </h1>
-              <AgentPresenceIndicator detail={presence} />
-            </div>
-            <ExpandableDescription>
-              {agent.description ||
-                t(($) => $.inspector.no_description_placeholder)}
-            </ExpandableDescription>
-            <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-caption text-muted-foreground">
-              <span className="inline-flex min-w-0 items-center gap-1.5">
-                <Bot className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                <span className="truncate">{agent.model || t(($) => $.pickers.model_default)}</span>
-              </span>
-              <span className="inline-flex min-w-0 items-center gap-1.5">
-                <Server className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                <span className="truncate">
-                  {runtime
-                    ? runtimeDisplayLabel(runtime)
-                    : t(($) => $.pickers.runtime_none)}
+        <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex min-w-0 items-start gap-4">
+            <ActorAvatar
+              actorType="agent"
+              actorId={agent.id}
+              size="2xl"
+              profileLink={false}
+              className="ring-1 ring-border"
+            />
+            <div className="min-w-0 pt-0.5">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+                <h1 className="min-w-0 text-balance text-title-lg font-semibold tracking-tight sm:text-display-sm">
+                  {agent.name}
+                </h1>
+                <AgentPresenceIndicator detail={presence} />
+              </div>
+              <ExpandableDescription>
+                {agent.description ||
+                  t(($) => $.inspector.no_description_placeholder)}
+              </ExpandableDescription>
+              <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-caption text-muted-foreground">
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <Bot className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  <span className="truncate">{agent.model || t(($) => $.pickers.model_default)}</span>
                 </span>
-              </span>
-              <VisibilityBadge value={agent.visibility} />
-              <span className="inline-flex items-center gap-1.5">
-                <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
-                {t(($) => $.detail.updated, { when: timeAgo(agent.updated_at) })}
-              </span>
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <Server className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  <span className="truncate">
+                    {runtime
+                      ? runtimeDisplayLabel(runtime)
+                      : t(($) => $.pickers.runtime_none)}
+                  </span>
+                </span>
+                <VisibilityBadge value={agent.visibility} />
+                <span className="inline-flex items-center gap-1.5">
+                  <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+                  {t(($) => $.detail.updated, { when: timeAgo(agent.updated_at) })}
+                </span>
+              </div>
             </div>
           </div>
-        </div>
 
-        <div className="flex shrink-0 items-center gap-2 self-end lg:self-start">
-          {!isArchived && (
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={dmPending}
-              // An anchor never matches `:disabled`, so the base variant's
-              // `disabled:` rules never fire here — Base UI's data-disabled
-              // is what carries the dimmed, inert look.
-              className="data-disabled:pointer-events-none data-disabled:opacity-50"
-              render={<AppLink href={dmHref} onClick={onDm} />}
-              nativeButton={false}
-            >
-              <MessageSquare className="h-4 w-4" aria-hidden="true" />
-              {t(($) => $.detail.dm)}
-            </Button>
-          )}
-          {!isArchived && canAssign && (
-            <Button type="button" size="sm" onClick={onAssign}>
-              <Plus className="h-4 w-4" aria-hidden="true" />
-              {t(($) => $.detail.assign_work)}
-            </Button>
-          )}
-          {!isArchived && canArchive && hasMoreActions ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={<Button variant="ghost" size="icon-sm" />}
-                aria-label={t(($) => $.detail.more_actions_aria)}
+          <div className="flex shrink-0 items-center gap-2 self-end lg:self-start">
+            {!isArchived && (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={dmPending}
+                // An anchor never matches `:disabled`, so the base variant's
+                // `disabled:` rules never fire here — Base UI's data-disabled
+                // is what carries the dimmed, inert look.
+                className="data-disabled:pointer-events-none data-disabled:opacity-50"
+                render={<AppLink href={dmHref} onClick={onDm} />}
+                nativeButton={false}
               >
-                <MoreHorizontal
-                  className="h-4 w-4 text-muted-foreground"
-                  aria-hidden="true"
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-auto">
-                {onArchive && (
-                  <DropdownMenuItem variant="destructive" onClick={onArchive}>
-                    <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-                    {t(($) => $.detail.more_archive)}
-                  </DropdownMenuItem>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : null}
+                <MessageSquare className="h-4 w-4" aria-hidden="true" />
+                {t(($) => $.detail.dm)}
+              </Button>
+            )}
+            {!isArchived && canAssign && (
+              <Button type="button" size="sm" onClick={onAssign}>
+                <Plus className="h-4 w-4" aria-hidden="true" />
+                {t(($) => $.detail.assign_work)}
+              </Button>
+            )}
+            {!isArchived && canArchive && hasMoreActions ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={<Button variant="ghost" size="icon-sm" />}
+                  aria-label={t(($) => $.detail.more_actions_aria)}
+                >
+                  <MoreHorizontal
+                    className="h-4 w-4 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-auto">
+                  {onArchive && (
+                    <DropdownMenuItem variant="destructive" onClick={onArchive}>
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      {t(($) => $.detail.more_archive)}
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
+          </div>
         </div>
-      </div>
       </div>
     </header>
   );
@@ -632,15 +632,15 @@ function DetailLoadingSkeleton() {
     <div className="flex flex-1 min-h-0 flex-col">
       <div className="shrink-0 border-b pb-5 pt-3">
         <div className={cn(PAGE_RAIL, PAGE_GUTTER)}>
-        <Skeleton className="h-4 w-48" />
-        <div className="mt-4 flex items-start gap-4">
-          <Skeleton className="h-14 w-14 rounded-full" />
-          <div className="flex-1 space-y-3">
-            <Skeleton className="h-7 w-64" />
-            <Skeleton className="h-4 w-full max-w-xl" />
-            <Skeleton className="h-4 w-full max-w-lg" />
+          <Skeleton className="h-4 w-48" />
+          <div className="mt-4 flex items-start gap-4">
+            <Skeleton className="h-14 w-14 rounded-full" />
+            <div className="flex-1 space-y-3">
+              <Skeleton className="h-7 w-64" />
+              <Skeleton className="h-4 w-full max-w-xl" />
+              <Skeleton className="h-4 w-full max-w-lg" />
+            </div>
           </div>
-        </div>
         </div>
       </div>
       <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex flex-1 flex-col py-6")}>

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -58,7 +58,7 @@ import {
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { cn } from "@multica/ui/lib/utils";
 import { AppLink, useNavigation } from "../../navigation";
-import { PAGE_GUTTER, PageHeader } from "../../layout/page-header";
+import { PAGE_GUTTER, PAGE_RAIL, PageHeader } from "../../layout/page-header";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { AgentPresenceIndicator } from "./agent-presence-indicator";
 import { VisibilityBadge } from "./visibility-badge";
@@ -358,7 +358,7 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
       />
 
       {!canEdit.allowed && (
-        <div className={cn(PAGE_GUTTER, "pt-3")}>
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "pt-3")}>
           <CapabilityBanner
             reason={canEdit.reason}
             resource="agent"
@@ -368,12 +368,8 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
       )}
 
       {isArchived && (
-        <div
-          className={cn(
-            "flex shrink-0 items-center gap-2 border-b bg-muted/50 py-2 text-caption text-muted-foreground",
-            PAGE_GUTTER,
-          )}
-        >
+        <div className="shrink-0 border-b bg-muted/50 py-2 text-caption text-muted-foreground">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-center gap-2")}>
           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
           <span className="flex-1">
             {t(($) => $.detail.archived_banner)}
@@ -389,15 +385,12 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
             </Button>
           )}
         </div>
+        </div>
       )}
 
       {!isArchived && !runtimeBound && (
-        <div
-          className={cn(
-            "flex shrink-0 items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 py-2 text-caption text-amber-900 dark:text-amber-100",
-            PAGE_GUTTER,
-          )}
-        >
+        <div className="shrink-0 border-b border-amber-500/30 bg-amber-500/10 py-2 text-caption text-amber-900 dark:text-amber-100">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-center gap-2")}>
           <Server className="h-3.5 w-3.5 shrink-0" />
           <span className="flex-1">
             {t(($) => $.detail.runtime_required_banner)}
@@ -412,6 +405,7 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
               {t(($) => $.detail.bind_runtime)}
             </Button>
           )}
+        </div>
         </div>
       )}
 
@@ -512,8 +506,9 @@ function DetailHeader({
 
   return (
     <header
-      className={cn("shrink-0 border-b bg-background pb-5 pt-3", PAGE_GUTTER)}
+      className="shrink-0 border-b bg-background pb-5 pt-3"
     >
+      <div className={cn(PAGE_RAIL, PAGE_GUTTER)}>
       <div className="flex min-w-0 items-center gap-1.5 text-caption text-muted-foreground">
         <AppLink
           href={backHref}
@@ -613,6 +608,7 @@ function DetailHeader({
           ) : null}
         </div>
       </div>
+      </div>
     </header>
   );
 }
@@ -634,7 +630,8 @@ function BackHeader({ paths, title }: { paths: string; title: string }) {
 function DetailLoadingSkeleton() {
   return (
     <div className="flex flex-1 min-h-0 flex-col">
-      <div className={cn("shrink-0 border-b pb-5 pt-3", PAGE_GUTTER)}>
+      <div className="shrink-0 border-b pb-5 pt-3">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER)}>
         <Skeleton className="h-4 w-48" />
         <div className="mt-4 flex items-start gap-4">
           <Skeleton className="h-14 w-14 rounded-full" />
@@ -644,8 +641,9 @@ function DetailLoadingSkeleton() {
             <Skeleton className="h-4 w-full max-w-lg" />
           </div>
         </div>
+        </div>
       </div>
-      <div className={cn("flex flex-1 flex-col py-6", PAGE_GUTTER)}>
+      <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex flex-1 flex-col py-6")}>
         <Skeleton className="h-9 w-96" />
         <div className="mt-6 grid flex-1 gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
           <div className="space-y-5">

--- a/packages/views/agents/components/agent-overview-pane.test.tsx
+++ b/packages/views/agents/components/agent-overview-pane.test.tsx
@@ -11,9 +11,16 @@ import {
   NavigationProvider,
   type NavigationAdapter,
 } from "../../navigation";
-import { PAGE_GUTTER } from "../../layout/page-header";
 
 const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+const RAIL_SENTINEL = "rail-sentinel";
+const GUTTER_SENTINEL = "gutter-sentinel";
+vi.mock("../../layout/page-header", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../layout/page-header")>()),
+  PAGE_RAIL: "rail-sentinel",
+  PAGE_GUTTER: "gutter-sentinel",
+}));
 
 // AgentOverviewPane pulls in ActorIssuesPanel which in turn touches the api
 // layer. The test only cares about which top-of-pane tab buttons render,
@@ -286,39 +293,52 @@ describe("AgentOverviewPane Environment tab visibility", () => {
 // centred rail and a panel on the page gutter agreed at 1440px and drifted
 // hundreds of pixels apart above it. A cap must be anchored, never centred.
 describe("AgentOverviewPane horizontal alignment", () => {
-  const centredCap = (root: HTMLElement) =>
-    Array.from(root.querySelectorAll<HTMLElement>(".mx-auto")).filter((el) =>
-      Array.from(el.classList).some((c) => c.startsWith("max-w-")),
-    );
+  // Every band on the page has to read the SAME rail: chrome on the rail with
+  // panels off it is the original bug, and panels on it with chrome off it is
+  // the mirror image. Both were shipped once (MUL-7107).
+  //
+  // The constants are overridden with sentinels rather than compared against
+  // their real values, which are ordinary Tailwind classes a hand-written
+  // element could match by accident. Only an element that reads the constant
+  // picks a sentinel up.
+  const panelFor = (container: HTMLElement) =>
+    container.querySelector('[role="tablist"]')?.nextElementSibling
+      ?.firstElementChild;
 
-  it("puts the tab bar on the shared page gutter, not a centred rail", () => {
+  it("puts the tab bar row on the rail", () => {
     const { container } = renderPane([makeRuntime("claude")]);
-    const tablist = container.querySelector('[role="tablist"]');
+    const row = container.querySelector('[role="tablist"] > div');
 
-    expect(tablist).toHaveClass(PAGE_GUTTER);
-    expect(centredCap(container as HTMLElement)).toEqual([]);
+    expect(row).toHaveClass(RAIL_SENTINEL);
+    expect(row).toHaveClass(GUTTER_SENTINEL);
   });
 
-  it("starts the Overview panel on that same gutter", () => {
+  it("puts the Overview panel on the same rail", () => {
     const { container } = renderPane([makeRuntime("claude")]);
-    const tablist = container.querySelector('[role="tablist"]');
-    const panel = tablist?.nextElementSibling?.firstElementChild;
 
-    expect(panel).toHaveClass(PAGE_GUTTER);
-    expect(panel).not.toHaveClass("mx-auto");
+    expect(panelFor(container as HTMLElement)).toHaveClass(RAIL_SENTINEL);
+    expect(panelFor(container as HTMLElement)).toHaveClass(GUTTER_SENTINEL);
+  });
+
+  it("puts the Work panel on the same rail", () => {
+    const { container } = renderPane([makeRuntime("claude")]);
+    fireEvent.click(screen.getByRole("tab", { name: /^Work$/i }));
+
+    // Work takes a bare rail: the issues toolbar inside it carries the gutter
+    // already, so adding one here would inset it past the tabs.
+    expect(panelFor(container as HTMLElement)).toHaveClass(RAIL_SENTINEL);
   });
 
   it.each([
     ["Capabilities", openCapabilities],
     ["Settings", openSettings],
-  ])("starts the %s nav rail on that same gutter", (_name, open) => {
+  ])("puts the %s nav-and-content row on the same rail", (_name, open) => {
     const { container } = renderPane([makeRuntime("claude")]);
     open();
 
-    // The rail is the leftmost thing in these panels, so it — not the content
-    // pane behind it — is what has to line up with the tabs above.
-    const rail = container.querySelector("aside");
-    expect(rail).toHaveClass(PAGE_GUTTER);
-    expect(centredCap(container as HTMLElement)).toEqual([]);
+    // Bare rail for the same reason as Work — the nav aside carries the gutter,
+    // and that aside, not the form behind it, is what meets the tabs above.
+    expect(panelFor(container as HTMLElement)).toHaveClass(RAIL_SENTINEL);
+    expect(container.querySelector("aside")).toHaveClass(GUTTER_SENTINEL);
   });
 });

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -27,7 +27,7 @@ import {
   AlertDialogTitle,
 } from "@multica/ui/components/ui/alert-dialog";
 import { cn } from "@multica/ui/lib/utils";
-import { PAGE_GUTTER } from "../../layout/page-header";
+import { PAGE_GUTTER, PAGE_RAIL } from "../../layout/page-header";
 import { ActivityTab } from "./tabs/activity-tab";
 import { InstructionsTab } from "./tabs/instructions-tab";
 import { SkillsTab } from "./tabs/skills-tab";
@@ -328,11 +328,11 @@ export function AgentOverviewPane({
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
       <div
-        className={cn("shrink-0 overflow-x-auto border-b", PAGE_GUTTER)}
+        className="shrink-0 overflow-x-auto border-b"
         role="tablist"
         aria-label={t(($) => $.tabs.page_navigation_aria)}
       >
-        <div className="flex items-center gap-6">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-center gap-6")}>
           {TOP_TABS.map((tab) => (
             <button
               key={tab.id}
@@ -353,14 +353,22 @@ export function AgentOverviewPane({
         </div>
       </div>
 
-      {/* One leading edge for the whole page: the header, the tab bar and
-          every panel start at PAGE_GUTTER (MUL-7107). The chrome used to sit
-          on a centred `max-w-[1440px]` rail while the panels did not, so above
-          ~1730px the tabs walked right and left the content behind them.
+      {/* Header, tab bar, banners and every panel read PAGE_RAIL, so the page
+          is one centred column at every width (MUL-7107). The first pass put
+          the chrome on the rail and left the panels off it, which is the bug;
+          the second put everything full-bleed, which aligned the leading edge
+          and then stretched this two-column layout to 2200px and stranded the
+          summary card 1200px from the list it summarises.
 
-          A panel caps its width by anchoring, never by centring — a centred cap
-          drifts away from that edge as the window grows. Lists stay full-bleed
-          (an issue table wants the width); reading and form content takes a cap.
+          A detail page is a document about one entity, not a table. Genuine
+          list surfaces — Issues, My Issues, member detail — stay full-bleed on
+          PAGE_GUTTER alone; `runtimes` and skill detail read the same rail.
+
+          Panels that own no inner gutter take PAGE_GUTTER on the rail element
+          itself; Work and the secondary nav layout take a bare rail because
+          their toolbar and nav rail already carry it. Below ~1730px the rail
+          is wider than the viewport, so it costs small and medium screens
+          nothing.
 
           Overview/Work scroll as one page. Sidebar views split scrolling on
           md+ (nav rail pinned, content pane scrolls) like settings-page.tsx;
@@ -373,10 +381,7 @@ export function AgentOverviewPane({
       >
         {effectiveView === "overview" && (
           <div
-            className={cn(
-              "w-full max-w-[1440px] py-4 sm:py-6",
-              PAGE_GUTTER,
-            )}
+            className={cn(PAGE_RAIL, PAGE_GUTTER, "py-4 sm:py-6")}
           >
             <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
               <ActivityTab agent={agent} showPerformance={false} />
@@ -390,13 +395,13 @@ export function AgentOverviewPane({
         )}
 
         {effectiveView === "work" && (
-          <div className="flex min-h-[620px] flex-col">
+          <div className={cn(PAGE_RAIL, "flex min-h-[620px] flex-col")}>
             <ActorIssuesPanel actorType="agent" actorId={agent.id} />
           </div>
         )}
 
         {secondaryTabs.length > 0 && activeSecondaryTab && (
-          <div className="flex min-h-full flex-col md:h-full md:flex-row">
+          <div className={cn(PAGE_RAIL, "flex min-h-full flex-col md:h-full md:flex-row")}>
             {/* Content-surface color, no shell tint — same rule as the settings
                 nav: in-card panels must not break the desktop tab merge (MUL-4439). */}
             <aside

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -16,6 +16,27 @@ import { SidebarTrigger, useSidebarSafe } from "@multica/ui/components/ui/sideba
 export const PAGE_GUTTER = "px-4";
 
 /**
+ * The centred column a detail page reads inside: `runtimes`, and the agent and
+ * skill detail pages. A detail page is a document about one entity, not a
+ * table, so past a point more width stops helping and starts stretching a
+ * two-column layout apart.
+ *
+ * Pair it with `PAGE_GUTTER` on the same element, or on a child that already
+ * carries the gutter itself (a toolbar, a secondary nav rail). Every band on
+ * the page — header, tab bar, banners, each panel — has to read this same
+ * constant, because the bug it fixes is chrome sitting on the rail while the
+ * content under it does not: below ~1730px they agree, and above it the tabs
+ * walk away from what they label (MUL-7107).
+ *
+ * Full-width borders and backgrounds stay on the outer element; the rail goes
+ * on the child that holds the content.
+ *
+ * Not for list surfaces that are genuinely tables — Issues, My Issues, member
+ * detail — which stay full-bleed on `PAGE_GUTTER` alone.
+ */
+export const PAGE_RAIL = "mx-auto w-full max-w-[1440px]";
+
+/**
  * The filter/actions row directly under a `PageHeader`: same height and
  * gutter so the two read as one chrome block. Shared for the same reason as
  * `PAGE_GUTTER` — the toolbars drifted when each page spelled its own row.

--- a/packages/views/runtimes/components/runtime-detail-page.tsx
+++ b/packages/views/runtimes/components/runtime-detail-page.tsx
@@ -371,14 +371,16 @@ export function RuntimeDetailPage({
 function MachineDetailSkeleton() {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="border-b px-6 pb-5 pt-3">
-        <Skeleton className="h-3 w-36" />
-        <div className="mt-4 flex items-start gap-4">
-          <Skeleton className="h-14 w-14 rounded-xl" />
-          <div className="flex-1">
-            <Skeleton className="h-7 w-64" />
-            <Skeleton className="mt-2 h-4 w-40" />
-            <Skeleton className="mt-3 h-3 w-72" />
+      <div className="border-b pb-5 pt-3">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER)}>
+          <Skeleton className="h-3 w-36" />
+          <div className="mt-4 flex items-start gap-4">
+            <Skeleton className="h-14 w-14 rounded-xl" />
+            <div className="flex-1">
+              <Skeleton className="h-7 w-64" />
+              <Skeleton className="mt-2 h-4 w-40" />
+              <Skeleton className="mt-3 h-3 w-72" />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/views/runtimes/components/runtime-detail-page.tsx
+++ b/packages/views/runtimes/components/runtime-detail-page.tsx
@@ -16,6 +16,8 @@ import {
 } from "@multica/core/workspace/queries";
 import { Button } from "@multica/ui/components/ui/button";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { PAGE_GUTTER, PAGE_RAIL } from "../../layout/page-header";
+import { cn } from "@multica/ui/lib/utils";
 import { AppLink } from "../../navigation";
 import { buildWorkloadIndex, RuntimeList } from "./runtime-list";
 import {
@@ -206,8 +208,8 @@ export function RuntimeDetailPage({
   const busyCount = machine.runningCount + machine.queuedCount;
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <header className="shrink-0 border-b bg-background px-4 pb-5 pt-3 sm:px-6">
-        <div className="mx-auto max-w-[1440px]">
+      <header className="shrink-0 border-b bg-background pb-5 pt-3">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER)}>
           <div className="flex min-w-0 items-center gap-1.5 text-caption text-muted-foreground">
             <AppLink
               href={paths.runtimes()}
@@ -292,7 +294,7 @@ export function RuntimeDetailPage({
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto bg-background">
-        <div className="mx-auto w-full max-w-[1440px] p-4 sm:p-6">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "py-4 sm:py-6")}>
           <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
             <div className="min-w-0">
               <h2 className="text-body font-semibold">
@@ -380,7 +382,7 @@ function MachineDetailSkeleton() {
           </div>
         </div>
       </div>
-      <div className="mx-auto w-full max-w-[1440px] p-6">
+      <div className={cn(PAGE_RAIL, PAGE_GUTTER, "py-6")}>
         <Skeleton className="h-4 w-24" />
         <Skeleton className="mt-2 h-3 w-72" />
         <div className="mt-4 overflow-hidden rounded-lg border">

--- a/packages/views/runtimes/components/runtime-detail-rail.test.tsx
+++ b/packages/views/runtimes/components/runtime-detail-rail.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enRuntimes from "../../locales/en/runtimes.json";
+import { RuntimeDetailPage } from "./runtime-detail-page";
+
+// MUL-7107: the loading header used to sit on a bare gutter while the header
+// that replaced it rode the rail, so on a wide window the title jumped inward
+// the moment the query resolved. The skeleton is not exported, so drive it
+// through the page's own isLoading branch rather than reaching past the seam.
+//
+// PAGE_RAIL is overridden with a sentinel because its real value is an
+// ordinary Tailwind class that a hand-written element could match by accident.
+const RAIL_SENTINEL = "rail-sentinel";
+vi.mock("../../layout/page-header", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../layout/page-header")>()),
+  PAGE_RAIL: "rail-sentinel",
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-query")>(
+      "@tanstack/react-query",
+    );
+  return {
+    ...actual,
+    useQuery: () => ({ data: [], isLoading: true }),
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  };
+});
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "ws-1" }));
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (sel: (s: { user: { id: string } }) => unknown) =>
+    sel({ user: { id: "user-1" } }),
+}));
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({ runtimes: () => "/runtimes", agentDetail: () => "/agents" }),
+}));
+vi.mock("@multica/core/realtime", () => ({ useWSEvent: () => {} }));
+vi.mock("@multica/core/agents", () => ({
+  agentTaskSnapshotOptions: () => ({ queryKey: ["tasks"] }),
+}));
+vi.mock("@multica/core/runtimes", () => ({
+  runtimeProfileListOptions: () => ({ queryKey: ["profiles"] }),
+  deriveRuntimeHealth: () => "online",
+  runtimeDisplayName: () => "machine",
+  isRuntimeUsableForUser: () => true,
+  parseRuntimeProfileBoundConflict: () => null,
+  useDeleteRuntimeProfile: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("@multica/core/runtimes/queries", () => ({
+  runtimeListOptions: () => ({ queryKey: ["runtimes"] }),
+  runtimeKeys: { list: () => ["runtimes"] },
+}));
+vi.mock("@multica/core/workspace/queries", () => ({
+  agentListOptions: () => ({ queryKey: ["agents"] }),
+  memberListOptions: () => ({ queryKey: ["members"] }),
+}));
+
+describe("RuntimeDetailPage loading state", () => {
+  it("puts the loading header on the same rail as the loaded header", () => {
+    const { container } = render(
+      <I18nProvider
+        locale="en"
+        resources={{ en: { common: enCommon, runtimes: enRuntimes } }}
+      >
+        <RuntimeDetailPage runtimeId="rt-1" />
+      </I18nProvider>,
+    );
+
+    const railed = container.querySelectorAll(`.${RAIL_SENTINEL}`);
+    // Header band and body band; neither may be left on a bare gutter, or the
+    // page shifts sideways when loading finishes.
+    expect(railed.length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelector(".border-b")).toContainElement(
+      container.querySelector(`.${RAIL_SENTINEL}`) as HTMLElement,
+    );
+  });
+});

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -42,7 +42,8 @@ import {
   CollectionPageHeaderAction,
   CollectionPageState,
 } from "../../layout/collection-page";
-import { PageHeader } from "../../layout/page-header";
+import { PAGE_GUTTER, PAGE_RAIL, PageHeader } from "../../layout/page-header";
+import { cn } from "@multica/ui/lib/utils";
 import { AppLink, useNavigation } from "../../navigation";
 import {
   getMikaOnboarding,
@@ -178,7 +179,7 @@ export function RuntimesPage({
         </div>
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto">
-          <div className="mx-auto flex w-full max-w-[1440px] flex-col p-4 sm:p-6">
+          <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex flex-col py-4 sm:py-6")}>
             {!agentsLoading &&
               !chatSessionsLoading &&
               memberNeedsMikaSetup(agents, chatSessions) &&
@@ -575,7 +576,7 @@ function RuntimesPageSkeleton() {
       <PageHeader>
         <Skeleton className="h-4 w-24" />
       </PageHeader>
-      <div className="mx-auto w-full max-w-[1440px] p-6">
+      <div className={cn(PAGE_RAIL, PAGE_GUTTER, "py-6")}>
         <div className="overflow-hidden rounded-lg border">
           {Array.from({ length: 5 }).map((_, index) => (
             <div key={index} className="flex h-[76px] items-center gap-3 border-b px-4 last:border-b-0">

--- a/packages/views/skills/components/skill-detail-page.test.tsx
+++ b/packages/views/skills/components/skill-detail-page.test.tsx
@@ -12,6 +12,19 @@ import { NavigationProvider, type NavigationAdapter } from "../../navigation";
 
 const TEST_RESOURCES = { en: { common: enCommon, skills: enSkills } };
 
+// MUL-7107: every band of a detail page reads the shared rail. The read-only
+// capability banner was the one left behind, so a viewer without edit rights
+// saw a near-full-width card above centred content on a wide window. The
+// constants are overridden with sentinels because their real values are
+// ordinary Tailwind classes a hand-written element could match by accident.
+const RAIL_SENTINEL = "rail-sentinel";
+const GUTTER_SENTINEL = "gutter-sentinel";
+vi.mock("../../layout/page-header", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../layout/page-header")>()),
+  PAGE_RAIL: "rail-sentinel",
+  PAGE_GUTTER: "gutter-sentinel",
+}));
+
 const skillRef = vi.hoisted(() => ({ current: null as unknown }));
 const agentsRef = vi.hoisted(() => ({ current: [] as unknown[] }));
 const membersRef = vi.hoisted(() => ({ current: [] as unknown[] }));
@@ -463,5 +476,30 @@ describe("SkillDetailPage origin link", () => {
     expect(
       screen.queryByRole("link", { name: "Imported · GitHub" }),
     ).toBeNull();
+  });
+});
+
+
+describe("SkillDetailPage rail", () => {
+  it("keeps the read-only capability banner on the shared rail", async () => {
+    canEditRef.current = false;
+    renderPage();
+    await screen.findAllByRole("tab", { name: /Overview|Files/ });
+
+    const banner = document.body.querySelector(
+      `.${RAIL_SENTINEL}.${GUTTER_SENTINEL}.pt-3`,
+    );
+    expect(banner).toBeTruthy();
+  });
+
+  it("puts the identity strip and the tab row on that same rail", async () => {
+    renderPage();
+    await screen.findAllByRole("tab", { name: /Overview|Files/ });
+
+    const railed = document.body.querySelectorAll(
+      `.${RAIL_SENTINEL}.${GUTTER_SENTINEL}`,
+    );
+    // Identity strip, tab row and the Overview panel at minimum.
+    expect(railed.length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -67,6 +67,7 @@ import {
 import { cn } from "@multica/ui/lib/utils";
 import { AppLink, useNavigation } from "../../navigation";
 import { BreadcrumbHeader } from "../../layout/breadcrumb-header";
+import { PAGE_GUTTER, PAGE_RAIL } from "../../layout/page-header";
 import { useCanEditSkill } from "../hooks/use-can-edit-skill";
 import { useSkillPermissions } from "@multica/core/permissions";
 import { CapabilityBanner } from "@multica/ui/components/common/capability-banner";
@@ -311,8 +312,14 @@ function SkillIdentity({
   const sourceUrl = originSourceUrl(origin);
 
   return (
-    <div className="shrink-0 border-b px-4 py-3 sm:px-6">
-      <div className="mx-auto flex max-w-[1440px] flex-wrap items-center gap-x-4 gap-y-1.5">
+    <div className="shrink-0 border-b py-3">
+      <div
+        className={cn(
+          PAGE_RAIL,
+          PAGE_GUTTER,
+          "flex flex-wrap items-center gap-x-4 gap-y-1.5",
+        )}
+      >
         <div className="flex min-w-0 items-center gap-2.5">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
             <SkillIcon className="h-4 w-4" aria-hidden="true" />
@@ -462,7 +469,8 @@ function OverviewTab({
   const { t } = useT("skills");
 
   return (
-    <div className="mx-auto w-full max-w-3xl p-4 sm:p-6 md:p-8">
+    <div className={cn(PAGE_RAIL, PAGE_GUTTER, "py-4 sm:py-6 md:py-8")}>
+      <div className="w-full max-w-3xl">
       <section>
         <h2 className="text-title-sm font-medium">{t(($) => $.detail.overview.properties)}</h2>
         <p className="mt-1 text-caption text-muted-foreground">
@@ -540,6 +548,7 @@ function OverviewTab({
             ? t(($) => $.detail.overview.permissions_locked_creator, { name: creatorName })
             : t(($) => $.detail.overview.permissions_locked)}
       </p>
+      </div>
     </div>
   );
 }
@@ -603,7 +612,7 @@ function FilesTab({
     : undefined;
 
   return (
-    <div className="flex min-h-full flex-col md:h-full md:flex-row">
+    <div className={cn(PAGE_RAIL, "flex min-h-full flex-col md:h-full md:flex-row")}>
       {/* The file list IS the second-level navigation, so it uses the same
           rail treatment as the agent detail page's capability/settings nav
           instead of inventing a third sidebar style. */}
@@ -611,7 +620,10 @@ function FilesTab({
         role="tablist"
         aria-orientation="vertical"
         aria-label={t(($) => $.detail.files.list_aria)}
-        className="shrink-0 border-b border-surface-border p-3 md:w-52 md:overflow-y-auto md:border-b-0 md:border-r md:p-4"
+        className={cn(
+          "shrink-0 border-b border-surface-border py-3 md:w-52 md:overflow-y-auto md:border-b-0 md:border-r md:py-4",
+          PAGE_GUTTER,
+        )}
       >
         <p className="px-2.5 pb-1 text-micro font-semibold uppercase tracking-wider text-muted-foreground">
           {t(($) => $.detail.files.main)}
@@ -1088,7 +1100,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
           <Skeleton className="h-3 w-3 rounded" />
           <Skeleton className="h-4 w-40" />
         </div>
-        <div className="space-y-3 p-6">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "space-y-3 py-6")}>
           <Skeleton className="h-4 w-full" />
           <Skeleton className="h-4 w-5/6" />
           <Skeleton className="h-4 w-3/4" />
@@ -1230,10 +1242,12 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
       {supportingQueryDown && (
         <div
           role="status"
-          className="flex shrink-0 items-start gap-2 border-b bg-warning/10 px-4 py-2 text-caption text-muted-foreground sm:px-6"
+          className="shrink-0 border-b bg-warning/10 py-2 text-caption text-muted-foreground"
         >
-          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
-          <span>{t(($) => $.detail.supporting_data_warning)}</span>
+          <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-start gap-2")}>
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
+            <span>{t(($) => $.detail.supporting_data_warning)}</span>
+          </div>
         </div>
       )}
 
@@ -1246,11 +1260,11 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
       />
 
       <div
-        className="shrink-0 overflow-x-auto border-b px-4 sm:px-6"
+        className="shrink-0 overflow-x-auto border-b"
         role="tablist"
         aria-label={t(($) => $.detail.tabs.aria)}
       >
-        <div className="mx-auto flex max-w-[1440px] items-center gap-6">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-center gap-6")}>
           {TABS.map((tab) => (
             <button
               key={tab.id}
@@ -1275,8 +1289,9 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
         <div
           role="status"
           aria-live="polite"
-          className="flex shrink-0 items-start gap-2 border-b border-warning/30 bg-warning/10 px-4 py-2 text-caption sm:px-6"
+          className="shrink-0 border-b border-warning/30 bg-warning/10 py-2 text-caption"
         >
+          <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-start gap-2")}>
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
           <div className="flex-1">
             <div className="font-medium text-foreground">
@@ -1285,6 +1300,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
             <div className="mt-0.5 text-muted-foreground">
               {t(($) => $.detail.conflict_banner.body)}
             </div>
+          </div>
           </div>
         </div>
       )}

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -471,83 +471,83 @@ function OverviewTab({
   return (
     <div className={cn(PAGE_RAIL, PAGE_GUTTER, "py-4 sm:py-6 md:py-8")}>
       <div className="w-full max-w-3xl">
-      <section>
-        <h2 className="text-title-sm font-medium">{t(($) => $.detail.overview.properties)}</h2>
-        <p className="mt-1 text-caption text-muted-foreground">
-          {t(($) => $.detail.overview.properties_hint)}
+        <section>
+          <h2 className="text-title-sm font-medium">{t(($) => $.detail.overview.properties)}</h2>
+          <p className="mt-1 text-caption text-muted-foreground">
+            {t(($) => $.detail.overview.properties_hint)}
+          </p>
+          <div className="mt-4 divide-y">
+            <PropertyRow label={t(($) => $.detail.overview.name)} htmlFor="skill-name">
+              <Input
+                id="skill-name"
+                value={name}
+                readOnly={!canEdit}
+                onChange={(e) => onNameChange(e.target.value)}
+                placeholder={t(($) => $.detail.name_placeholder)}
+                className="font-mono text-body read-only:cursor-default"
+              />
+            </PropertyRow>
+
+            <PropertyRow
+              label={t(($) => $.detail.overview.description)}
+              htmlFor="skill-description"
+            >
+              {/* Real descriptions run 500–900 characters (they carry the
+                  trigger vocabulary an agent matches on), so this field is
+                  sized for the data rather than the two rows it had before. */}
+              <Textarea
+                id="skill-description"
+                value={description}
+                readOnly={!canEdit}
+                onChange={(e) => onDescriptionChange(e.target.value)}
+                placeholder={t(($) => $.detail.description_placeholder)}
+                rows={6}
+                className="text-body leading-relaxed read-only:cursor-default"
+              />
+              <p className="mt-1.5 text-caption text-muted-foreground">
+                {t(($) => $.detail.overview.description_hint, {
+                  count: description.length,
+                })}
+              </p>
+            </PropertyRow>
+
+            <PropertyRow label={t(($) => $.detail.overview.labels)}>
+              <ResourceLabelPicker
+                resourceType="skill"
+                resourceId={skill.id}
+                canEdit={canEdit}
+              />
+            </PropertyRow>
+          </div>
+        </section>
+
+        <section className="mt-10">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="min-w-0 text-title-sm font-medium">
+              {t(($) => $.detail.overview.used_by, { count: skillAgents.length })}
+            </h2>
+            <Button
+              variant="outline"
+              size="xs"
+              className="shrink-0 gap-1"
+              onClick={onAddToAgents}
+            >
+              <UserPlus className="h-3 w-3" />
+              {t(($) => $.actions.add_to_agent)}
+            </Button>
+          </div>
+          <div className="mt-3">
+            <UsedByList agents={skillAgents} />
+          </div>
+        </section>
+
+        <p className="mt-10 rounded-lg bg-muted px-3 py-2.5 text-caption leading-relaxed text-muted-foreground">
+          {canEdit
+            ? t(($) => $.detail.overview.permissions_owner)
+            : creatorName
+              ? t(($) => $.detail.overview.permissions_locked_creator, { name: creatorName })
+              : t(($) => $.detail.overview.permissions_locked)}
         </p>
-        <div className="mt-4 divide-y">
-          <PropertyRow label={t(($) => $.detail.overview.name)} htmlFor="skill-name">
-            <Input
-              id="skill-name"
-              value={name}
-              readOnly={!canEdit}
-              onChange={(e) => onNameChange(e.target.value)}
-              placeholder={t(($) => $.detail.name_placeholder)}
-              className="font-mono text-body read-only:cursor-default"
-            />
-          </PropertyRow>
-
-          <PropertyRow
-            label={t(($) => $.detail.overview.description)}
-            htmlFor="skill-description"
-          >
-            {/* Real descriptions run 500–900 characters (they carry the
-                trigger vocabulary an agent matches on), so this field is
-                sized for the data rather than the two rows it had before. */}
-            <Textarea
-              id="skill-description"
-              value={description}
-              readOnly={!canEdit}
-              onChange={(e) => onDescriptionChange(e.target.value)}
-              placeholder={t(($) => $.detail.description_placeholder)}
-              rows={6}
-              className="text-body leading-relaxed read-only:cursor-default"
-            />
-            <p className="mt-1.5 text-caption text-muted-foreground">
-              {t(($) => $.detail.overview.description_hint, {
-                count: description.length,
-              })}
-            </p>
-          </PropertyRow>
-
-          <PropertyRow label={t(($) => $.detail.overview.labels)}>
-            <ResourceLabelPicker
-              resourceType="skill"
-              resourceId={skill.id}
-              canEdit={canEdit}
-            />
-          </PropertyRow>
-        </div>
-      </section>
-
-      <section className="mt-10">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="min-w-0 text-title-sm font-medium">
-            {t(($) => $.detail.overview.used_by, { count: skillAgents.length })}
-          </h2>
-          <Button
-            variant="outline"
-            size="xs"
-            className="shrink-0 gap-1"
-            onClick={onAddToAgents}
-          >
-            <UserPlus className="h-3 w-3" />
-            {t(($) => $.actions.add_to_agent)}
-          </Button>
-        </div>
-        <div className="mt-3">
-          <UsedByList agents={skillAgents} />
-        </div>
-      </section>
-
-      <p className="mt-10 rounded-lg bg-muted px-3 py-2.5 text-caption leading-relaxed text-muted-foreground">
-        {canEdit
-          ? t(($) => $.detail.overview.permissions_owner)
-          : creatorName
-            ? t(($) => $.detail.overview.permissions_locked_creator, { name: creatorName })
-            : t(($) => $.detail.overview.permissions_locked)}
-      </p>
       </div>
     </div>
   );
@@ -1230,7 +1230,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
       />
 
       {!canEdit && (
-        <div className="px-4 pt-3 sm:px-6">
+        <div className={cn(PAGE_RAIL, PAGE_GUTTER, "pt-3")}>
           <CapabilityBanner
             reason={skillPermissions.canEdit.reason}
             resource="skill"
@@ -1292,15 +1292,15 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
           className="shrink-0 border-b border-warning/30 bg-warning/10 py-2 text-caption"
         >
           <div className={cn(PAGE_RAIL, PAGE_GUTTER, "flex items-start gap-2")}>
-          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
-          <div className="flex-1">
-            <div className="font-medium text-foreground">
-              {t(($) => $.detail.conflict_banner.title)}
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
+            <div className="flex-1">
+              <div className="font-medium text-foreground">
+                {t(($) => $.detail.conflict_banner.title)}
+              </div>
+              <div className="mt-0.5 text-muted-foreground">
+                {t(($) => $.detail.conflict_banner.body)}
+              </div>
             </div>
-            <div className="mt-0.5 text-muted-foreground">
-              {t(($) => $.detail.conflict_banner.body)}
-            </div>
-          </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Supersedes this PR's original contents. It first proposed removing Overview's width cap; review on the issue landed on the opposite direction, so the branch was rebuilt on that decision.

## The actual bug

`max-w-[1440px]` was never wrong. What was wrong is that only *half* of each detail page sat on it: agent and skill detail had the rail on their chrome and not on their panels, so past ~1730px the tabs shrank inward while the content under them stayed put. `runtimes` already had header and body both on the rail and has always looked right.

Two earlier passes each fixed one edge and broke the other — #8100 aligned the leading edge and left the trailing edge short; removing the cap would have aligned both and then stretched the Overview grid to 2200px. One rail for the whole page makes both edges agree.

## Changes

- **`PAGE_RAIL`** added beside `PAGE_GUTTER`. Defined once instead of hand-spelled in ten places — the same failure mode `PAGE_GUTTER` was extracted for.
- **agent detail** — header, tab bar, three banners, loading skeleton, all four panels.
- **skill detail** — identity strip, tab bar, both warning banners, the read-only capability banner, skeleton, Overview and Files.
- **`runtimes`** — detail (including its loading header) and list.

Panels with no inner gutter take `PAGE_GUTTER` on the rail element. Work and the secondary nav layouts take a bare rail, because their toolbar and nav aside already carry one.

## Scope — corrected

An earlier revision of this description claimed the change is invisible below ~1730px. **That was only true of agent detail**, which #8100 had already moved onto `PAGE_GUTTER`. Accurately, at widths below the rail:

| surface | change |
|---|---|
| agent detail | none |
| runtime detail, runtimes list | gutter 24px → 16px at `sm`+ (8px left shift) |
| skill identity / tabs / banners | gutter 24px → 16px at `sm`+ |
| skill Files nav | 12px → 16px below `md` |
| **skill Overview form** | **was centred, now left-anchored — ~139px left at 1280px** |

The first four are the `PAGE_GUTTER` convergence #8100 already applied to agent detail, so those pages now match Issues/Inbox/Chat.

The last one is a real visual change at laptop widths and is the one worth a decision. It is not collateral: the before screenshot at 1280 shows the tabs at x=280 with the form starting at x=411 — the same leading-edge bug this PR exists to fix, just at a narrower width. After, both sit at 272. Keeping the old centring would leave skill detail misaligned at exactly the widths most people use.

Before/after screenshots at 1280px for skill Overview, skill Files, runtime detail and runtimes list are attached to MUL-7107 for confirmation.

## Verification

- `pnpm typecheck` — 9/9 packages.
- `pnpm lint --filter=@multica/views` — 0 errors (26 pre-existing warnings unchanged).
- `pnpm vitest run packages/views` — 410 files, 4904 tests.
- Regression coverage: every agent panel asserts it reads the rail; the skill read-only banner asserts it under a no-edit render; the runtime loading header asserts it under an `isLoading` render. All override the constants with sentinels, because the real values are ordinary Tailwind classes a hand-written element could match by accident, and each was confirmed to fail against the commit before it.
- Rendered at 2454px (agent, all tabs) and 1280px (skill, runtime).
