### PR TITLE
feat(auth): make OIDC endpoints configurable for self-hosted IdPs

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -61,6 +61,9 @@ function LoginPageContent() {
   const qc = useQueryClient();
   const { t } = useT("auth");
   const googleClientId = useConfigStore((state) => state.googleClientId);
+  const oidcAuthorizeUrl = useConfigStore((state) => state.oidcAuthorizeUrl);
+  const oidcScopes = useConfigStore((state) => state.oidcScopes);
+  const oidcDisplayName = useConfigStore((state) => state.oidcDisplayName);
   const user = useAuthStore((s) => s.user);
   const isLoading = useAuthStore((s) => s.isLoading);
   const searchParams = useSearchParams();
@@ -224,6 +227,11 @@ function LoginPageContent() {
               clientId: googleClientId,
               redirectUri: `${window.location.origin}/auth/callback`,
               state: googleState,
+              // Empty on a Google deployment — the view then falls back to
+              // Google's authorize URL and its branded button.
+              authorizeUrl: oidcAuthorizeUrl || undefined,
+              scopes: oidcScopes || undefined,
+              displayName: oidcDisplayName || undefined,
             }
           : undefined
       }

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -731,6 +731,12 @@ export interface AppConfigResponse {
   cdn_signed?: boolean;
   allow_signup: boolean;
   google_client_id?: string;
+  /** OIDC endpoint overrides. Absent when the deployment still uses the
+   * built-in Google provider, in which case the client falls back to
+   * Google's authorize URL — the historical behaviour. */
+  oidc_authorize_url?: string;
+  oidc_scopes?: string;
+  oidc_display_name?: string;
   posthog_key?: string;
   posthog_host?: string;
   analytics_environment?: string;
@@ -942,6 +948,9 @@ export const AppConfigSchema = z.object({
   cdn_signed: BooleanWithDefaultSchema(false),
   allow_signup: BooleanWithDefaultSchema(true),
   google_client_id: OptionalStringSchema,
+  oidc_authorize_url: OptionalStringSchema,
+  oidc_scopes: OptionalStringSchema,
+  oidc_display_name: OptionalStringSchema,
   posthog_key: OptionalStringSchema,
   posthog_host: OptionalStringSchema,
   analytics_environment: OptionalStringSchema,
@@ -960,6 +969,9 @@ export const EMPTY_APP_CONFIG: AppConfigResponse = {
   cdn_signed: false,
   allow_signup: true,
   google_client_id: "",
+  oidc_authorize_url: "",
+  oidc_scopes: "",
+  oidc_display_name: "",
   daemon_server_url: "",
   daemon_app_url: "",
   workspace_creation_disabled: false,

--- a/packages/core/config/index.ts
+++ b/packages/core/config/index.ts
@@ -9,6 +9,12 @@ interface ConfigState {
   cdnSigned: boolean;
   allowSignup: boolean;
   googleClientId: string;
+  // OIDC endpoint overrides published by /api/config. Empty means "still the
+  // built-in Google provider"; the sign-in view then uses Google's authorize
+  // URL and the Google-branded button, exactly as before generic OIDC.
+  oidcAuthorizeUrl: string;
+  oidcScopes: string;
+  oidcDisplayName: string;
   daemonServerUrl: string;
   daemonAppUrl: string;
   // Self-host gate (#3433): when true, every "Create workspace" affordance
@@ -40,6 +46,9 @@ interface ConfigState {
   setAuthConfig: (config: {
     allowSignup: boolean;
     googleClientId?: string;
+    oidcAuthorizeUrl?: string;
+    oidcScopes?: string;
+    oidcDisplayName?: string;
     workspaceCreationDisabled?: boolean;
     vcsIntegrationAvailable?: boolean;
   }) => void;
@@ -58,6 +67,9 @@ export const configStore = createStore<ConfigState>((set) => ({
   cdnSigned: false,
   allowSignup: true,
   googleClientId: "",
+  oidcAuthorizeUrl: "",
+  oidcScopes: "",
+  oidcDisplayName: "",
   daemonServerUrl: "",
   daemonAppUrl: "",
   workspaceCreationDisabled: false,
@@ -70,9 +82,21 @@ export const configStore = createStore<ConfigState>((set) => ({
   setAuthConfig: ({
     allowSignup,
     googleClientId = "",
+    oidcAuthorizeUrl = "",
+    oidcScopes = "",
+    oidcDisplayName = "",
     workspaceCreationDisabled = false,
     vcsIntegrationAvailable = false,
-  }) => set({ allowSignup, googleClientId, workspaceCreationDisabled, vcsIntegrationAvailable }),
+  }) =>
+    set({
+      allowSignup,
+      googleClientId,
+      oidcAuthorizeUrl,
+      oidcScopes,
+      oidcDisplayName,
+      workspaceCreationDisabled,
+      vcsIntegrationAvailable,
+    }),
   setDaemonConfig: ({ daemonServerUrl = "", daemonAppUrl = "" }) =>
     set({ daemonServerUrl, daemonAppUrl }),
   setFeatureFlags: (flags = {}) => set({ featureFlags: { ...flags } }),

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -69,6 +69,11 @@ export function AuthInitializer({
         configStore.getState().setAuthConfig({
           allowSignup: cfg.allow_signup,
           googleClientId: cfg.google_client_id,
+          // Absent on the managed cloud and on any server predating generic
+          // OIDC → empty → Google defaults downstream.
+          oidcAuthorizeUrl: cfg.oidc_authorize_url,
+          oidcScopes: cfg.oidc_scopes,
+          oidcDisplayName: cfg.oidc_display_name,
           // Old servers omit this field — treat that as "creation allowed"
           // (the managed-cloud default) rather than blocking the UI.
           workspaceCreationDisabled: cfg.workspace_creation_disabled === true,

--- a/packages/views/auth/login-page.tsx
+++ b/packages/views/auth/login-page.tsx
@@ -19,7 +19,9 @@ import {
   InputOTPGroup,
   InputOTPSlot,
 } from "@multica/ui/components/ui/input-otp";
+import { KeyRound } from "lucide-react";
 import { useAuthStore } from "@multica/core/auth";
+import { useConfigStore } from "@multica/core/config";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import { api } from "@multica/core/api";
 import type { User } from "@multica/core/types";
@@ -32,9 +34,20 @@ import { useT } from "../i18n";
 interface GoogleAuthConfig {
   clientId: string;
   redirectUri: string;
-  /** Opaque state passed through Google OAuth (e.g. "platform:desktop"). */
+  /** Opaque state passed through the OAuth round-trip (e.g. "platform:desktop"). */
   state?: string;
+  /** Authorization endpoint. Defaults to Google's when the deployment has not
+   *  configured a different OIDC provider. */
+  authorizeUrl?: string;
+  /** Space-separated scopes. Defaults to the standard OIDC set. */
+  scopes?: string;
+  /** Provider name for the button label. When absent the button keeps its
+   *  Google branding — logo included. */
+  displayName?: string;
 }
+
+const GOOGLE_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const DEFAULT_OIDC_SCOPES = "openid email profile";
 
 interface CliCallbackConfig {
   /** Validated localhost callback URL */
@@ -279,6 +292,13 @@ export function LoginPage({
     }
   };
 
+  // The desktop shell passes `onGoogleLogin` without a `google` config — it
+  // delegates the whole round-trip to the web app — so the provider name has
+  // to come from /api/config rather than from the prop alone. Empty on a
+  // Google deployment, which keeps the original branding.
+  const oidcDisplayName = useConfigStore((s) => s.oidcDisplayName);
+  const providerName = google?.displayName || oidcDisplayName || "";
+
   const handleGoogleLogin = () => {
     if (onGoogleLogin) {
       onGoogleLogin();
@@ -289,12 +309,16 @@ export function LoginPage({
       client_id: google.clientId,
       redirect_uri: google.redirectUri,
       response_type: "code",
-      scope: "openid email profile",
-      access_type: "offline",
-      prompt: "select_account",
+      scope: google.scopes || DEFAULT_OIDC_SCOPES,
+      // Google-specific hints. Keycloak ignores access_type outright, and
+      // `prompt=select_account` would force an account chooser on every
+      // sign-in for a provider that has only one account per session.
+      ...(google.authorizeUrl && google.authorizeUrl !== GOOGLE_AUTHORIZE_URL
+        ? {}
+        : { access_type: "offline", prompt: "select_account" }),
     });
     if (google.state) params.set("state", google.state);
-    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
+    window.location.href = `${google.authorizeUrl || GOOGLE_AUTHORIZE_URL}?${params}`;
   };
 
   // -------------------------------------------------------------------------
@@ -476,25 +500,31 @@ export function LoginPage({
               onClick={handleGoogleLogin}
               disabled={loading}
             >
-              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                <path
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                  fill="#4285F4"
-                />
-                <path
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                  fill="#34A853"
-                />
-                <path
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                  fill="#FBBC05"
-                />
-                <path
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                  fill="#EA4335"
-                />
-              </svg>
-              {t(($) => $.signin.google)}
+              {providerName ? (
+                <KeyRound className="mr-2 h-4 w-4" />
+              ) : (
+                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                  <path
+                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                    fill="#4285F4"
+                  />
+                  <path
+                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                    fill="#34A853"
+                  />
+                  <path
+                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                    fill="#FBBC05"
+                  />
+                  <path
+                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                    fill="#EA4335"
+                  />
+                </svg>
+              )}
+              {providerName
+                ? t(($) => $.signin.sso, { name: providerName })
+                : t(($) => $.signin.google)}
             </Button>
           )}
           {extra && <div className="w-full pt-1 text-center">{extra}</div>}

--- a/packages/views/locales/en/auth.json
+++ b/packages/views/locales/en/auth.json
@@ -4,7 +4,8 @@
     "description": "Enter your email to get a login code",
     "continue": "Continue",
     "sending": "Sending code...",
-    "google": "Continue with Google"
+    "google": "Continue with Google",
+    "sso": "Continue with {{name}}"
   },
   "verify": {
     "title": "Check your email",

--- a/packages/views/locales/ja/auth.json
+++ b/packages/views/locales/ja/auth.json
@@ -4,7 +4,8 @@
     "description": "ログインコードを受け取るメールアドレスを入力してください",
     "continue": "続ける",
     "sending": "コードを送信中...",
-    "google": "Googleで続ける"
+    "google": "Googleで続ける",
+    "sso": "{{name}}で続ける"
   },
   "verify": {
     "title": "メールを確認してください",

--- a/packages/views/locales/ko/auth.json
+++ b/packages/views/locales/ko/auth.json
@@ -4,7 +4,8 @@
     "description": "로그인 코드를 받을 이메일을 입력하세요",
     "continue": "계속",
     "sending": "코드 전송 중...",
-    "google": "Google로 계속"
+    "google": "Google로 계속",
+    "sso": "{{name}}(으)로 계속"
   },
   "verify": {
     "title": "이메일을 확인하세요",

--- a/packages/views/locales/zh-Hans/auth.json
+++ b/packages/views/locales/zh-Hans/auth.json
@@ -4,7 +4,8 @@
     "description": "输入邮箱以获取登录验证码",
     "continue": "继续",
     "sending": "发送验证码...",
-    "google": "使用 Google 登录"
+    "google": "使用 Google 登录",
+    "sso": "使用 {{name}} 登录"
   },
   "verify": {
     "title": "查看你的邮箱",

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -544,20 +544,21 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientID := os.Getenv("GOOGLE_CLIENT_ID")
-	clientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
-	if clientID == "" || clientSecret == "" {
-		writeError(w, http.StatusServiceUnavailable, "Google login is not configured")
+	provider := oidcProviderFromEnv()
+	if !provider.Configured() {
+		writeError(w, http.StatusServiceUnavailable, provider.DisplayName+" login is not configured")
 		return
 	}
+	clientID := provider.ClientID
+	clientSecret := provider.ClientSecret
 
 	redirectURI := req.RedirectURI
 	if redirectURI == "" {
-		redirectURI = os.Getenv("GOOGLE_REDIRECT_URI")
+		redirectURI = provider.RedirectURI
 	}
 
 	// Exchange authorization code for tokens.
-	tokenResp, err := h.googleHTTPClient().PostForm("https://oauth2.googleapis.com/token", url.Values{
+	tokenResp, err := h.googleHTTPClient().PostForm(provider.TokenURL, url.Values{
 		"code":          {req.Code},
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
@@ -604,8 +605,8 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch user info from Google.
-	userInfoReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://www.googleapis.com/oauth2/v2/userinfo", nil)
+	// Fetch user info from the identity provider.
+	userInfoReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, provider.UserInfoURL, nil)
 	if err != nil {
 		slog.Error("failed to create userinfo request", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
@@ -663,7 +664,7 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	if isNew {
 		evt := analytics.Signup(uuidToString(user.ID), user.Email, signupSourceFromRequest(r))
-		evt.Properties["auth_method"] = "google"
+		evt.Properties["auth_method"] = provider.AuthMethod
 		obsmetrics.RecordEvent(h.Analytics, h.Metrics, evt)
 	}
 

--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -25,6 +25,16 @@ type AppConfig struct {
 	// toggle signup or wire Google OAuth.
 	AllowSignup    bool   `json:"allow_signup"`
 	GoogleClientID string `json:"google_client_id,omitempty"`
+	// OIDC endpoint config for the sign-in button. The client id keeps the
+	// historical `google_client_id` name so a client that predates generic
+	// OIDC still renders the button; these three fields describe WHERE to
+	// send the user, and are omitted when the provider is still Google so
+	// the managed-cloud response keeps its previous shape. A client that
+	// does not understand them falls back to the Google authorize URL,
+	// which is exactly the old behaviour.
+	OIDCAuthorizeURL string `json:"oidc_authorize_url,omitempty"`
+	OIDCScopes       string `json:"oidc_scopes,omitempty"`
+	OIDCDisplayName  string `json:"oidc_display_name,omitempty"`
 	// WorkspaceCreationDisabled mirrors the server-side
 	// DISABLE_WORKSPACE_CREATION env var so the UI can hide every
 	// "Create workspace" affordance on self-hosted instances. Omitted
@@ -100,8 +110,16 @@ func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 		LocalWorktreeSupported:             true,
 		AgentConversationStartersSupported: true,
 		AllowSignup:                        os.Getenv("ALLOW_SIGNUP") != "false",
-		GoogleClientID:                     os.Getenv("GOOGLE_CLIENT_ID"),
+		GoogleClientID:                     oidcProviderFromEnv().ClientID,
 		WorkspaceCreationDisabled:          os.Getenv("DISABLE_WORKSPACE_CREATION") == "true",
+	}
+	// Only advertise the endpoint overrides when they actually differ from
+	// the built-in provider, so a Google deployment's /api/config response is
+	// byte-identical to what it was before generic OIDC existed.
+	if provider := oidcProviderFromEnv(); !provider.IsGoogle() {
+		config.OIDCAuthorizeURL = provider.AuthorizeURL
+		config.OIDCScopes = provider.Scopes
+		config.OIDCDisplayName = provider.DisplayName
 	}
 	if h.Storage != nil {
 		config.CdnDomain = h.Storage.CdnDomain()

--- a/server/internal/handler/oidc.go
+++ b/server/internal/handler/oidc.go
@@ -1,0 +1,106 @@
+package handler
+
+import "os"
+
+// Default endpoints of the historical, hard-coded provider. Keeping them here
+// (rather than inline in GoogleLogin) means a deployment that sets none of the
+// OIDC_* variables behaves exactly as it did before this file existed.
+const (
+	googleAuthorizeURL = "https://accounts.google.com/o/oauth2/v2/auth"
+	googleTokenURL     = "https://oauth2.googleapis.com/token"
+	googleUserInfoURL  = "https://www.googleapis.com/oauth2/v2/userinfo"
+
+	defaultOIDCScopes = "openid email profile"
+)
+
+// oidcProvider is the resolved single sign-on provider for this deployment.
+//
+// The upstream sign-in flow was already provider-agnostic — an authorization
+// code is swapped for an access token, and `/userinfo` is read for
+// {email, name, picture}, all of which are standard OpenID Connect. Only the
+// three endpoint URLs were pinned to Google. Making them configurable is
+// therefore the whole of what generic OIDC support requires; no new protocol
+// code is needed.
+type oidcProvider struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+	AuthorizeURL string
+	TokenURL     string
+	UserInfoURL  string
+	Scopes       string
+	// DisplayName labels the sign-in button and the operator-facing errors.
+	DisplayName string
+	// AuthMethod is the value reported to analytics for a signup via this
+	// provider.
+	AuthMethod string
+}
+
+// Configured reports whether sign-in through this provider can be attempted.
+func (p oidcProvider) Configured() bool {
+	return p.ClientID != "" && p.ClientSecret != ""
+}
+
+// IsGoogle reports whether the resolved provider is still the built-in one.
+func (p oidcProvider) IsGoogle() bool {
+	return p.TokenURL == googleTokenURL && p.UserInfoURL == googleUserInfoURL
+}
+
+func firstNonEmptyEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// oidcProviderFromEnv resolves the provider on every call rather than caching
+// it, matching GetConfig's existing "re-read from env on every request so
+// operators can rotate keys via secret refresh without a server restart"
+// contract.
+//
+// The OIDC_* names take precedence; the GOOGLE_* names remain accepted so an
+// existing deployment keeps working untouched. Endpoints are given explicitly
+// rather than discovered from an issuer: discovery would add a backchannel
+// call to the identity provider on the sign-in path, and every endpoint of a
+// Keycloak realm is derivable from its issuer by hand anyway.
+func oidcProviderFromEnv() oidcProvider {
+	p := oidcProvider{
+		ClientID:     firstNonEmptyEnv("OIDC_CLIENT_ID", "GOOGLE_CLIENT_ID"),
+		ClientSecret: firstNonEmptyEnv("OIDC_CLIENT_SECRET", "GOOGLE_CLIENT_SECRET"),
+		RedirectURI:  firstNonEmptyEnv("OIDC_REDIRECT_URI", "GOOGLE_REDIRECT_URI"),
+		AuthorizeURL: firstNonEmptyEnv("OIDC_AUTHORIZE_URL"),
+		TokenURL:     firstNonEmptyEnv("OIDC_TOKEN_URL"),
+		UserInfoURL:  firstNonEmptyEnv("OIDC_USERINFO_URL"),
+		Scopes:       firstNonEmptyEnv("OIDC_SCOPES"),
+		DisplayName:  firstNonEmptyEnv("OIDC_DISPLAY_NAME"),
+	}
+
+	if p.AuthorizeURL == "" {
+		p.AuthorizeURL = googleAuthorizeURL
+	}
+	if p.TokenURL == "" {
+		p.TokenURL = googleTokenURL
+	}
+	if p.UserInfoURL == "" {
+		p.UserInfoURL = googleUserInfoURL
+	}
+	if p.Scopes == "" {
+		p.Scopes = defaultOIDCScopes
+	}
+
+	if p.IsGoogle() {
+		p.AuthMethod = "google"
+		if p.DisplayName == "" {
+			p.DisplayName = "Google"
+		}
+		return p
+	}
+
+	p.AuthMethod = "oidc"
+	if p.DisplayName == "" {
+		p.DisplayName = "SSO"
+	}
+	return p
+}


### PR DESCRIPTION
### Problem

Self-hosting Multica behind an internal identity provider is currently impossible
without patching the source. The only SSO option is Google, and
`accounts.google.com`, `oauth2.googleapis.com` and `www.googleapis.com` are
hardcoded in both the Go backend and the frontend, with no issuer setting.

The e-mail-code fallback is not always an option either: a deployment with no SMTP
relay and no outbound access to Resend has no working sign-in path at all.

### What this changes

The existing flow is already generic — an authorization code is exchanged for a
token, then `/userinfo` is read for `{email, name, picture}`, which are standard
OIDC claims that Keycloak and friends serve as-is. Only the three endpoint URLs
were pinned. This PR makes them configurable and touches nothing else: 12 files,
no new dependency.

| Variable | Purpose |
|---|---|
| `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_REDIRECT_URI` | client identity |
| `OIDC_AUTHORIZE_URL` / `OIDC_TOKEN_URL` / `OIDC_USERINFO_URL` | the three endpoints |
| `OIDC_SCOPES` | defaults to `openid email profile` |
| `OIDC_DISPLAY_NAME` | sign-in button label and operator-facing errors |

### Backwards compatibility

This is the part I tried hardest to get right:

- `GOOGLE_*` variables are still accepted and take precedence when the `OIDC_*`
  ones are unset.
- `/api/config` only emits the new fields when the provider is no longer Google,
  so the managed-cloud response keeps its exact previous shape.
- `access_type=offline` and `prompt=select_account` are Google-specific hints and
  are now only sent to Google — Keycloak ignores the former and would show an
  account chooser on every sign-in for the latter.
- A client that does not understand the new fields falls back to Google's
  authorize URL, which is the previous behaviour.

An existing deployment that sets none of the new variables behaves exactly as
before.

### Notes

- The button label is resolved from `/api/config`, not from the `google` prop
  alone. The desktop shell renders `LoginPage` with `onGoogleLogin` only — it
  delegates the whole round-trip to the web app — so a prop-only lookup would keep
  Google branding on a non-Google deployment.
- One new i18n key (`signin.sso`) added to all four locales, so
  `locales/parity.test.ts` stays green.
- Happy to split this into backend and frontend commits, rename the variables, or
  add discovery via `OIDC_ISSUER` if you would prefer that shape. Endpoints are
  explicit here on purpose: discovery would add a backchannel call to the IdP on
  the sign-in path.

### Verification

Run against the current `main` this branch is based on:

- `go vet ./internal/handler/` — clean
- `go build ./...` — clean
- `go test ./internal/handler/` — pass
- `pnpm typecheck` — 9/9 packages
- `pnpm -C packages/views exec vitest run locales/parity.test.ts` — 160 tests pass

Also running in production on a self-hosted deployment backed by Keycloak.
