### PR TITLE
MUL-7068 fix(telegram): keep chat:done from duplicating an in-flight placeholder

### DIFF
--- a/server/internal/integrations/telegram/outbound.go
+++ b/server/internal/integrations/telegram/outbound.go
@@ -597,8 +597,12 @@ type terminalRequestResult struct {
 func (o *Outbound) sendNextTerminalRequest(ctx context.Context, reply *terminalReply) terminalRequestResult {
 	if !reply.initialized {
 		if reply.target == nil {
-			// Resolved once and cached: the retries below re-enter here, and
-			// every resolve is two queries plus a credential decrypt.
+			// Cached for the placeholder-settle retry only: that wait is
+			// bounded by the partial's own send context, and re-resolving it
+			// every 250ms costs two queries plus a credential decrypt. The
+			// capacity retry below drops the cache again, because that wait is
+			// unbounded and re-resolving is what re-checks the installation's
+			// status and picks up a rotated bot token.
 			target, err := o.resolveTarget(ctx, reply.event, false)
 			if err != nil {
 				return terminalRequestResult{done: true, err: err}
@@ -631,6 +635,10 @@ func (o *Outbound) sendNextTerminalRequest(ctx context.Context, reply *terminalR
 			schedule = o.retainChatLocked(target.botKey, target.chatID)
 			if schedule == nil {
 				o.mu.Unlock()
+				// Re-resolve on the next attempt: an installation revoked (or
+				// re-keyed) while this reply waited for capacity must not be
+				// delivered to from a target resolved before the change.
+				reply.target = nil
 				return terminalRequestResult{retryAt: o.now().Add(chatCapacityRetry)}
 			}
 		}

--- a/server/internal/integrations/telegram/outbound.go
+++ b/server/internal/integrations/telegram/outbound.go
@@ -72,10 +72,14 @@ type outboundQueries interface {
 
 // streamState tracks one in-flight streamed reply.
 type streamState struct {
-	chatID      int64
-	threadID    int64
-	replyTo     int64
-	messageID   int64 // placeholder message being edited; 0 until first send
+	chatID    int64
+	threadID  int64
+	replyTo   int64
+	messageID int64 // placeholder message being edited; 0 until first send
+	// sending marks the placeholder's sendMessage as in flight: Telegram
+	// already has the message but its id only lands when the call returns.
+	// Terminal delivery waits for that instead of reading messageID as 0.
+	sending     bool
 	accumulated string
 	schedule    *chatSchedule
 }
@@ -166,6 +170,7 @@ const (
 	terminalWorkerCount                = 4
 	maxBotFallbacks                    = 1024
 	chatCapacityRetry                  = time.Second
+	placeholderSettleRetry             = 250 * time.Millisecond
 	maxQueuedTerminalReplies           = 64
 	maxQueuedTerminalRepliesPerSession = 8
 	maxQueuedTerminalReplyBytes        = 16 << 20
@@ -295,7 +300,20 @@ func (o *Outbound) pushPartial(ctx context.Context, target *replyTarget, st *str
 		// reply is delivered in chunks by the final EventChatDone send.
 		text = chunkMessage(text, maxMessageUnits)[0]
 	}
+	// Re-read the id under the lock that guards it — the caller's snapshot was
+	// taken before this send was serialized behind schedule.mu — and publish a
+	// first send while it is in flight, so EventChatDone can tell "no
+	// placeholder yet" from "placeholder sent, id still in the air".
+	o.mu.Lock()
+	msgID = st.messageID
+	st.sending = msgID == 0
+	o.mu.Unlock()
 	if msgID == 0 {
+		defer func() {
+			o.mu.Lock()
+			st.sending = false
+			o.mu.Unlock()
+		}()
 		var reply *replyParameters
 		if st.replyTo != 0 {
 			reply = &replyParameters{MessageID: st.replyTo, AllowSendingWithoutReply: true}
@@ -572,7 +590,19 @@ func (o *Outbound) sendNextTerminalRequest(ctx context.Context, reply *terminalR
 		st := o.streams[target.streamKey]
 		var schedule *chatSchedule
 		if st != nil {
+			if st.sending {
+				// The placeholder is mid-sendMessage: Telegram has it, but its
+				// id arrives only when the call returns. Reading 0 here would
+				// skip the edit path below and post the whole reply a second
+				// time while the placeholder stayed in the chat — the
+				// duplicate in GH #8049. Retry instead of blocking: the wait
+				// spans one Telegram round trip and the worker stays free for
+				// another session.
+				o.mu.Unlock()
+				return terminalRequestResult{retryAt: o.now().Add(placeholderSettleRetry)}
+			}
 			schedule = st.schedule
+			reply.streamedMessageID = st.messageID
 		} else {
 			schedule = o.retainChatLocked(target.botKey, target.chatID)
 			if schedule == nil {
@@ -587,9 +617,6 @@ func (o *Outbound) sendNextTerminalRequest(ctx context.Context, reply *terminalR
 		reply.target = target
 		reply.schedule = schedule
 		reply.chunks = chunkMessage(chatDoneContent(reply.event.Payload), maxMessageUnits)
-		if st != nil {
-			reply.streamedMessageID = st.messageID
-		}
 		if len(reply.chunks) == 0 {
 			return terminalRequestResult{done: true}
 		}

--- a/server/internal/integrations/telegram/outbound.go
+++ b/server/internal/integrations/telegram/outbound.go
@@ -161,6 +161,14 @@ func (h *terminalRetryHeap) Pop() any {
 // well inside both without feeling static.
 const editInterval = 2500 * time.Millisecond
 
+// placeholderSettleRetry re-checks a stream whose placeholder sendMessage is
+// still in flight. A check costs one map lookup — the delivery target is
+// resolved once and cached — so the spacing only trades added latency against
+// wasted wakeups: 250ms is shorter than a typical Telegram round trip, so a
+// settled placeholder is picked up within a check or two, and the wait can
+// never outlast the partial's own 10s send context.
+const placeholderSettleRetry = 250 * time.Millisecond
+
 // Idle schedules remain briefly reusable so sequential tasks and cancellation
 // cannot discard a chat's edit cooldown or Telegram retry_after window. The
 // schedule and compressed-fallback maps both have hard capacity limits.
@@ -170,7 +178,6 @@ const (
 	terminalWorkerCount                = 4
 	maxBotFallbacks                    = 1024
 	chatCapacityRetry                  = time.Second
-	placeholderSettleRetry             = 250 * time.Millisecond
 	maxQueuedTerminalReplies           = 64
 	maxQueuedTerminalRepliesPerSession = 8
 	maxQueuedTerminalReplyBytes        = 16 << 20
@@ -300,11 +307,22 @@ func (o *Outbound) pushPartial(ctx context.Context, target *replyTarget, st *str
 		// reply is delivered in chunks by the final EventChatDone send.
 		text = chunkMessage(text, maxMessageUnits)[0]
 	}
-	// Re-read the id under the lock that guards it — the caller's snapshot was
-	// taken before this send was serialized behind schedule.mu — and publish a
-	// first send while it is in flight, so EventChatDone can tell "no
-	// placeholder yet" from "placeholder sent, id still in the air".
+	// o.streams is the single owner registry for a task's reply. The caller
+	// released o.mu before this point and terminal delivery consumes the
+	// stream under that same lock, so a chat:done may have taken ownership in
+	// the meantime — sending on a stream this partial no longer owns is what
+	// puts a second copy of the reply in the chat (GH #8049).
+	//
+	// Still the owner: re-read the id under the lock that guards it (the
+	// caller's snapshot predates this send being serialized behind
+	// schedule.mu) and publish a first send while it is in flight, so terminal
+	// delivery can tell "no placeholder yet" from "placeholder sent, id still
+	// in the air" and wait for the id instead of posting its own copy.
 	o.mu.Lock()
+	if o.streams[target.streamKey] != st {
+		o.mu.Unlock()
+		return
+	}
 	msgID = st.messageID
 	st.sending = msgID == 0
 	o.mu.Unlock()
@@ -578,13 +596,19 @@ type terminalRequestResult struct {
 // fixed worker available for another session.
 func (o *Outbound) sendNextTerminalRequest(ctx context.Context, reply *terminalReply) terminalRequestResult {
 	if !reply.initialized {
-		target, err := o.resolveTarget(ctx, reply.event, false)
-		if err != nil {
-			return terminalRequestResult{done: true, err: err}
+		if reply.target == nil {
+			// Resolved once and cached: the retries below re-enter here, and
+			// every resolve is two queries plus a credential decrypt.
+			target, err := o.resolveTarget(ctx, reply.event, false)
+			if err != nil {
+				return terminalRequestResult{done: true, err: err}
+			}
+			if target == nil {
+				return terminalRequestResult{done: true}
+			}
+			reply.target = target
 		}
-		if target == nil {
-			return terminalRequestResult{done: true}
-		}
+		target := reply.target
 
 		o.mu.Lock()
 		st := o.streams[target.streamKey]
@@ -614,7 +638,6 @@ func (o *Outbound) sendNextTerminalRequest(ctx context.Context, reply *terminalR
 		o.mu.Unlock()
 
 		reply.initialized = true
-		reply.target = target
 		reply.schedule = schedule
 		reply.chunks = chunkMessage(chatDoneContent(reply.event.Payload), maxMessageUnits)
 		if len(reply.chunks) == 0 {

--- a/server/internal/integrations/telegram/outbound_stream_race_test.go
+++ b/server/internal/integrations/telegram/outbound_stream_race_test.go
@@ -1,0 +1,115 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// A chat:done that lands while the streaming placeholder's sendMessage is
+// still in flight must still edit that placeholder. Reading the not-yet-
+// recorded message id used to yield 0, which sent the whole reply a second
+// time while the placeholder stayed in the chat — two identical messages
+// (GH #8049).
+func TestOutboundChatDoneRacingPlaceholderSendDoesNotDuplicate(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	var texts []string
+	release := make(chan struct{})
+	sendStarted := make(chan struct{}, 1)
+
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+		mu.Lock()
+		methods = append(methods, method)
+		text, _ := body["text"].(string)
+		texts = append(texts, text)
+		first := len(methods) == 1
+		mu.Unlock()
+		if method == "sendMessage" && first {
+			// Hold the placeholder mid-flight: Telegram has accepted the
+			// request but the id has not come back yet.
+			sendStarted <- struct{}{}
+			<-release
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if method == "sendMessage" {
+			_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":99,"chat":{"id":42,"type":"private"},"date":0,"text":"hello world"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"result":true}`))
+	}))
+	defer api.Close()
+
+	q := newTelegramOutboundQueries()
+	q.channelOrigin = true
+	o := NewOutbound(q, nil, api.URL, api.Client(), nil)
+	taskID := telegramTestEvent().TaskID
+
+	go o.handleTaskMessage(events.Event{
+		TaskID: taskID,
+		Type:   protocol.EventTaskMessage,
+		Payload: protocol.TaskMessagePayload{
+			TaskID: taskID, Type: "text", Content: "hello world",
+		},
+	})
+	<-sendStarted
+
+	done := telegramTestEvent()
+	done.Payload = protocol.ChatDonePayload{
+		TaskID: taskID, ChatSessionID: done.ChatSessionID, Content: "hello world",
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sendTerminalReplySynchronouslyForTest(context.Background(), o, done)
+	}()
+
+	// Give terminal delivery time to reach the placeholder-id read before the
+	// send is allowed to complete; that read is the raced one. It must now
+	// wait for the id rather than observe 0.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		o.mu.Lock()
+		_, streaming := o.streams[taskID]
+		o.mu.Unlock()
+		if !streaming {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(release)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("terminal delivery: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("terminal delivery hung")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	sends := 0
+	for _, m := range methods {
+		if m == "sendMessage" {
+			sends++
+		}
+	}
+	if sends != 1 {
+		t.Fatalf("reply delivered %d times, calls=%v texts=%q", sends, methods, texts)
+	}
+	if len(methods) != 2 || methods[1] != "editMessageText" {
+		t.Fatalf("final reply did not edit the placeholder: calls=%v", methods)
+	}
+}

--- a/server/internal/integrations/telegram/outbound_stream_race_test.go
+++ b/server/internal/integrations/telegram/outbound_stream_race_test.go
@@ -200,3 +200,56 @@ func TestOutboundPartialSkipsSendAfterTerminalConsumedTheStream(t *testing.T) {
 		t.Fatalf("partial posted a placeholder for a reply it no longer owned: %v", methods)
 	}
 }
+
+// A reply waiting for chat-schedule capacity waits without a bound, so it must
+// re-resolve its delivery target each attempt: an installation revoked during
+// that wait must stop the reply, not be delivered to from a target resolved
+// before the revocation.
+func TestOutboundCapacityRetryRechecksInstallation(t *testing.T) {
+	api, calls, _, release := gatedTelegramAPI(t)
+	release() // nothing to gate here
+	ctx := context.Background()
+
+	q := newTelegramOutboundQueries()
+	q.channelOrigin = true
+	o := NewOutbound(q, nil, api.URL, api.Client(), nil)
+
+	// Saturate the schedule cache with in-use entries so this reply's chat
+	// cannot be retained and delivery has to wait for capacity.
+	o.mu.Lock()
+	for chatID := int64(1); chatID <= maxChatSchedules; chatID++ {
+		o.retainChatLocked("bot-filler", chatID)
+	}
+	o.mu.Unlock()
+
+	done := telegramTestEvent()
+	done.Payload = protocol.ChatDonePayload{
+		TaskID: done.TaskID, ChatSessionID: done.ChatSessionID, Content: "hello world",
+	}
+	reply := &terminalReply{event: done, byteSize: len(chatDoneContent(done.Payload))}
+
+	result := o.sendNextTerminalRequest(ctx, reply)
+	if result.done || !result.retryAt.After(o.now()) {
+		t.Fatalf("delivery did not wait for capacity: %+v", result)
+	}
+	if reply.initialized {
+		t.Fatal("delivery initialized without a chat schedule")
+	}
+
+	// The installation is revoked while the reply waits, and a slot frees up.
+	q.installation.Status = "revoked"
+	o.mu.Lock()
+	delete(o.chats, chatScheduleKey{botKey: "bot-filler", chatID: 1})
+	o.mu.Unlock()
+
+	result = o.sendNextTerminalRequest(ctx, reply)
+	if reply.initialized {
+		t.Fatal("delivery initialized against a revoked installation")
+	}
+	if !result.done || result.err != nil {
+		t.Fatalf("delivery to a revoked installation was not dropped: %+v", result)
+	}
+	if methods, _ := calls(); len(methods) != 0 {
+		t.Fatalf("delivered to a revoked installation: %v", methods)
+	}
+}

--- a/server/internal/integrations/telegram/outbound_stream_race_test.go
+++ b/server/internal/integrations/telegram/outbound_stream_race_test.go
@@ -14,102 +14,189 @@ import (
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
-// A chat:done that lands while the streaming placeholder's sendMessage is
-// still in flight must still edit that placeholder. Reading the not-yet-
-// recorded message id used to yield 0, which sent the whole reply a second
-// time while the placeholder stayed in the chat — two identical messages
-// (GH #8049).
-func TestOutboundChatDoneRacingPlaceholderSendDoesNotDuplicate(t *testing.T) {
+// gatedTelegramAPI records every Bot API call and holds the first sendMessage
+// open until the returned release func runs, so a test can act while Telegram
+// has the placeholder but its id has not come back yet.
+func gatedTelegramAPI(t *testing.T) (server *httptest.Server, calls func() ([]string, []map[string]any), sendStarted <-chan struct{}, release func()) {
+	t.Helper()
 	var mu sync.Mutex
 	var methods []string
-	var texts []string
-	release := make(chan struct{})
-	sendStarted := make(chan struct{}, 1)
+	var bodies []map[string]any
+	started := make(chan struct{}, 1)
+	gate := make(chan struct{})
+	var releaseOnce sync.Once
 
-	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		method := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
 		mu.Lock()
 		methods = append(methods, method)
-		text, _ := body["text"].(string)
-		texts = append(texts, text)
+		bodies = append(bodies, body)
 		first := len(methods) == 1
 		mu.Unlock()
 		if method == "sendMessage" && first {
-			// Hold the placeholder mid-flight: Telegram has accepted the
-			// request but the id has not come back yet.
-			sendStarted <- struct{}{}
-			<-release
+			started <- struct{}{}
+			<-gate
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if method == "sendMessage" {
-			_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":99,"chat":{"id":42,"type":"private"},"date":0,"text":"hello world"}}`))
+			_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":99,"chat":{"id":42,"type":"private"},"date":0,"text":"x"}}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"ok":true,"result":true}`))
 	}))
-	defer api.Close()
+	t.Cleanup(srv.Close)
+
+	return srv, func() ([]string, []map[string]any) {
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]string(nil), methods...), append([]map[string]any(nil), bodies...)
+		}, started, func() {
+			releaseOnce.Do(func() { close(gate) })
+		}
+}
+
+func telegramPartialEvent(taskID, content string) events.Event {
+	return events.Event{
+		TaskID: taskID,
+		Type:   protocol.EventTaskMessage,
+		Payload: protocol.TaskMessagePayload{
+			TaskID: taskID, Type: "text", Content: content,
+		},
+	}
+}
+
+// A chat:done that lands while the placeholder's sendMessage is still in
+// flight must wait for that id and edit the placeholder. Reading the
+// not-yet-recorded id used to yield 0, which posted the whole reply a second
+// time while the placeholder stayed in the chat (GH #8049).
+func TestOutboundChatDoneWaitsForInFlightPlaceholderSend(t *testing.T) {
+	api, calls, sendStarted, release := gatedTelegramAPI(t)
+	defer release()
 
 	q := newTelegramOutboundQueries()
 	q.channelOrigin = true
 	o := NewOutbound(q, nil, api.URL, api.Client(), nil)
 	taskID := telegramTestEvent().TaskID
 
-	go o.handleTaskMessage(events.Event{
-		TaskID: taskID,
-		Type:   protocol.EventTaskMessage,
-		Payload: protocol.TaskMessagePayload{
-			TaskID: taskID, Type: "text", Content: "hello world",
-		},
-	})
-	<-sendStarted
+	partialDone := make(chan struct{})
+	go func() {
+		defer close(partialDone)
+		o.handleTaskMessage(telegramPartialEvent(taskID, "hello world"))
+	}()
+	<-sendStarted // Telegram has the placeholder; its id is still in the air.
 
 	done := telegramTestEvent()
 	done.Payload = protocol.ChatDonePayload{
 		TaskID: taskID, ChatSessionID: done.ChatSessionID, Content: "hello world",
 	}
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- sendTerminalReplySynchronouslyForTest(context.Background(), o, done)
-	}()
+	reply := &terminalReply{event: done, byteSize: len(chatDoneContent(done.Payload))}
 
-	// Give terminal delivery time to reach the placeholder-id read before the
-	// send is allowed to complete; that read is the raced one. It must now
-	// wait for the id rather than observe 0.
-	deadline := time.Now().Add(200 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		o.mu.Lock()
-		_, streaming := o.streams[taskID]
-		o.mu.Unlock()
-		if !streaming {
+	// Explicit handshake rather than a scheduling window: terminal delivery
+	// runs here, with the send provably mid-flight, and must defer instead of
+	// initializing against an id of 0.
+	result := o.sendNextTerminalRequest(context.Background(), reply)
+	if result.done || result.err != nil {
+		t.Fatalf("terminal delivery finished during the in-flight send: %+v", result)
+	}
+	if !result.retryAt.After(o.now()) {
+		t.Fatalf("terminal delivery did not defer: retryAt = %v", result.retryAt)
+	}
+	if reply.initialized {
+		t.Fatal("terminal delivery initialized against an unrecorded placeholder id")
+	}
+	o.mu.Lock()
+	_, streaming := o.streams[taskID]
+	o.mu.Unlock()
+	if !streaming {
+		t.Fatal("terminal delivery consumed the stream while its send was in flight")
+	}
+
+	release()
+	<-partialDone
+
+	// The placeholder has landed. Clear the chat's edit cooldown so the final
+	// edit is not paced by wall-clock time in a test.
+	o.mu.Lock()
+	schedule := o.streams[taskID].schedule
+	o.mu.Unlock()
+	schedule.mu.Lock()
+	schedule.lastEdit = time.Time{}
+	schedule.mu.Unlock()
+
+	for {
+		result = o.sendNextTerminalRequest(context.Background(), reply)
+		if result.done {
 			break
 		}
-		time.Sleep(time.Millisecond)
-	}
-	close(release)
-
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatalf("terminal delivery: %v", err)
-		}
-	case <-time.After(20 * time.Second):
-		t.Fatal("terminal delivery hung")
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	sends := 0
-	for _, m := range methods {
-		if m == "sendMessage" {
-			sends++
+		if result.retryAt.After(o.now()) {
+			t.Fatalf("unexpected wait after the placeholder settled: %+v", result)
 		}
 	}
-	if sends != 1 {
-		t.Fatalf("reply delivered %d times, calls=%v texts=%q", sends, methods, texts)
+	if result.err != nil {
+		t.Fatalf("terminal delivery: %v", result.err)
 	}
-	if len(methods) != 2 || methods[1] != "editMessageText" {
-		t.Fatalf("final reply did not edit the placeholder: calls=%v", methods)
+
+	methods, bodies := calls()
+	if len(methods) != 2 || methods[0] != "sendMessage" || methods[1] != "editMessageText" {
+		t.Fatalf("reply was not delivered as one placeholder plus one edit: %v", methods)
+	}
+	if bodies[1]["message_id"] != float64(99) || bodies[1]["text"] != "hello world" {
+		t.Fatalf("final edit body = %#v", bodies[1])
+	}
+}
+
+// The mirror case: terminal delivery gets the stream first, between the
+// partial registering it and that partial claiming the send. The partial no
+// longer owns the reply and must not post its placeholder on top of the
+// terminal one.
+func TestOutboundPartialSkipsSendAfterTerminalConsumedTheStream(t *testing.T) {
+	api, calls, _, release := gatedTelegramAPI(t)
+	release() // no gating needed here
+	ctx := context.Background()
+
+	q := newTelegramOutboundQueries()
+	q.channelOrigin = true
+	o := NewOutbound(q, nil, api.URL, api.Client(), nil)
+	taskID := telegramTestEvent().TaskID
+
+	target, err := o.resolveTarget(ctx, telegramPartialEvent(taskID, "hello world"), true)
+	if err != nil || target == nil {
+		t.Fatalf("resolve target: %v (target %v)", err, target)
+	}
+	// Register the stream exactly as handleTaskMessage does, and stop there:
+	// this is the state a partial is in when it is about to claim the send.
+	o.mu.Lock()
+	st := &streamState{
+		chatID: target.chatID, threadID: target.threadID, replyTo: target.replyTo,
+		accumulated: "hello world",
+		schedule:    o.retainChatLocked(target.botKey, target.chatID),
+	}
+	o.streams[target.streamKey] = st
+	o.mu.Unlock()
+
+	done := telegramTestEvent()
+	done.Payload = protocol.ChatDonePayload{
+		TaskID: taskID, ChatSessionID: done.ChatSessionID, Content: "hello world",
+	}
+	if err := sendTerminalReplySynchronouslyForTest(ctx, o, done); err != nil {
+		t.Fatalf("terminal delivery: %v", err)
+	}
+	if methods, _ := calls(); len(methods) != 1 || methods[0] != "sendMessage" {
+		t.Fatalf("terminal delivery calls = %v", methods)
+	}
+
+	// Clear the cooldown the terminal send just set, so the only thing that
+	// can hold this partial back is the ownership check under test.
+	st.schedule.mu.Lock()
+	st.schedule.lastEdit = time.Time{}
+	st.schedule.setBackoffTill(time.Time{})
+	st.schedule.mu.Unlock()
+
+	o.pushPartial(ctx, target, st, 0, "hello world")
+
+	if methods, _ := calls(); len(methods) != 1 {
+		t.Fatalf("partial posted a placeholder for a reply it no longer owned: %v", methods)
 	}
 }


### PR DESCRIPTION
## What

Reported in #8049: roughly 90% of Telegram replies arrive twice, with identical content.

A streamed Telegram reply posts a placeholder message on the agent's first text frame and edits it as the transcript grows, so the final `chat:done` edits that same message. The placeholder's id is only recorded once `sendMessage` returns, and terminal delivery read that id without knowing a send was still in flight. A `chat:done` landing inside the round trip read `0`, skipped the edit path, and posted the whole reply as a new message — while the placeholder, carrying the same text, stayed in the chat.

The window is not exotic. `task:message` is published on the synchronous bus, so the placeholder's `sendMessage` runs inside the daemon's transcript-report request (`ReportTaskMessages`), whose client timeout is 5s and whose failure is logged but not retried. In any deployment where a Telegram round trip can outlast that budget, the daemon gives up on the flush and completes the task while the placeholder is still in the air — and nearly every reply duplicates.

## Changes

- `o.streams` becomes the single owner registry for a task's reply: a partial confirms it still owns the stream in the same critical section that publishes its send, and gives up when terminal delivery has taken over.
- `streamState` gains a `sending` marker set while the placeholder's `sendMessage` is in flight. Terminal delivery returns a short `retryAt` when it sees that marker instead of reading a not-yet-recorded id. Retry rather than block: the wait spans one Telegram round trip and the fixed worker stays free for another session.
- The id is now read under the mutex that guards it — the unsynchronized read is what `-race` flagged. `pushPartial` re-reads it there too, so a frame that queued behind the first send can no longer post a second placeholder from a stale snapshot.
- The delivery target is resolved once and cached for the settle retry, so a check costs a map lookup rather than two queries plus a credential decrypt. The cache is scoped to that retry: the chat-capacity wait is unbounded, so it drops the cache and re-resolves, which is what re-checks the installation's status and picks up a rotated bot token.

One file, plus two regression tests.

## Verification

- `TestOutboundChatDoneWaitsForInFlightPlaceholderSend` holds the fake Bot API's first `sendMessage` open and drives terminal delivery by hand inside that window: it must defer with a future `retryAt`, leave the reply uninitialized and leave the stream in place, and once the placeholder settles the final content must land as an `editMessageText` on it. Drop the wait branch and it fails.
- `TestOutboundPartialSkipsSendAfterTerminalConsumedTheStream` covers the mirror case — the stream is registered but the partial has not claimed its send yet when `chat:done` consumes it. Drop the ownership check and it fails with `[sendMessage sendMessage]`.
- `TestOutboundCapacityRetryRechecksInstallation` saturates the schedule cache, revokes the installation while the reply waits for a slot, and asserts the reply is dropped rather than delivered. Keep the cache across that wait and it fails with `delivery initialized against a revoked installation`.
- No test waits on wall-clock time; five `-race` runs of the package take about six seconds.
- `go test ./internal/integrations/telegram/... -race` passes; the pre-existing data race between `outbound.go:316` and the terminal read is gone.
- `go build ./...` and `go vet ./internal/integrations/...` clean.

## Not in this PR

Deliberately left out so this stays a focused fix; each is a separate behavior change:

- Nothing retracts an orphaned placeholder. The `fallbackFreshSend` path (terminal edit fails with something other than 429 / "not modified") still posts a fresh message and leaves the placeholder behind; the package has no `deleteMessage`.
- The placeholder's `sendMessage` still runs inside the daemon's transcript-report request, so Telegram's RTT still decides whether that flush times out.
- Outbound delivery has no idempotency key and does not persist the delivered Telegram `message_id`, so a process restart cannot tell whether a reply already went out.
- A text frame that arrives after terminal delivery has consumed the stream registers a fresh one and posts a placeholder nothing will reconcile. The daemon drains the transcript before completing a task, so this needs a late flush to happen at all, and fixing it properly means tracking recently-completed tasks.

Because of the first item, #8049 should stay open until the reporter confirms the duplicates are gone in their environment.


