### PR TITLE
fix(sidebar): capitalize AI Team label

### DIFF
--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -53,7 +53,7 @@
     "new_issue_shortcut": "C",
     "pinned_label": "Pinned",
     "work_group": "Work",
-    "ai_team_group": "AI team",
+    "ai_team_group": "AI Team",
     "show_more_pins": "Show {{count}} more…",
     "show_fewer_pins": "Show fewer",
     "unread_overflow": "99+",


### PR DESCRIPTION
## What does this PR do?

Updates the shared web and desktop sidebar heading from “AI team” to “AI Team”, matching the requested capitalization.

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Update `sidebar.ai_team_group` in `packages/views/locales/en/layout.json`.

## How to Test

- `git diff --check` passed before commit.
- Automated tests were skipped because this changes only a display string.
- Manual verification: open the sidebar in English and confirm the heading reads “AI Team”.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above

Risk is limited to the capitalization of one English sidebar heading. No behavior changes or documentation updates are needed. Screenshots were not captured.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Requested “side bar name: AI team -> AI Team”. Updated the existing shared translation and checked the diff.
