### PR TITLE
fix(agent): recover from ghost ACP sessions — dead resume pointers self-heal instead of looping forever

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2974,6 +2974,21 @@ func TestShouldRetryWithFreshSession(t *testing.T) {
 			want:           true,
 		},
 		{
+			// The ghost-session incident: qodercli rejects, at session/resume,
+			// an id from a session that died at set_model before its first
+			// prompt (never persisted by the runtime). The backend fix flags
+			// ResumeRejected on that branch; this pins that the incident shape
+			// actually clears the daemon's fresh-session retry gate.
+			name: "qoder invalid session identifier at resume retries",
+			result: agent.Result{
+				Status:         "failed",
+				Error:          `qoder session/resume failed: session/resume: Invalid session identifier "27d8031c" (code=-32602)`,
+				ResumeRejected: true,
+			},
+			priorSessionID: "27d8031c",
+			want:           true,
+		},
+		{
 			name:           "no resume requested never retries",
 			result:         agent.Result{Status: "failed", Error: "boom", ResumeRejected: true},
 			priorSessionID: "",

--- a/server/internal/service/resume_unsafe_test.go
+++ b/server/internal/service/resume_unsafe_test.go
@@ -67,6 +67,27 @@ func TestResumeUnsafeFailureEmptyHistoryMessage(t *testing.T) {
 			want:          true,
 		},
 		{
+			// A runtime rejecting the recorded session id outright (qodercli
+			// "Invalid session identifier ..." at session/resume) can only be
+			// cured by a fresh session. Rows a fixed daemon writes carry
+			// ResumeRejected and never reach here, but an un-upgraded daemon
+			// writes agent_error.unknown with this text — the text guard is the
+			// only thing that stops a rerun from replaying the dead pointer.
+			name:          "invalid session identifier text flips resume even when the reason is unknown",
+			failureReason: "agent_error.unknown",
+			errorText:     `qoder session/resume failed: session/resume: Invalid session identifier "27d8031c". Searched for sessions in ~/.qoder/projects/-tmp. (code=-32602)`,
+			want:          true,
+		},
+		{
+			// The predicate is deliberately the full phrase: a session-shaped
+			// complaint that is NOT about the runtime refusing the recorded id
+			// must stay resumable.
+			name:          "shorter invalid-session wording stays resumable",
+			failureReason: "agent_error.unknown",
+			errorText:     "invalid session id supplied by client",
+			want:          false,
+		},
+		{
 			// Transient failures must stay resumable: the whole point of
 			// reusing the session on retry is to keep the conversation.
 			name:          "provider network drop stays resumable",

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -5247,6 +5247,16 @@ func ResumeUnsafeFailure(failureReason, errorText string) bool {
 	if taskfailure.AuthMethodUnresolved(errorText) {
 		return true
 	}
+	// Same defense-in-depth for a runtime rejecting the recorded session id
+	// outright ("Invalid session identifier ...", qodercli at session/resume):
+	// the daemon-side fix flags ResumeRejected and retires the pointer, but
+	// rows an older daemon wrote carry only the error text. Keep it in sync
+	// with the GetLastTaskSession / GetLastChatTaskSession /
+	// GetLastMultiAgentChatTaskSession resume queries; the phrase itself lives
+	// in taskfailure.InvalidSessionIdentifier.
+	if taskfailure.InvalidSessionIdentifier(errorText) {
+		return true
+	}
 	// Same defense-in-depth for the provider-agnostic empty-message shape:
 	// a daemon too old to carry classifyPoisonedError's new branch reports
 	// agent_error.unknown, and without this the manual-retry path would

--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -332,7 +332,15 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("grok session/load failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				if isACPSessionNotFound(err) {
+					// The runtime rejected the recorded session id outright,
+					// before set_model/prompt could surface it. Mirror
+					// zeroclaw/qwenpaw: flag ResumeRejected so the daemon's
+					// fresh-session retry fires and retires the dead pointer
+					// instead of every follow-up re-requesting it forever.
+					resumeRejected = true
+				}
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			var changed bool

--- a/server/pkg/agent/grok_test.go
+++ b/server/pkg/agent/grok_test.go
@@ -275,6 +275,82 @@ func TestGrokSetModelFailureFailsTask(t *testing.T) {
 	}
 }
 
+// fakeGrokACPGhostLoadScript impersonates `grok agent --always-approve stdio`
+// refusing an unknown session id directly at session/load. It answers
+// initialize with a cached_token auth method and authenticate with success,
+// because grok gates every session method behind authentication.
+func fakeGrokACPGhostLoadScript() string {
+	return `#!/bin/sh
+authenticated=
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"authMethods":[{"id":"cached_token","name":"Cached login"}],"agentCapabilities":{"loadSession":true,"mcpCapabilities":{"http":true,"sse":true}}}}\n' "$id"
+      ;;
+    *'"method":"authenticate"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+      authenticated=1
+      ;;
+    *'"method":"session/load"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Session not found"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestGrokBackendSignalsResumeRejectedAtLoad pins the ghost-session loop fix:
+// when session/load itself fails with a session-not-found error, the Result
+// must carry ResumeRejected=true so the daemon's fresh-session retry fires and
+// retires the dead pointer. Before the fix the flag stayed false on this path,
+// and every follow-up re-requested the same dead id forever.
+func TestGrokBackendSignalsResumeRejectedAtLoad(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "grok")
+	writeTestExecutable(t, fakePath, []byte(fakeGrokACPGhostLoadScript()))
+
+	backend, err := New("grok", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new grok backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_stale",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "Session not found") {
+			t.Errorf("expected error to surface the session-not-found message, got %q", result.Error)
+		}
+		if !result.ResumeRejected {
+			t.Fatal("expected ResumeRejected=true so the daemon's fresh-session retry fires")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 func TestGrokUsesSessionLoadForResume(t *testing.T) {
 	t.Parallel()
 	tempDir := t.TempDir()

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -515,7 +515,15 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("hermes session/resume failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				if isACPSessionNotFound(err) {
+					// The runtime rejected the recorded session id outright,
+					// before set_model/prompt could surface it. Mirror
+					// zeroclaw/qwenpaw: flag ResumeRejected so the daemon's
+					// fresh-session retry fires and retires the dead pointer
+					// instead of every follow-up re-requesting it forever.
+					resumeRejected = true
+				}
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			sessionResult = result
@@ -1380,7 +1388,12 @@ func (e *acpRPCError) Error() string {
 // unknown-session path (src/kimi_cli/acp/server.py), Reasonix says
 // "session/resume: unknown session <id>" under -32602, and ZeroClaw defines
 // its own SESSION_NOT_FOUND = -32000 in the implementation-defined range
-// (zeroclaw-api/src/jsonrpc.rs) — so neither the code nor one runtime's exact
+// (zeroclaw-api/src/jsonrpc.rs). qodercli (1.1.25, verified against the real
+// CLI) rejects an id it never persisted with -32602 "Invalid session
+// identifier <id>" plus data {"code":"INVALID_SESSION_IDENTIFIER"} — the
+// shape a session that died before its first prompt produces, since the
+// daemon kills the process on the set_model failure and the runtime never
+// flushes the transcript. So neither the code nor one runtime's exact
 // wording is discriminating and all of them are matched. The wording check
 // still carries the decision: -32000 is a generic server-error code, and a
 // transient failure reported under it must not read as a lost session.
@@ -1395,7 +1408,8 @@ func isACPSessionNotFound(err error) bool {
 	text := strings.ToLower(rpcErr.Message + " " + rpcErr.Data)
 	return strings.Contains(text, "session not found") ||
 		strings.Contains(text, "no session found") ||
-		strings.Contains(text, "unknown session")
+		strings.Contains(text, "unknown session") ||
+		strings.Contains(text, "invalid session identifier")
 }
 
 // isACPHeldByProcess reports whether a session/load error means the session

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -2960,6 +2960,15 @@ func TestIsACPSessionNotFound(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "qodercli invalid session identifier frame",
+			// qodercli 1.1.25 rejects an id it never persisted directly at
+			// session/resume as invalid_params "Invalid session identifier
+			// <id>" with a structured data object. Verified against the real
+			// CLI (`qodercli --yolo --acp`).
+			err:  &acpRPCError{Method: "session/resume", Code: -32602, Message: `Invalid session identifier "ses_ghost".` + "\n  Searched for sessions in ~/.qoder/projects/-tmp.", Data: `{"code":"INVALID_SESSION_IDENTIFIER","sessionId":"ses_ghost","projectRoot":"/tmp"}`},
+			want: true,
+		},
+		{
 			name: "invalid params without session wording",
 			err:  &acpRPCError{Method: "session/set_model", Code: -32602, Message: "model not available: bogus-model"},
 			want: false,
@@ -2987,6 +2996,77 @@ func TestIsACPSessionNotFound(t *testing.T) {
 				t.Errorf("isACPSessionNotFound(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+// fakeHermesACPRejectedResumeScript impersonates a runtime that refuses the
+// recorded session id directly at session/resume (JSON-RPC -32603 "Session
+// not found") instead of letting the failure surface at set_model/prompt.
+func fakeHermesACPRejectedResumeScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/resume"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Session not found"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestHermesBackendSignalsResumeRejectedAtResume pins the ghost-session loop
+// fix for the resume-time rejection shape: when session/resume itself fails
+// with a session-not-found error, the Result must carry ResumeRejected=true so
+// the daemon's fresh-session retry fires and retires the dead pointer. Before
+// the fix the flag stayed false on this path, and every follow-up re-requested
+// the same dead id forever.
+func TestHermesBackendSignalsResumeRejectedAtResume(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "hermes")
+	writeTestExecutable(t, fakePath, []byte(fakeHermesACPRejectedResumeScript()))
+
+	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_stale",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "Session not found") {
+			t.Errorf("expected error to surface the session-not-found message, got %q", result.Error)
+		}
+		if !result.ResumeRejected {
+			t.Fatal("expected ResumeRejected=true so the daemon's fresh-session retry fires")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
 	}
 }
 

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -260,7 +260,15 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kimi session/resume failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				if isACPSessionNotFound(err) {
+					// The runtime rejected the recorded session id outright,
+					// before set_model/prompt could surface it. Mirror
+					// zeroclaw/qwenpaw: flag ResumeRejected so the daemon's
+					// fresh-session retry fires and retires the dead pointer
+					// instead of every follow-up re-requesting it forever.
+					resumeRejected = true
+				}
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			var changed bool

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -469,6 +469,77 @@ done
 `
 }
 
+// fakeKimiACPGhostResumeScript impersonates kimi-cli refusing an unknown
+// session id directly at session/resume with its observed shape: -32602
+// "Invalid params" and {"session_id":"Session not found"} in data.
+func fakeKimiACPGhostResumeScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/resume"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"Invalid params","data":{"session_id":"Session not found"}}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestKimiBackendSignalsResumeRejectedAtResume pins the ghost-session loop
+// fix for the resume-time rejection shape: when session/resume itself fails
+// with a session-not-found error, the Result must carry ResumeRejected=true so
+// the daemon's fresh-session retry fires and retires the dead pointer. Before
+// the fix the flag stayed false on this path, and every follow-up re-requested
+// the same dead id forever.
+func TestKimiBackendSignalsResumeRejectedAtResume(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPGhostResumeScript()))
+
+	backend, err := New("kimi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kimi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_stale",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "Session not found") {
+			t.Errorf("expected error to surface the session-not-found message, got %q", result.Error)
+		}
+		if !result.ResumeRejected {
+			t.Fatal("expected ResumeRejected=true so the daemon's fresh-session retry fires")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 // TestKimiBackendClearsSessionIDWhenSetModelSessionNotFound pins the
 // set_model sibling of the resumed-session fix: with a model override,
 // session/set_model runs before session/prompt, so a dead resumed

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -270,7 +270,15 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kiro session/load failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				if isACPSessionNotFound(err) {
+					// The runtime rejected the recorded session id outright,
+					// before set_model/prompt could surface it. Mirror
+					// zeroclaw/qwenpaw: flag ResumeRejected so the daemon's
+					// fresh-session retry fires and retires the dead pointer
+					// instead of every follow-up re-requesting it forever.
+					resumeRejected = true
+				}
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			// Apply the same defensive resolution kimi/hermes use: if

--- a/server/pkg/agent/kiro_test.go
+++ b/server/pkg/agent/kiro_test.go
@@ -770,6 +770,76 @@ done
 `
 }
 
+// fakeKiroACPGhostLoadScript impersonates kiro-cli refusing an unknown
+// session id directly at session/load with its observed shape: -32603
+// "Internal error" and "No session found with id ..." in data.
+func fakeKiroACPGhostLoadScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"session/load"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Internal error","data":"No session found with id ses_stale"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestKiroBackendSignalsResumeRejectedAtLoad pins the ghost-session loop fix:
+// when session/load itself fails with a session-not-found error, the Result
+// must carry ResumeRejected=true so the daemon's fresh-session retry fires and
+// retires the dead pointer. Before the fix the flag stayed false on this path,
+// and every follow-up re-requested the same dead id forever.
+func TestKiroBackendSignalsResumeRejectedAtLoad(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kiro-cli")
+	writeTestExecutable(t, fakePath, []byte(fakeKiroACPGhostLoadScript()))
+
+	backend, err := New("kiro", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kiro backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_stale",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "No session found") {
+			t.Errorf("expected error to surface the session-not-found message, got %q", result.Error)
+		}
+		if !result.ResumeRejected {
+			t.Fatal("expected ResumeRejected=true so the daemon's fresh-session retry fires")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 // TestKiroBackendClearsSessionIDWhenSetModelSessionNotFound pins the
 // set_model sibling of the resumed-session fix: with a model override,
 // session/set_model runs before session/prompt, so a dead resumed

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -261,7 +261,17 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("qoder session/resume failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				if isACPSessionNotFound(err) {
+					// qodercli rejects an id it never persisted (a session
+					// that died before its first prompt, the set_model
+					// failure shape) directly at session/resume, unlike the
+					// sibling runtimes that surface it at set_model/prompt.
+					// Flag it so the daemon's fresh-session retry fires and
+					// the dead pointer is retired instead of every follow-up
+					// re-requesting the same id forever.
+					resumeRejected = true
+				}
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			var changed bool
@@ -321,6 +331,21 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 					)
 					sessionID = ""
 					resumeRejected = true
+				}
+				if opts.ResumeSessionID == "" {
+					// A fresh session that died before its first prompt has
+					// no conversation worth resuming, and qodercli may never
+					// have persisted it (the daemon tears the process down
+					// here and the runtime flushes on first use). Publishing
+					// the id would pin a ghost resume pointer that every
+					// follow-up re-requests and that the runtime rejects at
+					// session/resume. Suppress it; the next turn opens a
+					// clean session/new once the model config is fixed.
+					b.cfg.Logger.Warn("fresh session died at set_model time before any prompt; suppressing session id",
+						"backend", "qoder",
+						"session_id", sessionID,
+					)
+					sessionID = ""
 				}
 				resCh <- Result{
 					Status:         finalStatus,

--- a/server/pkg/agent/qoder_test.go
+++ b/server/pkg/agent/qoder_test.go
@@ -310,8 +310,11 @@ func TestQoderBackendSetModelFailureFailsTask(t *testing.T) {
 		if !strings.Contains(result.Error, "model not available") {
 			t.Errorf("expected error to surface upstream message, got %q", result.Error)
 		}
-		if result.SessionID != "ses_fake" {
-			t.Errorf("expected session id to be preserved on failure, got %q", result.SessionID)
+		if result.SessionID != "" {
+			// The session died before its first prompt, so its id must NOT be
+			// published: qodercli may never have persisted it, and a pointer
+			// to it would be a ghost every follow-up fails to resume.
+			t.Errorf("expected empty session id on fresh-session set_model failure, got %q", result.SessionID)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")
@@ -995,6 +998,83 @@ func TestQoderBackendClearsSessionIDWhenResumedSessionNotFoundAtSetModel(t *test
 		}
 		if result.SessionID != "" {
 			t.Errorf("expected empty session id so the daemon's fresh-session retry fires, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+// fakeQoderACPGhostResumeScript impersonates qodercli 1.1.25 rejecting, at
+// session/resume, an id it never persisted — the ghost-pointer shape produced
+// by a session that died at set_model before its first prompt. The error
+// frame mirrors the real CLI (verified by driving `qodercli --yolo --acp` by
+// hand): invalid_params (-32602) "Invalid session identifier <id>" with data
+// {"code":"INVALID_SESSION_IDENTIFIER"}.
+func fakeQoderACPGhostResumeScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/resume"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"Invalid session identifier ses_ghost. Searched for sessions in /Users/hawk/.qoder/projects/-tmp.","data":{"code":"INVALID_SESSION_IDENTIFIER","sessionId":"ses_ghost","projectRoot":"/tmp"}}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestQoderBackendSignalsResumeRejectedAtResume pins the ghost-session loop
+// fix: qodercli rejects an unknown id directly at session/resume (unlike the
+// sibling runtimes, which surface it at set_model/prompt), so that failure
+// must carry ResumeRejected=true for the daemon's fresh-session retry to fire
+// and retire the dead pointer. Before the fix the flag stayed false, no retry
+// fired, and every follow-up re-requested the same dead id forever.
+func TestQoderBackendSignalsResumeRejectedAtResume(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "qodercli")
+	writeTestExecutable(t, fakePath, []byte(fakeQoderACPGhostResumeScript()))
+
+	backend, err := New("qoder", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new qoder backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         30 * time.Second,
+		ResumeSessionID: "ses_ghost",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "Invalid session identifier") {
+			t.Errorf("expected error to surface the runtime's rejection, got %q", result.Error)
+		}
+		if !result.ResumeRejected {
+			t.Fatal("expected ResumeRejected=true so the daemon's fresh-session retry fires")
+		}
+		if result.SessionID != "" {
+			t.Errorf("expected empty session id, got %q", result.SessionID)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -274,7 +274,15 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("traecli session/load failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				if isACPSessionNotFound(err) {
+					// The runtime rejected the recorded session id outright,
+					// before set_model/prompt could surface it. Mirror
+					// zeroclaw/qwenpaw: flag ResumeRejected so the daemon's
+					// fresh-session retry fires and retires the dead pointer
+					// instead of every follow-up re-requesting it forever.
+					resumeRejected = true
+				}
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			var changed bool

--- a/server/pkg/agent/traecli_test.go
+++ b/server/pkg/agent/traecli_test.go
@@ -235,6 +235,76 @@ func TestTraecliSetModelFailureFailsTask(t *testing.T) {
 	}
 }
 
+// fakeTraecliACPGhostLoadScript impersonates traecli rejecting an unknown
+// session id directly at session/load — the shape every ghost-pointer chat
+// hits when the recorded id no longer exists on the runtime side.
+func fakeTraecliACPGhostLoadScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true,"mcpCapabilities":{"http":true,"sse":true}}}}\n' "$id"
+      ;;
+    *'"method":"session/load"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Session not found"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestTraecliBackendSignalsResumeRejectedAtLoad pins the ghost-session loop
+// fix: when session/load itself fails with a session-not-found error, the
+// Result must carry ResumeRejected=true so the daemon's fresh-session retry
+// fires and retires the dead pointer instead of every follow-up re-requesting
+// the same dead id forever.
+func TestTraecliBackendSignalsResumeRejectedAtLoad(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "traecli")
+	writeTestExecutable(t, fakePath, []byte(fakeTraecliACPGhostLoadScript()))
+
+	backend, err := New("traecli", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new traecli backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_stale",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "Session not found") {
+			t.Errorf("expected error to surface the session-not-found message, got %q", result.Error)
+		}
+		if !result.ResumeRejected {
+			t.Fatal("expected ResumeRejected=true so the daemon's fresh-session retry fires")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 func TestTraecliUsesSessionLoadForResume(t *testing.T) {
 	t.Parallel()
 	tempDir := t.TempDir()

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -4479,6 +4479,14 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
       -- daemon's in-turn fresh-session retry reads (GH #6777). This guard stays
       -- because it is the only protection for rows an older daemon wrote.
       AND NOT (COALESCE(error, '') ILIKE '%could not resolve authentication method%')
+      -- A runtime rejecting the recorded session id outright ("Invalid session
+      -- identifier ...", qodercli at session/resume) never recovers by retry:
+      -- the id names a session that was never persisted, so the next run must
+      -- open a fresh session instead of replaying the dead pointer. The daemon
+      -- flags this as ResumeRejected going forward; this text guard is the only
+      -- protection for rows an older daemon wrote.
+      -- Keep in sync with ResumeUnsafeFailure and GetLastChatTaskSession.
+      AND NOT (COALESCE(error, '') ILIKE '%invalid session identifier%')
       AND NOT (COALESCE(error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
                AND COALESCE(error, '') ~* 'role[^a-z0-9]{0,2}assistant|assistant message|message at position|messages\.[0-9]|messages\[[0-9]')
     )

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -984,6 +984,12 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
       -- daemon's in-turn fresh-session retry reads (GH #6777). This guard stays
       -- because it is the only protection for rows an older daemon wrote.
       AND NOT (COALESCE(error, '') ILIKE '%could not resolve authentication method%')
+      -- Mirrors the GetLastTaskSession invalid-session guard: a runtime that
+      -- rejects the recorded id outright ("Invalid session identifier ...")
+      -- can only be recovered by a fresh session, and rows an older daemon
+      -- wrote carry only this error text. This and GetLastTaskSession must
+      -- move together.
+      AND NOT (COALESCE(error, '') ILIKE '%invalid session identifier%')
       AND NOT (COALESCE(error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
                AND COALESCE(error, '') ~* 'role[^a-z0-9]{0,2}assistant|assistant message|message at position|messages\.[0-9]|messages\[[0-9]')
     )

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -1154,6 +1154,14 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
       -- daemon's in-turn fresh-session retry reads (GH #6777). This guard stays
       -- because it is the only protection for rows an older daemon wrote.
       AND NOT (COALESCE(error, '') ILIKE '%could not resolve authentication method%')
+      -- A runtime rejecting the recorded session id outright ("Invalid session
+      -- identifier ...", qodercli at session/resume) never recovers by retry:
+      -- the id names a session that was never persisted, so the next run must
+      -- open a fresh session instead of replaying the dead pointer. The daemon
+      -- flags this as ResumeRejected going forward; this text guard is the only
+      -- protection for rows an older daemon wrote.
+      -- Keep in sync with ResumeUnsafeFailure and GetLastChatTaskSession.
+      AND NOT (COALESCE(error, '') ILIKE '%invalid session identifier%')
       AND NOT (COALESCE(error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
                AND COALESCE(error, '') ~* 'role[^a-z0-9]{0,2}assistant|assistant message|message at position|messages\.[0-9]|messages\[[0-9]')
     )

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -1217,6 +1217,12 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
       -- daemon's in-turn fresh-session retry reads (GH #6777). This guard stays
       -- because it is the only protection for rows an older daemon wrote.
       AND NOT (COALESCE(error, '') ILIKE '%could not resolve authentication method%')
+      -- Mirrors the GetLastTaskSession invalid-session guard: a runtime that
+      -- rejects the recorded id outright ("Invalid session identifier ...")
+      -- can only be recovered by a fresh session, and rows an older daemon
+      -- wrote carry only this error text. This and GetLastTaskSession must
+      -- move together.
+      AND NOT (COALESCE(error, '') ILIKE '%invalid session identifier%')
       AND NOT (COALESCE(error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
                AND COALESCE(error, '') ~* 'role[^a-z0-9]{0,2}assistant|assistant message|message at position|messages\.[0-9]|messages\[[0-9]')
     )

--- a/server/pkg/taskfailure/resume.go
+++ b/server/pkg/taskfailure/resume.go
@@ -75,6 +75,30 @@ func AuthMethodUnresolved(errText string) bool {
 // with %v rather than replacing it.
 const authMethodUnresolvedPhrase = "could not resolve authentication method"
 
+// InvalidSessionIdentifier reports whether an agent error is the runtime
+// refusing to resume the recorded session id outright ("Invalid session
+// identifier <id>", observed from qodercli 1.1.25 at session/resume). The id
+// names a session that was never persisted — a conversation that died before
+// its first prompt — so every retry of the recorded pointer reproduces the
+// same rejection; only a fresh session recovers.
+//
+// Deliberately the exact phrase and nothing looser: "invalid session id"
+// shaped errors that are NOT about persistence (e.g. a malformed id sent by a
+// future client bug) should surface loudly rather than be silently retried
+// with lost context. Erring toward NOT matching keeps healthy pointers.
+//
+// This is the single source of truth for the phrase. Keep it in sync with the
+// GetLastTaskSession / GetLastChatTaskSession / GetLastMultiAgentChatTaskSession
+// resume queries (pkg/db/queries), which apply the same guard server-side so
+// rows written by a daemon too old to flag ResumeRejected are still excluded
+// from resume.
+func InvalidSessionIdentifier(errText string) bool {
+	if errText == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(errText), "invalid session identifier")
+}
+
 // emptyContentRe matches the provider's complaint that a content field is
 // empty, in the wordings observed across providers.
 var emptyContentRe = regexp.MustCompile(`(?i)must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty`)


### PR DESCRIPTION
Fixes #8116

## Problem

When the first turn of a chat dies at `session/set_model` (invalid model id), qodercli exits **without persisting the session** — yet the id was still reported by the backend and pinned as the conversation's resume pointer (the poison survives the COALESCE in `UpdateChatSessionSession`). Every follow-up then fails at `session/resume` with `Invalid session identifier "…"` forever:

- the phrase was not in `isACPSessionNotFound`'s match set, so the rejection was invisible;
- the `session/resume` / `session/load` failure branches did not set `ResumeRejected`, so the daemon's fresh-session retry never fired;
- no CLI escape hatch exists — the only workaround was abandoning the conversation.

Wording verified by hand-driving `qodercli --yolo --acp` 1.1.25: invalid_params (-32602) `Invalid session identifier <id>` with a structured data object. The code was already in the accepted error-code set; only the phrase was missing.

## Fix — two commits

**1. Backend/daemon self-heal (new rows)**

- `qoder`: on `set_model` failure for a *fresh* session, suppress the session id — a session that never ran a prompt has no conversation worth resuming, and publishing it can only publish a ghost pointer.
- `isACPSessionNotFound` (shared classifier): also match `"invalid session identifier"`.
- `qoder`/`hermes`/`kimi` (`session/resume`) and `kiro`/`traecli`/`grok` (`session/load`): flag `ResumeRejected` when the runtime rejects the recorded id outright, so the daemon's in-turn fresh-session retry fires and retires the dead pointer (`ClearChatSessionSessionIfMatches`). The next message recovers by itself. Previously only zeroclaw/qwenpaw/mcode/dim/reasonix carried the flag on this path.

**2. Server-side guard for legacy rows** (a daemon older than the fix writes the failure with no flag)

- `taskfailure.InvalidSessionIdentifier`: single-source predicate; only the full phrase matches so lookalike errors don't discard healthy pointers.
- `ResumeUnsafeFailure` consults it → a manual rerun starts fresh instead of replaying the rejection.
- `GetLastTaskSession` / `GetLastChatTaskSession` gain the same error-text guard as the existing auth-resolution one; sqlc regenerated.

## Tests

- Per-backend tests pin each runtime's real rejection shape (qodercli frame, kimi `Invalid params` + data, kiro `-32603` data, traecli/grok plain, hermes) and assert `ResumeRejected=true`.
- `TestIsACPSessionNotFound` gains the qodercli frame case.
- Fresh-session `set_model` failures must report an empty session id (qoder).
- `TestShouldRetryWithFreshSession` gains an end-to-end case matching the incident.
- `ResumeUnsafeFailure` table gains positive and negative cases (shorter "invalid session id" wording must NOT flip resume).

Verified on this branch: `go build ./...`, `go vet`, and the touched packages' tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>