### PR TITLE
fix(issues): truncate long thread outline labels

### DIFF
--- a/packages/views/issues/components/thread-minimap.tsx
+++ b/packages/views/issues/components/thread-minimap.tsx
@@ -50,8 +50,8 @@ export function waveScale(distancePx: number): number {
 }
 
 /**
- * Caps applied by `commentPreview`. The preview card clamps visually
- * (`truncate` / `line-clamp-3`), but agent comments can be tens of KB of
+ * Caps applied by `commentPreview`. Outline labels truncate visually,
+ * but agent comments can be tens of KB of
  * markdown — capping here keeps the flattened strings (and the aria-labels
  * derived from them) small instead of shipping the whole comment into the DOM.
  */
@@ -497,13 +497,13 @@ export function ThreadMinimap({
                       ? t(($) => $.detail.thread_nav_resolved_label, { title })
                       : title}
                     aria-description={participantNames.join(", ") || undefined}
-                    className="flex w-full items-start gap-3 rounded-md px-3 py-2 text-left text-body text-muted-foreground transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-active:font-medium data-active:text-brand"
+                    className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-body text-muted-foreground transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-active:font-medium data-active:text-brand"
                   >
-                    <span className="min-w-0 flex-1 break-words">
-                      {title}
+                    <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                      <span className="truncate">{title}</span>
                       {thread.resolved && (
                         <CheckCircle2
-                          className="ml-1.5 inline-block size-3.5 align-text-bottom text-success"
+                          className="size-3.5 shrink-0 text-success"
                           aria-label={t(($) => $.comment.resolve.thread_resolved_badge)}
                         />
                       )}


### PR DESCRIPTION
## What does this PR do?

When a comment has no heading, the outline uses its first nonempty line as its label. A long paragraph therefore wraps into many lines and dominates the hover panel. Limit every outline label to one line with an ellipsis, keeping rows compact for both long headings and ordinary comments.

The resolved check remains immediately after the visible label in a separate, nonshrinking element. Participant avatars stay right-aligned and visible. Existing accessible labels and click-to-jump behavior are preserved.

## Related Issue

Follow-up to #8120, based on the reported long-comment screenshot.

## Type of Change

- [x] Bug fix

## Changes Made

- `packages/views/issues/components/thread-minimap.tsx`: truncate only the text span and center-align the label, status icon, and avatars in a single row.

## How to Test

1. Open an issue with multiple threads, including a long heading and a long comment without a heading.
2. Hover the outline rail. Both long labels should display on one line with an ellipsis.
3. Check a resolved thread with multiple participants: its check and avatars should remain visible. Click the truncated label to jump to the original comment.

Validation completed:
- `pnpm --filter @multica/views exec vitest run issues/components/thread-minimap.test.tsx` — 19 tests passed.
- `pnpm --filter @multica/views exec eslint issues/components/thread-minimap.tsx` — passed.
- `git diff --check` — passed.

Browser acceptance was not rerun; the local development environment remains stopped. Existing component tests verify navigation, resolution, and avatar behavior but do not measure CSS overflow.

## Checklist

- [x] Included the problem and rationale
- [x] Ran relevant local tests
- [x] Considered risks: visual truncation only; original comments remain available by clicking through
- [ ] Before/after screenshots attached

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Fix long outline entries for comments without titles and create a new PR. Apply CSS ellipsis to text while reserving space for status and participant avatars; run the existing component suite and ESLint.
