### PR TITLE
feat(sidebar): organize navigation by work and AI team

### DIFF
--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@multica/core/api";
+import { renderWithI18n } from "../test/i18n";
 import { AppSidebar } from "./app-sidebar";
 
 const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, navigation, pins, sidebarState, summary, workspaces } = vi.hoisted(() => ({
@@ -57,12 +58,13 @@ vi.mock("@multica/ui/components/ui/sidebar", () => ({
     children,
     isActive,
     render,
+    ...props
   }: {
     children: React.ReactNode;
     isActive?: boolean;
     render?: React.ReactElement<{ href?: string }>;
-  }) => (
-    <button type="button" data-active={isActive ? "true" : undefined} data-href={render?.props.href}>
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props} type="button" data-active={isActive ? "true" : undefined} data-href={render?.props.href}>
       {children}
     </button>
   ),
@@ -233,6 +235,42 @@ describe("PinRow", () => {
       "true",
     );
     expect(container.querySelector('button[data-href="/acme/issues"]')).not.toHaveAttribute("data-active");
+  });
+
+  it("keeps the parent route active until a hidden pin is expanded", () => {
+    const originalPins = pins.current;
+    pins.current = Array.from({ length: 6 }, (_, index) => ({
+      ...originalPins[0]!,
+      id: `pin-${index + 1}`,
+      item_id: `issue-${index + 1}`,
+      position: index,
+    }));
+    navigation.current.pathname = "/acme/issues/issue-6";
+    detail.current = {
+      isPending: false,
+      isError: false,
+      data: { identifier: "MUL-123", title: "Pinned issue", status: "todo" },
+      error: null,
+    };
+
+    try {
+      const { container } = renderWithI18n(<AppSidebar />);
+      const parent = () => container.querySelector('button[data-href="/acme/issues"]');
+      const lastPin = () => container.querySelector('button[data-href="/acme/issues/issue-6"]');
+
+      expect(lastPin()).not.toBeInTheDocument();
+      expect(parent()).toHaveAttribute("data-active", "true");
+
+      fireEvent.click(screen.getByRole("button", { name: "Show 1 more…" }));
+      expect(lastPin()).toHaveAttribute("data-active", "true");
+      expect(parent()).not.toHaveAttribute("data-active");
+
+      fireEvent.click(screen.getByRole("button", { name: "Show fewer" }));
+      expect(lastPin()).not.toBeInTheDocument();
+      expect(parent()).toHaveAttribute("data-active", "true");
+    } finally {
+      pins.current = originalPins;
+    }
   });
 });
 

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -106,6 +106,7 @@ const EMPTY_WORKSPACES: Awaited<ReturnType<typeof api.listWorkspaces>> = [];
 const EMPTY_INVITATIONS: Awaited<ReturnType<typeof api.listMyInvitations>> = [];
 const EMPTY_INBOX: Awaited<ReturnType<typeof api.listInbox>> = [];
 const EMPTY_INBOX_SUMMARY: Awaited<ReturnType<typeof api.getInboxUnreadSummary>> = [];
+const PINNED_PREVIEW_LIMIT = 5;
 
 // Nav items reference WorkspacePaths method names so they can be resolved
 // against the current workspace slug at render time (see AppSidebar body).
@@ -145,22 +146,25 @@ type NavLabelKey =
 // always agree. See route-icon-components.tsx.
 const personalNav: { key: NavKey; labelKey: NavLabelKey }[] = [
   { key: "inbox", labelKey: "inbox" },
-  { key: "chat", labelKey: "chat" },
   { key: "myIssues", labelKey: "my_issues" },
+  { key: "chat", labelKey: "chat" },
 ];
 
-const workspaceNav: { key: NavKey; labelKey: NavLabelKey }[] = [
+const workNav: { key: NavKey; labelKey: NavLabelKey }[] = [
   { key: "issues", labelKey: "issues" },
   { key: "projects", labelKey: "projects" },
   { key: "autopilots", labelKey: "autopilots" },
-  { key: "agents", labelKey: "agents" },
-  { key: "squads", labelKey: "squads" },
-  { key: "usage", labelKey: "usage" },
 ];
 
-const configureNav: { key: NavKey; labelKey: NavLabelKey }[] = [
-  { key: "runtimes", labelKey: "runtimes" },
+const aiTeamNav: { key: NavKey; labelKey: NavLabelKey }[] = [
+  { key: "agents", labelKey: "agents" },
+  { key: "squads", labelKey: "squads" },
   { key: "skills", labelKey: "skills" },
+  { key: "runtimes", labelKey: "runtimes" },
+];
+
+const utilityNav: { key: NavKey; labelKey: NavLabelKey }[] = [
+  { key: "usage", labelKey: "usage" },
   { key: "settings", labelKey: "settings" },
 ];
 
@@ -526,6 +530,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   // DOM under dnd-kit while its drop animation is still interpolating.
   const [localPinned, setLocalPinned] = useState<PinnedItem[]>(pinnedItems);
   const [localPinnedWsId, setLocalPinnedWsId] = useState<string | null>(wsId ?? null);
+  const [expandedPinsWorkspaceId, setExpandedPinsWorkspaceId] = useState<string | null>(null);
   const isDraggingRef = useRef(false);
   useEffect(() => {
     if (!isDraggingRef.current) {
@@ -536,10 +541,12 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
     setLocalPinnedWsId(wsId ?? null);
   }, [wsId]);
   const visiblePinned = localPinnedWsId === (wsId ?? null) ? localPinned : EMPTY_PINS;
+  const pinsExpanded = expandedPinsWorkspaceId === wsId;
+  const displayedPinned = pinsExpanded ? visiblePinned : visiblePinned.slice(0, PINNED_PREVIEW_LIMIT);
   // View pins are absent here (their href resolves async): while a view
   // pin is active the plain nav row for its surface stays highlighted too.
   // Accepted — suppressing it would need every view detail lifted up here.
-  const isActivePinnedRoute = visiblePinned.some((pin) => pathname === getPinHref(pin));
+  const isActivePinnedRoute = displayedPinned.some((pin) => pathname === getPinHref(pin));
 
   const handleDragStart = useCallback(() => {
     isDraggingRef.current = true;
@@ -804,9 +811,9 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                 <CollapsibleContent>
                   <SidebarGroupContent>
                     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-                      <SortableContext items={visiblePinned.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+                      <SortableContext items={displayedPinned.map((p) => p.id)} strategy={verticalListSortingStrategy}>
                         <SidebarMenu className="gap-0.5">
-                          {visiblePinned.map((pin: PinnedItem) => (
+                          {displayedPinned.map((pin: PinnedItem) => (
                             <PinRow
                               key={pin.id}
                               pin={pin}
@@ -819,6 +826,20 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                         </SidebarMenu>
                       </SortableContext>
                     </DndContext>
+                    {visiblePinned.length > PINNED_PREVIEW_LIMIT && (
+                      <SidebarMenuButton
+                        size="sm"
+                        aria-expanded={pinsExpanded}
+                        className="mt-0.5 pl-7 text-muted-foreground"
+                        onClick={() => setExpandedPinsWorkspaceId(pinsExpanded ? null : wsId ?? null)}
+                      >
+                        <span>
+                          {pinsExpanded
+                            ? t(($) => $.sidebar.show_fewer_pins)
+                            : t(($) => $.sidebar.show_more_pins, { count: visiblePinned.length - PINNED_PREVIEW_LIMIT })}
+                        </span>
+                      </SidebarMenuButton>
+                    )}
                   </SidebarGroupContent>
                 </CollapsibleContent>
               </SidebarGroup>
@@ -826,10 +847,10 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
           )}
 
           <SidebarGroup>
-            <SidebarGroupLabel>{t(($) => $.sidebar.workspace_group)}</SidebarGroupLabel>
+            <SidebarGroupLabel>{t(($) => $.sidebar.work_group)}</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu className="gap-0.5">
-                {workspaceNav.map((item) => {
+                {workNav.map((item) => {
                   const href = p[item.key]();
                   const Icon = routeIconForPath(href);
                   const isActive = !isActivePinnedRoute && isNavActive(pathname, href);
@@ -851,10 +872,10 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
           </SidebarGroup>
 
           <SidebarGroup>
-            <SidebarGroupLabel>{t(($) => $.sidebar.configure_group)}</SidebarGroupLabel>
+            <SidebarGroupLabel>{t(($) => $.sidebar.ai_team_group)}</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu className="gap-0.5">
-                {configureNav.map((item) => {
+                {aiTeamNav.map((item) => {
                   const href = p[item.key]();
                   const Icon = routeIconForPath(href);
                   const isActive = isNavActive(pathname, href);
@@ -877,6 +898,24 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
         </SidebarContent>
 
         <SidebarFooter className="p-2">
+          <SidebarMenu className="gap-0.5">
+            {utilityNav.map((item) => {
+              const href = p[item.key]();
+              const Icon = routeIconForPath(href);
+              return (
+                <SidebarMenuItem key={item.key}>
+                  <SidebarMenuButton
+                    isActive={isNavActive(pathname, href)}
+                    render={<AppLink href={href} />}
+                    className="text-caption text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
+                  >
+                    <Icon />
+                    <span>{t(($) => $.nav[item.labelKey])}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              );
+            })}
+          </SidebarMenu>
           {/* One utility strip: the Discord link takes the leading space the
               help trigger was leaving empty. `justify-end` keeps the trigger
               right-aligned once the Discord link is dismissed. */}

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -52,8 +52,10 @@
     "new_issue": "New Issue",
     "new_issue_shortcut": "C",
     "pinned_label": "Pinned",
-    "workspace_group": "Workspace",
-    "configure_group": "Configure",
+    "work_group": "Work",
+    "ai_team_group": "AI team",
+    "show_more_pins": "Show {{count}} more…",
+    "show_fewer_pins": "Show fewer",
     "unread_overflow": "99+",
     "discord_card": {
       "title": "Join our Discord",

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -52,8 +52,10 @@
     "new_issue": "新規タスク",
     "new_issue_shortcut": "C",
     "pinned_label": "ピン留め済み",
-    "workspace_group": "ワークスペース",
-    "configure_group": "設定",
+    "work_group": "仕事",
+    "ai_team_group": "AI チーム",
+    "show_more_pins": "さらに {{count}} 件を表示…",
+    "show_fewer_pins": "表示を減らす",
     "unread_overflow": "99+",
     "discord_card": {
       "title": "Discord に参加",

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -52,8 +52,10 @@
     "new_issue": "새 태스크",
     "new_issue_shortcut": "C",
     "pinned_label": "고정됨",
-    "workspace_group": "워크스페이스",
-    "configure_group": "설정",
+    "work_group": "업무",
+    "ai_team_group": "AI 팀",
+    "show_more_pins": "{{count}}개 더 보기…",
+    "show_fewer_pins": "접기",
     "unread_overflow": "99+",
     "discord_card": {
       "title": "Discord 참여하기",

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -52,8 +52,10 @@
     "new_issue": "新建任务",
     "new_issue_shortcut": "C",
     "pinned_label": "固定",
-    "workspace_group": "工作区",
-    "configure_group": "配置",
+    "work_group": "工作",
+    "ai_team_group": "AI 团队",
+    "show_more_pins": "再显示 {{count}} 项...",
+    "show_fewer_pins": "收起",
     "unread_overflow": "99+",
     "discord_card": {
       "title": "加入 Discord",


### PR DESCRIPTION
## What does this PR do?

Separate everyday work from AI team management in the shared web/desktop sidebar. The previous Workspace and Configure groups mixed these destinations; the new Work and AI team groups keep related pages together, with Analytics and Settings anchored below the scrollable navigation.

Pinned items show five entries by default and offer Show more / Show fewer. When the current destination is a hidden pin, its parent navigation entry remains highlighted until the pin is revealed.

## Related Issue

No linked issue.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `packages/views/layout/app-sidebar.tsx`: order personal navigation as Inbox, My Issues, Chat; introduce Work and AI team groups; move Analytics and Settings to the footer; limit the initial pinned list to five items.
- `packages/views/locales/{en,zh-Hans,ja,ko}/layout.json`: translate the new groups and pin expansion controls.
- `packages/views/layout/app-sidebar.test.tsx`: cover active-route highlighting while revealing and hiding the sixth pin.

## How to Test

1. Open a workspace and verify both navigation groups and the fixed Analytics / Settings footer.
2. Pin six projects or issues. Expand the sixth entry, then select Show fewer.
3. Open a hidden pinned issue directly and verify the parent Issues entry stays active until the pin is revealed.

Validation completed:

- 33 tests passed across app-sidebar, sidebar-resize, sidebar-auto-collapse, and join-discord-card. On local Node 25, tests used `NODE_OPTIONS=--no-experimental-webstorage` to avoid its native localStorage conflicting with jsdom.
- `pnpm --filter @multica/views typecheck`
- ESLint on both changed TSX files and `git diff --check`
- Browser verification in an isolated local environment with six pinned demo projects, including Show more / Show fewer.

## Checklist

- [x] Included project context and the rationale for the change
- [x] Ran relevant tests locally and they pass
- [x] Added regression coverage where applicable
- [ ] Attached before/after screenshots
- [x] Checked Chinese copy against the project conventions
- [x] Considered risks: pin expansion is temporary UI state; navigation routes and backend contracts are unchanged

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Reviewed the existing sidebar, presented a mockup matching the current UI, then implemented the user-approved structure and verified it with component tests and a local browser session.
