### PR TITLE
fix(editor): handle shortcuts at the selected list level

### DIFF
--- a/packages/views/editor/extensions/list-item.ts
+++ b/packages/views/editor/extensions/list-item.ts
@@ -86,26 +86,37 @@ function sinkListItemRange(itemType: NodeType): Command {
  * and must be swallowed even when the structural indent is a no-op (first child
  * with nothing to nest under, or already at max depth). Otherwise the unhandled
  * Tab falls through to the browser and moves focus out of the editor to the
- * next control. So the return value tracks "is the caret in this list?"
- * (`editor.isActive(name)`), NOT "did the indent move anything?": indent
- * best-effort, then swallow while in a list, fall through (focus nav) when not.
+ * next control. Handle only the nearest list range containing the selection:
+ * `isActive` also matches ancestor items, so a checkbox keymap would otherwise
+ * swallow Tab or lift the parent checkbox while editing a nested bullet.
  */
 function listItemKeymap(editor: Editor, name: string) {
+  const ownsSelection = () => {
+    const { $from, $to } = editor.state.selection;
+    const range = $from.blockRange($to, (node) => {
+      const itemName = node.firstChild?.type.name;
+      return itemName === "listItem" || itemName === "taskItem";
+    });
+    return range?.parent.firstChild?.type.name === name;
+  };
+
   return {
     Enter: () =>
+      ownsSelection() &&
       editor.commands.first(({ commands }) => [
         () => commands.splitListItem(name),
         () => commands.liftListItem(name),
       ]),
     Tab: () => {
+      if (!ownsSelection()) return false;
       const itemType = editor.schema.nodes[name];
       if (!itemType) return false;
       sinkListItemRange(itemType)(editor.state, (tr) =>
         editor.view.dispatch(tr),
       );
-      return editor.isActive(name);
+      return true;
     },
-    "Shift-Tab": () => editor.commands.liftListItem(name),
+    "Shift-Tab": () => ownsSelection() && editor.commands.liftListItem(name),
   };
 }
 

--- a/packages/views/editor/extensions/list-keyboard.test.ts
+++ b/packages/views/editor/extensions/list-keyboard.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import { createEditorExtensions } from ".";
+
+let editor: Editor;
+
+afterEach(() => {
+  editor?.destroy();
+  document.body.innerHTML = "";
+});
+
+function load(markdown: string) {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  editor = new Editor({
+    element,
+    extensions: createEditorExtensions({
+      disableMentions: true,
+      onUploadFileRef: { current: undefined },
+    }),
+    content: markdown,
+    contentType: "markdown",
+  });
+}
+
+function selectText(text: string) {
+  let position: number | undefined;
+  editor.state.doc.descendants((node, pos) => {
+    if (node.isText && node.text === text) position = pos;
+  });
+  if (position === undefined) throw new Error(`Missing text: ${text}`);
+  editor.commands.setTextSelection(position);
+}
+
+function press(key: string, shiftKey = false) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    shiftKey,
+    bubbles: true,
+    cancelable: true,
+  });
+  editor.view.dom.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+function itemAncestors() {
+  const { $from } = editor.state.selection;
+  const names: string[] = [];
+  for (let depth = 1; depth <= $from.depth; depth++) {
+    const name = $from.node(depth).type.name;
+    if (name === "listItem" || name === "taskItem") names.push(name);
+  }
+  return names;
+}
+
+describe("list shortcuts through the production keymaps", () => {
+  it.each(["-", "1.", "- [ ]"])("indents and outdents a %s item", (marker) => {
+    load(`${marker} first\n${marker} second`);
+    selectText("second");
+    expect(press("Tab")).toBe(true);
+    expect(itemAncestors()).toHaveLength(2);
+    expect(press("Tab", true)).toBe(true);
+    expect(itemAncestors()).toHaveLength(1);
+  });
+
+  it.each(["-", "1."])("indents a %s item nested under a checkbox", (marker) => {
+    load(`- [ ] outer\n   ${marker} first\n   ${marker} second`);
+    selectText("second");
+    expect(press("Tab")).toBe(true);
+    expect(itemAncestors()).toEqual(["taskItem", "listItem", "listItem"]);
+    expect(press("Tab", true)).toBe(true);
+    expect(itemAncestors()).toEqual(["taskItem", "listItem"]);
+  });
+
+  it("outdents an inner bullet without lifting its enclosing checkbox", () => {
+    load("- [ ] outer\n   - first\n      - second");
+    selectText("second");
+    expect(press("Tab", true)).toBe(true);
+    expect(itemAncestors()).toEqual(["taskItem", "listItem"]);
+    expect(editor.getJSON().content?.[0]?.type).toBe("taskList");
+  });
+
+  it("splits an inner bullet without splitting its enclosing checkbox", () => {
+    load("- [ ] outer\n   - first\n   - second");
+    selectText("second");
+    expect(press("Enter")).toBe(true);
+    expect(itemAncestors()).toEqual(["taskItem", "listItem"]);
+    expect(editor.getJSON().content?.[0]?.content).toHaveLength(1);
+  });
+
+  it("keeps the first nested bullet in place instead of indenting its enclosing checkbox", () => {
+    load("- [ ] previous\n- [ ] outer\n   - first\n   - second");
+    selectText("first");
+    const before = editor.getJSON();
+    expect(press("Tab")).toBe(true);
+    expect(editor.getJSON()).toEqual(before);
+  });
+
+  it("indents and outdents a checkbox nested under a bullet", () => {
+    load("- outer\n   - [ ] first\n   - [ ] second");
+    selectText("second");
+    expect(press("Tab")).toBe(true);
+    expect(itemAncestors()).toEqual(["listItem", "taskItem", "taskItem"]);
+    expect(press("Tab", true)).toBe(true);
+    expect(itemAncestors()).toEqual(["listItem", "taskItem"]);
+  });
+
+  it("indents a nested whole-list selection, preserves Markdown, and undoes in one step", () => {
+    load("- [ ] outer\n   - first\n   - second\n   - third");
+    selectText("first");
+    const from = editor.state.selection.from;
+    selectText("third");
+    editor.commands.setTextSelection({ from, to: editor.state.selection.from + 5 });
+    const before = editor.getJSON();
+
+    expect(press("Tab")).toBe(true);
+    const indented = editor.getJSON();
+    const markdown = editor.getMarkdown();
+    expect(markdown.trim()).toBe("- [ ] outer\n   - first\n      - second\n      - third");
+    expect(editor.commands.undo()).toBe(true);
+    expect(editor.getJSON()).toEqual(before);
+    editor.commands.setContent(markdown, { contentType: "markdown" });
+    expect(editor.getJSON()).toEqual(indented);
+  });
+
+  it("leaves Tab available for focus navigation in plain text", () => {
+    load("plain");
+    selectText("plain");
+    expect(press("Tab")).toBe(false);
+    expect(press("Tab", true)).toBe(false);
+  });
+
+  it("preserves table cell navigation", () => {
+    load("| first | second |\n| --- | --- |\n| third | fourth |");
+    selectText("first");
+    expect(press("Tab")).toBe(true);
+    expect(editor.state.selection.$from.parent.textContent).toBe("second");
+    expect(press("Tab", true)).toBe(true);
+    expect(editor.state.selection.$from.parent.textContent).toBe("first");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes Tab, Shift+Tab, and Enter targeting the wrong list level in the shared description and comment editor. With bullet or numbered items nested under a checkbox, Tab could do nothing or indent the enclosing checkbox; Shift+Tab and Enter could lift that checkbox instead of editing the inner item.

Both item keymaps are registered together, and checking whether an item is active also matches ancestors. The keymaps now handle only the nearest list range containing the selection, preserving existing multi-item indentation and first-item behavior.

## Related Issue

Reported directly during editor testing; no linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `packages/views/editor/extensions/list-item.ts`: scope Enter, Tab, and Shift+Tab to the selected list level before running list commands.
- `packages/views/editor/extensions/list-keyboard.test.ts`: add 12 tests using DOM keyboard events and the production extension array, covering mixed nesting, parent preservation, multi-item indentation, undo, Markdown round-trips, plain-text Tab handling, and table navigation.

## How to Test

1. In a description or comment, create a checkbox containing two nested bullet or numbered items.
2. Place the cursor in the second nested item and press Tab: it should nest under the first item while its enclosing checkbox stays in place.
3. Press Shift+Tab to restore its level; press Enter within the inner item to split it without lifting the checkbox.

Automated validation completed locally:

- `pnpm --filter @multica/views test editor/` — 71 files, 1,337 tests passed.
- `pnpm --filter @multica/views typecheck` — passed.
- `pnpm --filter @multica/views exec eslint editor/extensions/list-item.ts editor/extensions/list-keyboard.test.ts` — passed.
- `git diff --check` — passed.

Risk is limited to list shortcut routing shared by web and desktop. First items without a preceding sibling still cannot indent. Browser manual validation has not been performed; keyboard behavior is exercised through production keymaps in jsdom.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- Screenshots and documentation updates: not applicable to this keyboard behavior fix; no visual design, runtime, or product copy changes.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Investigate intermittent Tab indentation in description and comment editors. Reproduced five failing mixed-list scenarios using production keyboard dispatch, scoped commands to the selected list level, and ran editor regression tests, type checking, and lint.
