### PR TITLE
MUL-7127 fix: authenticate GitHub release updates

### DIFF
--- a/server/internal/cli/update.go
+++ b/server/internal/cli/update.go
@@ -10,9 +10,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,6 +33,10 @@ import (
 const ChecksumManifestName = "checksums.txt"
 
 const DefaultUpdateDownloadTimeout = 120 * time.Second
+
+const githubAPIVersion = "2022-11-28"
+const githubJSONAccept = "application/vnd.github+json"
+const githubBinaryAccept = "application/octet-stream"
 
 // GitHubRelease is the subset of the GitHub releases API response we need.
 type GitHubRelease struct {
@@ -124,6 +130,7 @@ func parseReleaseVersion(v string) ([3]int, bool) {
 
 type GitHubReleaseAsset struct {
 	Name               string `json:"name"`
+	APIURL             string `json:"url"`
 	BrowserDownloadURL string `json:"browser_download_url"`
 }
 
@@ -224,13 +231,82 @@ func verifyAssetSHA256(data []byte, expectedHex, assetName string) error {
 	return nil
 }
 
-func fetchReleaseByTag(tag string) (*GitHubRelease, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/multica-ai/multica/releases/tags/"+tag, nil)
+func githubAPIToken() string {
+	if token := strings.TrimSpace(os.Getenv("GH_TOKEN")); token != "" {
+		return token
+	}
+	return strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+}
+
+func isTrustedGitHubAuthURL(target *url.URL) bool {
+	if target == nil || target.Scheme != "https" || target.User != nil {
+		return false
+	}
+	if port := target.Port(); port != "" && port != "443" {
+		return false
+	}
+	return target.Hostname() == "api.github.com" || target.Hostname() == "github.com"
+}
+
+func releaseAssetAPIURL(asset *GitHubReleaseAsset) (string, error) {
+	if asset == nil || strings.TrimSpace(asset.APIURL) == "" {
+		return "", errors.New("release asset is missing its API URL")
+	}
+	target, err := url.Parse(asset.APIURL)
+	if err != nil || !isTrustedGitHubAuthURL(target) || target.Hostname() != "api.github.com" {
+		return "", fmt.Errorf("release asset %q has an untrusted API URL", asset.Name)
+	}
+	return target.String(), nil
+}
+
+func newGitHubGETRequest(rawURL, accept string) (*http.Request, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Accept", "application/vnd.github+json")
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+	if req.URL.Hostname() == "api.github.com" {
+		req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	}
+
+	// Never attach credentials to redirects, mirrors, or lookalike hosts.
+	if isTrustedGitHubAuthURL(req.URL) {
+		if token := githubAPIToken(); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+	return req, nil
+}
+
+func githubHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			req.Header.Del("Authorization")
+			if isTrustedGitHubAuthURL(req.URL) {
+				if token := githubAPIToken(); token != "" {
+					req.Header.Set("Authorization", "Bearer "+token)
+				}
+			}
+			if req.URL.Hostname() != "api.github.com" {
+				req.Header.Del("X-GitHub-Api-Version")
+			}
+			return nil
+		},
+	}
+}
+
+func fetchReleaseByTag(tag string) (*GitHubRelease, error) {
+	client := githubHTTPClient(10 * time.Second)
+	req, err := newGitHubGETRequest("https://api.github.com/repos/multica-ai/multica/releases/tags/"+tag, githubJSONAccept)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -251,12 +327,11 @@ func fetchReleaseByTag(tag string) (*GitHubRelease, error) {
 
 // FetchLatestRelease fetches the latest release tag from the multica GitHub repo.
 func FetchLatestRelease() (*GitHubRelease, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/multica-ai/multica/releases/latest", nil)
+	client := githubHTTPClient(10 * time.Second)
+	req, err := newGitHubGETRequest("https://api.github.com/repos/multica-ai/multica/releases/latest", githubJSONAccept)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Accept", "application/vnd.github+json")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -349,8 +424,12 @@ func updateDownloadTimeoutOrDefault(timeout time.Duration) time.Duration {
 // archive (single-digit MB). The checksum verification path requires buffered
 // bytes so streaming would just push the buffer into the caller anyway.
 func fetchURLBytes(url string, timeout time.Duration) ([]byte, error) {
-	client := &http.Client{Timeout: updateDownloadTimeoutOrDefault(timeout)}
-	resp, err := client.Get(url)
+	client := githubHTTPClient(updateDownloadTimeoutOrDefault(timeout))
+	req, err := newGitHubGETRequest(url, githubBinaryAccept)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -392,14 +471,21 @@ func UpdateViaDownloadWithTimeout(targetVersion string, downloadTimeout time.Dur
 	if err != nil {
 		return "", err
 	}
-	downloadURL := asset.BrowserDownloadURL
+	downloadURL, err := releaseAssetAPIURL(asset)
+	if err != nil {
+		return "", err
+	}
+	manifestURL, err := releaseAssetAPIURL(manifestAsset)
+	if err != nil {
+		return "", err
+	}
 	assetName := asset.Name
 
 	// Pull the checksum manifest first so a release that is half-published
 	// (archives uploaded but checksums.txt not yet) fails before we eat the
 	// archive's bandwidth.
 	timeout := updateDownloadTimeoutOrDefault(downloadTimeout)
-	manifestData, err := fetchURLBytes(manifestAsset.BrowserDownloadURL, timeout)
+	manifestData, err := fetchURLBytes(manifestURL, timeout)
 	if err != nil {
 		return "", fmt.Errorf("download checksum manifest: %w", err)
 	}

--- a/server/internal/cli/update_test.go
+++ b/server/internal/cli/update_test.go
@@ -3,10 +3,193 @@ package cli
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestNewGitHubGETRequestAuthentication(t *testing.T) {
+	t.Run("omits authorization without a token", func(t *testing.T) {
+		t.Setenv("GH_TOKEN", "")
+		t.Setenv("GITHUB_TOKEN", "")
+
+		req, err := newGitHubGETRequest("https://api.github.com/repos/multica-ai/multica/releases/latest", githubJSONAccept)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := req.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization = %q, want empty", got)
+		}
+	})
+
+	t.Run("prefers GH_TOKEN and trims whitespace", func(t *testing.T) {
+		t.Setenv("GH_TOKEN", "  gh-token  ")
+		t.Setenv("GITHUB_TOKEN", "github-token")
+
+		req, err := newGitHubGETRequest("https://api.github.com/repos/multica-ai/multica/releases/latest", githubJSONAccept)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := req.Header.Get("Authorization"); got != "Bearer gh-token" {
+			t.Fatalf("Authorization = %q, want GH_TOKEN bearer", got)
+		}
+		if strings.Contains(req.URL.String(), "gh-token") {
+			t.Fatal("token leaked into request URL")
+		}
+	})
+
+	t.Run("falls back to GITHUB_TOKEN", func(t *testing.T) {
+		t.Setenv("GH_TOKEN", "")
+		t.Setenv("GITHUB_TOKEN", "github-token")
+
+		req, err := newGitHubGETRequest("https://api.github.com/repos/multica-ai/multica/releases/latest", githubJSONAccept)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := req.Header.Get("Authorization"); got != "Bearer github-token" {
+			t.Fatalf("Authorization = %q, want GITHUB_TOKEN bearer", got)
+		}
+	})
+
+	t.Run("never authenticates outside the exact GitHub API origin", func(t *testing.T) {
+		t.Setenv("GH_TOKEN", "secret-token")
+		t.Setenv("GITHUB_TOKEN", "")
+
+		for _, rawURL := range []string{
+			"http://api.github.com/repos/multica-ai/multica/releases/latest",
+			"https://api.github.com.evil.example/releases/latest",
+			"https://user@api.github.com/repos/multica-ai/multica/releases/latest",
+			"https://api.github.com:444/repos/multica-ai/multica/releases/latest",
+		} {
+			req, err := newGitHubGETRequest(rawURL, githubJSONAccept)
+			if err != nil {
+				t.Fatalf("newGitHubGETRequest(%q): %v", rawURL, err)
+			}
+			if got := req.Header.Get("Authorization"); got != "" {
+				t.Fatalf("Authorization for %q = %q, want empty", rawURL, got)
+			}
+		}
+	})
+
+	t.Run("authenticates exact GitHub hosts on default HTTPS port", func(t *testing.T) {
+		t.Setenv("GH_TOKEN", "secret-token")
+		t.Setenv("GITHUB_TOKEN", "")
+
+		for _, rawURL := range []string{
+			"https://api.github.com/repos/multica-ai/multica/releases/latest",
+			"https://api.github.com:443/repos/multica-ai/multica/releases/latest",
+			"https://github.com/multica-ai/multica/releases/download/v1.2.3/archive.tar.gz",
+		} {
+			req, err := newGitHubGETRequest(rawURL, githubBinaryAccept)
+			if err != nil {
+				t.Fatalf("newGitHubGETRequest(%q): %v", rawURL, err)
+			}
+			if got := req.Header.Get("Authorization"); got != "Bearer secret-token" {
+				t.Fatalf("Authorization for %q = %q", rawURL, got)
+			}
+		}
+	})
+
+	t.Run("sets stable GitHub API headers", func(t *testing.T) {
+		t.Setenv("GH_TOKEN", "")
+		t.Setenv("GITHUB_TOKEN", "")
+
+		req, err := newGitHubGETRequest("https://api.github.com/repos/multica-ai/multica/releases/latest", githubJSONAccept)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := req.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Fatalf("Accept = %q", got)
+		}
+		if got := req.Header.Get("X-GitHub-Api-Version"); got != githubAPIVersion {
+			t.Fatalf("X-GitHub-Api-Version = %q", got)
+		}
+	})
+}
+
+func TestReleaseAssetAPIURL(t *testing.T) {
+	t.Run("accepts exact GitHub API asset URL", func(t *testing.T) {
+		asset := &GitHubReleaseAsset{
+			Name:   "archive.tar.gz",
+			APIURL: "https://api.github.com/repos/multica-ai/multica/releases/assets/123",
+		}
+		got, err := releaseAssetAPIURL(asset)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != asset.APIURL {
+			t.Fatalf("URL = %q, want %q", got, asset.APIURL)
+		}
+	})
+
+	t.Run("rejects missing or untrusted asset URL", func(t *testing.T) {
+		for _, asset := range []*GitHubReleaseAsset{
+			nil,
+			{Name: "missing.tar.gz"},
+			{Name: "browser.tar.gz", APIURL: "https://github.com/multica-ai/multica/releases/download/v1.2.3/browser.tar.gz"},
+			{Name: "http.tar.gz", APIURL: "http://api.github.com/repos/multica-ai/multica/releases/assets/123"},
+			{Name: "evil.tar.gz", APIURL: "https://api.github.com.evil.example/releases/assets/123"},
+		} {
+			if _, err := releaseAssetAPIURL(asset); err == nil {
+				t.Fatalf("expected error for asset %+v", asset)
+			}
+		}
+	})
+}
+
+func TestGitHubHTTPClientRedirectAuthentication(t *testing.T) {
+	t.Setenv("GH_TOKEN", "secret-token")
+	t.Setenv("GITHUB_TOKEN", "")
+	client := githubHTTPClient(time.Second)
+
+	initial, err := newGitHubGETRequest("https://github.com/multica-ai/multica/releases/download/v1.2.3/archive.tar.gz", githubBinaryAccept)
+	if err != nil {
+		t.Fatalf("unexpected initial request error: %v", err)
+	}
+
+	t.Run("retains auth only for trusted redirect", func(t *testing.T) {
+		redirect, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/multica-ai/multica/releases/latest", nil)
+		if err != nil {
+			t.Fatalf("unexpected redirect request error: %v", err)
+		}
+		redirect.Header.Set("Authorization", initial.Header.Get("Authorization"))
+		if err := client.CheckRedirect(redirect, []*http.Request{initial}); err != nil {
+			t.Fatalf("unexpected redirect error: %v", err)
+		}
+		if got := redirect.Header.Get("Authorization"); got != "Bearer secret-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+	})
+
+	t.Run("strips auth from CDN redirect", func(t *testing.T) {
+		redirect, err := http.NewRequest(http.MethodGet, "https://objects.githubusercontent.com/private-release", nil)
+		if err != nil {
+			t.Fatalf("unexpected redirect request error: %v", err)
+		}
+		redirect.Header.Set("Authorization", initial.Header.Get("Authorization"))
+		if err := client.CheckRedirect(redirect, []*http.Request{initial}); err != nil {
+			t.Fatalf("unexpected redirect error: %v", err)
+		}
+		if got := redirect.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization = %q, want empty", got)
+		}
+	})
+
+	t.Run("stops after ten redirects", func(t *testing.T) {
+		redirect, err := http.NewRequest(http.MethodGet, "https://github.com/final", nil)
+		if err != nil {
+			t.Fatalf("unexpected redirect request error: %v", err)
+		}
+		via := make([]*http.Request, 10)
+		for i := range via {
+			via[i] = initial
+		}
+		if err := client.CheckRedirect(redirect, via); err == nil {
+			t.Fatal("expected redirect limit error")
+		}
+	})
+}
 
 func TestReleaseAssetCandidates(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- authenticate GitHub release metadata requests with `GH_TOKEN`, falling back to `GITHUB_TOKEN`
- download release assets through their authenticated GitHub API URLs with `application/octet-stream`
- strip authorization on untrusted redirects and reject non-HTTPS/lookalike asset URLs
- preserve the existing checksum verification and atomic replacement flow

## Why

The dashboard updater receives HTTP 403 when release metadata or assets require authenticated GitHub access, even when a valid token is available in the Multica environment. This makes in-app updates fail while manual authenticated GitHub requests succeed.

## Security

- credentials are attached only to exact HTTPS `api.github.com` or `github.com` origins on the default port
- credentials are removed before redirects to CDN or other hosts
- release asset API URLs fail closed unless they are exact trusted `api.github.com` URLs
- credentials never enter request URLs or error strings
- redirects remain limited to 10

## Verification

Per deployment policy, verification ran in the explicitly identified Railway production service using an isolated temporary directory; it did not replace the running binary.

- full `./internal/cli` package suite: PASS
- live authenticated GitHub flow: PASS (`FetchLatestRelease` → archive/checksum API assets → CDN redirects → SHA-256 verification)
- `gofmt` check: PASS
- `git diff --check`: PASS

The temporary live-network test was removed before commit.