### PR TITLE
fix(installer): default to user-local CLI install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -167,21 +167,43 @@ install_cli_binary() {
 
   tar -xzf "$tmp_dir/multica.tar.gz" -C "$tmp_dir" multica
 
-  # Try /usr/local/bin first, fall back to ~/.local/bin. Tests and scripted
-  # installs can override the first choice with MULTICA_BIN_DIR.
-  local bin_dir="${MULTICA_BIN_DIR:-/usr/local/bin}"
-  if [ -w "$bin_dir" ]; then
-    mv "$tmp_dir/multica" "$bin_dir/multica"
+  # New installs default to a user-writable location and never require sudo.
+  # Explicit targets (MULTICA_BIN_DIR / --bin-dir / --system) may use sudo if
+  # needed. Upgrades keep using the directory of an existing multica binary so
+  # previous system-wide installations remain upgradeable.
+  local bin_dir
+  local allow_sudo=false
+  if [ -n "${MULTICA_BIN_DIR:-}" ]; then
+    bin_dir="$MULTICA_BIN_DIR"
+    allow_sudo=true
+  elif command_exists multica; then
+    bin_dir="$(dirname "$(command -v multica)")"
+    allow_sudo=true
   else
     bin_dir="$HOME/.local/bin"
-    mkdir -p "$bin_dir"
+    info "Using user install directory $bin_dir (use --system for /usr/local/bin)"
+  fi
+
+  if mkdir -p "$bin_dir" 2>/dev/null && [ -w "$bin_dir" ]; then
     mv "$tmp_dir/multica" "$bin_dir/multica"
-    chmod +x "$bin_dir/multica"
-    # Add to PATH if not already there
-    if ! echo "$PATH" | tr ':' '\n' | grep -q "^$bin_dir$"; then
-      export PATH="$bin_dir:$PATH"
-      add_to_path "$bin_dir"
+  elif [ "$allow_sudo" = true ] && command_exists sudo; then
+    info "Installing to $bin_dir requires elevated privileges..."
+    if ! sudo mkdir -p "$bin_dir" || ! sudo mv "$tmp_dir/multica" "$bin_dir/multica"; then
+      rm -rf "$tmp_dir"
+      fail "Could not install to $bin_dir. Choose a writable directory with --bin-dir PATH, or omit the option for a user-local install."
     fi
+  else
+    rm -rf "$tmp_dir"
+    fail "Could not write to $bin_dir. Choose a writable directory with --bin-dir PATH, or use --system for a system-wide install."
+  fi
+
+  chmod +x "$bin_dir/multica" 2>/dev/null || true
+
+  # Add user/custom install directories to PATH if not already there. System
+  # locations such as /usr/local/bin are normally already on PATH.
+  if ! echo "$PATH" | tr ':' '\n' | grep -q "^$bin_dir$"; then
+    export PATH="$bin_dir:$PATH"
+    add_to_path "$bin_dir"
   fi
 
   rm -rf "$tmp_dir"
@@ -215,6 +237,7 @@ get_selfhost_ref() {
     printf '%s' "$latest"
     return
   fi
+
   printf '%s' "main"
 }
 
@@ -516,19 +539,40 @@ main() {
       --with-server) mode="with-server" ;;
       --local)       mode="with-server" ;;  # backwards compat alias
       --stop)        mode="stop" ;;
+      --system)
+        MULTICA_BIN_DIR="/usr/local/bin"
+        export MULTICA_BIN_DIR
+        ;;
+      --bin-dir)
+        shift
+        [ $# -gt 0 ] || fail "--bin-dir requires a path"
+        MULTICA_BIN_DIR="$1"
+        export MULTICA_BIN_DIR
+        ;;
+      --bin-dir=*)
+        MULTICA_BIN_DIR="${1#*=}"
+        [ -n "$MULTICA_BIN_DIR" ] || fail "--bin-dir requires a path"
+        export MULTICA_BIN_DIR
+        ;;
       --help|-h)
-        echo "Usage: install.sh [--with-server | --stop]"
+        echo "Usage: install.sh [--with-server | --stop] [--system | --bin-dir PATH]"
         echo ""
         echo "  (default)       Install / upgrade the Multica CLI"
         echo "  --with-server   Install CLI + provision a self-host server (Docker)"
         echo "  --stop          Stop a self-hosted installation"
+        echo "  --system        Install the CLI system-wide to /usr/local/bin"
+        echo "                  (may request sudo if the directory is not writable)"
+        echo "  --bin-dir PATH  Install the CLI to an explicit directory"
+        echo ""
+        echo "Installation location:"
+        echo "  New installs default to \$HOME/.local/bin and do not require sudo."
+        echo "  Use --system to make the CLI available system-wide to all users."
         echo ""
         echo "Environment variables:"
         echo "  MULTICA_INSTALL_DIR   Self-host server install directory"
         echo "                        (default: \$HOME/.multica/server)"
-        echo "  MULTICA_BIN_DIR       Target directory for the CLI binary when"
-        echo "                        installing from GitHub Releases"
-        echo "                        (default: /usr/local/bin, then \$HOME/.local/bin)"
+        echo "  MULTICA_BIN_DIR       Explicit target directory for the CLI binary"
+        echo "                        (default for new installs: \$HOME/.local/bin)"
         echo "  MULTICA_SELFHOST_REF  Git ref to check out for self-host assets"
         echo "                        (default: latest release tag, falling back to main)"
         echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -172,8 +172,6 @@ install_cli_binary() {
   local bin_dir="${MULTICA_BIN_DIR:-/usr/local/bin}"
   if [ -w "$bin_dir" ]; then
     mv "$tmp_dir/multica" "$bin_dir/multica"
-  elif command_exists sudo; then
-    sudo mv "$tmp_dir/multica" "$bin_dir/multica"
   else
     bin_dir="$HOME/.local/bin"
     mkdir -p "$bin_dir"
@@ -217,7 +215,6 @@ get_selfhost_ref() {
     printf '%s' "$latest"
     return
   fi
-
   printf '%s' "main"
 }
 

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -77,6 +77,31 @@ _run_installer() {
   fi
 }
 
+# Run the release-binary installer without Homebrew or inherited environment
+# state. Tests can pass installer CLI arguments after the sandbox path.
+_run_binary_installer() {
+  local tmp="$1"
+  shift
+  local out="$tmp/install.out"
+  local err="$tmp/install.err"
+
+  mkdir -p "$tmp/home"
+  : >"$tmp/sudo.log"
+
+  if ! env -i \
+    PATH="$tmp/stub-bin:/usr/bin:/bin" \
+    HOME="$tmp/home" \
+    MULTICA_TEST_ARCHIVE="$tmp/multica.tar.gz" \
+    MULTICA_TEST_SUDO_LOG="$tmp/sudo.log" \
+    MULTICA_TEST_SYSTEM_SHADOW="$tmp/stub-bin" \
+    bash "$ROOT_DIR/scripts/install.sh" "$@" >"$out" 2>"$err"; then
+    echo "install.sh exited non-zero" >&2
+    cat "$out" >&2 || true
+    cat "$err" >&2 || true
+    return 1
+  fi
+}
+
 test_brew_install_failure_falls_back_to_release_binary() {
   local tmp
   tmp="$(mktemp -d)"
@@ -231,6 +256,126 @@ STUB
   fi
   if grep -q "multica login --token <YOUR_TOKEN>" "$tmp/install.out"; then
     echo "did not expect token login command in local installer output" >&2
+    cat "$tmp/install.out" >&2 || true
+    return 1
+  fi
+}
+
+test_default_install_is_user_local_and_never_calls_sudo() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  _setup_sandbox "$tmp"
+  cat >"$tmp/stub-bin/sudo" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >>"$MULTICA_TEST_SUDO_LOG"
+exit 99
+STUB
+  chmod +x "$tmp/stub-bin/sudo"
+
+  _run_binary_installer "$tmp"
+
+  if [[ ! -x "$tmp/home/.local/bin/multica" ]]; then
+    echo "expected default install at $tmp/home/.local/bin/multica" >&2
+    cat "$tmp/install.out" >&2 || true
+    cat "$tmp/install.err" >&2 || true
+    return 1
+  fi
+  if [[ -s "$tmp/sudo.log" ]]; then
+    echo "default user-local install must not invoke sudo" >&2
+    cat "$tmp/sudo.log" >&2 || true
+    return 1
+  fi
+  if ! grep -q "Using user install directory $tmp/home/.local/bin" "$tmp/install.out"; then
+    echo "expected installer to report the user-local install directory" >&2
+    cat "$tmp/install.out" >&2 || true
+    return 1
+  fi
+}
+
+test_bin_dir_overrides_default_without_sudo_when_writable() {
+  local tmp custom_bin
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  custom_bin="$tmp/custom-bin"
+
+  _setup_sandbox "$tmp"
+  mkdir -p "$custom_bin"
+  cat >"$tmp/stub-bin/sudo" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >>"$MULTICA_TEST_SUDO_LOG"
+exit 99
+STUB
+  chmod +x "$tmp/stub-bin/sudo"
+
+  _run_binary_installer "$tmp" --bin-dir "$custom_bin"
+
+  if [[ ! -x "$custom_bin/multica" ]]; then
+    echo "expected --bin-dir install at $custom_bin/multica" >&2
+    cat "$tmp/install.out" >&2 || true
+    cat "$tmp/install.err" >&2 || true
+    return 1
+  fi
+  if [[ -s "$tmp/sudo.log" ]]; then
+    echo "writable --bin-dir target must not invoke sudo" >&2
+    cat "$tmp/sudo.log" >&2 || true
+    return 1
+  fi
+}
+
+test_system_install_uses_sudo_when_system_dir_is_not_writable() {
+  local tmp
+
+  # Avoid touching a real system directory when the test itself runs as root or
+  # otherwise has direct write access. Hosted CI runners normally take this path.
+  if [ -w /usr/local/bin ]; then
+    echo "skipping --system sudo test: /usr/local/bin is writable"
+    return 0
+  fi
+
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  _setup_sandbox "$tmp"
+  cat >"$tmp/stub-bin/sudo" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >>"$MULTICA_TEST_SUDO_LOG"
+case "${1:-}" in
+  mkdir)
+    # The real directory already exists on normal CI hosts; acknowledge the
+    # privileged mkdir without mutating the host filesystem.
+    exit 0
+    ;;
+  mv)
+    # Put a shadow copy on PATH so install.sh's final command_exists check can
+    # succeed without writing to the host's /usr/local/bin.
+    cp "$2" "$MULTICA_TEST_SYSTEM_SHADOW/multica"
+    chmod +x "$MULTICA_TEST_SYSTEM_SHADOW/multica"
+    exit 0
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+STUB
+  chmod +x "$tmp/stub-bin/sudo"
+
+  _run_binary_installer "$tmp" --system
+
+  if ! grep -q '^mkdir -p /usr/local/bin$' "$tmp/sudo.log"; then
+    echo "expected --system to use sudo for /usr/local/bin when it is not writable" >&2
+    cat "$tmp/sudo.log" >&2 || true
+    return 1
+  fi
+  if ! grep -q '^mv .* /usr/local/bin/multica$' "$tmp/sudo.log"; then
+    echo "expected --system to install multica to /usr/local/bin through sudo" >&2
+    cat "$tmp/sudo.log" >&2 || true
+    return 1
+  fi
+  if ! grep -q "Installing to /usr/local/bin requires elevated privileges" "$tmp/install.out"; then
+    echo "expected --system to report its privilege escalation" >&2
     cat "$tmp/install.out" >&2 || true
     return 1
   fi
@@ -513,6 +658,9 @@ test_brew_install_failure_falls_back_to_release_binary
 test_brew_tap_failure_falls_back_to_release_binary
 test_remote_ssh_install_prints_token_login_hint
 test_local_install_does_not_print_token_login_hint
+test_default_install_is_user_local_and_never_calls_sudo
+test_bin_dir_overrides_default_without_sudo_when_writable
+test_system_install_uses_sudo_when_system_dir_is_not_writable
 test_with_server_uses_compose_published_ports
 test_with_server_fails_when_compose_port_is_unavailable
 echo "install.sh tests passed"


### PR DESCRIPTION
## What does this PR do?

This PR changes the Linux installer to default to a user-local CLI installation instead of implicitly attempting privilege escalation.

Currently, `install.sh` prefers `/usr/local/bin` and checks only whether the `sudo` executable exists. On systems where `sudo` is installed but the current user is not in `sudoers`, the installer attempts `sudo mv` and fails instead of using the existing user-local installation path.

This change makes new CLI installs default to:

```bash
$HOME/.local/bin
```

which does not require root privileges.

System-wide installation remains available explicitly through:

```bash
--system
```

which targets `/usr/local/bin` and may use `sudo` if required.

Custom installation locations are also supported through:

```bash
--bin-dir PATH
```

The existing `MULTICA_BIN_DIR` environment variable remains supported.

For upgrades, if an existing `multica` binary is already installed, the installer continues using its current directory so existing system-wide installations are not unexpectedly migrated to the user's home directory.

## Related Issue

Closes #8110

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking installation option)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

### `scripts/install.sh`

- Default new binary installs to `$HOME/.local/bin`.
- Do not invoke `sudo` during the default user-level installation flow.
- Add `--system` for explicit system-wide installation to `/usr/local/bin`.
- Add `--bin-dir PATH` / `--bin-dir=PATH` for custom install locations.
- Preserve support for `MULTICA_BIN_DIR`.
- Preserve the existing installation directory when upgrading an already-installed CLI.
- Only attempt `sudo` when the user has explicitly selected a location that requires elevated privileges.
- Update `--help` output to explain the new installation-location behavior.

### `scripts/install.test.sh`

Add regression coverage for:

- default installation to `$HOME/.local/bin`;
- verifying that the default installation never invokes `sudo`;
- explicit `--bin-dir` installation without unnecessary privilege escalation;
- explicit `--system` installation using the elevated path when `/usr/local/bin` is not writable.

The `--system` test uses a stubbed `sudo` implementation and does not modify the CI host's real `/usr/local/bin`.

## How to Test

### Default user install

```bash
curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash
```

Expected:

```text
$HOME/.local/bin/multica
```

No sudo prompt should occur.

### System-wide install

```bash
curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh \
  | bash -s -- --system
```

Expected:

```text
/usr/local/bin/multica
```

If `/usr/local/bin` is not writable, the installer may request sudo explicitly for this system-wide installation.

### Custom directory

```bash
curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh \
  | bash -s -- --bin-dir "$HOME/bin"
```

Expected:

```text
$HOME/bin/multica
```

### Automated tests

The relevant test suite is:

```bash
bash scripts/install.test.sh
```

Regression tests for the new install-location behavior have been added. I have not run the complete installer test suite locally yet; CI should exercise `scripts/install.test.sh`.

## Rationale / Risk

The installer already supports user-local installation, and the Multica daemon itself does not require root privileges. Making the user-local directory the default avoids unexpected privilege escalation for a user-level CLI.

The main compatibility consideration is existing system-wide installations. To avoid changing their upgrade behavior, the installer detects an existing `multica` executable and continues upgrading it in its current directory.

Users who intentionally want a system-wide installation retain that functionality through the explicit `--system` option.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs
- [ ] If this PR touches Chinese product copy, I checked it against the relevant conventions
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** ChatGPT (GPT-5.6 Sol)

**Prompt / approach:**

The issue was first identified while installing Multica under a restricted Unix account where `sudo` was present on the host but unavailable to the current user.

I used ChatGPT to review the installer logic, compare the privilege model with Multica's user-level daemon behavior, design a user-local-by-default installation flow, preserve explicit system-wide installation and upgrade compatibility, and add regression tests for the affected installer paths.

The implementation was reviewed iteratively with particular attention to avoiding unnecessary privilege escalation and preserving existing system-wide installations.