### PR TITLE
feat(issues): show agent execution inline in comment threads

### DIFF
--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -579,6 +579,11 @@ describe("TimelineEntriesSchema", () => {
 });
 
 describe("AgentTaskListSchema", () => {
+  it.each([true, false, undefined, null, "true", 1])("safely parses comment cancellation metadata: %s", (value) => {
+    const parsed = AgentTaskListSchema.parse([{ id: "run", cancelled_by_comment_change: value }]);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.cancelled_by_comment_change).toBe(typeof value === "boolean" ? value : undefined);
+  });
   const task = {
     id: "task-1",
     agent_id: "agent-1",

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -1738,6 +1738,7 @@ const TaskUsageSchema = z.object({
 }).loose();
 
 export const AgentTaskSchema = z.object({
+  cancelled_by_comment_change: z.boolean().optional().catch(undefined),
   id: z.string(),
   agent_id: z.string().default(""),
   runtime_id: z.string().default(""),

--- a/packages/core/chat/queries.ts
+++ b/packages/core/chat/queries.ts
@@ -215,18 +215,22 @@ export function taskMessagesOptions(taskId: string) {
 }
 
 /** A visible run follows WS updates and backfills on mount and completion. */
-export function useTaskMessages(taskId: string, isLive: boolean) {
+export function useTaskMessages(taskId: string, isLive: boolean, enabled = true) {
   const query = useQuery({
     ...taskMessagesOptions(taskId),
+    enabled: enabled && isTaskMessageTaskId(taskId),
     refetchOnMount: "always",
     refetchOnWindowFocus: "always",
   });
-  const previousLive = useRef(isLive);
+  const previous = useRef({ isLive, enabled });
   const { refetch } = query;
   useEffect(() => {
-    if (previousLive.current && !isLive && isTaskMessageTaskId(taskId)) void refetch();
-    previousLive.current = isLive;
-  }, [taskId, isLive, refetch]);
+    if (enabled && isTaskMessageTaskId(taskId)
+      && (!previous.current.enabled || (previous.current.isLive && !isLive))) {
+      void refetch({ cancelRefetch: false });
+    }
+    previous.current = { isLive, enabled };
+  }, [taskId, isLive, enabled, refetch]);
   return query;
 }
 

--- a/packages/core/chat/queries.ts
+++ b/packages/core/chat/queries.ts
@@ -1,4 +1,5 @@
-import { infiniteQueryOptions, queryOptions, type QueryClient } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions, useQuery, type QueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { api } from "../api";
 import type { TaskMessagePayload } from "../types/events";
 import type {
@@ -211,6 +212,22 @@ export function taskMessagesOptions(taskId: string) {
         next as TaskMessagePayload[],
       ),
   });
+}
+
+/** A visible run follows WS updates and backfills on mount and completion. */
+export function useTaskMessages(taskId: string, isLive: boolean) {
+  const query = useQuery({
+    ...taskMessagesOptions(taskId),
+    refetchOnMount: "always",
+    refetchOnWindowFocus: "always",
+  });
+  const previousLive = useRef(isLive);
+  const { refetch } = query;
+  useEffect(() => {
+    if (previousLive.current && !isLive && isTaskMessageTaskId(taskId)) void refetch();
+    previousLive.current = isLive;
+  }, [taskId, isLive, refetch]);
+  return query;
 }
 
 /**

--- a/packages/core/chat/use-task-messages.test.tsx
+++ b/packages/core/chat/use-task-messages.test.tsx
@@ -13,6 +13,28 @@ const id = "4a2e8d1c-7f9b-4e2a-9c1d-123456789abc";
 const msg = (seq: number): TaskMessagePayload => ({ task_id: id, issue_id: "issue", type: "text", content: `part${seq}`, seq });
 
 describe("useTaskMessages", () => {
+  it("defers historical transcript requests and backfills cached data when opened", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData(chatKeys.taskMessages(id), [msg(1)]);
+    vi.mocked(api.listTaskMessages).mockResolvedValue([msg(1), msg(2)]);
+    const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    const { result, rerender } = renderHook(({ enabled }) => useTaskMessages(id, false, enabled), {
+      wrapper, initialProps: { enabled: false },
+    });
+    expect(api.listTaskMessages).not.toHaveBeenCalled();
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.data).toHaveLength(2));
+    expect(api.listTaskMessages).toHaveBeenCalledTimes(1);
+    rerender({ enabled: false });
+    await act(async () => { await client.invalidateQueries({ queryKey: chatKeys.taskMessagesAll() }); });
+    expect(api.listTaskMessages).toHaveBeenCalledTimes(1);
+    vi.mocked(api.listTaskMessages).mockResolvedValue([msg(1), msg(2), msg(3)]);
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.data).toHaveLength(3));
+    expect(api.listTaskMessages).toHaveBeenCalledTimes(2);
+    client.clear();
+  });
+
   it("backfills cached live data without dropping concurrent WS events and recovers the terminal tail", async () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     client.setQueryDefaults(chatKeys.taskMessages(id), { structuralSharing: taskMessagesOptions(id).structuralSharing });

--- a/packages/core/chat/use-task-messages.test.tsx
+++ b/packages/core/chat/use-task-messages.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "../api";
+import type { TaskMessagePayload } from "../types/events";
+import { chatKeys, taskMessagesOptions, useTaskMessages } from "./queries";
+
+vi.mock("../api", () => ({ api: { listTaskMessages: vi.fn() } }));
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+const id = "4a2e8d1c-7f9b-4e2a-9c1d-123456789abc";
+const msg = (seq: number): TaskMessagePayload => ({ task_id: id, issue_id: "issue", type: "text", content: `part${seq}`, seq });
+
+describe("useTaskMessages", () => {
+  it("backfills cached live data without dropping concurrent WS events and recovers the terminal tail", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryDefaults(chatKeys.taskMessages(id), { structuralSharing: taskMessagesOptions(id).structuralSharing });
+    client.setQueryData(chatKeys.taskMessages(id), [msg(1)]);
+    let resolve!: (messages: TaskMessagePayload[]) => void;
+    vi.mocked(api.listTaskMessages).mockImplementationOnce(() => new Promise((done) => { resolve = done; }));
+    const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    const { result, rerender } = renderHook(({ live }) => { const query = useTaskMessages(id, live); return { data: query.data }; }, { wrapper, initialProps: { live: true } });
+    await waitFor(() => expect(api.listTaskMessages).toHaveBeenCalledTimes(1));
+    act(() => client.setQueryData(chatKeys.taskMessages(id), [msg(1), msg(3)]));
+    await act(async () => resolve([msg(1), msg(2)]));
+    await waitFor(() => expect(result.current.data?.map((row) => row.seq)).toEqual([1, 2, 3]));
+    vi.mocked(api.listTaskMessages).mockResolvedValue([msg(1), msg(2), msg(3), msg(4)]);
+    rerender({ live: false });
+    await waitFor(() => expect(result.current.data?.map((row) => row.seq)).toEqual([1, 2, 3, 4]));
+    vi.mocked(api.listTaskMessages).mockResolvedValue([msg(1), msg(2), msg(3), msg(4), msg(5)]);
+    await act(async () => { await client.invalidateQueries({ queryKey: chatKeys.taskMessagesAll() }); });
+    await waitFor(() => expect(result.current.data).toHaveLength(5));
+    client.clear();
+  });
+});

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -1137,3 +1137,19 @@ export function useUnsubscribeFromIssueSubtree(issueId: string) {
     },
   });
 }
+
+export function useCancelIssueRun(issueId: string) {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (taskId: string) => api.cancelTask(issueId, taskId),
+    onSuccess: () => client.invalidateQueries({ queryKey: issueKeys.tasks(issueId) }),
+  });
+}
+
+export function useRetryIssueRun(issueId: string) {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (taskId: string) => api.rerunIssue(issueId, taskId),
+    onSuccess: () => client.invalidateQueries({ queryKey: issueKeys.tasks(issueId) }),
+  });
+}

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -20,6 +20,16 @@ import type {
 } from "../types";
 import { ALL_STATUSES } from "./config";
 
+export function issueTasksOptions(issueId: string) {
+  return queryOptions({
+    queryKey: issueKeys.tasks(issueId),
+    queryFn: () => api.listTasksByIssue(issueId),
+    enabled: !!issueId,
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
 export interface IssueSortParam {
   sort_by?: ListIssuesParams["sort_by"];
   sort_direction?: ListIssuesParams["sort_direction"];

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -312,6 +312,8 @@ export interface AgentTask {
   // coarse values; `string & {}` admits the rest without collapsing the
   // hints.
   failure_reason?: TaskFailureReason | (string & {}) | "";
+  /** The input comment was edited or deleted, invalidating this run. */
+  cancelled_by_comment_change?: boolean;
   created_at: string;
   /** Non-empty when the task was spawned from a chat session. */
   chat_session_id?: string;

--- a/packages/ui/components/common/quick-emoji-picker.tsx
+++ b/packages/ui/components/common/quick-emoji-picker.tsx
@@ -2,6 +2,7 @@
 
 import { useState, lazy, Suspense } from "react";
 import { SmilePlus } from "lucide-react";
+import { cn } from "@multica/ui/lib/utils";
 import { Popover, PopoverTrigger, PopoverContent } from "@multica/ui/components/ui/popover";
 
 const EmojiPicker = lazy(() =>
@@ -14,9 +15,10 @@ interface QuickEmojiPickerProps {
   onSelect: (emoji: string) => void;
   align?: "start" | "end";
   className?: string;
+  ariaLabel?: string;
 }
 
-function QuickEmojiPicker({ onSelect, align = "start", className }: QuickEmojiPickerProps) {
+function QuickEmojiPicker({ onSelect, align = "start", className, ariaLabel = "Add reaction" }: QuickEmojiPickerProps) {
   const [open, setOpen] = useState(false);
   const [showFull, setShowFull] = useState(false);
 
@@ -37,9 +39,11 @@ function QuickEmojiPicker({ onSelect, align = "start", className }: QuickEmojiPi
         render={
           <button
             type="button"
-            className={`inline-flex items-center justify-center h-6 w-6 rounded-full text-muted-foreground hover:bg-accent hover:text-foreground transition-colors ${className ?? ""}`}
+            aria-label={ariaLabel}
+            title={ariaLabel}
+            className={cn("inline-flex shrink-0 items-center justify-center h-6 w-6 rounded-full text-muted-foreground hover:bg-accent hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring", className)}
           >
-            <SmilePlus className="h-3.5 w-3.5" />
+            <SmilePlus className="h-3.5 w-3.5" aria-hidden />
           </button>
         }
       />

--- a/packages/ui/components/common/reaction-bar.tsx
+++ b/packages/ui/components/common/reaction-bar.tsx
@@ -40,6 +40,7 @@ interface ReactionBarProps {
   onToggle: (emoji: string) => void;
   getActorName: (type: string, id: string) => string;
   className?: string;
+  showPicker?: boolean;
 }
 
 function ReactionBar({
@@ -48,8 +49,10 @@ function ReactionBar({
   onToggle,
   getActorName,
   className,
+  showPicker = true,
 }: ReactionBarProps) {
   const grouped = groupReactions(reactions, currentUserId);
+  if (!showPicker && grouped.length === 0) return null;
 
   return (
     <div className={`flex flex-wrap items-center gap-1.5 ${className ?? ""}`}>
@@ -76,7 +79,7 @@ function ReactionBar({
           </TooltipContent>
         </Tooltip>
       ))}
-      <QuickEmojiPicker onSelect={onToggle} />
+      {showPicker && <QuickEmojiPicker onSelect={onToggle} />}
     </div>
   );
 }

--- a/packages/ui/styles/base.css
+++ b/packages/ui/styles/base.css
@@ -302,8 +302,23 @@ html[data-dnd-dragging="true"] * {
     animation: none;
   }
 
+  .animate-chat-text-shimmer {
+    background-image: none;
+    color: var(--muted-foreground);
+    -webkit-text-fill-color: currentColor;
+  }
+
   [data-right-sidebar-panel] {
     transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .animate-chat-text-shimmer {
+    animation: none;
+    background-image: none;
+    color: CanvasText;
+    -webkit-text-fill-color: currentColor;
   }
 }
 

--- a/packages/ui/styles/base.css
+++ b/packages/ui/styles/base.css
@@ -290,6 +290,21 @@ html[data-dnd-dragging="true"] * {
   transition: none;
 }
 
+/* Each block owns only its own author/body, excluding nested replies.
+ * Keep space reserved and keyboard access intact when mouse actions fade out.
+ * Portaled menus hold their trigger visible even after focus leaves the block. */
+[data-comment-actions] {
+  transition: opacity 120ms ease-out;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  [data-comment-block]:not(:hover):not(:focus-within)
+    [data-comment-actions]:not(:has([aria-haspopup][aria-expanded="true"])) {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-entrance-spin,
   .animate-onboarding-enter,
@@ -308,6 +323,7 @@ html[data-dnd-dragging="true"] * {
     -webkit-text-fill-color: currentColor;
   }
 
+  [data-comment-actions],
   [data-right-sidebar-panel] {
     transition: none;
   }

--- a/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
@@ -431,26 +431,27 @@ describe("AgentTranscriptDialog", () => {
     expect(screen.getByText("1 of 3 steps")).toBeInTheDocument();
   });
 
-  it("hides the timeline for a run too short for it to say anything", () => {
+  it("hides the timeline when steps have no timestamps", () => {
     renderDialog();
 
     expect(screen.queryByText("Model")).not.toBeInTheDocument();
     expect(screen.queryByText("Tools")).not.toBeInTheDocument();
   });
 
-  it("shows model and tool lanes once a run is long enough to have spent time", () => {
+  it.each([{ count: 1, seconds: 20 }, { count: 8, seconds: 30 }, { count: 8, seconds: 320 }])("shows the timeline for $count steps over $seconds seconds", ({ count, seconds }) => {
     const at = (seconds: number) =>
       new Date(Date.parse("2026-06-08T08:00:00Z") + seconds * 1000).toISOString();
     const longRun: TimelineItem[] = [];
-    for (let i = 0; i < 8; i++) {
+    for (let i = 0; i < count; i++) {
+      const start = (seconds / count) * i;
       longRun.push(
-        { seq: i * 2 + 1, type: "tool_use", tool: "Bash", input: { command: `step ${i}` }, created_at: at(i * 40) },
-        { seq: i * 2 + 2, type: "tool_result", tool: "Bash", output: "ok", created_at: at(i * 40 + 20) },
+        { seq: i * 2 + 1, type: "tool_use", tool: "Bash", input: { command: `step ${i}` }, created_at: at(start) },
+        { seq: i * 2 + 2, type: "tool_result", tool: "Bash", output: "ok", created_at: at(start + seconds / count / 2) },
       );
     }
 
     renderDialog(longRun, {
-      task: { ...baseTask, started_at: at(0), completed_at: at(320) },
+      task: { ...baseTask, started_at: at(0), completed_at: at(seconds) },
     });
 
     expect(screen.getByText("Model")).toBeInTheDocument();

--- a/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
@@ -12,6 +12,11 @@ import { renderWithI18n } from "../../test/i18n";
 import { AgentTranscriptDialog } from "./agent-transcript-dialog";
 import type { TimelineItem } from "./build-timeline";
 
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "workspace" }));
+vi.mock("./use-trace-issue-labels", () => ({
+  useTraceIssueLabels: () => (text: string) => text.replaceAll("01a07eca-8e82-775e-be06-e4a97ccfa299", "DEV-17"),
+}));
+
 const copyTextMock = vi.hoisted(() => vi.fn().mockResolvedValue(true));
 
 vi.mock("@multica/core/api", () => ({
@@ -900,5 +905,19 @@ describe("AgentTranscriptDialog — reason vs raw diagnostics", () => {
 
     expect(screen.queryByText("Technical details")).not.toBeInTheDocument();
     expect(screen.queryByText("Reason")).not.toBeInTheDocument();
+  });
+});
+
+
+describe("readable issue references", () => {
+  it("searches both the displayed identifier and original UUID", async () => {
+    const issueId = "01a07eca-8e82-775e-be06-e4a97ccfa299";
+    renderDialog([{ seq: 1, type: "tool_use", tool: "exec_command", input: { command: `multica issue get ${issueId} --output json` } }]);
+    expect(screen.getByText("multica issue get DEV-17 --output json")).toBeInTheDocument();
+    const search = screen.getByRole("textbox");
+    fireEvent.change(search, { target: { value: "DEV-17" } });
+    expect(screen.getByText("multica issue get DEV-17 --output json")).toBeInTheDocument();
+    fireEvent.change(search, { target: { value: issueId } });
+    expect(screen.getByText("multica issue get DEV-17 --output json")).toBeInTheDocument();
   });
 });

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -117,6 +117,8 @@ interface AgentTranscriptDialogProps {
   items: TimelineItem[];
   agentName: string;
   isLive?: boolean;
+  /** Loading/error content while the caller retrieves the transcript. */
+  contentState?: React.ReactNode;
   /**
    * Optional content rendered between the header chips and the event list.
    * Used by autopilot run rows to surface the inbound webhook trigger
@@ -306,6 +308,7 @@ export function AgentTranscriptDialog({
   agentName,
   isLive = false,
   headerSlot,
+  contentState,
 }: AgentTranscriptDialogProps) {
   const { t } = useT("agents");
   const locale = useLocale();
@@ -1199,7 +1202,7 @@ export function AgentTranscriptDialog({
         {/* ── Steps, and the inspector when one is selected ───────────── */}
         <div className="flex min-h-0 flex-1">
           <div className="flex min-w-0 flex-1 flex-col">
-            {displayRows.length === 0 ? (
+            {contentState ? <div className="flex h-full items-center justify-center p-4">{contentState}</div> : displayRows.length === 0 ? (
               <div className="flex h-full items-center justify-center text-body text-muted-foreground">
                 {isAntigravityLiveEmpty ? (
                   <div className="flex max-w-md items-center gap-2 px-4 text-center">

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -68,7 +68,6 @@ import {
   isCallStep,
   isGroupRow,
   rowCalls,
-  shouldShowTimeline,
   toolKindTotals,
   type TraceCallStep,
   type TraceGroupRow,
@@ -523,9 +522,6 @@ export function AgentTranscriptDialog({
   const runEnd = task.completed_at ?? lastStamp;
 
   const lanes = useMemo(() => buildLanes(steps, runStart, runEnd), [steps, runStart, runEnd]);
-  // A short run's timeline says less than the durations already on each row,
-  // so it does not render at all.
-  const showTimeline = shouldShowTimeline(steps, lanes);
   const toolKinds = useMemo(() => toolKindTotals(steps), [steps]);
   const outcome = useMemo(() => buildRunOutcome(steps), [steps]);
 
@@ -1070,7 +1066,7 @@ export function AgentTranscriptDialog({
         <RunOutcomeRow outcome={outcome} branch={task.branch_name} />
 
         {/* ── Where the time went ────────────────────────────────────── */}
-        {showTimeline && lanes && (
+        {lanes && (
           <RunTimeline
             lanes={lanes}
             toolKinds={toolKinds}
@@ -1731,7 +1727,7 @@ function InspectorSection({ label, children }: { label: string; children: React.
 }
 
 /** One payload, rendered as what it is. */
-function StepBody({ item }: { item: TimelineItem }) {
+export function StepBody({ item }: { item: TimelineItem }) {
   const { t } = useT("agents");
   const detail = useMemo(() => traceEventDetail(item), [item]);
   const image = useMemo(() => readImageResult(item.output), [item.output]);

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo, forwardRef } from "react";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useTraceIssueLabels } from "./use-trace-issue-labels";
 import { Virtuoso, type VirtuosoHandle, type Components } from "react-virtuoso";
 import {
   Bot,
@@ -307,6 +309,7 @@ export function AgentTranscriptDialog({
 }: AgentTranscriptDialogProps) {
   const { t } = useT("agents");
   const locale = useLocale();
+  const formatText = useTraceIssueLabels(useWorkspaceId(), task.issue_id, items, open);
   const [selectedSeq, setSelectedSeq] = useState<number | null>(null);
   const [expandedGroups, setExpandedGroups] = useState<Set<number>>(() => new Set());
   const [query, setQuery] = useState("");
@@ -493,10 +496,13 @@ export function AgentTranscriptDialog({
     if (activeFilterSet.size === 0 && trimmedQuery.length === 0) return steps;
     return steps.filter((step) => {
       if (activeFilterSet.size > 0 && !activeFilterSet.has(stepFilterKey(step))) return false;
-      if (trimmedQuery.length > 0 && !stepHaystack(step).includes(trimmedQuery)) return false;
+      if (trimmedQuery.length > 0) {
+        const raw = stepHaystack(step);
+        if (!raw.includes(trimmedQuery) && !formatText(raw).toLowerCase().includes(trimmedQuery)) return false;
+      }
       return true;
     });
-  }, [steps, activeFilterSet, trimmedQuery]);
+  }, [steps, activeFilterSet, trimmedQuery, formatText]);
 
   // Grouping runs on what the reader is looking at: filtering breaks adjacency,
   // and a group that spans a hidden step would be a lie about what ran.
@@ -1240,6 +1246,7 @@ export function AgentTranscriptDialog({
                 itemContent={(_, row) => (
                   <TranscriptRow
                     row={row}
+                    formatText={formatText}
                     runStartMs={runStartMs}
                     isLive={isLive}
                     selectedSeq={selectedSeq}
@@ -1351,6 +1358,7 @@ function RunOutcomeRow({
 // ─── Rows ───────────────────────────────────────────────────────────────────
 
 interface TranscriptRowProps {
+  formatText: (text: string) => string;
   row: TraceRow;
   runStartMs?: number;
   isLive: boolean;
@@ -1440,6 +1448,7 @@ function ProseRow({ row, runStartMs }: TranscriptRowProps & { row: TraceMessageS
  *  click away in the inspector. */
 function StepRow({
   row,
+  formatText,
   runStartMs,
   isLive,
   selectedSeq,
@@ -1448,10 +1457,11 @@ function StepRow({
   const { t } = useT("agents");
   const summaryLabels = useMemo<TraceSummaryLabels>(
     () => ({
+      formatText,
       morePaths: (path, extraCount) =>
         t(($) => $.transcript.patch_summary_more, { path, extra: extraCount }),
     }),
-    [t],
+    [t, formatText],
   );
 
   const call = isCallStep(row) ? row : null;
@@ -1518,6 +1528,7 @@ function StepRow({
 /** Consecutive same-tool calls, folded to one line until asked. */
 function GroupRow({
   row,
+  formatText,
   runStartMs,
   selectedSeq,
   expanded,
@@ -1527,10 +1538,11 @@ function GroupRow({
   const { t } = useT("agents");
   const summaryLabels = useMemo<TraceSummaryLabels>(
     () => ({
+      formatText,
       morePaths: (path, extraCount) =>
         t(($) => $.transcript.patch_summary_more, { path, extra: extraCount }),
     }),
-    [t],
+    [t, formatText],
   );
 
   return (
@@ -1603,7 +1615,7 @@ function callSummary(step: TraceCallStep, labels: TraceSummaryLabels): string {
   }
   if (!step.result) return "";
   if (readImageResult(step.result.output)) return "";
-  return traceEventSummary({ type: "tool_result", output: step.result.output });
+  return traceEventSummary({ type: "tool_result", output: step.result.output }, labels);
 }
 
 function firstLineOf(value: string | undefined): string {

--- a/packages/views/common/task-transcript/build-steps.test.ts
+++ b/packages/views/common/task-transcript/build-steps.test.ts
@@ -6,7 +6,6 @@ import {
   groupSteps,
   laneSegmentPosition,
   rowCalls,
-  shouldShowTimeline,
   timelineTicks,
   toolKindTotals,
   type TraceCallStep,
@@ -302,35 +301,5 @@ describe("toolKindTotals", () => {
       read: 1_000,
       other: 0,
     });
-  });
-});
-
-describe("shouldShowTimeline", () => {
-  function longRun(stepCount: number, seconds: number) {
-    const items: TimelineItem[] = [];
-    for (let i = 0; i < stepCount; i++) {
-      const start = (seconds / stepCount) * i;
-      items.push(call("Bash", start), result("Bash", start + 1));
-    }
-    return buildSteps(items);
-  }
-
-  it("shows for a long run with many steps", () => {
-    const steps = longRun(10, 600);
-    expect(shouldShowTimeline(steps, buildLanes(steps, at(0), at(600)))).toBe(true);
-  });
-
-  it("hides for a short run — a handful of bars says less than the row durations", () => {
-    const steps = longRun(3, 600);
-    expect(shouldShowTimeline(steps, buildLanes(steps, at(0), at(600)))).toBe(false);
-  });
-
-  it("hides for a fast run even with many steps", () => {
-    const steps = longRun(10, 20);
-    expect(shouldShowTimeline(steps, buildLanes(steps, at(0), at(20)))).toBe(false);
-  });
-
-  it("hides when lanes could not be built", () => {
-    expect(shouldShowTimeline(longRun(10, 600), null)).toBe(false);
   });
 });

--- a/packages/views/common/task-transcript/build-steps.ts
+++ b/packages/views/common/task-transcript/build-steps.ts
@@ -426,13 +426,3 @@ export function toolKindTotals(steps: TraceStep[]): ToolKindTotals {
   }
   return totals;
 }
-
-/** Below these, a timeline is chrome: it would render a handful of bars that
- *  say less than the durations already on each row. */
-export const TIMELINE_MIN_STEPS = 8;
-export const TIMELINE_MIN_MS = 60_000;
-
-export function shouldShowTimeline(steps: TraceStep[], lanes: TraceLanes | null): boolean {
-  if (!lanes) return false;
-  return steps.length >= TIMELINE_MIN_STEPS && lanes.totalMs >= TIMELINE_MIN_MS;
-}

--- a/packages/views/common/task-transcript/trace-event-presenter.ts
+++ b/packages/views/common/task-transcript/trace-event-presenter.ts
@@ -104,6 +104,8 @@ function clip(value: string, max: number): string {
  * keeps the fallback safe rather than blank.
  */
 export interface TraceSummaryLabels {
+  /** Resolve known entity IDs before a summary is clipped; evidence stays raw. */
+  formatText?: (text: string) => string;
   /**
    * Phrase a multi-file patch, e.g. `src/a.go +2 more`.
    *
@@ -124,7 +126,7 @@ export function traceToolArgSummary(
   labels?: TraceSummaryLabels,
 ): string {
   if (!input) return "";
-  const str = (v: unknown): string => (typeof v === "string" ? v : "");
+  const str = (v: unknown): string => (typeof v === "string" ? labels?.formatText?.(v) ?? v : "");
   if (str(input.query)) return str(input.query);
   // A multi-file patch has no single path field; without this the row's
   // summary would fall through to the generic scan and come back empty.
@@ -134,11 +136,12 @@ export function traceToolArgSummary(
   if (str(input.path)) return shortenTracePath(str(input.path));
   if (str(input.pattern)) return str(input.pattern);
   if (str(input.description)) return str(input.description);
-  if (str(input.command)) return clip(stripShellWrapper(str(input.command)), 120);
+  const command = str(input.command) || str(input.cmd);
+  if (command) return clip(stripShellWrapper(command), 120);
   if (str(input.prompt)) return clip(str(input.prompt), 120);
   if (str(input.skill)) return str(input.skill);
   for (const v of Object.values(input)) {
-    if (typeof v === "string" && v.length > 0 && v.length < 120) return v;
+    if (typeof v === "string" && v.length > 0 && str(v).length < 120) return str(v);
   }
   return "";
 }
@@ -166,7 +169,7 @@ export function traceEventSummary(event: TraceEvent, labels?: TraceSummaryLabels
     case "tool_result":
       // Unwrap first: the collapsed row is the one people read without
       // clicking, so it must not show transport escaping.
-      return clip(collapseWhitespace(unwrapToolOutput(event.output ?? "")), 200);
+      return clip(collapseWhitespace(labels?.formatText?.(unwrapToolOutput(event.output ?? "")) ?? unwrapToolOutput(event.output ?? "")), 200);
     default:
       return firstLine(event.content ?? event.output);
   }

--- a/packages/views/common/task-transcript/trace-issue-labels.test.ts
+++ b/packages/views/common/task-transcript/trace-issue-labels.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { collectTraceIssueIds, replaceTraceIssueIds } from "./trace-issue-labels";
+import { traceEventCopyText, traceEventDetail, traceToolArgSummary } from "./trace-event-presenter";
+
+const issue = "01a07eca-8e82-775e-be06-e4a97ccfa299";
+const other = "01a07cd3-f171-706d-9e76-b3428d0de333";
+const thread = "01a07cd9-610f-7b89-98e2-a194339b1372";
+const labels = new Map([[issue, "DEV-17"], [other, "DEV-14"]]);
+
+describe("trace issue labels", () => {
+  it("resolves only issue targets, deduplicating commands and preserving comment IDs", () => {
+    expect(collectTraceIssueIds(issue, [
+      { type: "tool_use", input: { command: `multica issue comment list '${issue}' --thread ${thread}` } },
+      { type: "tool_use", input: { cmd: `multica issue get ${other.toUpperCase()} --output json` } },
+      { type: "tool_use", input: { issue_id: other } },
+      { type: "tool_use", input: { command: `multica issue comment update ${thread}` } },
+      { type: "tool_result", output: `multica issue get ${thread}` },
+      { type: "text", content: `multica issue get ${thread}` },
+    ])).toEqual([issue, other]);
+  });
+
+  it("replaces exact known UUIDs case-insensitively and leaves unknown IDs intact", () => {
+    expect(replaceTraceIssueIds(`${issue.toUpperCase()} (${other}) --thread ${thread}`, labels))
+      .toBe(`DEV-17 (DEV-14) --thread ${thread}`);
+    expect(replaceTraceIssueIds(`prefix${issue} ${issue}-suffix ${issue}f`, labels))
+      .toBe(`prefix${issue} ${issue}-suffix ${issue}f`);
+    expect(replaceTraceIssueIds(issue, new Map())).toBe(issue);
+  });
+
+  it("formats before truncation without changing raw input, detail or copy text", () => {
+    const command = `multica issue update ${issue} --description '${other} ${issue} visible-tail'`;
+    const input = { command };
+    const event = { type: "tool_use", tool: "exec_command", input };
+    expect(traceToolArgSummary(input, { formatText: (text) => replaceTraceIssueIds(text, labels) }))
+      .toBe("multica issue update DEV-17 --description 'DEV-14 DEV-17 visible-tail'");
+    expect(traceToolArgSummary({ cmd: command }, { formatText: (text) => replaceTraceIssueIds(text, labels) }))
+      .toBe("multica issue update DEV-17 --description 'DEV-14 DEV-17 visible-tail'");
+    expect(input.command).toBe(command);
+    expect(traceEventDetail(event)).toEqual({ kind: "text", text: JSON.stringify(input, null, 2) });
+    expect(traceEventCopyText(event)).toContain(issue);
+    expect(traceEventCopyText(event)).not.toContain("DEV-17");
+  });
+});

--- a/packages/views/common/task-transcript/trace-issue-labels.ts
+++ b/packages/views/common/task-transcript/trace-issue-labels.ts
@@ -1,0 +1,34 @@
+import type { TraceEvent } from "./trace-event-presenter";
+
+const UUID = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+const UUID_VALUE = new RegExp(`^${UUID}$`, "i");
+// Only these positional arguments identify issues. In particular --thread and
+// --parent identify comments, and must never be sent to the issue resolver.
+const ISSUE_COMMAND = new RegExp(
+  `\\bmultica\\s+issue\\s+(?:get|update|comment\\s+(?:list|add))\\s+["']?(${UUID})(?![\\w-])`,
+  "gi",
+);
+
+export function collectTraceIssueIds(issueId: string, events: readonly TraceEvent[]): string[] {
+  const ids = new Set<string>();
+  const add = (id: unknown) => {
+    if (typeof id === "string" && UUID_VALUE.test(id)) ids.add(id.toLowerCase());
+  };
+  add(issueId);
+  for (const event of events) {
+    if (event.type !== "tool_use" || !event.input) continue;
+    add(event.input.issue_id);
+    for (const key of ["command", "cmd"]) {
+      const command = event.input[key];
+      if (typeof command !== "string") continue;
+      for (const match of command.matchAll(ISSUE_COMMAND)) add(match[1]);
+    }
+  }
+  return [...ids];
+}
+
+/** Display-only: never rewrite stored events, expanded evidence, or clipboard text. */
+export function replaceTraceIssueIds(text: string, labels: ReadonlyMap<string, string>): string {
+  return text.replace(new RegExp(`(?<![\\w-])${UUID}(?![\\w-])`, "gi"),
+    (id) => labels.get(id.toLowerCase()) ?? id);
+}

--- a/packages/views/common/task-transcript/use-trace-issue-labels.ts
+++ b/packages/views/common/task-transcript/use-trace-issue-labels.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { issueDetailOptions } from "@multica/core/issues/queries";
+import type { TraceEvent } from "./trace-event-presenter";
+import { collectTraceIssueIds, replaceTraceIssueIds } from "./trace-issue-labels";
+
+export function useTraceIssueLabels(wsId: string, issueId: string, events: readonly TraceEvent[], enabled = true) {
+  const ids = useMemo(() => collectTraceIssueIds(issueId, events), [issueId, events]);
+  const issues = useQueries({
+    queries: ids.map((id) => ({
+      ...issueDetailOptions(wsId, id),
+      enabled: enabled && !!wsId,
+      staleTime: 60_000,
+      retry: false,
+    })),
+    combine: (results) => results.flatMap(({ data }) =>
+      data?.id && data.identifier ? [{ id: data.id, identifier: data.identifier }] : []),
+  });
+  const labels = useMemo(() => new Map(issues.map((issue) => [issue.id.toLowerCase(), issue.identifier])), [issues]);
+  return useCallback((text: string) => replaceTraceIssueIds(text, labels), [labels]);
+}

--- a/packages/views/issues/components/active-task-order.test.ts
+++ b/packages/views/issues/components/active-task-order.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import type { AgentTask } from "@multica/core/types";
+import { compareActiveIssueTasks } from "./active-task-order";
+
+const task = (id: string, status: AgentTask["status"], priority = 0, created_at = "2026-09-08T03:00:00Z") =>
+  ({ id, status, priority, created_at });
+const ids = (tasks: ReturnType<typeof task>[]) => tasks.toSorted(compareActiveIssueTasks).map((t) => t.id);
+
+describe("active issue task display order", () => {
+  it("keeps running and already claimed tasks ahead of pending work", () => {
+    expect(ids([task("queued", "queued", 10), task("parked", "waiting_local_directory"),
+      task("dispatched", "dispatched"), task("running", "running")]))
+      .toEqual(["running", "dispatched", "parked", "queued"]);
+  });
+
+  it("matches queue priority descending, enqueue time ascending, then task ID", () => {
+    expect(ids([task("new", "queued", 0, "2026-09-08T04:00:00Z"),
+      task("old-b", "queued"), task("urgent", "queued", 2, "2026-09-08T05:00:00Z"),
+      task("old-a", "queued")])).toEqual(["urgent", "old-a", "old-b", "new"]);
+  });
+
+  it("compares timestamp instants instead of timezone strings", () => {
+    expect(ids([task("later", "queued", 0, "2026-09-08T03:01:00Z"),
+      task("earlier", "queued", 0, "2026-09-08T11:00:00+08:00")])).toEqual(["earlier", "later"]);
+    expect(compareActiveIssueTasks(task("a", "queued", 0, "2026-09-08T11:00:00+08:00"), task("b", "queued"))).toBeLessThan(0);
+  });
+});

--- a/packages/views/issues/components/active-task-order.ts
+++ b/packages/views/issues/components/active-task-order.ts
@@ -1,0 +1,21 @@
+import type { AgentTask } from "@multica/core/types";
+
+type OrderedTask = Pick<AgentTask, "id" | "status" | "priority" | "created_at">;
+
+function phase(task: OrderedTask): number {
+  if (task.status === "running") return 0;
+  if (task.status === "dispatched" || task.status === "waiting_local_directory") return 1;
+  return 2;
+}
+
+/** Show current execution first, then queued work in ClaimAgentTask order. */
+export function compareActiveIssueTasks(a: OrderedTask, b: OrderedTask): number {
+  const phaseDiff = phase(a) - phase(b);
+  if (phaseDiff) return phaseDiff;
+  const priorityDiff = (b.priority ?? 0) - (a.priority ?? 0);
+  if (priorityDiff) return priorityDiff;
+  // Queue age belongs to the run, not its latest coalesced comment. Parse
+  // timestamps so equivalent instants with different offsets sort identically.
+  const ageDiff = Date.parse(a.created_at) - Date.parse(b.created_at);
+  return (Number.isFinite(ageDiff) ? ageDiff : 0) || a.id.localeCompare(b.id);
+}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -46,7 +46,7 @@ import { CommentsFoldBar } from "./resolved-thread-bar";
 import { deriveThreadResolution } from "./thread-utils";
 import { RevisionConflictCompare } from "./revision-conflict-compare";
 import { InlineCommentRun, useInlineCommentRunState, type InlineCommentRunState } from "./inline-comment-run";
-import { EMPTY_COMMENT_RUNS, type CommentRun } from "./comment-runs";
+import { EMPTY_COMMENT_RUNS, showCommentRunInHeader, type CommentRun } from "./comment-runs";
 import { useRunCommentMotion } from "./use-run-comment-motion";
 
 const commentActionClassName =
@@ -891,9 +891,9 @@ export function AgentRunComment({ run, standalone = false, commentProps, enterin
         <CommentRow {...commentProps}
           isHighlighted={commentProps.highlightedCommentId === reply?.id}
           isResolution={!!reply?.resolved_at}
-          runHeader={run.task.status === "completed" && run.hasReply
+          runHeader={showCommentRunInHeader(run)
             ? <InlineCommentRun run={run} viewState={viewState} presentation="header" /> : undefined}
-          runMetadata={run.task.status !== "completed" || !run.hasReply
+          runMetadata={!showCommentRunInHeader(run)
             ? <InlineCommentRun run={run} viewState={viewState} /> : undefined} />
       ) : <div className="px-4 max-md:px-3">
         <InlineCommentRun run={run} viewState={viewState} showIdentity />
@@ -957,7 +957,7 @@ function CommentCardImpl({
   const slottedReplyIds = new Set(runs.filter((run) => run.hasReply && run.anchorCommentId && run.commentId !== entry.id)
     .map((run) => run.commentId));
   const renderRuns = (commentId: string, presentation: "inline" | "header" = "inline") => runs.filter((run) => run.commentId === commentId && run.hasReply
-    && (run.task.status === "completed") === (presentation === "header")
+    && showCommentRunInHeader(run) === (presentation === "header")
     && (!run.anchorCommentId || run.anchorCommentId === commentId || replyFolded))
     .map((run) => <InlineCommentRun key={run.task.id} run={run} presentation={presentation} viewState={run.commentId === entry.id ? runViewState : undefined} />);
 

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -862,8 +862,6 @@ export function AgentRunComment({ run, standalone = false, commentProps, enterin
   entering?: boolean;
   commentProps?: CommentCardProps;
 }) {
-  const { getActorName } = useActorName();
-  const timeAgo = useTimeAgo();
   const viewState = useInlineCommentRunState();
   const reply = commentProps?.entry;
   const motionRef = useRunCommentMotion(entering, reply?.id, run.task.status);
@@ -879,16 +877,9 @@ export function AgentRunComment({ run, standalone = false, commentProps, enterin
           isHighlighted={commentProps.highlightedCommentId === reply?.id}
           isResolution={!!reply?.resolved_at}
           runMetadata={<InlineCommentRun run={run} viewState={viewState} />} />
-      ) : <>
-        <StickyHeaderShell className="flex items-center gap-2.5 px-4 pt-1 pb-1.5 max-md:px-3">
-          <ActorAvatar actorType="agent" actorId={run.task.agent_id} size="md" enableHoverCard showStatusDot />
-          <span className="text-body font-medium">{getActorName("agent", run.task.agent_id)}</span>
-          <span className="text-caption text-muted-foreground">{timeAgo(run.task.created_at)}</span>
-        </StickyHeaderShell>
-        <div className="pl-12 pr-4 max-md:pl-3 max-md:pr-3">
-          <InlineCommentRun run={run} viewState={viewState} />
-        </div>
-      </>}
+      ) : <div className="px-4 max-md:px-3">
+        <InlineCommentRun run={run} viewState={viewState} showIdentity />
+      </div>}
     </div>
   );
 }

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -593,6 +593,7 @@ function CommentRevisionConflict({
 // ---------------------------------------------------------------------------
 
 function CommentRow({
+  runHeader,
   runMetadata,
   issueId,
   entry,
@@ -606,6 +607,7 @@ function CommentRow({
   onCreateSubIssue,
   onResolveToggle,
 }: {
+  runHeader?: ReactNode;
   runMetadata?: ReactNode;
   issueId: string;
   entry: TimelineEntry;
@@ -671,6 +673,8 @@ function CommentRow({
             {new Date(entry.created_at).toLocaleString(locale)}
           </TooltipContent>
         </Tooltip>
+
+        {runHeader}
 
         {isResolution && (
           <span className="text-caption font-medium text-success">
@@ -884,7 +888,10 @@ export function AgentRunComment({ run, standalone = false, commentProps, enterin
         <CommentRow {...commentProps}
           isHighlighted={commentProps.highlightedCommentId === reply?.id}
           isResolution={!!reply?.resolved_at}
-          runMetadata={<InlineCommentRun run={run} viewState={viewState} />} />
+          runHeader={run.task.status === "completed" && run.hasReply
+            ? <InlineCommentRun run={run} viewState={viewState} presentation="header" /> : undefined}
+          runMetadata={run.task.status !== "completed" || !run.hasReply
+            ? <InlineCommentRun run={run} viewState={viewState} /> : undefined} />
       ) : <div className="px-4 max-md:px-3">
         <InlineCommentRun run={run} viewState={viewState} showIdentity />
       </div>}
@@ -946,9 +953,10 @@ function CommentCardImpl({
   const allNestedReplies = replies;
   const slottedReplyIds = new Set(runs.filter((run) => run.hasReply && run.anchorCommentId && run.commentId !== entry.id)
     .map((run) => run.commentId));
-  const renderRuns = (commentId: string) => runs.filter((run) => run.commentId === commentId && run.hasReply
+  const renderRuns = (commentId: string, presentation: "inline" | "header" = "inline") => runs.filter((run) => run.commentId === commentId && run.hasReply
+    && (run.task.status === "completed") === (presentation === "header")
     && (!run.anchorCommentId || run.anchorCommentId === commentId || replyFolded))
-    .map((run) => <InlineCommentRun key={run.task.id} run={run} viewState={run.commentId === entry.id ? runViewState : undefined} />);
+    .map((run) => <InlineCommentRun key={run.task.id} run={run} presentation={presentation} viewState={run.commentId === entry.id ? runViewState : undefined} />);
 
   const renderAnchoredRuns = (commentId: string) => runs.filter((run) => run.anchorCommentId === commentId
     && !(replyFolded && run.hasReply))
@@ -1049,6 +1057,8 @@ function CommentCardImpl({
                   {new Date(entry.created_at).toLocaleString(locale)}
                 </TooltipContent>
               </Tooltip>
+
+              {renderRuns(entry.id, "header")}
 
               {!open && contentPreview && (
                 <span className="min-w-0 flex-1 truncate text-caption text-muted-foreground">
@@ -1299,6 +1309,7 @@ function CommentCardImpl({
                     <CommentRow
                       issueId={issueId}
                       entry={resolutionReply}
+                      runHeader={renderRuns(resolutionReply.id, "header")}
                       runMetadata={renderRuns(resolutionReply.id)}
                       currentUserId={currentUserId}
                       canModerate={canModerate}
@@ -1342,6 +1353,7 @@ function CommentCardImpl({
                     <CommentRow
                       issueId={issueId}
                       entry={reply}
+                      runHeader={renderRuns(reply.id, "header")}
                       runMetadata={renderRuns(reply.id)}
                       currentUserId={currentUserId}
                       canModerate={canModerate}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -641,7 +641,7 @@ function CommentRow({
   const reactions = entry.reactions ?? [];
 
   return (
-    <div className="pb-3">
+    <div data-comment-block className="pb-3">
       {/* Header pins to the timeline's scroll parent within this reply's own
           row box, so a LONG reply keeps its
           author + actions visible while you scroll its body, then releases once
@@ -685,7 +685,7 @@ function CommentRow({
           </span>
         )}
 
-        <div className="ml-auto flex shrink-0 items-center gap-0.5">
+        <div data-comment-actions className="ml-auto flex shrink-0 items-center gap-0.5">
           {!edit.editing && <QuickEmojiPicker
             onSelect={(emoji) => onToggleReaction(entry.id, emoji)}
             ariaLabel={t(($) => $.comment.add_reaction)}
@@ -1027,7 +1027,7 @@ function CommentCardImpl({
             That is what keeps exactly one header pinned at a time: without this
             wrapper the header's containing block is the whole thread and it
             stays stuck behind every reply. */}
-        <div className={cn("transition-colors duration-700", isHighlighted && highlightedCommentBackgroundClass)}>
+        <div data-comment-block className={cn("transition-colors duration-700", isHighlighted && highlightedCommentBackgroundClass)}>
           {/* Keep the author aligned with replies; thread controls sit on the right. */}
           <StickyHeaderShell
             sticky={stickyHeader}
@@ -1074,7 +1074,7 @@ function CommentCardImpl({
                 </span>
               )}
 
-              <div className="ml-auto flex shrink-0 items-center gap-0.5">
+              <div data-comment-actions className="ml-auto flex shrink-0 items-center gap-0.5">
                 <Button
                   type="button"
                   variant="ghost"

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -25,6 +25,7 @@ import {
 } from "@multica/ui/components/ui/alert-dialog";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
+import { QuickEmojiPicker } from "@multica/ui/components/common/quick-emoji-picker";
 import { cn } from "@multica/ui/lib/utils";
 import { copyText } from "@multica/ui/lib/clipboard";
 import { useActorName } from "@multica/core/workspace/hooks";
@@ -677,7 +678,13 @@ function CommentRow({
           </span>
         )}
 
-        <div className="ml-auto flex items-center gap-0.5">
+        <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          {!edit.editing && <QuickEmojiPicker
+            onSelect={(emoji) => onToggleReaction(entry.id, emoji)}
+            ariaLabel={t(($) => $.comment.add_reaction)}
+            align="end"
+            className="h-7 w-7 hover:bg-transparent"
+          />}
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -846,6 +853,7 @@ function CommentRow({
       <div className="pl-12 pr-4 max-md:pl-3 max-md:pr-3">{runMetadata}</div>
       {!edit.editing && <ReactionBar
         reactions={reactions}
+        showPicker={false}
         currentUserId={currentUserId}
         onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
         getActorName={getActorName}
@@ -1068,6 +1076,12 @@ function CommentCardImpl({
                   <ChevronRight aria-hidden className={cn("h-3.5 w-3.5 transition-transform motion-reduce:transition-none", open && "rotate-90")} />
                 </Button>
                 {open && <>
+                  {!edit.editing && <QuickEmojiPicker
+                    onSelect={(emoji) => onToggleReaction(entry.id, emoji)}
+                    ariaLabel={t(($) => $.comment.add_reaction)}
+                    align="end"
+                    className="h-7 w-7 hover:bg-transparent"
+                  />}
                   <DropdownMenu>
                     <DropdownMenuTrigger
                       render={
@@ -1246,6 +1260,7 @@ function CommentCardImpl({
             <div className="pl-8 max-md:pl-0">{renderRuns(entry.id)}</div>
             {!edit.editing && <ReactionBar
               reactions={reactions}
+              showPicker={false}
               currentUserId={currentUserId}
               onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
               getActorName={getActorName}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -1009,22 +1009,13 @@ function CommentCardImpl({
             wrapper the header's containing block is the whole thread and it
             stays stuck behind every reply. */}
         <div className={cn("transition-colors duration-700", isHighlighted && highlightedCommentBackgroundClass)}>
-          {/* Header — always visible, acts as toggle */}
+          {/* Keep the author aligned with replies; thread controls sit on the right. */}
           <StickyHeaderShell
             sticky={stickyHeader}
             highlighted={isHighlighted}
             className="px-4 max-md:px-3 py-3"
           >
             <div className="flex items-center gap-2.5">
-              <button
-                type="button"
-                aria-expanded={open}
-                aria-controls={`comment-body-${entry.id}`}
-                onClick={handleToggle}
-                className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-              >
-                <ChevronRight className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-90")} />
-              </button>
               <ActorAvatar
                 actorType={entry.actor_type}
                 actorId={entry.actor_id}
@@ -1062,8 +1053,21 @@ function CommentCardImpl({
                 </span>
               )}
 
-              {open && (
-                <div className="ml-auto flex items-center gap-0.5">
+              <div className="ml-auto flex shrink-0 items-center gap-0.5">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={open ? t(($) => $.comment.collapse_thread) : t(($) => $.comment.expand_thread)}
+                  title={open ? t(($) => $.comment.collapse_thread) : t(($) => $.comment.expand_thread)}
+                  aria-expanded={open}
+                  aria-controls={open ? `comment-body-${entry.id}` : undefined}
+                  onClick={handleToggle}
+                  className="text-muted-foreground"
+                >
+                  <ChevronRight aria-hidden className={cn("h-3.5 w-3.5 transition-transform motion-reduce:transition-none", open && "rotate-90")} />
+                </Button>
+                {open && <>
                   <DropdownMenu>
                     <DropdownMenuTrigger
                       render={
@@ -1136,8 +1140,8 @@ function CommentCardImpl({
                     onConfirm={() => onDelete(entry.id)}
                     hasReplies
                   />
-                </div>
-              )}
+                </>}
+              </div>
             </div>
           </StickyHeaderShell>
 
@@ -1149,7 +1153,7 @@ function CommentCardImpl({
             {edit.editing ? (
               <div
                 {...edit.dropZoneProps}
-                className="relative pl-10 max-md:pl-0"
+                className="relative pl-8 max-md:pl-0"
                 onKeyDown={(e) => { if (e.key === "Escape") edit.cancelEdit(); }}
               >
                 <div className="text-body leading-relaxed">
@@ -1226,26 +1230,26 @@ function CommentCardImpl({
               </div>
             ) : (
               <>
-                <div data-comment-content={entry.id} className="pl-10 max-md:pl-0 text-body leading-relaxed text-foreground">
+                <div data-comment-content={entry.id} className="pl-8 max-md:pl-0 text-body leading-relaxed text-foreground">
                   <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
                 </div>
-                <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-10 max-md:pl-0" />
+                <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-8 max-md:pl-0" />
                 {retryableAgentFailureComment(entry) && (
                   <TaskCommentRetryButton
                     issueId={issueId}
                     taskId={entry.source_task_id}
-                    className="mt-2 pl-10 max-md:pl-0"
+                    className="mt-2 pl-8 max-md:pl-0"
                   />
                 )}
               </>
             )}
-            <div className="pl-10 max-md:pl-0">{renderRuns(entry.id)}</div>
+            <div className="pl-8 max-md:pl-0">{renderRuns(entry.id)}</div>
             {!edit.editing && <ReactionBar
               reactions={reactions}
               currentUserId={currentUserId}
               onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
               getActorName={getActorName}
-              className="mt-1.5 pl-10 max-md:pl-0"
+              className="mt-1.5 pl-8 max-md:pl-0"
             />}
           </div>
         )}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -4,7 +4,7 @@ import { Fragment, memo, useCallback, useEffect, useRef, useState, type ReactNod
 import { CheckCircle2, ChevronRight, ListChevronsDownUp, Copy, Loader2, MessageSquarePlus, MoreHorizontal, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@multica/ui/components/ui/card";
-import { Button } from "@multica/ui/components/ui/button";
+import { Button, buttonVariants } from "@multica/ui/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -48,6 +48,9 @@ import { RevisionConflictCompare } from "./revision-conflict-compare";
 import { InlineCommentRun, useInlineCommentRunState, type InlineCommentRunState } from "./inline-comment-run";
 import { EMPTY_COMMENT_RUNS, type CommentRun } from "./comment-runs";
 import { useRunCommentMotion } from "./use-run-comment-motion";
+
+const commentActionClassName =
+  "text-muted-foreground aria-expanded:bg-transparent aria-expanded:hover:bg-muted dark:aria-expanded:hover:bg-muted/50";
 
 const highlightedCommentBackgroundClass =
   "bg-[color-mix(in_srgb,var(--card)_95%,var(--brand)_5%)]";
@@ -687,7 +690,7 @@ function CommentRow({
             onSelect={(emoji) => onToggleReaction(entry.id, emoji)}
             ariaLabel={t(($) => $.comment.add_reaction)}
             align="end"
-            className="h-7 w-7 hover:bg-transparent"
+            className={buttonVariants({ variant: "ghost", size: "icon-sm", className: commentActionClassName })}
           />}
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -695,7 +698,7 @@ function CommentRow({
                 <Button
                   variant="ghost"
                   size="icon-sm"
-                  className="text-muted-foreground"
+                  className={commentActionClassName}
                   aria-label={t(($) => $.comment.more_actions)}
                 >
                   <MoreHorizontal className="h-4 w-4" aria-hidden />
@@ -1081,7 +1084,7 @@ function CommentCardImpl({
                   aria-expanded={open}
                   aria-controls={open ? `comment-body-${entry.id}` : undefined}
                   onClick={handleToggle}
-                  className="text-muted-foreground hover:bg-transparent aria-expanded:bg-transparent dark:hover:bg-transparent"
+                  className={commentActionClassName}
                 >
                   <ChevronRight aria-hidden className={cn("h-3.5 w-3.5 transition-transform motion-reduce:transition-none", open && "rotate-90")} />
                 </Button>
@@ -1090,7 +1093,7 @@ function CommentCardImpl({
                     onSelect={(emoji) => onToggleReaction(entry.id, emoji)}
                     ariaLabel={t(($) => $.comment.add_reaction)}
                     align="end"
-                    className="h-7 w-7 hover:bg-transparent"
+                    className={buttonVariants({ variant: "ghost", size: "icon-sm", className: commentActionClassName })}
                   />}
                   <DropdownMenu>
                     <DropdownMenuTrigger
@@ -1098,7 +1101,7 @@ function CommentCardImpl({
                         <Button
                           variant="ghost"
                           size="icon-sm"
-                          className="text-muted-foreground"
+                          className={commentActionClassName}
                           aria-label={t(($) => $.comment.more_actions)}
                         >
                           <MoreHorizontal className="h-4 w-4" aria-hidden />

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { Fragment, memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { CheckCircle2, ChevronRight, ListChevronsDownUp, Copy, Loader2, MessageSquarePlus, MoreHorizontal, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@multica/ui/components/ui/card";
@@ -44,6 +44,9 @@ import { useT } from "../../i18n";
 import { CommentsFoldBar } from "./resolved-thread-bar";
 import { deriveThreadResolution } from "./thread-utils";
 import { RevisionConflictCompare } from "./revision-conflict-compare";
+import { InlineCommentRun, useInlineCommentRunState, type InlineCommentRunState } from "./inline-comment-run";
+import { EMPTY_COMMENT_RUNS, type CommentRun } from "./comment-runs";
+import { useRunCommentMotion } from "./use-run-comment-motion";
 
 const highlightedCommentBackgroundClass =
   "bg-[color-mix(in_srgb,var(--card)_95%,var(--brand)_5%)]";
@@ -89,6 +92,9 @@ function StickyHeaderShell({
 
 interface CommentCardProps {
   issueId: string;
+  runs?: CommentRun[];
+  runViewState?: InlineCommentRunState;
+  enteringRunIds?: ReadonlySet<string>;
   entry: TimelineEntry;
   /**
    * Flat list of every nested reply under this thread root, in render order.
@@ -586,6 +592,7 @@ function CommentRevisionConflict({
 // ---------------------------------------------------------------------------
 
 function CommentRow({
+  runMetadata,
   issueId,
   entry,
   currentUserId,
@@ -598,6 +605,7 @@ function CommentRow({
   onCreateSubIssue,
   onResolveToggle,
 }: {
+  runMetadata?: ReactNode;
   issueId: string;
   entry: TimelineEntry;
   currentUserId?: string;
@@ -822,7 +830,7 @@ function CommentRow({
         </div>
       ) : (
         <>
-          <div className="pl-12 pr-4 max-md:pl-3 max-md:pr-3 pt-1 text-body leading-relaxed text-foreground">
+          <div data-comment-content={entry.id} className="pl-12 pr-4 max-md:pl-3 max-md:pr-3 pt-1 text-body leading-relaxed text-foreground">
             <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
           </div>
           <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-12 pr-4 max-md:pl-3 max-md:pr-3" />
@@ -833,15 +841,54 @@ function CommentRow({
               className="mt-2 pl-12 pr-4 max-md:pl-3 max-md:pr-3"
             />
           )}
-          <ReactionBar
-            reactions={reactions}
-            currentUserId={currentUserId}
-            onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
-            getActorName={getActorName}
-            className="mt-1.5 pl-12 pr-4 max-md:pl-3 max-md:pr-3"
-          />
         </>
       )}
+      <div className="pl-12 pr-4 max-md:pl-3 max-md:pr-3">{runMetadata}</div>
+      {!edit.editing && <ReactionBar
+        reactions={reactions}
+        currentUserId={currentUserId}
+        onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
+        getActorName={getActorName}
+        className="mt-1.5 pl-12 pr-4 max-md:pl-3 max-md:pr-3"
+      />}
+    </div>
+  );
+}
+
+/** A run without a persisted reply still belongs to the agent, never its trigger author. */
+export function AgentRunComment({ run, standalone = false, commentProps, entering = false }: {
+  run: CommentRun;
+  standalone?: boolean;
+  entering?: boolean;
+  commentProps?: CommentCardProps;
+}) {
+  const { getActorName } = useActorName();
+  const timeAgo = useTimeAgo();
+  const viewState = useInlineCommentRunState();
+  const reply = commentProps?.entry;
+  const motionRef = useRunCommentMotion(entering, reply?.id, run.task.status);
+  return (
+    <div ref={motionRef} data-run-slot-id={run.task.id}
+      data-run-comment-id={!reply ? run.task.id : undefined}
+      id={!standalone && reply ? `comment-${reply.id}` : undefined}
+      className={cn(standalone ? !reply && "rounded-xl border bg-card" : "border-t border-border/50", !reply && "py-1.5", reply && commentProps?.highlightedCommentId === reply.id && highlightedCommentBackgroundClass)}>
+      {commentProps ? standalone ? (
+        <CommentCard {...commentProps} runs={commentProps.runs ?? [run]} runViewState={viewState} />
+      ) : (
+        <CommentRow {...commentProps}
+          isHighlighted={commentProps.highlightedCommentId === reply?.id}
+          isResolution={!!reply?.resolved_at}
+          runMetadata={<InlineCommentRun run={run} viewState={viewState} />} />
+      ) : <>
+        <StickyHeaderShell className="flex items-center gap-2.5 px-4 pt-1 pb-1.5 max-md:px-3">
+          <ActorAvatar actorType="agent" actorId={run.task.agent_id} size="md" enableHoverCard showStatusDot />
+          <span className="text-body font-medium">{getActorName("agent", run.task.agent_id)}</span>
+          <span className="text-caption text-muted-foreground">{timeAgo(run.task.created_at)}</span>
+        </StickyHeaderShell>
+        <div className="pl-12 pr-4 max-md:pl-3 max-md:pr-3">
+          <InlineCommentRun run={run} viewState={viewState} />
+        </div>
+      </>}
     </div>
   );
 }
@@ -859,6 +906,9 @@ function CommentRow({
 
 function CommentCardImpl({
   issueId,
+  runs = EMPTY_COMMENT_RUNS,
+  runViewState,
+  enteringRunIds,
   entry,
   replies,
   currentUserId,
@@ -895,6 +945,21 @@ function CommentCardImpl({
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const allNestedReplies = replies;
+  const slottedReplyIds = new Set(runs.filter((run) => run.hasReply && run.anchorCommentId && run.commentId !== entry.id)
+    .map((run) => run.commentId));
+  const renderRuns = (commentId: string) => runs.filter((run) => run.commentId === commentId && run.hasReply
+    && (!run.anchorCommentId || run.anchorCommentId === commentId || replyFolded))
+    .map((run) => <InlineCommentRun key={run.task.id} run={run} viewState={run.commentId === entry.id ? runViewState : undefined} />);
+
+  const renderAnchoredRuns = (commentId: string) => runs.filter((run) => run.anchorCommentId === commentId
+    && !(replyFolded && run.hasReply))
+    .map((run) => {
+      const reply = run.hasReply ? allNestedReplies.find((entry) => entry.id === run.commentId) : undefined;
+      return <Fragment key={run.task.id}><AgentRunComment run={run} entering={enteringRunIds?.has(run.task.id)} commentProps={reply ? {
+        issueId, entry: reply, replies: [], currentUserId, canModerate, onReply, onEdit, onDelete,
+        onToggleReaction, onCreateSubIssue, onResolveToggle, highlightedCommentId, enteringRunIds,
+      } : undefined} />{reply && reply.id !== commentId && renderAnchoredRuns(reply.id)}</Fragment>;
+    });
 
   const replyCount = allNestedReplies.length;
   const contentPreview = (entry.content ?? "").replace(/\n/g, " ").slice(0, 80);
@@ -1170,7 +1235,7 @@ function CommentCardImpl({
               </div>
             ) : (
               <>
-                <div className="pl-10 max-md:pl-0 text-body leading-relaxed text-foreground">
+                <div data-comment-content={entry.id} className="pl-10 max-md:pl-0 text-body leading-relaxed text-foreground">
                   <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
                 </div>
                 <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-10 max-md:pl-0" />
@@ -1181,15 +1246,16 @@ function CommentCardImpl({
                     className="mt-2 pl-10 max-md:pl-0"
                   />
                 )}
-                <ReactionBar
-                  reactions={reactions}
-                  currentUserId={currentUserId}
-                  onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
-                  getActorName={getActorName}
-                  className="mt-1.5 pl-10 max-md:pl-0"
-                />
               </>
             )}
+            <div className="pl-10 max-md:pl-0">{renderRuns(entry.id)}</div>
+            {!edit.editing && <ReactionBar
+              reactions={reactions}
+              currentUserId={currentUserId}
+              onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
+              getActorName={getActorName}
+              className="mt-1.5 pl-10 max-md:pl-0"
+            />}
           </div>
         )}
         </div>
@@ -1199,6 +1265,7 @@ function CommentCardImpl({
             to mirror the body Panel's collapse visibility. */}
         {open && (
           <>
+          {renderAnchoredRuns(entry.id)}
           {replyFolded ? (
             <>
               {/* reply-mode folded: other replies behind a bar, resolution pinned below */}
@@ -1211,27 +1278,31 @@ function CommentCardImpl({
                 </div>
               )}
               {resolutionReply && (
-                <div
-                  id={`comment-${resolutionReply.id}`}
-                  className={cn(
-                    "border-t border-border/50 transition-colors duration-700",
-                    highlightedCommentId === resolutionReply.id && highlightedCommentBackgroundClass,
-                  )}
-                >
-                  <CommentRow
-                    issueId={issueId}
-                    entry={resolutionReply}
-                    currentUserId={currentUserId}
-                    canModerate={canModerate}
-                    isResolution
-                    isHighlighted={highlightedCommentId === resolutionReply.id}
-                    onEdit={onEdit}
-                    onDelete={onDelete}
-                    onToggleReaction={onToggleReaction}
-                    onCreateSubIssue={onCreateSubIssue}
-                    onResolveToggle={onResolveToggle}
-                  />
-                </div>
+                <>
+                  <div
+                    id={`comment-${resolutionReply.id}`}
+                    className={cn(
+                      "border-t border-border/50 transition-colors duration-700",
+                      highlightedCommentId === resolutionReply.id && highlightedCommentBackgroundClass,
+                    )}
+                  >
+                    <CommentRow
+                      issueId={issueId}
+                      entry={resolutionReply}
+                      runMetadata={renderRuns(resolutionReply.id)}
+                      currentUserId={currentUserId}
+                      canModerate={canModerate}
+                      isResolution
+                      isHighlighted={highlightedCommentId === resolutionReply.id}
+                      onEdit={onEdit}
+                      onDelete={onDelete}
+                      onToggleReaction={onToggleReaction}
+                      onCreateSubIssue={onCreateSubIssue}
+                      onResolveToggle={onResolveToggle}
+                    />
+                  </div>
+                  {renderAnchoredRuns(resolutionReply.id)}
+                </>
               )}
             </>
           ) : (
@@ -1249,29 +1320,32 @@ function CommentCardImpl({
                 </button>
               )}
               {/* Replies — chronological; the resolution keeps its place with a badge */}
-              {allNestedReplies.map((reply) => (
-                <div
-                  key={reply.id}
-                  id={`comment-${reply.id}`}
-                  className={cn(
-                    "border-t border-border/50 transition-colors duration-700",
-                    highlightedCommentId === reply.id && highlightedCommentBackgroundClass,
-                  )}
-                >
-                  <CommentRow
-                    issueId={issueId}
-                    entry={reply}
-                    currentUserId={currentUserId}
-                    canModerate={canModerate}
-                    isResolution={reply.id === replyResolutionId}
-                    isHighlighted={highlightedCommentId === reply.id}
-                    onEdit={onEdit}
-                    onDelete={onDelete}
-                    onToggleReaction={onToggleReaction}
-                    onCreateSubIssue={onCreateSubIssue}
-                    onResolveToggle={onResolveToggle}
-                  />
-                </div>
+              {allNestedReplies.filter((reply) => !slottedReplyIds.has(reply.id)).map((reply) => (
+                <Fragment key={reply.id}>
+                  <div
+                    id={`comment-${reply.id}`}
+                    className={cn(
+                      "border-t border-border/50 transition-colors duration-700",
+                      highlightedCommentId === reply.id && highlightedCommentBackgroundClass,
+                    )}
+                  >
+                    <CommentRow
+                      issueId={issueId}
+                      entry={reply}
+                      runMetadata={renderRuns(reply.id)}
+                      currentUserId={currentUserId}
+                      canModerate={canModerate}
+                      isResolution={reply.id === replyResolutionId}
+                      isHighlighted={highlightedCommentId === reply.id}
+                      onEdit={onEdit}
+                      onDelete={onDelete}
+                      onToggleReaction={onToggleReaction}
+                      onCreateSubIssue={onCreateSubIssue}
+                      onResolveToggle={onResolveToggle}
+                    />
+                  </div>
+                  {renderAnchoredRuns(reply.id)}
+                </Fragment>
               ))}
 
               {/* Reply input */}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -638,7 +638,7 @@ function CommentRow({
   const reactions = entry.reactions ?? [];
 
   return (
-    <div className="py-1.5">
+    <div className="pb-3">
       {/* Header pins to the timeline's scroll parent within this reply's own
           row box, so a LONG reply keeps its
           author + actions visible while you scroll its body, then releases once
@@ -646,7 +646,7 @@ function CommentRow({
           highlight state while it occludes the body scrolling underneath. */}
       <StickyHeaderShell
         highlighted={isHighlighted}
-        className="flex items-center gap-2.5 px-4 max-md:px-3 pt-1 pb-1.5"
+        className="flex items-center gap-2.5 px-4 max-md:px-3 pt-3 pb-2"
       >
         <ActorAvatar
           actorType={entry.actor_type}
@@ -841,7 +841,7 @@ function CommentRow({
         </div>
       ) : (
         <>
-          <div data-comment-content={entry.id} className="pl-12 pr-4 max-md:pl-3 max-md:pr-3 pt-1 text-body leading-relaxed text-foreground">
+          <div data-comment-content={entry.id} className="pl-12 pr-4 max-md:pl-3 max-md:pr-3 text-body leading-relaxed text-foreground">
             <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
           </div>
           <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-12 pr-4 max-md:pl-3 max-md:pr-3" />
@@ -1029,7 +1029,7 @@ function CommentCardImpl({
           <StickyHeaderShell
             sticky={stickyHeader}
             highlighted={isHighlighted}
-            className="px-4 max-md:px-3 py-3"
+            className={cn("px-4 max-md:px-3", open ? "pt-3 pb-2" : "py-3")}
           >
             <div className="flex items-center gap-2.5">
               <ActorAvatar
@@ -1173,7 +1173,7 @@ function CommentCardImpl({
             probes computed styles to detect animations, forcing a style
             recalculation across long issue-detail documents. */}
         {open && (
-          <div id={`comment-body-${entry.id}`} className="px-4 max-md:px-3 pt-1 pb-3">
+          <div id={`comment-body-${entry.id}`} className="px-4 max-md:px-3 pb-3">
             {edit.editing ? (
               <div
                 {...edit.dropZoneProps}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -1063,7 +1063,7 @@ function CommentCardImpl({
                   aria-expanded={open}
                   aria-controls={open ? `comment-body-${entry.id}` : undefined}
                   onClick={handleToggle}
-                  className="text-muted-foreground"
+                  className="text-muted-foreground hover:bg-transparent aria-expanded:bg-transparent dark:hover:bg-transparent"
                 >
                   <ChevronRight aria-hidden className={cn("h-3.5 w-3.5 transition-transform motion-reduce:transition-none", open && "rotate-90")} />
                 </Button>

--- a/packages/views/issues/components/comment-runs.test.ts
+++ b/packages/views/issues/components/comment-runs.test.ts
@@ -40,8 +40,26 @@ describe("groupCommentRuns", () => {
     expect(before.standaloneRuns).toEqual([]);
     expect(before.runs.size).toBe(0);
     const after = buildCommentRunView([original, retry], [old, next]);
-    expect(after.runs.get(old.id)?.map((run) => run.anchorCommentId)).toEqual([next.id, next.id]);
+    expect(after.runs.get(old.id)?.map((run) => run.anchorCommentId)).toEqual([old.id, old.id]);
     expect(after.standaloneRuns).toEqual([]);
+  });
+
+  it("keeps a queued run in place as its thread receives more instructions and its answer", () => {
+    const root = comment("root");
+    const first = comment("first", { parent_id: root.id });
+    const other = comment("other-thread");
+    const second = comment("second", { parent_id: root.id, created_at: "2026-09-07T00:01:00Z" });
+    const run = task("run", { status: "queued", trigger_comment_id: first.id });
+    const before = buildCommentRunView([run], [root, first, other]);
+    const merged = { ...run, trigger_comment_id: second.id, coalesced_comment_ids: [first.id] };
+    const awaitingComment = buildCommentRunView([merged], [root, first, other], before.runs);
+    expect(awaitingComment.runs.get(root.id)?.[0]?.anchorCommentId).toBe(first.id);
+    const after = buildCommentRunView([merged], [root, first, other, second], before.runs);
+    expect(after.runs.get(root.id)?.[0]?.anchorCommentId).toBe(first.id);
+    expect(after.runs.has(other.id)).toBe(false);
+    const answer = comment("answer", { actor_type: "agent", source_task_id: run.id });
+    const complete = buildCommentRunView([{ ...merged, status: "completed", delivered_comment_ids: [first.id, second.id] }], [root, first, other, second, answer]);
+    expect(complete.runs.get(root.id)?.[0]).toMatchObject({ anchorCommentId: first.id, commentId: answer.id, hasReply: true });
   });
 
   it("projects chained answers and assignment subtrees before finding run roots", () => {
@@ -103,10 +121,10 @@ describe("groupCommentRuns", () => {
     expect(buildCommentRunView([run], [reply]).standaloneRuns).toHaveLength(1);
     expect(buildCommentRunView([run], []).standaloneRuns).toEqual([]);
   });
-  it("places merged runs once under their newest trigger, including nested replies", () => {
+  it("keeps merged runs at their earliest input, including nested replies", () => {
     const timeline = [comment("root"), comment("reply", { parent_id: "root" }), comment("nested", { parent_id: "reply" })];
     const run = task("run", { trigger_comment_id: "nested", coalesced_comment_ids: ["root", "reply"], delivered_comment_ids: ["root", "reply", "nested"] });
-    expect([...groupCommentRuns([run], timeline)]).toEqual([["root", [{ task: run, commentId: "nested", anchorCommentId: "nested", hasReply: false }]]]);
+    expect([...groupCommentRuns([run], timeline)]).toEqual([["root", [{ task: run, commentId: "root", anchorCommentId: "root", hasReply: false }]]]);
   });
 
   it.each([{ receipt: [] }, { receipt: ["old"] }])("uses planned comment coverage while queued, even with a delivery receipt of $receipt", ({ receipt }) => {

--- a/packages/views/issues/components/comment-runs.test.ts
+++ b/packages/views/issues/components/comment-runs.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import type { AgentTask, TimelineEntry } from "@multica/core/types";
+import { commentRunOutput, groupCommentRuns, standaloneCommentRuns } from "./comment-runs";
+
+function task(id: string, overrides: Partial<AgentTask> = {}): AgentTask {
+  return { id, agent_id: "agent", runtime_id: "runtime", issue_id: "issue", status: "running", priority: 0,
+    created_at: "2026-09-07T00:00:00Z", started_at: null, dispatched_at: null, completed_at: null, result: null, error: null, ...overrides };
+}
+function comment(id: string, overrides: Partial<TimelineEntry> = {}): TimelineEntry {
+  return { id, type: "comment", actor_type: "member", actor_id: "user", created_at: "2026-09-07T00:00:00Z", ...overrides };
+}
+
+describe("groupCommentRuns", () => {
+  it("replaces invalidated queued runs without adding cancelled comment blocks", () => {
+    const old = task("old", { status: "cancelled", trigger_comment_id: "root", cancelled_by_comment_change: true });
+    const next = task("new", { status: "queued", trigger_comment_id: "root" });
+    const later = task("later", { status: "queued", trigger_comment_id: "followup" });
+    const tasks = [old, { ...old, id: "second-edit" }, next, later];
+    const timeline = [comment("root"), comment("followup", { parent_id: "root" })];
+    const grouped = groupCommentRuns(tasks, timeline);
+    expect(grouped.get("root")?.map((run) => run.task.id)).toEqual(["later", "new"]);
+    expect(standaloneCommentRuns(tasks, grouped)).toEqual([]);
+    expect(tasks).toHaveLength(4); // Full execution history remains intact.
+    const reply = comment("answer", { actor_type: "agent", source_task_id: next.id });
+    expect(groupCommentRuns(tasks, [...timeline, reply]).get("root")?.find((run) => run.task.id === next.id))
+      .toMatchObject({ anchorCommentId: "root", commentId: "answer", hasReply: true });
+  });
+
+  it.each([
+    { cancelled_by_comment_change: undefined },
+    { cancelled_by_comment_change: false },
+    { dispatched_at: "2026-09-07T00:00:01Z" },
+    { started_at: "2026-09-07T00:00:01Z" },
+    { delivered_comment_ids: ["root"] },
+    { status: "failed" as const },
+  ])("retains manual cancellation and actual execution: %j", (overrides) => {
+    const run = task("old", { status: "cancelled", trigger_comment_id: "root", cancelled_by_comment_change: true, ...overrides });
+    expect(groupCommentRuns([run], [comment("root")]).get("root")?.[0]?.task.id).toBe(run.id);
+  });
+
+  it("keeps actual replies even when cancellation metadata says the input changed", () => {
+    const run = task("old", { status: "cancelled", cancelled_by_comment_change: true });
+    const reply = comment("answer", { actor_type: "agent", source_task_id: run.id });
+    const grouped = groupCommentRuns([run], [reply]);
+    expect(standaloneCommentRuns([run], grouped)).toHaveLength(1);
+    expect(standaloneCommentRuns([run], groupCommentRuns([run], []))).toEqual([]);
+  });
+  it("places merged runs once under their newest trigger, including nested replies", () => {
+    const timeline = [comment("root"), comment("reply", { parent_id: "root" }), comment("nested", { parent_id: "reply" })];
+    const run = task("run", { trigger_comment_id: "nested", coalesced_comment_ids: ["root", "reply"], delivered_comment_ids: ["root", "reply", "nested"] });
+    expect([...groupCommentRuns([run], timeline)]).toEqual([["root", [{ task: run, commentId: "nested", anchorCommentId: "nested", hasReply: false }]]]);
+  });
+
+  it.each([{ receipt: [] }, { receipt: ["old"] }])("uses planned comment coverage while queued, even with a delivery receipt of $receipt", ({ receipt }) => {
+    const run = task("queued", {
+      status: "queued", trigger_comment_id: "new", coalesced_comment_ids: ["old"],
+      delivered_comment_ids: receipt,
+    });
+    const timeline = [comment("old"), comment("new")];
+    expect(groupCommentRuns([run], timeline).get("new")).toEqual([
+      { task: run, commentId: "new", anchorCommentId: "new", hasReply: false },
+    ]);
+  });
+
+  it("keeps the trigger position while binding the latest persisted reply", () => {
+    const run = task("run", { status: "completed", trigger_comment_id: "root" });
+    const timeline = [comment("root"),
+      comment("progress", { parent_id: "root", actor_type: "agent", source_task_id: run.id }),
+      comment("final", { parent_id: "root", actor_type: "agent", source_task_id: run.id, created_at: "2026-09-07T00:01:00Z" }),
+      comment("unrelated", { actor_type: "agent", source_task_id: "other" })];
+    const map = groupCommentRuns([run], timeline);
+    expect(map.get("root")).toEqual([{ task: run, commentId: "final", anchorCommentId: "root", hasReply: true }]);
+    expect(map.size).toBe(1);
+  });
+
+  it.each(["cancelled", "failed"] as const)("preserves the planned anchor after a queued run is %s before dispatch", (status) => {
+    const run = task("stopped", {
+      status, trigger_comment_id: "new", coalesced_comment_ids: ["old"],
+      delivered_comment_ids: [], completed_at: "2026-09-07T00:01:00Z",
+    });
+    const retry = task("retry", { status: "queued", parent_task_id: run.id, delivered_comment_ids: [] });
+    expect(groupCommentRuns([run, retry], [comment("old"), comment("new")]).get("new")?.map((row) => row.task.id))
+      .toEqual(["retry", "stopped"]);
+    expect(groupCommentRuns([{ ...run, dispatched_at: "2026-09-07T00:00:30Z" }], [comment("new")]).size).toBe(0);
+  });
+
+  it("uses authoritative delivered comments when the newest trigger was not delivered", () => {
+    const run = task("run", { trigger_comment_id: "new", coalesced_comment_ids: ["old"], delivered_comment_ids: ["old"] });
+    expect(groupCommentRuns([run], [comment("old"), comment("new")]).get("old")?.[0]?.commentId).toBe("old");
+    expect(groupCommentRuns([{ ...run, delivered_comment_ids: [] }], [comment("old"), comment("new")]).size).toBe(0);
+  });
+
+  it("keeps retries on their original trigger and ignores missing or cyclic ancestry", () => {
+    const original = task("original", { trigger_comment_id: "root" });
+    const retry = task("retry", { parent_task_id: original.id });
+    expect(groupCommentRuns([retry, original], [comment("root")]).get("root")?.map((row) => row.task.id)).toEqual(["original", "retry"]);
+    expect(groupCommentRuns([task("a", { parent_task_id: "b" }), task("b", { parent_task_id: "a" })], []).size).toBe(0);
+    expect(groupCommentRuns([task("deleted", { trigger_comment_id: "missing" })], []).size).toBe(0);
+  });
+
+  it("associates assignment runs with their own replies and preserves unrelated thread references", () => {
+    const run = task("assigned");
+    const timeline = [comment("delivery", { actor_type: "agent", source_task_id: run.id })];
+    const before = groupCommentRuns([run], timeline);
+    const after = groupCommentRuns([run, task("other", { trigger_comment_id: "other" })], [...timeline, comment("other")], before);
+    expect(after.get("delivery")).toBe(before.get("delivery"));
+  });
+});
+
+describe("commentRunOutput", () => {
+  it("only exposes the completed daemon deliverable and tolerates response drift", () => {
+    expect(commentRunOutput(task("r", { status: "completed", result: { comment: "Done" } }))).toBe("Done");
+    for (const result of [null, "Done", {}, { comment: 1 }, { comment: " " }]) {
+      expect(commentRunOutput(task("r", { status: "completed", result }))).toBeNull();
+    }
+    expect(commentRunOutput(task("r", { result: { comment: "Still working" } }))).toBeNull();
+  });
+});
+
+describe("standaloneCommentRuns", () => {
+  it.each(["queued", "dispatched", "running", "failed", "cancelled", "completed"] as const)("keeps an unanchored %s run visible", (status) => {
+    const run = task("assignment", { status, delivered_comment_ids: [] });
+    expect(standaloneCommentRuns([run], groupCommentRuns([run], [])))
+      .toEqual([{ task: run, hasReply: false }]);
+  });
+
+  it("keeps assignment slots after replies arrive and excludes comment-triggered slots", () => {
+    const assigned = task("assignment");
+    const triggered = task("comment-run", { trigger_comment_id: "trigger" });
+    const tasks = [assigned, triggered];
+    const timeline = [comment("trigger")];
+    expect(standaloneCommentRuns(tasks, groupCommentRuns(tasks, timeline)).map((run) => run.task.id)).toEqual([assigned.id]);
+    const reply = comment("answer", { actor_type: "agent", source_task_id: assigned.id });
+    expect(standaloneCommentRuns(tasks, groupCommentRuns(tasks, [...timeline, reply])))
+      .toEqual([{ task: assigned, commentId: reply.id, anchorCommentId: undefined, hasReply: true }]);
+  });
+});

--- a/packages/views/issues/components/comment-runs.test.ts
+++ b/packages/views/issues/components/comment-runs.test.ts
@@ -1,7 +1,9 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { AgentTask, TimelineEntry } from "@multica/core/types";
-import { commentRunOutput, groupCommentRuns, standaloneCommentRuns } from "./comment-runs";
+import { commentRunOutput, buildCommentRunView, standaloneCommentRuns } from "./comment-runs";
+
+const groupCommentRuns = (...args: Parameters<typeof buildCommentRunView>) => buildCommentRunView(...args).runs;
 
 function task(id: string, overrides: Partial<AgentTask> = {}): AgentTask {
   return { id, agent_id: "agent", runtime_id: "runtime", issue_id: "issue", status: "running", priority: 0,
@@ -12,6 +14,32 @@ function comment(id: string, overrides: Partial<TimelineEntry> = {}): TimelineEn
 }
 
 describe("groupCommentRuns", () => {
+  it("projects chained answers and assignment subtrees before finding run roots", () => {
+    const first = task("first", { trigger_comment_id: "root" });
+    const second = task("second", { trigger_comment_id: "answer-a" });
+    const assigned = task("assigned");
+    const followup = task("followup", { trigger_comment_id: "nested" });
+    const timeline = [comment("root"),
+      comment("answer-a", { actor_type: "agent", source_task_id: first.id }),
+      comment("answer-b", { actor_type: "agent", source_task_id: second.id }),
+      comment("assigned-answer", { parent_id: "root", actor_type: "agent", source_task_id: assigned.id }),
+      comment("nested", { parent_id: "assigned-answer" })];
+    const view = buildCommentRunView([followup, second, assigned, first], timeline);
+    expect(view.runs.get("root")?.map((run) => run.task.id)).toEqual(["first", "second"]);
+    expect(view.runs.get("assigned-answer")?.map((run) => run.task.id)).toEqual(["assigned", "followup"]);
+    expect(view.timeline.find((entry) => entry.id === "answer-a")?.parent_id).toBe("root");
+    expect(view.timeline.find((entry) => entry.id === "answer-b")?.parent_id).toBe("answer-a");
+    expect(view.timeline.find((entry) => entry.id === "assigned-answer")?.parent_id).toBeUndefined();
+    expect(timeline.find((entry) => entry.id === "assigned-answer")?.parent_id).toBe("root");
+  });
+
+  it("does not project reply relationships that would create a comment cycle", () => {
+    const first = task("first", { trigger_comment_id: "b" });
+    const second = task("second", { trigger_comment_id: "a" });
+    const timeline = [comment("a", { actor_type: "agent", source_task_id: first.id }),
+      comment("b", { actor_type: "agent", source_task_id: second.id })];
+    expect(buildCommentRunView([first, second], timeline).timeline).toEqual(timeline);
+  });
   it("replaces invalidated queued runs without adding cancelled comment blocks", () => {
     const old = task("old", { status: "cancelled", trigger_comment_id: "root", cancelled_by_comment_change: true });
     const next = task("new", { status: "queued", trigger_comment_id: "root" });

--- a/packages/views/issues/components/comment-runs.test.ts
+++ b/packages/views/issues/components/comment-runs.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { AgentTask, TimelineEntry } from "@multica/core/types";
-import { commentRunOutput, buildCommentRunView, standaloneCommentRuns } from "./comment-runs";
+import { commentRunOutput, buildCommentRunView } from "./comment-runs";
 
 const groupCommentRuns = (...args: Parameters<typeof buildCommentRunView>) => buildCommentRunView(...args).runs;
 
@@ -14,6 +14,36 @@ function comment(id: string, overrides: Partial<TimelineEntry> = {}): TimelineEn
 }
 
 describe("groupCommentRuns", () => {
+  it.each(["queued", "dispatched", "running", "completed"] as const)("waits for a missing trigger before placing a %s run and its reply", (status) => {
+    const run = task("run", { status, trigger_comment_id: "trigger",
+      delivered_comment_ids: status === "queued" || status === "dispatched" ? [] : ["trigger"] });
+    const root = comment("root");
+    const trigger = comment("trigger", { parent_id: root.id });
+    const before = buildCommentRunView([run], [root]);
+    expect(before.standaloneRuns).toEqual([]);
+    expect(before.runs.size).toBe(0);
+    const reply = comment("answer", { actor_type: "agent", source_task_id: run.id });
+    const earlyReply = buildCommentRunView([run], [root, reply]);
+    expect(earlyReply.standaloneRuns).toEqual([]);
+    expect(earlyReply.timeline.find((entry) => entry.id === reply.id)?.parent_id).toBe(trigger.id);
+    const after = buildCommentRunView([run], [root, trigger, reply]);
+    expect(after.standaloneRuns).toEqual([]);
+    expect(after.runs.get(root.id)).toEqual([{ task: run, anchorCommentId: trigger.id, commentId: reply.id, hasReply: true }]);
+  });
+
+  it("waits for the intended merged trigger and preserves retry ancestry", () => {
+    const original = task("original", { status: "queued", trigger_comment_id: "new", coalesced_comment_ids: ["old"], delivered_comment_ids: [] });
+    const retry = task("retry", { status: "queued", parent_task_id: original.id, delivered_comment_ids: [] });
+    const old = comment("old");
+    const next = comment("new", { parent_id: old.id });
+    const before = buildCommentRunView([original, retry], [old]);
+    expect(before.standaloneRuns).toEqual([]);
+    expect(before.runs.size).toBe(0);
+    const after = buildCommentRunView([original, retry], [old, next]);
+    expect(after.runs.get(old.id)?.map((run) => run.anchorCommentId)).toEqual([next.id, next.id]);
+    expect(after.standaloneRuns).toEqual([]);
+  });
+
   it("projects chained answers and assignment subtrees before finding run roots", () => {
     const first = task("first", { trigger_comment_id: "root" });
     const second = task("second", { trigger_comment_id: "answer-a" });
@@ -48,7 +78,7 @@ describe("groupCommentRuns", () => {
     const timeline = [comment("root"), comment("followup", { parent_id: "root" })];
     const grouped = groupCommentRuns(tasks, timeline);
     expect(grouped.get("root")?.map((run) => run.task.id)).toEqual(["later", "new"]);
-    expect(standaloneCommentRuns(tasks, grouped)).toEqual([]);
+    expect(buildCommentRunView(tasks, timeline).standaloneRuns).toEqual([]);
     expect(tasks).toHaveLength(4); // Full execution history remains intact.
     const reply = comment("answer", { actor_type: "agent", source_task_id: next.id });
     expect(groupCommentRuns(tasks, [...timeline, reply]).get("root")?.find((run) => run.task.id === next.id))
@@ -70,9 +100,8 @@ describe("groupCommentRuns", () => {
   it("keeps actual replies even when cancellation metadata says the input changed", () => {
     const run = task("old", { status: "cancelled", cancelled_by_comment_change: true });
     const reply = comment("answer", { actor_type: "agent", source_task_id: run.id });
-    const grouped = groupCommentRuns([run], [reply]);
-    expect(standaloneCommentRuns([run], grouped)).toHaveLength(1);
-    expect(standaloneCommentRuns([run], groupCommentRuns([run], []))).toEqual([]);
+    expect(buildCommentRunView([run], [reply]).standaloneRuns).toHaveLength(1);
+    expect(buildCommentRunView([run], []).standaloneRuns).toEqual([]);
   });
   it("places merged runs once under their newest trigger, including nested replies", () => {
     const timeline = [comment("root"), comment("reply", { parent_id: "root" }), comment("nested", { parent_id: "reply" })];
@@ -149,7 +178,7 @@ describe("commentRunOutput", () => {
 describe("standaloneCommentRuns", () => {
   it.each(["queued", "dispatched", "running", "failed", "cancelled", "completed"] as const)("keeps an unanchored %s run visible", (status) => {
     const run = task("assignment", { status, delivered_comment_ids: [] });
-    expect(standaloneCommentRuns([run], groupCommentRuns([run], [])))
+    expect(buildCommentRunView([run], []).standaloneRuns)
       .toEqual([{ task: run, hasReply: false }]);
   });
 
@@ -158,9 +187,9 @@ describe("standaloneCommentRuns", () => {
     const triggered = task("comment-run", { trigger_comment_id: "trigger" });
     const tasks = [assigned, triggered];
     const timeline = [comment("trigger")];
-    expect(standaloneCommentRuns(tasks, groupCommentRuns(tasks, timeline)).map((run) => run.task.id)).toEqual([assigned.id]);
+    expect(buildCommentRunView(tasks, timeline).standaloneRuns.map((run) => run.task.id)).toEqual([assigned.id]);
     const reply = comment("answer", { actor_type: "agent", source_task_id: assigned.id });
-    expect(standaloneCommentRuns(tasks, groupCommentRuns(tasks, [...timeline, reply])))
+    expect(buildCommentRunView(tasks, [...timeline, reply]).standaloneRuns)
       .toEqual([{ task: assigned, commentId: reply.id, anchorCommentId: undefined, hasReply: true }]);
   });
 });

--- a/packages/views/issues/components/comment-runs.ts
+++ b/packages/views/issues/components/comment-runs.ts
@@ -29,11 +29,11 @@ function isObsoleteCommentRun(task: AgentTask): boolean {
 }
 
 /** Keep each run at its trigger; associate replies by task identity, never arrival order. */
-export function groupCommentRuns(
+export function buildCommentRunView(
   tasks: readonly AgentTask[],
   timeline: readonly TimelineEntry[],
   previous = new Map<string, CommentRun[]>(),
-): Map<string, CommentRun[]> {
+): { timeline: readonly TimelineEntry[]; runs: Map<string, CommentRun[]> } {
   const comments = new Map(timeline.filter((entry) => entry.type === "comment").map((entry) => [entry.id, entry]));
   const replies = new Map<string, TimelineEntry>();
   for (const entry of comments.values()) {
@@ -44,7 +44,7 @@ export function groupCommentRuns(
     }
   }
   const byTask = new Map(tasks.map((task) => [task.id, task]));
-  const grouped = new Map<string, CommentRun[]>();
+  const placements: CommentRun[] = [];
   for (const task of [...tasks].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))) {
     const reply = replies.get(task.id);
     if (isObsoleteCommentRun(task) && !reply) continue;
@@ -66,16 +66,45 @@ export function groupCommentRuns(
         ?? candidates.sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
       source = source.parent_task_id ? byTask.get(source.parent_task_id) : undefined;
     }
-    const location = anchor ?? reply;
-    if (!location) continue;
-    let root = location;
+    placements.push({ task, commentId: reply?.id ?? anchor?.id, anchorCommentId: anchor?.id, hasReply: !!reply });
+  }
+  // Project every task-owned answer first, then use that same tree for run
+  // grouping, replies, resolution, and navigation. Assignment answers become
+  // roots even if the agent originally posted them inside an existing thread.
+  const parents = new Map<string, string | undefined>();
+  for (const run of placements) {
+    if (run.hasReply && run.commentId && run.commentId !== run.anchorCommentId) {
+      parents.set(run.commentId, run.anchorCommentId);
+    }
+  }
+  const cyclic = new Set<string>();
+  for (const id of parents.keys()) {
+    const seen = new Set([id]);
+    let parent = parents.get(id);
+    while (parent) {
+      if (seen.has(parent)) { cyclic.add(id); break; }
+      seen.add(parent);
+      parent = parents.has(parent) ? parents.get(parent) : comments.get(parent)?.parent_id ?? undefined;
+    }
+  }
+  for (const id of cyclic) parents.delete(id);
+  const projected = timeline.map((entry) => {
+    const parent = parents.get(entry.id);
+    return parents.has(entry.id) && (entry.parent_id ?? undefined) !== parent
+      ? { ...entry, parent_id: parent } : entry;
+  });
+  const projectedComments = new Map(projected.filter((entry) => entry.type === "comment").map((entry) => [entry.id, entry]));
+  const grouped = new Map<string, CommentRun[]>();
+  for (const run of placements) {
+    let root = projectedComments.get(run.anchorCommentId ?? run.commentId ?? "");
+    if (!root) continue;
     const ancestors = new Set([root.id]);
-    while (root.parent_id && comments.has(root.parent_id) && !ancestors.has(root.parent_id)) {
-      root = comments.get(root.parent_id)!;
+    while (root.parent_id && projectedComments.has(root.parent_id) && !ancestors.has(root.parent_id)) {
+      root = projectedComments.get(root.parent_id)!;
       ancestors.add(root.id);
     }
     const rows = grouped.get(root.id) ?? [];
-    rows.push({ task, commentId: reply?.id ?? anchor?.id, anchorCommentId: anchor?.id, hasReply: !!reply });
+    rows.push(run);
     grouped.set(root.id, rows);
   }
   // Preserve memoized comment cards when a different thread receives an event.
@@ -86,7 +115,7 @@ export function groupCommentRuns(
       grouped.set(root, prior);
     }
   }
-  return grouped;
+  return { timeline: projected, runs: grouped };
 }
 
 /** Runs without a comment anchor still appear as their own agent activity. */

--- a/packages/views/issues/components/comment-runs.ts
+++ b/packages/views/issues/components/comment-runs.ts
@@ -38,7 +38,7 @@ export function buildCommentRunView(
   tasks: readonly AgentTask[],
   timeline: readonly TimelineEntry[],
   previous = new Map<string, CommentRun[]>(),
-): { timeline: readonly TimelineEntry[]; runs: Map<string, CommentRun[]> } {
+): { timeline: readonly TimelineEntry[]; runs: Map<string, CommentRun[]>; standaloneRuns: CommentRun[] } {
   const comments = new Map(timeline.filter((entry) => entry.type === "comment").map((entry) => [entry.id, entry]));
   const replies = new Map<string, TimelineEntry>();
   for (const entry of comments.values()) {
@@ -53,25 +53,31 @@ export function buildCommentRunView(
   for (const task of [...tasks].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))) {
     const reply = replies.get(task.id);
     if (isObsoleteCommentRun(task) && !reply) continue;
-    let anchor: TimelineEntry | undefined;
+    let anchorId: string | undefined;
     let source: AgentTask | undefined = task;
     const visited = new Set<string>();
-    while (!anchor && source && !visited.has(source.id)) {
+    while (!anchorId && source && !visited.has(source.id)) {
       visited.add(source.id);
       // Before claim, the receipt is empty (or belongs to a previous claim).
-      // Keep that planned anchor if the run terminates before dispatch, too.
+      // Dispatch can precede receipt persistence; retain the planned anchor
+      // until delivery is known, or if the run terminates before dispatch.
       const usesPlannedCoverage = source.status === "queued"
+        || (source.status === "dispatched" && !source.delivered_comment_ids?.length)
         || ((source.status === "cancelled" || source.status === "failed")
           && !source.dispatched_at && !source.started_at);
       const ids = !usesPlannedCoverage && source.delivered_comment_ids !== undefined
         ? source.delivered_comment_ids
         : [source.trigger_comment_id, ...(source.coalesced_comment_ids ?? [])];
       const candidates = ids.flatMap((id) => id && comments.has(id) ? [comments.get(id)!] : []);
-      anchor = candidates.find((entry) => entry.id === source?.trigger_comment_id)
-        ?? candidates.sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
+      // Task events can arrive before their comments. Preserve the intended
+      // anchor even when it cannot be rendered yet; it is not an assignment.
+      anchorId = source.trigger_comment_id && ids.includes(source.trigger_comment_id)
+        ? source.trigger_comment_id
+        : candidates.sort((a, b) => b.created_at.localeCompare(a.created_at))[0]?.id
+          ?? ids.find((id) => !!id);
       source = source.parent_task_id ? byTask.get(source.parent_task_id) : undefined;
     }
-    placements.push({ task, commentId: reply?.id ?? anchor?.id, anchorCommentId: anchor?.id, hasReply: !!reply });
+    placements.push({ task, commentId: reply?.id ?? anchorId, anchorCommentId: anchorId, hasReply: !!reply });
   }
   // Project every task-owned answer first, then use that same tree for run
   // grouping, replies, resolution, and navigation. Assignment answers become
@@ -120,16 +126,10 @@ export function buildCommentRunView(
       grouped.set(root, prior);
     }
   }
-  return { timeline: projected, runs: grouped };
-}
-
-/** Runs without a comment anchor still appear as their own agent activity. */
-export function standaloneCommentRuns(
-  tasks: readonly AgentTask[],
-  grouped: ReadonlyMap<string, readonly CommentRun[]>,
-): CommentRun[] {
-  const known = new Map([...grouped.values()].flatMap((runs) => runs.map((run) => [run.task.id, run] as const)));
-  return tasks.filter((task) => (!isObsoleteCommentRun(task) || known.get(task.id)?.hasReply === true)
-    && !known.get(task.id)?.anchorCommentId)
-    .map((task) => known.get(task.id) ?? { task, hasReply: false });
+  // Missing comment data must not turn a thread-owned run into a root block.
+  return {
+    timeline: projected,
+    runs: grouped,
+    standaloneRuns: placements.filter((run) => !run.anchorCommentId),
+  };
 }

--- a/packages/views/issues/components/comment-runs.ts
+++ b/packages/views/issues/components/comment-runs.ts
@@ -22,6 +22,11 @@ export function isActiveCommentRun(task: AgentTask): boolean {
   return ["queued", "dispatched", "waiting_local_directory", "running"].includes(task.status);
 }
 
+/** Published replies own their log entry even while the agent finishes its run. */
+export function showCommentRunInHeader(run: CommentRun): boolean {
+  return run.hasReply && (isActiveCommentRun(run.task) || run.task.status === "completed");
+}
+
 /** Invalidated queued input is history, not an agent response to the new text. */
 function isObsoleteCommentRun(task: AgentTask): boolean {
   return task.status === "cancelled" && task.cancelled_by_comment_change === true

--- a/packages/views/issues/components/comment-runs.ts
+++ b/packages/views/issues/components/comment-runs.ts
@@ -1,0 +1,101 @@
+import type { AgentTask, TimelineEntry } from "@multica/core/types";
+
+export interface CommentRun {
+  task: AgentTask;
+  commentId?: string;
+  /** Stable trigger location; absent for issue-level runs such as assignment. */
+  anchorCommentId?: string;
+  /** The comment already contains this run's reply; only append its activity. */
+  hasReply: boolean;
+}
+
+export const EMPTY_COMMENT_RUNS: CommentRun[] = [];
+
+/** Use the daemon's deliverable, never guess a final answer from progress text. */
+export function commentRunOutput(task: AgentTask): string | null {
+  if (task.status !== "completed" || !task.result || typeof task.result !== "object") return null;
+  return "comment" in task.result && typeof task.result.comment === "string" && task.result.comment.trim()
+    ? task.result.comment : null;
+}
+
+export function isActiveCommentRun(task: AgentTask): boolean {
+  return ["queued", "dispatched", "waiting_local_directory", "running"].includes(task.status);
+}
+
+/** Invalidated queued input is history, not an agent response to the new text. */
+function isObsoleteCommentRun(task: AgentTask): boolean {
+  return task.status === "cancelled" && task.cancelled_by_comment_change === true
+    && !task.dispatched_at && !task.started_at && !task.delivered_comment_ids?.length;
+}
+
+/** Keep each run at its trigger; associate replies by task identity, never arrival order. */
+export function groupCommentRuns(
+  tasks: readonly AgentTask[],
+  timeline: readonly TimelineEntry[],
+  previous = new Map<string, CommentRun[]>(),
+): Map<string, CommentRun[]> {
+  const comments = new Map(timeline.filter((entry) => entry.type === "comment").map((entry) => [entry.id, entry]));
+  const replies = new Map<string, TimelineEntry>();
+  for (const entry of comments.values()) {
+    if (!entry.source_task_id || entry.actor_type !== "agent") continue;
+    const prior = replies.get(entry.source_task_id);
+    if (!prior || entry.created_at > prior.created_at || (entry.created_at === prior.created_at && entry.id > prior.id)) {
+      replies.set(entry.source_task_id, entry);
+    }
+  }
+  const byTask = new Map(tasks.map((task) => [task.id, task]));
+  const grouped = new Map<string, CommentRun[]>();
+  for (const task of [...tasks].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))) {
+    const reply = replies.get(task.id);
+    if (isObsoleteCommentRun(task) && !reply) continue;
+    let anchor: TimelineEntry | undefined;
+    let source: AgentTask | undefined = task;
+    const visited = new Set<string>();
+    while (!anchor && source && !visited.has(source.id)) {
+      visited.add(source.id);
+      // Before claim, the receipt is empty (or belongs to a previous claim).
+      // Keep that planned anchor if the run terminates before dispatch, too.
+      const usesPlannedCoverage = source.status === "queued"
+        || ((source.status === "cancelled" || source.status === "failed")
+          && !source.dispatched_at && !source.started_at);
+      const ids = !usesPlannedCoverage && source.delivered_comment_ids !== undefined
+        ? source.delivered_comment_ids
+        : [source.trigger_comment_id, ...(source.coalesced_comment_ids ?? [])];
+      const candidates = ids.flatMap((id) => id && comments.has(id) ? [comments.get(id)!] : []);
+      anchor = candidates.find((entry) => entry.id === source?.trigger_comment_id)
+        ?? candidates.sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
+      source = source.parent_task_id ? byTask.get(source.parent_task_id) : undefined;
+    }
+    const location = anchor ?? reply;
+    if (!location) continue;
+    let root = location;
+    const ancestors = new Set([root.id]);
+    while (root.parent_id && comments.has(root.parent_id) && !ancestors.has(root.parent_id)) {
+      root = comments.get(root.parent_id)!;
+      ancestors.add(root.id);
+    }
+    const rows = grouped.get(root.id) ?? [];
+    rows.push({ task, commentId: reply?.id ?? anchor?.id, anchorCommentId: anchor?.id, hasReply: !!reply });
+    grouped.set(root.id, rows);
+  }
+  // Preserve memoized comment cards when a different thread receives an event.
+  for (const [root, rows] of grouped) {
+    const prior = previous.get(root);
+    if (prior?.length === rows.length && rows.every((row, i) =>
+      row.task === prior[i]!.task && row.commentId === prior[i]!.commentId && row.anchorCommentId === prior[i]!.anchorCommentId && row.hasReply === prior[i]!.hasReply)) {
+      grouped.set(root, prior);
+    }
+  }
+  return grouped;
+}
+
+/** Runs without a comment anchor still appear as their own agent activity. */
+export function standaloneCommentRuns(
+  tasks: readonly AgentTask[],
+  grouped: ReadonlyMap<string, readonly CommentRun[]>,
+): CommentRun[] {
+  const known = new Map([...grouped.values()].flatMap((runs) => runs.map((run) => [run.task.id, run] as const)));
+  return tasks.filter((task) => (!isObsoleteCommentRun(task) || known.get(task.id)?.hasReply === true)
+    && !known.get(task.id)?.anchorCommentId)
+    .map((task) => known.get(task.id) ?? { task, hasReply: false });
+}

--- a/packages/views/issues/components/comment-runs.ts
+++ b/packages/views/issues/components/comment-runs.ts
@@ -40,6 +40,16 @@ export function buildCommentRunView(
   previous = new Map<string, CommentRun[]>(),
 ): { timeline: readonly TimelineEntry[]; runs: Map<string, CommentRun[]>; standaloneRuns: CommentRun[] } {
   const comments = new Map(timeline.filter((entry) => entry.type === "comment").map((entry) => [entry.id, entry]));
+  const threadRoot = (id: string): string | undefined => {
+    const seen = new Set<string>();
+    let entry = comments.get(id);
+    while (entry?.parent_id) {
+      if (seen.has(entry.id)) return undefined;
+      seen.add(entry.id);
+      entry = comments.get(entry.parent_id);
+    }
+    return entry?.id;
+  };
   const replies = new Map<string, TimelineEntry>();
   for (const entry of comments.values()) {
     if (!entry.source_task_id || entry.actor_type !== "agent") continue;
@@ -49,6 +59,7 @@ export function buildCommentRunView(
     }
   }
   const byTask = new Map(tasks.map((task) => [task.id, task]));
+  const priorAnchors = new Map([...previous.values()].flatMap((runs) => runs.map((run) => [run.task.id, run.anchorCommentId] as const)));
   const placements: CommentRun[] = [];
   for (const task of [...tasks].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))) {
     const reply = replies.get(task.id);
@@ -75,6 +86,19 @@ export function buildCommentRunView(
         ? source.trigger_comment_id
         : candidates.sort((a, b) => b.created_at.localeCompare(a.created_at))[0]?.id
           ?? ids.find((id) => !!id);
+      // Same-thread batches retain their first input's slot as newer replies
+      // coalesce. Wait for missing comments instead of guessing their thread;
+      // historical batches spanning several threads retain their trigger.
+      const root = candidates[0] && threadRoot(candidates[0].id);
+      if (root && candidates.length === ids.filter(Boolean).length
+        && candidates.every((entry) => threadRoot(entry.id) === root)) {
+        anchorId = candidates.sort((a, b) => a.created_at.localeCompare(b.created_at)
+          || timeline.indexOf(a) - timeline.indexOf(b))[0]?.id;
+      }
+      const priorAnchor = priorAnchors.get(source.id);
+      if (priorAnchor && ids.includes(priorAnchor) && candidates.length < ids.filter(Boolean).length) {
+        anchorId = priorAnchor;
+      }
       source = source.parent_task_id ? byTask.get(source.parent_task_id) : undefined;
     }
     placements.push({ task, commentId: reply?.id ?? anchorId, anchorCommentId: anchorId, hasReply: !!reply });

--- a/packages/views/issues/components/execution-log-section.test.tsx
+++ b/packages/views/issues/components/execution-log-section.test.tsx
@@ -318,6 +318,16 @@ describe("execution log header geometry", () => {
     );
   }
 
+  it("shows the running task before pending tasks in queue order", () => {
+    renderSection([
+      makeTask({ id: "new", status: "queued", trigger_summary: "Order: second", created_at: "2026-09-08T03:02:00Z" }),
+      makeTask({ id: "old", status: "queued", trigger_summary: "Order: first", created_at: "2026-09-08T03:01:00Z" }),
+      makeTask({ id: "running", status: "running", trigger_summary: "Order: running", created_at: "2026-09-08T03:00:00Z" }),
+    ]);
+    expect(screen.getAllByText(/^Order:/).map((el) => el.textContent))
+      .toEqual(["Order: running", "Order: first", "Order: second"]);
+  });
+
   function headerOf(): HTMLElement {
     const label = screen.getByText("Execution log");
     const header = label.closest("div");

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -19,6 +19,7 @@ import { formatDuration } from "../../agents/components/agent-activity-hover-con
 import { TranscriptButton } from "../../common/task-transcript";
 import { cancelReasonLabel, failureReasonLabel } from "../../agents/components/tabs/task-failure";
 import { useT } from "../../i18n";
+import { compareActiveIssueTasks } from "./active-task-order";
 import {
   formatTokens,
   formatUsd,
@@ -93,7 +94,7 @@ export function ExecutionLogSection({ issueId, identifier }: ExecutionLogSection
           // what tells the user the agent is alive and will resume.
           t.status === "waiting_local_directory" ||
           t.status === "running",
-      ),
+      ).toSorted(compareActiveIssueTasks),
     [tasks],
   );
 

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ChevronRight, Loader2, RotateCcw, Square } from "lucide-react";
 import { toast } from "sonner";
 import { api, dispatchReasonCode } from "@multica/core/api";
-import { issueKeys } from "@multica/core/issues/queries";
+import { issueTasksOptions } from "@multica/core/issues/queries";
 import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-store";
 import type { AgentTask } from "@multica/core/types";
 import { useTimeAgo } from "../../i18n";
@@ -80,12 +80,7 @@ export function ExecutionLogSection({ issueId, identifier }: ExecutionLogSection
   // a `["issues", "tasks"]` prefix-match — no local WS subscriptions
   // needed, and the cache stays fresh even when this component isn't
   // mounted (e.g. user cancels from agent-side, then navigates here).
-  const { data: tasks = [] } = useQuery({
-    queryKey: issueKeys.tasks(issueId),
-    queryFn: () => api.listTasksByIssue(issueId),
-    staleTime: 30_000,
-    refetchOnWindowFocus: true,
-  });
+  const { data: tasks = [] } = useQuery(issueTasksOptions(issueId));
 
   const activeTasks = useMemo(
     () =>

--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -17,7 +17,7 @@ vi.mock("@multica/core/workspace/hooks", () => ({ useActorName: () => ({ getActo
 vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
 vi.mock("../../editor", () => ({ ReadonlyContent: ({ content }: { content: string }) => <div>{content}</div> }));
 vi.mock("../../common/task-transcript/agent-transcript-dialog", () => ({
-  AgentTranscriptDialog: ({ contentState }: { contentState?: ReactNode }) => <div role="dialog">{contentState ?? "Full transcript"}</div>,
+  AgentTranscriptDialog: ({ contentState, isLive }: { contentState?: ReactNode; isLive?: boolean }) => <div role="dialog" data-live={isLive}>{contentState ?? "Full transcript"}</div>,
   StepBody: ({ item }: { item: { output?: string } }) => <div>{item.output}</div>,
 }));
 
@@ -57,6 +57,25 @@ describe("InlineCommentRun", () => {
     await act(async () => resolve(messages));
     await screen.findByText("Full transcript");
     expect(api.listTaskMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps published reply logs live and stoppable until the run finishes", async () => {
+    vi.mocked(api.listTaskMessages).mockResolvedValue(messages);
+    const current = task();
+    const { rerender } = setup(current, true, "header");
+    expect(screen.queryByRole("button", { name: /View activity/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Working");
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    const trigger = screen.getByRole("button", { name: "Open full log" });
+    fireEvent.click(trigger);
+    await screen.findByText("Full transcript");
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-live", "true");
+    rerender({ ...current, status: "completed", completed_at: "2026-09-07T00:01:23Z" });
+    expect(screen.getByRole("button", { name: "Open full log" })).toBe(trigger);
+    expect(screen.getByRole("dialog")).toHaveTextContent("Full transcript");
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-live", "false");
+    expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /View activity/ })).not.toBeInTheDocument();
   });
 
   it("lets a completed header log recover when its initial fetch fails", async () => {
@@ -162,15 +181,17 @@ describe("InlineCommentRun", () => {
     expect(api.listTaskMessages).not.toHaveBeenCalled();
   });
 
-  it("explains queued runs and confirms stopping the specific run", async () => {
+  it.each(["queued", "published"] as const)("confirms stopping the specific %s run", async (state) => {
     vi.mocked(api.cancelTask).mockResolvedValue(task({ status: "cancelled" }));
-    setup(task({ status: "queued" }));
-    expect(screen.getByText("Waiting for an available agent.")).toBeInTheDocument();
-    expect(api.listTaskMessages).not.toHaveBeenCalled();
-    vi.mocked(api.listTaskMessages).mockResolvedValue([]);
-    fireEvent.click(screen.getByRole("button", { name: /View activity/ }));
-    await screen.findByText("No activity recorded yet.");
-    expect(screen.queryByText("Waiting for the agent to respond.")).not.toBeInTheDocument();
+    setup(task({ status: state === "queued" ? "queued" : "running" }), state === "published", state === "published" ? "header" : "inline");
+    if (state === "queued") {
+      expect(screen.getByText("Waiting for an available agent.")).toBeInTheDocument();
+      expect(api.listTaskMessages).not.toHaveBeenCalled();
+      vi.mocked(api.listTaskMessages).mockResolvedValue([]);
+      fireEvent.click(screen.getByRole("button", { name: /View activity/ }));
+      await screen.findByText("No activity recorded yet.");
+      expect(screen.queryByText("Waiting for the agent to respond.")).not.toBeInTheDocument();
+    }
     fireEvent.click(screen.getByRole("button", { name: "Stop" }));
     expect(api.cancelTask).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole("button", { name: "Stop run" }));

--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -41,6 +41,20 @@ function setup(initialTask: AgentTask, hasReply = false) {
 }
 
 describe("InlineCommentRun", () => {
+  it.each(["completed", "queued"] as const)("retains keyboard focus when a %s disclosure replaces its trigger", async (status) => {
+    vi.mocked(api.listTaskMessages).mockResolvedValue(messages);
+    setup(task({ status }));
+    const before = screen.getByRole("button", { name: /View activity/ });
+    before.focus();
+    fireEvent.click(before, { detail: 0 });
+    const expanded = screen.getByRole("button", { name: /View activity/ });
+    expect(expanded).toHaveFocus();
+    expect(expanded).toHaveAttribute("aria-expanded", "true");
+    await screen.findByRole("button", { name: "Open full log" });
+    fireEvent.click(expanded, { detail: 0 });
+    expect(screen.getByRole("button", { name: /View activity/ })).toHaveFocus();
+    expect(screen.getByRole("button", { name: /View activity/ })).toHaveAttribute("aria-expanded", "false");
+  });
   it("shows real activity, expands in place, follows WS data and retains the open transcript at completion", async () => {
     vi.mocked(api.listTaskMessages).mockResolvedValue(messages);
     const current = task();

--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -9,8 +9,9 @@ import { renderWithI18n } from "../../test/i18n";
 import { InlineCommentRun } from "./inline-comment-run";
 
 vi.mock("@multica/core/api", () => ({ api: {
-  listTaskMessages: vi.fn(), cancelTask: vi.fn(), rerunIssue: vi.fn(),
+  getIssue: vi.fn(), listTaskMessages: vi.fn(), cancelTask: vi.fn(), rerunIssue: vi.fn(),
 }, dispatchReasonCode: () => undefined }));
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "workspace" }));
 vi.mock("@multica/core/workspace/hooks", () => ({ useActorName: () => ({ getActorName: () => "Reviewer" }) }));
 vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
 vi.mock("../../editor", () => ({ ReadonlyContent: ({ content }: { content: string }) => <div>{content}</div> }));
@@ -41,6 +42,19 @@ function setup(initialTask: AgentTask, hasReply = false) {
 }
 
 describe("InlineCommentRun", () => {
+  it("uses a readable issue identifier in live progress and expanded activity", async () => {
+    const issueId = "01a07eca-8e82-775e-be06-e4a97ccfa299";
+    vi.mocked(api.getIssue).mockResolvedValue({ id: issueId, identifier: "DEV-17" } as Awaited<ReturnType<typeof api.getIssue>>);
+    vi.mocked(api.listTaskMessages).mockResolvedValue([
+      { task_id: id, issue_id: issueId, seq: 1, type: "tool_use", tool: "exec_command", input: { command: `multica issue get ${issueId} --output json` } },
+    ]);
+    setup(task({ issue_id: issueId }));
+    await screen.findByText("multica issue get DEV-17 --output json");
+    fireEvent.click(screen.getByRole("button", { name: /View activity/ }));
+    expect(screen.getAllByText("multica issue get DEV-17 --output json")).toHaveLength(2);
+    expect(api.getIssue).toHaveBeenCalledTimes(1);
+  });
+
   it.each(["completed", "queued"] as const)("keeps the same focused disclosure button for a %s run", async (status) => {
     vi.mocked(api.listTaskMessages).mockResolvedValue(messages);
     setup(task({ status }));

--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -1,0 +1,132 @@
+import { act, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "@multica/core/api";
+import { chatKeys } from "@multica/core/chat/queries";
+import type { AgentTask } from "@multica/core/types";
+import type { TaskMessagePayload } from "@multica/core/types/events";
+import { renderWithI18n } from "../../test/i18n";
+import { InlineCommentRun } from "./inline-comment-run";
+
+vi.mock("@multica/core/api", () => ({ api: {
+  listTaskMessages: vi.fn(), cancelTask: vi.fn(), rerunIssue: vi.fn(),
+}, dispatchReasonCode: () => undefined }));
+vi.mock("@multica/core/workspace/hooks", () => ({ useActorName: () => ({ getActorName: () => "Reviewer" }) }));
+vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
+vi.mock("../../editor", () => ({ ReadonlyContent: ({ content }: { content: string }) => <div>{content}</div> }));
+vi.mock("../../common/task-transcript/agent-transcript-dialog", () => ({
+  AgentTranscriptDialog: () => <div role="dialog">Full transcript</div>,
+  StepBody: ({ item }: { item: { output?: string } }) => <div>{item.output}</div>,
+}));
+
+const id = "4a2e8d1c-7f9b-4e2a-9c1d-123456789abc";
+function task(overrides: Partial<AgentTask> = {}): AgentTask {
+  return { id, agent_id: "agent", runtime_id: "runtime", issue_id: "issue", status: "running", priority: 0,
+    created_at: "2026-09-07T00:00:00Z", started_at: "2026-09-07T00:00:00Z", dispatched_at: null,
+    completed_at: null, result: null, error: null, ...overrides };
+}
+const messages: TaskMessagePayload[] = [
+  { task_id: id, issue_id: "issue", seq: 1, type: "text", content: "Checking navigation." },
+  { task_id: id, issue_id: "issue", seq: 2, type: "tool_use", tool: "exec_command", input: { command: "pnpm test" } },
+];
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+function setup(initialTask: AgentTask, hasReply = false) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const view = (current: AgentTask, reply = hasReply) => <QueryClientProvider client={client}>
+    <InlineCommentRun run={{ task: current, commentId: "comment", hasReply: reply }} />
+  </QueryClientProvider>;
+  const rendered = renderWithI18n(view(initialTask));
+  return { client, rerender: (current: AgentTask, reply = hasReply) => rendered.rerender(view(current, reply)) };
+}
+
+describe("InlineCommentRun", () => {
+  it("shows real activity, expands in place, follows WS data and retains the open transcript at completion", async () => {
+    vi.mocked(api.listTaskMessages).mockResolvedValue(messages);
+    const current = task();
+    const { client, rerender } = setup(current);
+    await screen.findByText("pnpm test");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    const toggle = screen.getByRole("button", { name: /View activity/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    const tail: TaskMessagePayload = { task_id: id, issue_id: "issue", seq: 3, type: "tool_result", tool: "exec_command", output: "12 passed" };
+    act(() => client.setQueryData(chatKeys.taskMessages(id), [...messages, tail]));
+    expect(screen.queryByText("Waiting for the agent to respond.")).not.toBeInTheDocument();
+    vi.mocked(api.listTaskMessages).mockResolvedValue([...messages, tail]);
+    rerender({ ...current, status: "completed", completed_at: "2026-09-07T00:01:23Z" }, true);
+    await screen.findByText("Completed");
+    expect(screen.getByRole("button", { name: /View activity/ })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open full log" }));
+    expect(screen.getByRole("dialog")).toHaveTextContent("Full transcript");
+  });
+
+  it("retains the last meaningful activity between tool results and the next agent message", async () => {
+    vi.mocked(api.listTaskMessages).mockResolvedValue([]);
+    const { client } = setup(task());
+    await screen.findByText("Waiting for the agent to respond.");
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    const events: TaskMessagePayload[] = [];
+    async function receive(event: Omit<TaskMessagePayload, "task_id" | "issue_id" | "seq">) {
+      events.push({ task_id: id, issue_id: "issue", seq: events.length + 1, ...event });
+      await act(async () => {
+        client.setQueryData(chatKeys.taskMessages(id), [...events]);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+    await receive({ type: "text", content: "Checking navigation." });
+    await screen.findByText("Checking navigation.");
+    await receive({ type: "tool_use", tool: "exec_command", input: { command: "pnpm test" } });
+    await screen.findByText("pnpm test");
+    await receive({ type: "tool_result", tool: "exec_command", output: "12 passed" });
+    expect(screen.getByText("pnpm test")).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for the agent to respond.")).not.toBeInTheDocument();
+    await receive({ type: "text", content: "  " });
+    expect(screen.getByText("pnpm test")).toBeInTheDocument();
+    await receive({ type: "text", content: "Tests passed. Reviewing the changes." });
+    await screen.findByText("Tests passed. Reviewing the changes.");
+    expect(screen.queryByText("pnpm test")).not.toBeInTheDocument();
+  });
+
+  it("keeps completed replies readable without fetching or duplicating their deliverable", () => {
+    setup(task({ status: "completed", result: { comment: "Already posted" } }), true);
+    expect(api.listTaskMessages).not.toHaveBeenCalled();
+    expect(screen.queryByText("Already posted")).not.toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+  });
+
+  it("shows a completed deliverable if the corresponding comment is missing", () => {
+    setup(task({ status: "completed", result: { comment: "Review complete." } }));
+    expect(screen.getByText("Review complete.")).toBeInTheDocument();
+    expect(screen.getByText("Review complete.").closest('[data-slot="card"]')).toBeNull();
+    expect(screen.getByText("Completed").closest('[data-slot="card"]')).not.toBeNull();
+    expect(api.listTaskMessages).not.toHaveBeenCalled();
+  });
+
+  it("explains queued runs and confirms stopping the specific run", async () => {
+    vi.mocked(api.cancelTask).mockResolvedValue(task({ status: "cancelled" }));
+    setup(task({ status: "queued" }));
+    expect(screen.getByText("Waiting for an available agent.")).toBeInTheDocument();
+    expect(api.listTaskMessages).not.toHaveBeenCalled();
+    vi.mocked(api.listTaskMessages).mockResolvedValue([]);
+    fireEvent.click(screen.getByRole("button", { name: /View activity/ }));
+    await screen.findByText("No activity recorded yet.");
+    expect(screen.queryByText("Waiting for the agent to respond.")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+    expect(api.cancelTask).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Stop run" }));
+    await waitFor(() => expect(api.cancelTask).toHaveBeenCalledWith("issue", id));
+  });
+
+  it("keeps a failed transcript fetch recoverable inside the comment", async () => {
+    vi.mocked(api.listTaskMessages).mockRejectedValueOnce(new Error("offline"));
+    setup(task({ status: "failed" }));
+    fireEvent.click(screen.getByRole("button", { name: /View activity/ }));
+    await screen.findByRole("alert");
+    vi.mocked(api.listTaskMessages).mockResolvedValue(messages);
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  });
+});

--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -59,14 +59,16 @@ describe("InlineCommentRun", () => {
     expect(api.listTaskMessages).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps published reply logs live and stoppable until the run finishes", async () => {
+  it("keeps published replies visually settled while their full log remains live", async () => {
     vi.mocked(api.listTaskMessages).mockResolvedValue(messages);
     const current = task();
     const { rerender } = setup(current, true, "header");
     expect(screen.queryByRole("button", { name: /View activity/ })).not.toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent("Working");
-    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
     const trigger = screen.getByRole("button", { name: "Open full log" });
+    const icon = trigger.querySelector("svg");
+    expect(icon).not.toHaveClass("animate-spin");
     fireEvent.click(trigger);
     await screen.findByText("Full transcript");
     expect(screen.getByRole("dialog")).toHaveAttribute("data-live", "true");
@@ -74,6 +76,7 @@ describe("InlineCommentRun", () => {
     expect(screen.getByRole("button", { name: "Open full log" })).toBe(trigger);
     expect(screen.getByRole("dialog")).toHaveTextContent("Full transcript");
     expect(screen.getByRole("dialog")).toHaveAttribute("data-live", "false");
+    expect(trigger.querySelector("svg")).toBe(icon);
     expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /View activity/ })).not.toBeInTheDocument();
   });
@@ -181,9 +184,9 @@ describe("InlineCommentRun", () => {
     expect(api.listTaskMessages).not.toHaveBeenCalled();
   });
 
-  it.each(["queued", "published"] as const)("confirms stopping the specific %s run", async (state) => {
+  it.each(["queued", "running"] as const)("confirms stopping the specific %s run before its reply", async (state) => {
     vi.mocked(api.cancelTask).mockResolvedValue(task({ status: "cancelled" }));
-    setup(task({ status: state === "queued" ? "queued" : "running" }), state === "published", state === "published" ? "header" : "inline");
+    setup(task({ status: state }));
     if (state === "queued") {
       expect(screen.getByText("Waiting for an available agent.")).toBeInTheDocument();
       expect(api.listTaskMessages).not.toHaveBeenCalled();

--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -41,13 +41,14 @@ function setup(initialTask: AgentTask, hasReply = false) {
 }
 
 describe("InlineCommentRun", () => {
-  it.each(["completed", "queued"] as const)("retains keyboard focus when a %s disclosure replaces its trigger", async (status) => {
+  it.each(["completed", "queued"] as const)("keeps the same focused disclosure button for a %s run", async (status) => {
     vi.mocked(api.listTaskMessages).mockResolvedValue(messages);
     setup(task({ status }));
     const before = screen.getByRole("button", { name: /View activity/ });
     before.focus();
     fireEvent.click(before, { detail: 0 });
     const expanded = screen.getByRole("button", { name: /View activity/ });
+    expect(expanded).toBe(before);
     expect(expanded).toHaveFocus();
     expect(expanded).toHaveAttribute("aria-expanded", "true");
     await screen.findByRole("button", { name: "Open full log" });
@@ -115,7 +116,7 @@ describe("InlineCommentRun", () => {
     setup(task({ status: "completed", result: { comment: "Review complete." } }));
     expect(screen.getByText("Review complete.")).toBeInTheDocument();
     expect(screen.getByText("Review complete.").closest('[data-slot="card"]')).toBeNull();
-    expect(screen.getByText("Completed").closest('[data-slot="card"]')).not.toBeNull();
+    expect(screen.getByText("Completed").closest('[data-slot="card"]')).toBeNull();
     expect(api.listTaskMessages).not.toHaveBeenCalled();
   });
 

--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import { api } from "@multica/core/api";
 import { chatKeys } from "@multica/core/chat/queries";
 import type { AgentTask } from "@multica/core/types";
@@ -16,7 +17,7 @@ vi.mock("@multica/core/workspace/hooks", () => ({ useActorName: () => ({ getActo
 vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
 vi.mock("../../editor", () => ({ ReadonlyContent: ({ content }: { content: string }) => <div>{content}</div> }));
 vi.mock("../../common/task-transcript/agent-transcript-dialog", () => ({
-  AgentTranscriptDialog: () => <div role="dialog">Full transcript</div>,
+  AgentTranscriptDialog: ({ contentState }: { contentState?: ReactNode }) => <div role="dialog">{contentState ?? "Full transcript"}</div>,
   StepBody: ({ item }: { item: { output?: string } }) => <div>{item.output}</div>,
 }));
 
@@ -32,16 +33,43 @@ const messages: TaskMessagePayload[] = [
 ];
 afterEach(() => { cleanup(); vi.clearAllMocks(); });
 
-function setup(initialTask: AgentTask, hasReply = false) {
+function setup(initialTask: AgentTask, hasReply = false, presentation: "inline" | "header" = "inline") {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
   const view = (current: AgentTask, reply = hasReply) => <QueryClientProvider client={client}>
-    <InlineCommentRun run={{ task: current, commentId: "comment", hasReply: reply }} />
+    <InlineCommentRun run={{ task: current, commentId: "comment", hasReply: reply }} presentation={presentation} />
   </QueryClientProvider>;
   const rendered = renderWithI18n(view(initialTask));
   return { client, rerender: (current: AgentTask, reply = hasReply) => rendered.rerender(view(current, reply)) };
 }
 
 describe("InlineCommentRun", () => {
+  it("opens completed reply logs from a compact header button and loads only on demand", async () => {
+    let resolve!: (value: TaskMessagePayload[]) => void;
+    vi.mocked(api.listTaskMessages).mockImplementation(() => new Promise((done) => { resolve = done; }));
+    setup(task({ status: "completed", completed_at: "2026-09-07T00:01:23Z" }), true, "header");
+    expect(screen.queryByText("Completed")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /View activity/ })).not.toBeInTheDocument();
+    expect(api.listTaskMessages).not.toHaveBeenCalled();
+    const trigger = screen.getByRole("button", { name: "Open full log" });
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+    fireEvent.click(trigger);
+    expect(screen.getByRole("dialog")).toHaveTextContent("Loading activity");
+    await act(async () => resolve(messages));
+    await screen.findByText("Full transcript");
+    expect(api.listTaskMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a completed header log recover when its initial fetch fails", async () => {
+    vi.mocked(api.listTaskMessages).mockRejectedValueOnce(new Error("offline"));
+    setup(task({ status: "completed" }), true, "header");
+    fireEvent.click(screen.getByRole("button", { name: "Open full log" }));
+    await screen.findByRole("alert");
+    vi.mocked(api.listTaskMessages).mockResolvedValue(messages);
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await screen.findByText("Full transcript");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("uses a readable issue identifier in live progress and expanded activity", async () => {
     const issueId = "01a07eca-8e82-775e-be06-e4a97ccfa299";
     vi.mocked(api.getIssue).mockResolvedValue({ id: issueId, identifier: "DEV-17" } as Awaited<ReturnType<typeof api.getIssue>>);

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -25,7 +25,7 @@ import { cancelReasonLabel, failureReasonLabel } from "../../agents/components/t
 import { TerminateTaskConfirmDialog } from "./terminate-task-confirm-dialog";
 import { TaskStatusIcon } from "./task-status-icon";
 import { useStatusLabel } from "./task-run-labels";
-import { commentRunOutput, isActiveCommentRun, type CommentRun } from "./comment-runs";
+import { commentRunOutput, isActiveCommentRun, showCommentRunInHeader, type CommentRun } from "./comment-runs";
 
 import { useRunDisclosureMotion } from "./use-run-comment-motion";
 
@@ -106,18 +106,30 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
       : isError ? <div role="alert" className="text-body text-destructive">{t(($) => $.inline_run.load_failed)}
         <button className="ml-2 underline" type="button" onClick={() => void refetch()}>{t(($) => $.inline_run.try_again)}</button>
       </div> : undefined} />;
-  if (presentation === "header" && task.status === "completed" && hasReply) {
+  const stopButton = active && <Button size="icon-sm" variant="ghost" className="text-muted-foreground"
+    aria-label={stopLabel} title={stopLabel} disabled={cancel.isPending || cancel.isSuccess}
+    onClick={() => setConfirmStop(true)}>
+    {cancel.isPending || cancel.isSuccess ? <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" /> : <Square className="size-3.5" />}
+  </Button>;
+  const stopDialog = <TerminateTaskConfirmDialog open={confirmStop} onOpenChange={setConfirmStop}
+    showRunningNote={task.status !== "queued"}
+    onConfirm={() => cancel.mutate(task.id, { onError: () => toast.error(t(($) => $.execution_log.cancel_failed)) })} />;
+  if (presentation === "header" && showCommentRunInHeader(run)) {
     return <span className="inline-flex shrink-0" data-run-id={task.id}>
       <Tooltip>
         <TooltipTrigger render={<Button type="button" size="icon-sm" variant="ghost"
           className="text-muted-foreground aria-expanded:bg-transparent aria-expanded:hover:bg-muted dark:aria-expanded:hover:bg-muted/50"
           aria-label={t(($) => $.inline_run.full_log)} aria-haspopup="dialog" aria-expanded={fullLogOpen}
           onClick={() => setFullLogOpen(true)}>
-          <ScrollText aria-hidden className="size-3.5" />
+          {active ? <Loader2 aria-hidden className="size-3.5 animate-spin motion-reduce:animate-none" />
+            : <ScrollText aria-hidden className="size-3.5" />}
         </Button>} />
         <TooltipContent>{t(($) => $.inline_run.full_log)} · {status}{elapsed && ` · ${elapsed}`}</TooltipContent>
       </Tooltip>
+      {active && <span role="status" className="sr-only">{status}</span>}
+      {stopButton}
       {transcript}
+      {stopDialog}
     </span>;
   }
   return (
@@ -148,11 +160,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
           <ChevronRight ref={state.disclosure.chevronRef} aria-hidden className={cn("size-3.5 shrink-0", expanded && "rotate-90")} />
         </button>
         <span className={cn("shrink-0 whitespace-nowrap text-caption tabular-nums text-muted-foreground", showIdentity && !active && "max-sm:hidden")}>{elapsed}</span>
-        {active && <Button size="icon-sm" variant="ghost" className="text-muted-foreground"
-          aria-label={stopLabel} title={stopLabel} disabled={cancel.isPending || cancel.isSuccess}
-          onClick={() => setConfirmStop(true)}>
-          {cancel.isPending || cancel.isSuccess ? <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" /> : <Square className="size-3.5" />}
-        </Button>}
+        {stopButton}
         {!hasReply && (task.status === "failed" || task.status === "cancelled") && <Button
           size="sm" variant="ghost" className={cn("text-muted-foreground", showIdentity && "max-sm:size-7 max-sm:p-0")} disabled={retry.isPending || retry.isSuccess}
           onClick={() => retry.mutate(task.id, { onError: (error) => toast.error(
@@ -177,9 +185,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
         </div>}
       </div>
       {transcript}
-      <TerminateTaskConfirmDialog open={confirmStop} onOpenChange={setConfirmStop}
-        showRunningNote={task.status !== "queued"}
-        onConfirm={() => cancel.mutate(task.id, { onError: () => toast.error(t(($) => $.execution_log.cancel_failed)) })} />
+      {stopDialog}
     </section>
   );
 }

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { AlertCircle, Brain, ChevronRight, ExternalLink, Loader2, MessageSquare, RotateCcw, Square, Terminal } from "lucide-react";
 import { toast } from "sonner";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useTaskMessages } from "@multica/core/chat/queries";
 import { useCancelIssueRun, useRetryIssueRun } from "@multica/core/issues/mutations";
 import { dispatchReasonCode } from "@multica/core/api";
-import { Card } from "@multica/ui/components/ui/card";
+import { ActorAvatar } from "../../common/actor-avatar";
 import { Button } from "@multica/ui/components/ui/button";
 import { cn } from "@multica/ui/lib/utils";
 import { AgentTranscriptDialog, StepBody } from "../../common/task-transcript/agent-transcript-dialog";
@@ -35,7 +35,12 @@ export function useInlineCommentRunState() {
 
 export type InlineCommentRunState = ReturnType<typeof useInlineCommentRunState>;
 
-export function InlineCommentRun({ run, className, viewState }: { run: CommentRun; className?: string; viewState?: InlineCommentRunState }) {
+export function InlineCommentRun({ run, className, viewState, showIdentity = false }: {
+  run: CommentRun;
+  className?: string;
+  viewState?: InlineCommentRunState;
+  showIdentity?: boolean;
+}) {
   const { task, hasReply } = run;
   const { t } = useT("issues");
   const { t: tAgents } = useT("agents");
@@ -45,12 +50,19 @@ export function InlineCommentRun({ run, className, viewState }: { run: CommentRu
   const active = isActiveCommentRun(task);
   const localViewState = useInlineCommentRunState();
   const state = viewState ?? localViewState;
-  const { expanded, setExpanded } = state;
+  const { expanded, setExpanded, fullLogOpen, setFullLogOpen } = state;
   const [confirmStop, setConfirmStop] = useState(false);
   const [now, setNow] = useState(Date.now);
+  const [visibleCount, setVisibleCount] = useState(12);
   const cancel = useCancelIssueRun(task.issue_id);
   const retry = useRetryIssueRun(task.issue_id);
   const regionId = useId();
+  // Keep one disclosure button mounted across queued, live, and historical states.
+  // Historical, collapsed runs still don't fetch transcripts.
+  const { data, isPending, isError, refetch } = useTaskMessages(task.id, active, task.status === "running" || expanded || fullLogOpen);
+  const items = useMemo(() => buildTimeline(data ?? []), [data]);
+  const steps = useMemo(() => buildSteps(items), [items]);
+  const rows = useMemo(() => groupSteps(steps), [steps]);
   useEffect(() => {
     if (!active) return;
     const timer = setInterval(() => setNow(Date.now()), 1000);
@@ -63,124 +75,84 @@ export function InlineCommentRun({ run, className, viewState }: { run: CommentRu
   const failure = task.status === "failed"
     ? failureReasonLabel(task.failure_reason, tAgents)
     : cancelReasonLabel(task, tAgents);
-  const compact = !active && !failure;
-  // Historical, collapsed runs don't fetch transcripts.
-  const showActivity = task.status === "running" || expanded;
   const output = !hasReply ? commentRunOutput(task) : null;
-  const header = (
-    <div className="flex min-w-0 flex-auto flex-wrap items-center gap-x-2.5 gap-y-1">
-      <span className="flex items-center gap-1.5 whitespace-nowrap text-caption text-muted-foreground" role="status" data-run-status>
-        {task.status === "running"
-          ? <span aria-hidden className="size-1.5 rounded-full bg-info" />
-          : <TaskStatusIcon status={task.status} />}
-        {status}
-      </span>
-      <span className="whitespace-nowrap text-caption tabular-nums text-muted-foreground">{elapsed}</span>
-    </div>
-  );
-  const controls = (
-    <>
-      {active && <Button size="sm" variant="ghost" disabled={cancel.isPending || cancel.isSuccess}
-        onClick={() => setConfirmStop(true)}>
-        {cancel.isPending || cancel.isSuccess ? <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" /> : <Square className="size-3.5" />}
-        {cancel.isPending || cancel.isSuccess ? t(($) => $.inline_run.stopping) : t(($) => $.inline_run.stop)}
-      </Button>}
-      {!hasReply && (task.status === "failed" || task.status === "cancelled") && <Button
-        size="sm" variant="ghost" disabled={retry.isPending || retry.isSuccess}
-        onClick={() => retry.mutate(task.id, { onError: (error) => toast.error(
-          dispatchReasonCode(error) === "invocation_not_allowed" ? t(($) => $.execution_log.retry_blocked) : t(($) => $.execution_log.retry_failed),
-        ) })}>
-        <RotateCcw className="size-3.5" />{t(($) => $.execution_log.retry_task_tooltip)}
-      </Button>}
-    </>
-  );
+  const latest = steps.findLast((step) => step.kind !== "text" || step.item.content?.trim());
+  const pendingCall = steps.findLast((step) => isCallStep(step) && !step.result);
+  const current = pendingCall ?? latest;
+  // Keep the last activity visible after a tool returns, until new progress arrives.
+  const activitySummary = current && isCallStep(current)
+    ? redactSecrets(traceToolArgSummary(current.call?.input) || current.tool)
+    : current?.kind === "text" ? redactSecrets(current.item.content ?? "")
+    : current?.kind === "thinking" ? t(($) => $.inline_run.thinking)
+    : current?.kind === "error" ? t(($) => $.inline_run.error)
+    : t(($) => $.inline_run.waiting_response);
+  const summary = task.status === "queued" ? t(($) => $.inline_run.queued)
+    : task.status === "dispatched" ? t(($) => $.inline_run.starting)
+    : task.status === "waiting_local_directory" ? t(($) => $.inline_run.waiting_directory)
+    : activitySummary;
+  const showProgress = active && !hasReply;
+  const activityLabel = t(($) => $.inline_run.view_activity);
+  const stepLabel = steps.length > 0 ? t(($) => $.inline_run.steps, { count: steps.length }) : "";
+  const stopLabel = cancel.isPending || cancel.isSuccess ? t(($) => $.inline_run.stopping) : t(($) => $.inline_run.stop);
   return (
     <section aria-label={t(($) => $.inline_run.label, { name })}
-      className={cn("my-2.5 min-w-0", className)} data-run-id={task.id}>
-      {output && <div className="mb-3 text-body"><ReadonlyContent content={redactSecrets(output)} /></div>}
-      <Card className="gap-0 rounded-lg border-border/70 bg-card p-0 shadow-none">
-        {!hasReply && !compact && <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 pt-3 max-md:px-3">{header}<div className="ml-auto flex items-center">{controls}</div></div>}
-        {(failure || ["queued", "dispatched", "waiting_local_directory"].includes(task.status)) && (
-          <div className="space-y-2 px-4 py-3 max-md:px-3">
-            {failure && <p className="text-caption text-destructive">{failure}</p>}
-            {task.status === "queued" && <p className="text-body text-muted-foreground">{t(($) => $.inline_run.queued)}</p>}
-            {task.status === "dispatched" && <p className="text-body text-muted-foreground">{t(($) => $.inline_run.starting)}</p>}
-            {task.status === "waiting_local_directory" && <p className="text-body text-muted-foreground">{t(($) => $.inline_run.waiting_directory)}</p>}
-          </div>
-        )}
-        {showActivity ? (
-          <InlineRunActivity run={run} viewState={state} expanded={expanded} onExpandedChange={setExpanded}
-            regionId={regionId} name={name} statusLine={hasReply || compact ? header : undefined} controls={hasReply || compact ? controls : undefined} />
-        ) : (
-          <div className={cn("flex flex-wrap items-center justify-between gap-x-4 gap-y-2 bg-muted/20 px-4 py-2.5 max-md:px-3", !hasReply && !compact && "border-t border-border/50")}>
-            {(hasReply || compact) && header}
-            <div className={cn("flex items-center gap-3", (hasReply || compact) && "ml-auto")}>
-              {(hasReply || compact) && controls}
-              <button type="button" className="flex items-center gap-1.5 rounded text-caption text-muted-foreground hover:text-foreground"
-                aria-expanded={false} onClick={(event) => { state.disclosure.onTrigger(event); setExpanded(true); }}>
-                <ChevronRight ref={state.disclosure.chevronRef} className="size-3.5" />{t(($) => $.inline_run.view_activity)}
-              </button>
-            </div>
-          </div>
-        )}
-      </Card>
+      className={cn("min-w-0 py-2", className)} data-run-id={task.id}>
+      <div className="flex min-h-7 min-w-0 items-center gap-2" data-run-summary-row>
+        {showIdentity && <>
+          <ActorAvatar actorType="agent" actorId={task.agent_id} size="md" enableHoverCard />
+          <span className="max-w-[30%] shrink-0 truncate text-body font-medium" title={name}>{name}</span>
+        </>}
+        <span className={cn("flex shrink-0 items-center gap-1.5 whitespace-nowrap text-caption text-muted-foreground", showProgress && "sr-only")}
+          role="status" data-run-status>
+          <TaskStatusIcon status={task.status} />{status}
+        </span>
+        <button type="button"
+          className={cn("flex min-w-0 items-center gap-1.5 rounded py-1 text-left text-caption text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            showProgress ? "flex-1 text-body" : "order-last ml-auto shrink-0")}
+          aria-label={stepLabel ? `${activityLabel} · ${stepLabel}` : activityLabel}
+          aria-expanded={expanded} aria-controls={expanded ? regionId : undefined}
+          onClick={(event) => { state.disclosure.onTrigger(event); setExpanded(!expanded); }}>
+          {showProgress
+            ? <span data-run-summary className="min-w-0 flex-1 truncate" title={summary}>{summary}</span>
+            : <span className={cn(showIdentity && "max-sm:sr-only")}>{activityLabel}</span>}
+          {!showProgress && stepLabel && <span className="text-faint-foreground max-sm:hidden">· {stepLabel}</span>}
+          <ChevronRight ref={state.disclosure.chevronRef} aria-hidden className={cn("size-3.5 shrink-0", expanded && "rotate-90")} />
+        </button>
+        <span className={cn("shrink-0 whitespace-nowrap text-caption tabular-nums text-muted-foreground", showIdentity && !active && "max-sm:hidden")}>{elapsed}</span>
+        {active && <Button size="icon-sm" variant="ghost" className="text-muted-foreground"
+          aria-label={stopLabel} title={stopLabel} disabled={cancel.isPending || cancel.isSuccess}
+          onClick={() => setConfirmStop(true)}>
+          {cancel.isPending || cancel.isSuccess ? <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" /> : <Square className="size-3.5" />}
+        </Button>}
+        {!hasReply && (task.status === "failed" || task.status === "cancelled") && <Button
+          size="sm" variant="ghost" className={cn("text-muted-foreground", showIdentity && "max-sm:size-7 max-sm:p-0")} disabled={retry.isPending || retry.isSuccess}
+          onClick={() => retry.mutate(task.id, { onError: (error) => toast.error(
+            dispatchReasonCode(error) === "invocation_not_allowed" ? t(($) => $.execution_log.retry_blocked) : t(($) => $.execution_log.retry_failed),
+          ) })}>
+          <RotateCcw className="size-3.5" /><span className={cn(showIdentity && "max-sm:sr-only")}>{t(($) => $.execution_log.retry_task_tooltip)}</span>
+        </Button>}
+      </div>
+      <div className={cn(showIdentity && "pl-8")}>
+        {output && <div className="mt-2 text-body"><ReadonlyContent content={redactSecrets(output)} /></div>}
+        {failure && <p className="mt-1 text-caption text-destructive">{failure}</p>}
+        {expanded && <div ref={state.disclosure.contentRef} id={regionId} className="mt-2 min-w-0 space-y-1">
+          {isPending && <p className="text-caption text-muted-foreground">{t(($) => $.inline_run.loading)}</p>}
+          {isError && <div role="alert" className="text-caption text-destructive">{t(($) => $.inline_run.load_failed)}
+            <button className="ml-2 underline" type="button" onClick={() => void refetch()}>{t(($) => $.inline_run.try_again)}</button></div>}
+          {!isPending && !isError && rows.length === 0 && <p className="text-caption text-muted-foreground">{t(($) => $.inline_run.empty)}</p>}
+          {rows.length > visibleCount && <button type="button" className="py-1 text-caption text-muted-foreground hover:text-foreground"
+            onClick={() => setVisibleCount((count) => count + 12)}>{t(($) => $.inline_run.show_earlier, { count: rows.length - visibleCount })}</button>}
+          {rows.slice(-visibleCount).map((row) => <InlineStep key={row.seq} row={row} live={active} />)}
+          <button type="button" className="flex items-center gap-1.5 rounded py-2 text-caption text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => setFullLogOpen(true)}>{t(($) => $.inline_run.full_log)}<ExternalLink className="size-3" /></button>
+        </div>}
+      </div>
+      {fullLogOpen && <AgentTranscriptDialog open onOpenChange={setFullLogOpen} task={task} items={items} agentName={name} isLive={active} />}
       <TerminateTaskConfirmDialog open={confirmStop} onOpenChange={setConfirmStop}
         showRunningNote={task.status !== "queued"}
         onConfirm={() => cancel.mutate(task.id, { onError: () => toast.error(t(($) => $.execution_log.cancel_failed)) })} />
     </section>
   );
-}
-
-function InlineRunActivity({ run, viewState, expanded, onExpandedChange, regionId, name, statusLine, controls }: {
-  run: CommentRun; viewState: InlineCommentRunState; expanded: boolean; onExpandedChange: (value: boolean) => void; regionId: string; name: string; statusLine?: ReactNode; controls?: ReactNode;
-}) {
-  const { t } = useT("issues");
-  const live = isActiveCommentRun(run.task);
-  const { data, isPending, isError, refetch } = useTaskMessages(run.task.id, live);
-  const items = useMemo(() => buildTimeline(data ?? []), [data]);
-  const steps = useMemo(() => buildSteps(items), [items]);
-  const rows = useMemo(() => groupSteps(steps), [steps]);
-  const { fullLogOpen, setFullLogOpen } = viewState;
-  const [visibleCount, setVisibleCount] = useState(12);
-  const latest = steps.findLast((step) => step.kind !== "text" || step.item.content?.trim());
-  const pendingCall = steps.findLast((step) => isCallStep(step) && !step.result);
-  const current = pendingCall ?? latest;
-  // Keep the last activity visible after a tool returns, until new progress arrives.
-  const summary = current && isCallStep(current)
-    ? redactSecrets(traceToolArgSummary(current.call?.input) || current.tool)
-    : current?.kind === "text" ? current.item.content
-    : current?.kind === "thinking" ? t(($) => $.inline_run.thinking)
-    : current?.kind === "error" ? t(($) => $.inline_run.error)
-    : t(($) => $.inline_run.waiting_response);
-  return <>
-    {run.task.status === "running" && !run.hasReply && <p className="mx-4 mb-3 mt-2 min-h-[1lh] truncate text-body text-foreground max-md:mx-3" title={summary}>{summary}</p>}
-    <div className={cn("bg-muted/20 px-4 py-2.5 max-md:px-3", !statusLine && "border-t border-border/50")}>
-      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-        {statusLine}
-        <div className={cn("flex items-center gap-3", statusLine && "ml-auto")}>
-          {controls}
-          <button type="button" className="flex items-center gap-1.5 rounded text-caption text-muted-foreground hover:text-foreground"
-            aria-expanded={expanded} aria-controls={expanded ? regionId : undefined} onClick={(event) => { viewState.disclosure.onTrigger(event); onExpandedChange(!expanded); }}>
-            <ChevronRight ref={viewState.disclosure.chevronRef} className={cn("size-3.5", expanded && "rotate-90")} />
-            {t(($) => $.inline_run.view_activity)}
-            {steps.length > 0 && <span className="text-faint-foreground">· {t(($) => $.inline_run.steps, { count: steps.length })}</span>}
-          </button>
-        </div>
-      </div>
-      {expanded && <div ref={viewState.disclosure.contentRef} id={regionId} className="mt-3 min-w-0 space-y-1">
-        {isPending && <p className="text-caption text-muted-foreground">{t(($) => $.inline_run.loading)}</p>}
-        {isError && <div role="alert" className="text-caption text-destructive">{t(($) => $.inline_run.load_failed)}
-          <button className="ml-2 underline" type="button" onClick={() => void refetch()}>{t(($) => $.inline_run.try_again)}</button></div>}
-        {!isPending && !isError && rows.length === 0 && <p className="text-caption text-muted-foreground">{t(($) => $.inline_run.empty)}</p>}
-        {rows.length > visibleCount && <button type="button" className="py-1 text-caption text-muted-foreground hover:text-foreground"
-          onClick={() => setVisibleCount((count) => count + 12)}>{t(($) => $.inline_run.show_earlier, { count: rows.length - visibleCount })}</button>}
-        {rows.slice(-visibleCount).map((row) => <InlineStep key={row.seq} row={row} live={live} />)}
-        <button type="button" className="flex items-center gap-1.5 py-2 text-caption text-muted-foreground hover:text-foreground"
-          onClick={() => setFullLogOpen(true)}>{t(($) => $.inline_run.full_log)}<ExternalLink className="size-3" /></button>
-      </div>}
-    </div>
-    {fullLogOpen && <AgentTranscriptDialog open onOpenChange={setFullLogOpen} task={run.task} items={items} agentName={name} isLive={live} />}
-  </>;
 }
 
 function InlineStep({ row, live }: { row: TraceRow; live: boolean }) {

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -130,7 +130,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   }
   return (
     <section aria-label={t(($) => $.inline_run.label, { name })}
-      className={cn("min-w-0 py-2", className)} data-run-id={task.id}>
+      className={cn("@container/run min-w-0 py-2", className)} data-run-id={task.id}>
       <div className="flex min-h-7 min-w-0 items-center gap-2" data-run-summary-row>
         {showIdentity && <>
           <ActorAvatar actorType="agent" actorId={task.agent_id} size="md" enableHoverCard />
@@ -142,7 +142,8 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
         </span>
         <button type="button"
           className={cn("flex min-w-0 items-center gap-1.5 rounded py-1 text-left text-caption text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            showProgress ? "flex-1 text-body" : "order-last ml-auto shrink-0")}
+            showProgress ? "flex-1 text-body" : "order-last ml-auto shrink-0",
+            showIdentity && !showProgress && "@max-[32rem]/run:min-w-7 @max-[32rem]/run:justify-center")}
           aria-label={stepLabel ? `${activityLabel} · ${stepLabel}` : activityLabel}
           aria-expanded={expanded} aria-controls={expanded ? regionId : undefined}
           onClick={(event) => { state.disclosure.onTrigger(event); setExpanded(!expanded); }}>
@@ -151,18 +152,18 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
                 <span className={cn("inline-block max-w-full truncate align-bottom",
                   (task.status === "running" || task.status === "dispatched") && "animate-chat-text-shimmer")}>{summary}</span>
               </span>
-            : <span className={cn(showIdentity && "max-sm:sr-only")}>{activityLabel}</span>}
-          {!showProgress && stepLabel && <span className="text-faint-foreground max-sm:hidden">· {stepLabel}</span>}
+            : <span className={cn(showIdentity && "@max-[32rem]/run:sr-only")}>{activityLabel}</span>}
+          {!showProgress && stepLabel && <span className="text-faint-foreground @max-[32rem]/run:hidden">· {stepLabel}</span>}
           <ChevronRight ref={state.disclosure.chevronRef} aria-hidden className={cn("size-3.5 shrink-0", expanded && "rotate-90")} />
         </button>
-        <span className={cn("shrink-0 whitespace-nowrap text-caption tabular-nums text-muted-foreground", showIdentity && !active && "max-sm:hidden")}>{elapsed}</span>
+        <span className={cn("shrink-0 whitespace-nowrap text-caption tabular-nums text-muted-foreground", showIdentity && !active && "@max-[32rem]/run:hidden")}>{elapsed}</span>
         {stopButton}
         {!hasReply && (task.status === "failed" || task.status === "cancelled") && <Button
-          size="sm" variant="ghost" className={cn("text-muted-foreground", showIdentity && "max-sm:size-7 max-sm:p-0")} disabled={retry.isPending || retry.isSuccess}
+          size="sm" variant="ghost" className={cn("text-muted-foreground", showIdentity && "@max-[32rem]/run:size-7 @max-[32rem]/run:p-0")} disabled={retry.isPending || retry.isSuccess}
           onClick={() => retry.mutate(task.id, { onError: (error) => toast.error(
             dispatchReasonCode(error) === "invocation_not_allowed" ? t(($) => $.execution_log.retry_blocked) : t(($) => $.execution_log.retry_failed),
           ) })}>
-          <RotateCcw className="size-3.5" /><span className={cn(showIdentity && "max-sm:sr-only")}>{t(($) => $.execution_log.retry_task_tooltip)}</span>
+          <RotateCcw className="size-3.5" /><span className={cn(showIdentity && "@max-[32rem]/run:sr-only")}>{t(($) => $.execution_log.retry_task_tooltip)}</span>
         </Button>}
       </div>
       <div className={cn(showIdentity && "pl-8")}>

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -121,15 +121,11 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
           className="text-muted-foreground aria-expanded:bg-transparent aria-expanded:hover:bg-muted dark:aria-expanded:hover:bg-muted/50"
           aria-label={t(($) => $.inline_run.full_log)} aria-haspopup="dialog" aria-expanded={fullLogOpen}
           onClick={() => setFullLogOpen(true)}>
-          {active ? <Loader2 aria-hidden className="size-3.5 animate-spin motion-reduce:animate-none" />
-            : <ScrollText aria-hidden className="size-3.5" />}
+          <ScrollText aria-hidden className="size-3.5" />
         </Button>} />
-        <TooltipContent>{t(($) => $.inline_run.full_log)} · {status}{elapsed && ` · ${elapsed}`}</TooltipContent>
+        <TooltipContent>{t(($) => $.inline_run.full_log)}</TooltipContent>
       </Tooltip>
-      {active && <span role="status" className="sr-only">{status}</span>}
-      {stopButton}
       {transcript}
-      {stopDialog}
     </span>;
   }
   return (

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
+import { AlertCircle, Brain, ChevronRight, ExternalLink, Loader2, MessageSquare, RotateCcw, Square, Terminal } from "lucide-react";
+import { toast } from "sonner";
+import { useActorName } from "@multica/core/workspace/hooks";
+import { useTaskMessages } from "@multica/core/chat/queries";
+import { useCancelIssueRun, useRetryIssueRun } from "@multica/core/issues/mutations";
+import { dispatchReasonCode } from "@multica/core/api";
+import { Card } from "@multica/ui/components/ui/card";
+import { Button } from "@multica/ui/components/ui/button";
+import { cn } from "@multica/ui/lib/utils";
+import { AgentTranscriptDialog, StepBody } from "../../common/task-transcript/agent-transcript-dialog";
+import { buildTimeline } from "../../common/task-transcript/build-timeline";
+import { buildSteps, groupSteps, isCallStep, isGroupRow, type TraceRow } from "../../common/task-transcript/build-steps";
+import { traceEventSummary, traceToolArgSummary } from "../../common/task-transcript/trace-event-presenter";
+import { redactSecrets } from "../../common/task-transcript/redact";
+import { ReadonlyContent } from "../../editor";
+import { useT } from "../../i18n";
+import { formatDuration } from "../../agents/components/agent-activity-hover-content";
+import { cancelReasonLabel, failureReasonLabel } from "../../agents/components/tabs/task-failure";
+import { TerminateTaskConfirmDialog } from "./terminate-task-confirm-dialog";
+import { TaskStatusIcon } from "./task-status-icon";
+import { useStatusLabel } from "./task-run-labels";
+import { commentRunOutput, isActiveCommentRun, type CommentRun } from "./comment-runs";
+
+import { useRunDisclosureMotion } from "./use-run-comment-motion";
+
+export function useInlineCommentRunState() {
+  const [expanded, setExpanded] = useState(false);
+  const [fullLogOpen, setFullLogOpen] = useState(false);
+  const disclosure = useRunDisclosureMotion(expanded);
+  return { expanded, setExpanded, fullLogOpen, setFullLogOpen, disclosure };
+}
+
+export type InlineCommentRunState = ReturnType<typeof useInlineCommentRunState>;
+
+export function InlineCommentRun({ run, className, viewState }: { run: CommentRun; className?: string; viewState?: InlineCommentRunState }) {
+  const { task, hasReply } = run;
+  const { t } = useT("issues");
+  const { t: tAgents } = useT("agents");
+  const { getActorName } = useActorName();
+  const name = getActorName("agent", task.agent_id);
+  const status = useStatusLabel(task.status);
+  const active = isActiveCommentRun(task);
+  const localViewState = useInlineCommentRunState();
+  const state = viewState ?? localViewState;
+  const { expanded, setExpanded } = state;
+  const [confirmStop, setConfirmStop] = useState(false);
+  const [now, setNow] = useState(Date.now);
+  const cancel = useCancelIssueRun(task.issue_id);
+  const retry = useRetryIssueRun(task.issue_id);
+  const regionId = useId();
+  useEffect(() => {
+    if (!active) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [active]);
+  const start = task.started_at ?? task.dispatched_at ?? task.created_at;
+  const end = active ? now : task.completed_at ? Date.parse(task.completed_at) : undefined;
+  const elapsed = end !== undefined && Number.isFinite(Date.parse(start)) && Number.isFinite(end)
+    ? formatDuration(start, end) : "";
+  const failure = task.status === "failed"
+    ? failureReasonLabel(task.failure_reason, tAgents)
+    : cancelReasonLabel(task, tAgents);
+  const compact = !active && !failure;
+  // Historical, collapsed runs don't fetch transcripts.
+  const showActivity = task.status === "running" || expanded;
+  const output = !hasReply ? commentRunOutput(task) : null;
+  const header = (
+    <div className="flex min-w-0 flex-auto flex-wrap items-center gap-x-2.5 gap-y-1">
+      <span className="flex items-center gap-1.5 whitespace-nowrap text-caption text-muted-foreground" role="status" data-run-status>
+        {task.status === "running"
+          ? <span aria-hidden className="size-1.5 rounded-full bg-info" />
+          : <TaskStatusIcon status={task.status} />}
+        {status}
+      </span>
+      <span className="whitespace-nowrap text-caption tabular-nums text-muted-foreground">{elapsed}</span>
+    </div>
+  );
+  const controls = (
+    <>
+      {active && <Button size="sm" variant="ghost" disabled={cancel.isPending || cancel.isSuccess}
+        onClick={() => setConfirmStop(true)}>
+        {cancel.isPending || cancel.isSuccess ? <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" /> : <Square className="size-3.5" />}
+        {cancel.isPending || cancel.isSuccess ? t(($) => $.inline_run.stopping) : t(($) => $.inline_run.stop)}
+      </Button>}
+      {!hasReply && (task.status === "failed" || task.status === "cancelled") && <Button
+        size="sm" variant="ghost" disabled={retry.isPending || retry.isSuccess}
+        onClick={() => retry.mutate(task.id, { onError: (error) => toast.error(
+          dispatchReasonCode(error) === "invocation_not_allowed" ? t(($) => $.execution_log.retry_blocked) : t(($) => $.execution_log.retry_failed),
+        ) })}>
+        <RotateCcw className="size-3.5" />{t(($) => $.execution_log.retry_task_tooltip)}
+      </Button>}
+    </>
+  );
+  return (
+    <section aria-label={t(($) => $.inline_run.label, { name })}
+      className={cn("my-2.5 min-w-0", className)} data-run-id={task.id}>
+      {output && <div className="mb-3 text-body"><ReadonlyContent content={redactSecrets(output)} /></div>}
+      <Card className="gap-0 rounded-lg border-border/70 bg-card p-0 shadow-none">
+        {!hasReply && !compact && <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 pt-3 max-md:px-3">{header}<div className="ml-auto flex items-center">{controls}</div></div>}
+        {(failure || ["queued", "dispatched", "waiting_local_directory"].includes(task.status)) && (
+          <div className="space-y-2 px-4 py-3 max-md:px-3">
+            {failure && <p className="text-caption text-destructive">{failure}</p>}
+            {task.status === "queued" && <p className="text-body text-muted-foreground">{t(($) => $.inline_run.queued)}</p>}
+            {task.status === "dispatched" && <p className="text-body text-muted-foreground">{t(($) => $.inline_run.starting)}</p>}
+            {task.status === "waiting_local_directory" && <p className="text-body text-muted-foreground">{t(($) => $.inline_run.waiting_directory)}</p>}
+          </div>
+        )}
+        {showActivity ? (
+          <InlineRunActivity run={run} viewState={state} expanded={expanded} onExpandedChange={setExpanded}
+            regionId={regionId} name={name} statusLine={hasReply || compact ? header : undefined} controls={hasReply || compact ? controls : undefined} />
+        ) : (
+          <div className={cn("flex flex-wrap items-center justify-between gap-x-4 gap-y-2 bg-muted/20 px-4 py-2.5 max-md:px-3", !hasReply && !compact && "border-t border-border/50")}>
+            {(hasReply || compact) && header}
+            <div className={cn("flex items-center gap-3", (hasReply || compact) && "ml-auto")}>
+              {(hasReply || compact) && controls}
+              <button type="button" className="flex items-center gap-1.5 rounded text-caption text-muted-foreground hover:text-foreground"
+                aria-expanded={false} onClick={(event) => { state.disclosure.onTrigger(event); setExpanded(true); }}>
+                <ChevronRight ref={state.disclosure.chevronRef} className="size-3.5" />{t(($) => $.inline_run.view_activity)}
+              </button>
+            </div>
+          </div>
+        )}
+      </Card>
+      <TerminateTaskConfirmDialog open={confirmStop} onOpenChange={setConfirmStop}
+        showRunningNote={task.status !== "queued"}
+        onConfirm={() => cancel.mutate(task.id, { onError: () => toast.error(t(($) => $.execution_log.cancel_failed)) })} />
+    </section>
+  );
+}
+
+function InlineRunActivity({ run, viewState, expanded, onExpandedChange, regionId, name, statusLine, controls }: {
+  run: CommentRun; viewState: InlineCommentRunState; expanded: boolean; onExpandedChange: (value: boolean) => void; regionId: string; name: string; statusLine?: ReactNode; controls?: ReactNode;
+}) {
+  const { t } = useT("issues");
+  const live = isActiveCommentRun(run.task);
+  const { data, isPending, isError, refetch } = useTaskMessages(run.task.id, live);
+  const items = useMemo(() => buildTimeline(data ?? []), [data]);
+  const steps = useMemo(() => buildSteps(items), [items]);
+  const rows = useMemo(() => groupSteps(steps), [steps]);
+  const { fullLogOpen, setFullLogOpen } = viewState;
+  const [visibleCount, setVisibleCount] = useState(12);
+  const latest = steps.findLast((step) => step.kind !== "text" || step.item.content?.trim());
+  const pendingCall = steps.findLast((step) => isCallStep(step) && !step.result);
+  const current = pendingCall ?? latest;
+  // Keep the last activity visible after a tool returns, until new progress arrives.
+  const summary = current && isCallStep(current)
+    ? redactSecrets(traceToolArgSummary(current.call?.input) || current.tool)
+    : current?.kind === "text" ? current.item.content
+    : current?.kind === "thinking" ? t(($) => $.inline_run.thinking)
+    : current?.kind === "error" ? t(($) => $.inline_run.error)
+    : t(($) => $.inline_run.waiting_response);
+  return <>
+    {run.task.status === "running" && !run.hasReply && <p className="mx-4 mb-3 mt-2 min-h-[1lh] truncate text-body text-foreground max-md:mx-3" title={summary}>{summary}</p>}
+    <div className={cn("bg-muted/20 px-4 py-2.5 max-md:px-3", !statusLine && "border-t border-border/50")}>
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        {statusLine}
+        <div className={cn("flex items-center gap-3", statusLine && "ml-auto")}>
+          {controls}
+          <button type="button" className="flex items-center gap-1.5 rounded text-caption text-muted-foreground hover:text-foreground"
+            aria-expanded={expanded} aria-controls={expanded ? regionId : undefined} onClick={(event) => { viewState.disclosure.onTrigger(event); onExpandedChange(!expanded); }}>
+            <ChevronRight ref={viewState.disclosure.chevronRef} className={cn("size-3.5", expanded && "rotate-90")} />
+            {t(($) => $.inline_run.view_activity)}
+            {steps.length > 0 && <span className="text-faint-foreground">· {t(($) => $.inline_run.steps, { count: steps.length })}</span>}
+          </button>
+        </div>
+      </div>
+      {expanded && <div ref={viewState.disclosure.contentRef} id={regionId} className="mt-3 min-w-0 space-y-1">
+        {isPending && <p className="text-caption text-muted-foreground">{t(($) => $.inline_run.loading)}</p>}
+        {isError && <div role="alert" className="text-caption text-destructive">{t(($) => $.inline_run.load_failed)}
+          <button className="ml-2 underline" type="button" onClick={() => void refetch()}>{t(($) => $.inline_run.try_again)}</button></div>}
+        {!isPending && !isError && rows.length === 0 && <p className="text-caption text-muted-foreground">{t(($) => $.inline_run.empty)}</p>}
+        {rows.length > visibleCount && <button type="button" className="py-1 text-caption text-muted-foreground hover:text-foreground"
+          onClick={() => setVisibleCount((count) => count + 12)}>{t(($) => $.inline_run.show_earlier, { count: rows.length - visibleCount })}</button>}
+        {rows.slice(-visibleCount).map((row) => <InlineStep key={row.seq} row={row} live={live} />)}
+        <button type="button" className="flex items-center gap-1.5 py-2 text-caption text-muted-foreground hover:text-foreground"
+          onClick={() => setFullLogOpen(true)}>{t(($) => $.inline_run.full_log)}<ExternalLink className="size-3" /></button>
+      </div>}
+    </div>
+    {fullLogOpen && <AgentTranscriptDialog open onOpenChange={setFullLogOpen} task={run.task} items={items} agentName={name} isLive={live} />}
+  </>;
+}
+
+function InlineStep({ row, live }: { row: TraceRow; live: boolean }) {
+  const { t } = useT("issues");
+  const [open, setOpen] = useState(false);
+  const disclosure = useRunDisclosureMotion(open);
+  const [limit, setLimit] = useState(12);
+  const onToggle = (event: React.SyntheticEvent<HTMLDetailsElement>) => setOpen(event.currentTarget.open);
+  const grouped = isGroupRow(row);
+  const call = isCallStep(row);
+  const pending = call && live && !row.result;
+  const error = !grouped && !call && row.kind === "error";
+  const Icon = grouped || call ? Terminal : row.kind === "text" ? MessageSquare : row.kind === "thinking" ? Brain : AlertCircle;
+  const summary = call
+    ? redactSecrets(traceToolArgSummary(row.call?.input) || (row.result ? traceEventSummary(row.result) : "")) || row.tool
+    : grouped ? row.tool
+    : row.kind === "text" ? t(($) => $.inline_run.message)
+    : row.kind === "thinking" ? t(($) => $.inline_run.thinking)
+    : t(($) => $.inline_run.error);
+  return <details className="min-w-0 text-caption" onToggle={onToggle}>
+    <summary onClick={disclosure.onTrigger} className="flex cursor-pointer list-none items-center gap-2 rounded py-1.5 hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+      {pending ? <Loader2 aria-hidden className="size-3.5 shrink-0 animate-spin text-info motion-reduce:animate-none" />
+        : <Icon aria-hidden className={cn("size-3.5 shrink-0", error ? "text-destructive" : "text-muted-foreground")} />}
+      <span className={cn("min-w-0 flex-1 truncate", error && "text-destructive")} title={summary}>{summary}</span>
+      {(grouped || call) && <span className="shrink-0 text-micro text-muted-foreground">
+        {grouped ? t(($) => $.inline_run.steps, { count: row.steps.length }) : row.tool}
+      </span>}
+      <ChevronRight ref={disclosure.chevronRef} aria-hidden className={cn("size-3 shrink-0 text-muted-foreground", open && "rotate-90")} />
+    </summary>
+    {open && <div ref={disclosure.contentRef} className="min-w-0 space-y-2 overflow-hidden pl-5.5">
+      {grouped ? <>
+        {row.steps.length > limit && <button type="button" className="py-1 text-muted-foreground" onClick={() => setLimit((value) => value + 12)}>
+          {t(($) => $.inline_run.show_earlier, { count: row.steps.length - limit })}</button>}
+        {row.steps.slice(-limit).map((step) => <InlineStep key={step.seq} row={step} live={live} />)}
+      </> : call ? <>
+        {row.call && <StepBody item={row.call} />}
+        {row.result && <StepBody item={row.result} />}
+        {pending && <p className="text-muted-foreground">{t(($) => $.inline_run.waiting_result)}</p>}
+      </> : <StepBody item={row.item} />}
+    </div>}
+  </details>;
+}

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -115,7 +115,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
     showRunningNote={task.status !== "queued"}
     onConfirm={() => cancel.mutate(task.id, { onError: () => toast.error(t(($) => $.execution_log.cancel_failed)) })} />;
   if (presentation === "header" && showCommentRunInHeader(run)) {
-    return <span className="inline-flex shrink-0" data-run-id={task.id}>
+    return <span className="inline-flex shrink-0" data-comment-actions data-run-id={task.id}>
       <Tooltip>
         <TooltipTrigger render={<Button type="button" size="icon-sm" variant="ghost"
           className="text-muted-foreground aria-expanded:bg-transparent aria-expanded:hover:bg-muted dark:aria-expanded:hover:bg-muted/50"

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -110,7 +110,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
     return <span className="inline-flex shrink-0" data-run-id={task.id}>
       <Tooltip>
         <TooltipTrigger render={<Button type="button" size="icon-sm" variant="ghost"
-          className="text-muted-foreground hover:bg-transparent aria-expanded:bg-transparent dark:hover:bg-transparent"
+          className="text-muted-foreground aria-expanded:bg-transparent aria-expanded:hover:bg-muted dark:aria-expanded:hover:bg-muted/50"
           aria-label={t(($) => $.inline_run.full_log)} aria-haspopup="dialog" aria-expanded={fullLogOpen}
           onClick={() => setFullLogOpen(true)}>
           <ScrollText aria-hidden className="size-3.5" />

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useId, useMemo, useState } from "react";
 import { AlertCircle, Brain, ChevronRight, ExternalLink, Loader2, MessageSquare, RotateCcw, Square, Terminal } from "lucide-react";
 import { toast } from "sonner";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useTraceIssueLabels } from "../../common/task-transcript/use-trace-issue-labels";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useTaskMessages } from "@multica/core/chat/queries";
 import { useCancelIssueRun, useRetryIssueRun } from "@multica/core/issues/mutations";
@@ -61,6 +63,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   // Historical, collapsed runs still don't fetch transcripts.
   const { data, isPending, isError, refetch } = useTaskMessages(task.id, active, task.status === "running" || expanded || fullLogOpen);
   const items = useMemo(() => buildTimeline(data ?? []), [data]);
+  const formatText = useTraceIssueLabels(useWorkspaceId(), task.issue_id, items, task.status === "running" || expanded || fullLogOpen);
   const steps = useMemo(() => buildSteps(items), [items]);
   const rows = useMemo(() => groupSteps(steps), [steps]);
   useEffect(() => {
@@ -81,8 +84,8 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   const current = pendingCall ?? latest;
   // Keep the last activity visible after a tool returns, until new progress arrives.
   const activitySummary = current && isCallStep(current)
-    ? redactSecrets(traceToolArgSummary(current.call?.input) || current.tool)
-    : current?.kind === "text" ? redactSecrets(current.item.content ?? "")
+    ? redactSecrets(traceToolArgSummary(current.call?.input, { formatText }) || current.tool)
+    : current?.kind === "text" ? redactSecrets(formatText(current.item.content ?? ""))
     : current?.kind === "thinking" ? t(($) => $.inline_run.thinking)
     : current?.kind === "error" ? t(($) => $.inline_run.error)
     : t(($) => $.inline_run.waiting_response);
@@ -142,7 +145,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
           {!isPending && !isError && rows.length === 0 && <p className="text-caption text-muted-foreground">{t(($) => $.inline_run.empty)}</p>}
           {rows.length > visibleCount && <button type="button" className="py-1 text-caption text-muted-foreground hover:text-foreground"
             onClick={() => setVisibleCount((count) => count + 12)}>{t(($) => $.inline_run.show_earlier, { count: rows.length - visibleCount })}</button>}
-          {rows.slice(-visibleCount).map((row) => <InlineStep key={row.seq} row={row} live={active} />)}
+          {rows.slice(-visibleCount).map((row) => <InlineStep key={row.seq} row={row} live={active} formatText={formatText} />)}
           <button type="button" className="flex items-center gap-1.5 rounded py-2 text-caption text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={() => setFullLogOpen(true)}>{t(($) => $.inline_run.full_log)}<ExternalLink className="size-3" /></button>
         </div>}
@@ -155,7 +158,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   );
 }
 
-function InlineStep({ row, live }: { row: TraceRow; live: boolean }) {
+function InlineStep({ row, live, formatText }: { row: TraceRow; live: boolean; formatText: (text: string) => string }) {
   const { t } = useT("issues");
   const [open, setOpen] = useState(false);
   const disclosure = useRunDisclosureMotion(open);
@@ -167,7 +170,7 @@ function InlineStep({ row, live }: { row: TraceRow; live: boolean }) {
   const error = !grouped && !call && row.kind === "error";
   const Icon = grouped || call ? Terminal : row.kind === "text" ? MessageSquare : row.kind === "thinking" ? Brain : AlertCircle;
   const summary = call
-    ? redactSecrets(traceToolArgSummary(row.call?.input) || (row.result ? traceEventSummary(row.result) : "")) || row.tool
+    ? redactSecrets(traceToolArgSummary(row.call?.input, { formatText }) || (row.result ? traceEventSummary(row.result, { formatText }) : "")) || row.tool
     : grouped ? row.tool
     : row.kind === "text" ? t(($) => $.inline_run.message)
     : row.kind === "thinking" ? t(($) => $.inline_run.thinking)
@@ -186,7 +189,7 @@ function InlineStep({ row, live }: { row: TraceRow; live: boolean }) {
       {grouped ? <>
         {row.steps.length > limit && <button type="button" className="py-1 text-muted-foreground" onClick={() => setLimit((value) => value + 12)}>
           {t(($) => $.inline_run.show_earlier, { count: row.steps.length - limit })}</button>}
-        {row.steps.slice(-limit).map((step) => <InlineStep key={step.seq} row={step} live={live} />)}
+        {row.steps.slice(-limit).map((step) => <InlineStep key={step.seq} row={step} live={live} formatText={formatText} />)}
       </> : call ? <>
         {row.call && <StepBody item={row.call} />}
         {row.result && <StepBody item={row.result} />}

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useId, useMemo, useState } from "react";
-import { AlertCircle, Brain, ChevronRight, ExternalLink, Loader2, MessageSquare, RotateCcw, Square, Terminal } from "lucide-react";
+import { AlertCircle, Brain, ChevronRight, ExternalLink, Loader2, MessageSquare, RotateCcw, ScrollText, Square, Terminal } from "lucide-react";
 import { toast } from "sonner";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useTraceIssueLabels } from "../../common/task-transcript/use-trace-issue-labels";
@@ -11,6 +11,7 @@ import { useCancelIssueRun, useRetryIssueRun } from "@multica/core/issues/mutati
 import { dispatchReasonCode } from "@multica/core/api";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { Button } from "@multica/ui/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { cn } from "@multica/ui/lib/utils";
 import { AgentTranscriptDialog, StepBody } from "../../common/task-transcript/agent-transcript-dialog";
 import { buildTimeline } from "../../common/task-transcript/build-timeline";
@@ -37,11 +38,12 @@ export function useInlineCommentRunState() {
 
 export type InlineCommentRunState = ReturnType<typeof useInlineCommentRunState>;
 
-export function InlineCommentRun({ run, className, viewState, showIdentity = false }: {
+export function InlineCommentRun({ run, className, viewState, showIdentity = false, presentation = "inline" }: {
   run: CommentRun;
   className?: string;
   viewState?: InlineCommentRunState;
   showIdentity?: boolean;
+  presentation?: "inline" | "header";
 }) {
   const { task, hasReply } = run;
   const { t } = useT("issues");
@@ -61,9 +63,10 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   const regionId = useId();
   // Keep one disclosure button mounted across queued, live, and historical states.
   // Historical, collapsed runs still don't fetch transcripts.
-  const { data, isPending, isError, refetch } = useTaskMessages(task.id, active, task.status === "running" || expanded || fullLogOpen);
+  const loadTranscript = task.status === "running" || (presentation === "inline" && expanded) || fullLogOpen;
+  const { data, isPending, isError, refetch } = useTaskMessages(task.id, active, loadTranscript);
   const items = useMemo(() => buildTimeline(data ?? []), [data]);
-  const formatText = useTraceIssueLabels(useWorkspaceId(), task.issue_id, items, task.status === "running" || expanded || fullLogOpen);
+  const formatText = useTraceIssueLabels(useWorkspaceId(), task.issue_id, items, loadTranscript);
   const steps = useMemo(() => buildSteps(items), [items]);
   const rows = useMemo(() => groupSteps(steps), [steps]);
   useEffect(() => {
@@ -97,6 +100,26 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   const activityLabel = t(($) => $.inline_run.view_activity);
   const stepLabel = steps.length > 0 ? t(($) => $.inline_run.steps, { count: steps.length }) : "";
   const stopLabel = cancel.isPending || cancel.isSuccess ? t(($) => $.inline_run.stopping) : t(($) => $.inline_run.stop);
+  const transcript = fullLogOpen && <AgentTranscriptDialog open onOpenChange={setFullLogOpen}
+    task={task} items={items} agentName={name} isLive={active}
+    contentState={isPending ? <p role="status" className="text-body text-muted-foreground">{t(($) => $.inline_run.loading)}</p>
+      : isError ? <div role="alert" className="text-body text-destructive">{t(($) => $.inline_run.load_failed)}
+        <button className="ml-2 underline" type="button" onClick={() => void refetch()}>{t(($) => $.inline_run.try_again)}</button>
+      </div> : undefined} />;
+  if (presentation === "header" && task.status === "completed" && hasReply) {
+    return <span className="inline-flex shrink-0" data-run-id={task.id}>
+      <Tooltip>
+        <TooltipTrigger render={<Button type="button" size="icon-sm" variant="ghost"
+          className="text-muted-foreground hover:bg-transparent aria-expanded:bg-transparent dark:hover:bg-transparent"
+          aria-label={t(($) => $.inline_run.full_log)} aria-haspopup="dialog" aria-expanded={fullLogOpen}
+          onClick={() => setFullLogOpen(true)}>
+          <ScrollText aria-hidden className="size-3.5" />
+        </Button>} />
+        <TooltipContent>{t(($) => $.inline_run.full_log)} · {status}{elapsed && ` · ${elapsed}`}</TooltipContent>
+      </Tooltip>
+      {transcript}
+    </span>;
+  }
   return (
     <section aria-label={t(($) => $.inline_run.label, { name })}
       className={cn("min-w-0 py-2", className)} data-run-id={task.id}>
@@ -150,7 +173,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
             onClick={() => setFullLogOpen(true)}>{t(($) => $.inline_run.full_log)}<ExternalLink className="size-3" /></button>
         </div>}
       </div>
-      {fullLogOpen && <AgentTranscriptDialog open onOpenChange={setFullLogOpen} task={task} items={items} agentName={name} isLive={active} />}
+      {transcript}
       <TerminateTaskConfirmDialog open={confirmStop} onOpenChange={setConfirmStop}
         showRunningNote={task.status !== "queued"}
         onConfirm={() => cancel.mutate(task.id, { onError: () => toast.error(t(($) => $.execution_log.cancel_failed)) })} />

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -139,7 +139,10 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
           aria-expanded={expanded} aria-controls={expanded ? regionId : undefined}
           onClick={(event) => { state.disclosure.onTrigger(event); setExpanded(!expanded); }}>
           {showProgress
-            ? <span data-run-summary className="min-w-0 flex-1 truncate" title={summary}>{summary}</span>
+            ? <span data-run-summary className="min-w-0 flex-1 truncate" title={summary}>
+                <span className={cn("inline-block max-w-full truncate align-bottom",
+                  (task.status === "running" || task.status === "dispatched") && "animate-chat-text-shimmer")}>{summary}</span>
+              </span>
             : <span className={cn(showIdentity && "max-sm:sr-only")}>{activityLabel}</span>}
           {!showProgress && stepLabel && <span className="text-faint-foreground max-sm:hidden">· {stepLabel}</span>}
           <ChevronRight ref={state.disclosure.chevronRef} aria-hidden className={cn("size-3.5 shrink-0", expanded && "rotate-90")} />

--- a/packages/views/issues/components/issue-agent-header-chip.test.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.test.tsx
@@ -189,6 +189,18 @@ beforeEach(() => {
 });
 
 describe("IssueAgentHeaderChip", () => {
+  it("lists pending threads oldest first after the running task, even after coalescing", () => {
+    // ListTasksByIssue returns newest first, as in DEV-24.
+    mockState.tasks = [
+      makeTask({ id: "dlc", status: "queued", created_at: "2026-09-08T11:44:52+08:00" }),
+      makeTask({ id: "beginner", status: "queued", created_at: "2026-09-08T11:44:34+08:00", trigger_comment_id: "new-supplement", coalesced_comment_ids: ["original"] }),
+      makeTask({ id: "running", created_at: "2026-09-08T11:44:26+08:00" }),
+    ];
+    renderWithI18n(<IssueAgentHeaderChip issueId="issue-1" />);
+    expect(screen.getAllByTestId("active-task-row").map((row) => row.querySelector("span")?.textContent))
+      .toEqual(["running", "beginner", "dlc"]);
+  });
+
   it("shows the active agent name without event count or elapsed time", () => {
     mockState.tasks = [makeTask({})];
 

--- a/packages/views/issues/components/issue-agent-header-chip.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.tsx
@@ -16,6 +16,7 @@ import { TranscriptButton } from "../../common/task-transcript";
 import { AgentAvatarStack } from "../../agents/components/agent-avatar-stack";
 import { ActiveTaskRow } from "./execution-log-section";
 import { useT } from "../../i18n";
+import { compareActiveIssueTasks } from "./active-task-order";
 
 // Per-issue "is an agent working on this right now?" chip for the issue
 // detail header. Lives in the header (not the scrollable body) so the live
@@ -59,9 +60,9 @@ export const IssueAgentHeaderChip = memo(function IssueAgentHeaderChip({
   const { running, queued } = useMemo(() => {
     const running: AgentTask[] = [];
     const queued: AgentTask[] = [];
-    // The list is already issue-scoped by the endpoint, so only the status
-    // split matters here.
-    for (const task of tasks) {
+    // The endpoint returns history newest first. Active work instead uses
+    // execution/queue order, shared with the right-panel log.
+    for (const task of tasks.toSorted(compareActiveIssueTasks)) {
       if (task.status === "running") running.push(task);
       else if (
         task.status === "queued" ||

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -320,6 +320,8 @@ const mockApiObj = vi.hoisted(() => ({
   removeCommentReaction: vi.fn(),
   listMembers: vi.fn().mockResolvedValue([{ user_id: "user-1", name: "Test User", email: "test@test.com", role: "admin" }]),
   listAgents: vi.fn().mockResolvedValue([]),
+  getAgent: vi.fn().mockResolvedValue(null),
+  listRuntimes: vi.fn().mockResolvedValue([]),
   getProject: vi.fn(),
   listProjects: vi.fn().mockResolvedValue({ projects: [] }),
 }));
@@ -1251,7 +1253,8 @@ describe("IssueDetail (shared)", () => {
     });
     const body = await screen.findByText(reply.content!);
     const replyRow = container.querySelector("#comment-run-reply")!;
-    await waitFor(() => expect(within(replyRow as HTMLElement).getByText("Completed")).toBeInTheDocument());
+    await waitFor(() => expect(within(replyRow as HTMLElement).getByRole("button", { name: "Open full log" })).toBeInTheDocument());
+    expect(within(replyRow as HTMLElement).queryByText("Completed")).not.toBeInTheDocument();
     const run = replyRow.querySelector(`[data-run-id="${taskId}"]`)!;
     expect(run.querySelector('[data-slot="card"]')).toBeNull();
     expect(container.querySelectorAll(`[data-run-id="${taskId}"]`)).toHaveLength(1);
@@ -1260,8 +1263,8 @@ describe("IssueDetail (shared)", () => {
     expect(container.querySelector(`[data-run-comment-id="${taskId}"]`)).toBeNull();
     expect(userBlock.querySelector("[data-run-id]")).toBeNull();
     expect(within(run as HTMLElement).queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
-    fireEvent.click(within(run as HTMLElement).getByRole("button", { name: /View activity/ }));
-    await waitFor(() => expect(within(run as HTMLElement).getByText("pnpm test")).toBeInTheDocument());
+    fireEvent.click(within(run as HTMLElement).getByRole("button", { name: "Open full log" }));
+    await screen.findByRole("dialog");
     expect(mockApiObj.listTaskMessages).toHaveBeenCalledWith(taskId);
   });
 
@@ -1350,7 +1353,8 @@ describe("IssueDetail (shared)", () => {
       expect(slots[index]!.textContent).toContain(reply.content);
       expect(container.querySelectorAll(`[data-run-id="${tasks[index]!.id}"]`)).toHaveLength(1);
     }
-    expect(within(slots[0] as HTMLElement).getByRole("button", { name: /View activity/ })).toHaveAttribute("aria-expanded", "true");
+    expect(within(slots[0] as HTMLElement).getByRole("button", { name: "Open full log" })).toBeInTheDocument();
+    expect(within(slots[0] as HTMLElement).queryByRole("button", { name: /View activity/ })).not.toBeInTheDocument();
     expect(slots[0]!.nextElementSibling?.id).toBe("comment-request-two");
     expect(slots[1]!.nextElementSibling?.id).toBe("comment-request-three");
     expect(container.querySelector(`[data-run-slot-id="${tasks[2]!.id}"]`)).toBe(slots[2]);

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -2,7 +2,8 @@ import { forwardRef, useEffect, useRef, useState, useImperativeHandle } from "re
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Issue, IssueStatusEntry, Label, TimelineEntry } from "@multica/core/types";
+import type { AgentTask, Issue, IssueStatusEntry, Label, TimelineEntry } from "@multica/core/types";
+import { issueKeys } from "@multica/core/issues/queries";
 import { issueStatusKeys } from "@multica/core/issue-statuses";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { toast } from "sonner";
@@ -704,6 +705,7 @@ describe("IssueDetail (shared)", () => {
     mockApiObj.listIssues.mockResolvedValue({ issues: [], total: 0 });
     mockApiObj.getActiveTasksForIssue.mockResolvedValue({ tasks: [] });
     mockApiObj.listTasksByIssue.mockResolvedValue([]);
+    mockApiObj.listTaskMessages.mockResolvedValue([]);
     mockApiObj.rerunIssue.mockResolvedValue({ id: "task-rerun" });
     mockApiObj.listMembers.mockResolvedValue([
       { user_id: "user-1", name: "Test User", email: "test@test.com", role: "admin" },
@@ -1197,6 +1199,183 @@ describe("IssueDetail (shared)", () => {
     });
 
     expect(screen.queryByRole("button", { name: /^Metadata\b/ })).not.toBeInTheDocument();
+  });
+
+  // Mapping edge cases live in comment-runs.test.ts; this verifies the shipped
+  // IssueDetail -> CommentCard -> metadata card wiring as server caches change.
+  it("keeps execution in an agent block before and after its persisted reply arrives", async () => {
+    const taskId = "4a2e8d1c-7f9b-4e2a-9c1d-123456789abc";
+    const task: AgentTask = {
+      id: taskId, agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",
+      status: "queued", priority: 0, created_at: "2026-01-16T00:00:00Z",
+      started_at: null, dispatched_at: null, completed_at: null, result: null, error: null,
+      trigger_comment_id: "comment-1", delivered_comment_ids: [],
+    };
+    const root = mockTimeline[0]!;
+    mockApiObj.listTimeline.mockResolvedValue([root]);
+    mockApiObj.listTasksByIssue.mockResolvedValue([task]);
+    mockApiObj.listTaskMessages.mockResolvedValue([
+      { task_id: taskId, issue_id: "issue-1", seq: 1, type: "tool_use", tool: "exec_command", input: { command: "pnpm test" } },
+    ]);
+    const client = createTestQueryClient();
+    const { container } = render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <QueryClientProvider client={client}>
+          <IssueDetail issueId="issue-1" defaultSidebarOpen={false} />
+        </QueryClientProvider>
+      </I18nProvider>,
+    );
+    await screen.findByText("Waiting for an available agent.");
+    const userBlock = container.querySelector(`#comment-body-${root.id}`)!.parentElement!;
+    const agentBlock = container.querySelector(`[data-run-comment-id="${taskId}"]`)!;
+    expect(agentBlock).not.toBeNull();
+    expect(userBlock.contains(agentBlock)).toBe(false);
+    expect(agentBlock.parentElement).toBe(userBlock.parentElement);
+    expect(agentBlock.querySelector(`[data-run-id="${taskId}"]`)).not.toBeNull();
+    const running: AgentTask = { ...task, status: "running", started_at: task.created_at, delivered_comment_ids: [root.id] };
+    act(() => client.setQueryData(issueKeys.tasks("issue-1"), [running]));
+    await screen.findByText("pnpm test");
+    expect(container.querySelector(`[data-run-comment-id="${taskId}"]`)).toBe(agentBlock);
+    expect(userBlock.querySelector("[data-run-id]")).toBeNull();
+
+    const reply: TimelineEntry = {
+      ...mockTimeline[1]!, id: "run-reply", parent_id: root.id, source_task_id: taskId,
+      content: "Review complete. The navigation is ready.",
+    };
+    const completed: AgentTask = { ...running, status: "completed", completed_at: "2026-01-16T00:01:00Z" };
+    mockApiObj.listTasksByIssue.mockResolvedValue([completed]);
+    mockApiObj.listTimeline.mockResolvedValue([root, reply]);
+    act(() => {
+      client.setQueryData(issueKeys.tasks("issue-1"), [completed]);
+      client.setQueryData(issueKeys.timeline("issue-1"), [root, reply]);
+    });
+    const body = await screen.findByText(reply.content!);
+    const replyRow = container.querySelector("#comment-run-reply")!;
+    await waitFor(() => expect(within(replyRow as HTMLElement).getByText("Completed")).toBeInTheDocument());
+    const run = replyRow.querySelector(`[data-run-id="${taskId}"]`)!;
+    const metadata = run.querySelector('[data-slot="card"]')!;
+    expect(container.querySelectorAll(`[data-run-id="${taskId}"]`)).toHaveLength(1);
+    expect(metadata.contains(body)).toBe(false);
+    expect(replyRow.contains(body)).toBe(true);
+    expect(container.querySelector(`[data-run-comment-id="${taskId}"]`)).toBeNull();
+    expect(userBlock.querySelector("[data-run-id]")).toBeNull();
+    expect(within(run as HTMLElement).queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    fireEvent.click(within(run as HTMLElement).getByRole("button", { name: /View activity/ }));
+    await waitFor(() => expect(within(metadata as HTMLElement).getByText("pnpm test")).toBeInTheDocument());
+    expect(mockApiObj.listTaskMessages).toHaveBeenCalledWith(taskId);
+  });
+
+  it("shows an assignment run without a trigger comment and moves its metadata to the agent reply", async () => {
+    const task: AgentTask = {
+      id: "ba2e8d1c-7f9b-4e2a-9c1d-123456789abc", agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",
+      status: "queued", priority: 0, created_at: "2026-01-16T00:00:00Z",
+      started_at: null, dispatched_at: null, completed_at: null, result: null, error: null,
+      delivered_comment_ids: [],
+    };
+    mockApiObj.listTimeline.mockResolvedValue([]);
+    mockApiObj.listTasksByIssue.mockResolvedValue([task]);
+    mockApiObj.listTaskMessages.mockResolvedValue([
+      { task_id: task.id, issue_id: "issue-1", seq: 1, type: "tool_use", tool: "exec_command", input: { command: "pnpm test" } },
+    ]);
+    const queryClient = createTestQueryClient();
+    const { container } = render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail issueId="issue-1" defaultSidebarOpen={false} />
+        </QueryClientProvider>
+      </I18nProvider>,
+    );
+    await screen.findByText("Waiting for an available agent.");
+    expect(container.querySelector(`[data-run-comment-id="${task.id}"]`)).not.toBeNull();
+    const assignmentSlot = container.querySelector(`[data-run-slot-id="${task.id}"]`);
+    const running: AgentTask = { ...task, status: "running", started_at: task.created_at };
+    act(() => queryClient.setQueryData(issueKeys.tasks("issue-1"), [running]));
+    await screen.findByText("pnpm test");
+    expect(container.querySelectorAll(`[data-run-id="${task.id}"]`)).toHaveLength(1);
+    const reply: TimelineEntry = {
+      ...mockTimeline[1]!, id: "assignment-reply", parent_id: null, source_task_id: task.id,
+      content: "Assignment complete.", created_at: "2026-01-16T00:01:00Z",
+    };
+    const completed: AgentTask = { ...running, status: "completed", completed_at: reply.created_at };
+    mockApiObj.listTasksByIssue.mockResolvedValue([completed]);
+    mockApiObj.listTimeline.mockResolvedValue([reply]);
+    act(() => {
+      queryClient.setQueryData(issueKeys.tasks("issue-1"), [completed]);
+      queryClient.setQueryData(issueKeys.timeline("issue-1"), [reply]);
+    });
+    await screen.findByText(reply.content!);
+    await waitFor(() => expect(container.querySelector(`[data-run-comment-id="${task.id}"]`)).toBeNull());
+    expect(container.querySelector(`[data-run-slot-id="${task.id}"]`)).toBe(assignmentSlot);
+    const replyBlock = container.querySelector("#comment-assignment-reply")!;
+    expect(replyBlock.querySelector(`[data-run-id="${task.id}"]`)).not.toBeNull();
+    expect(container.querySelectorAll(`[data-run-id="${task.id}"]`)).toHaveLength(1);
+  });
+
+  it("replaces each queued run in place without moving replies behind later requests", async () => {
+    const root = mockTimeline[0]!;
+    const second = { ...root, id: "request-two", parent_id: root.id, content: "Second request", created_at: "2026-01-16T00:00:02Z" };
+    const third = { ...root, id: "request-three", parent_id: root.id, content: "Third request", created_at: "2026-01-16T00:00:04Z" };
+    const tasks: AgentTask[] = [root, second, third].map((trigger, index) => ({
+      id: `ba2e8d1c-7f9b-4e2a-9c1d-123456789ab${index}`, agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",
+      status: "queued", priority: 0, created_at: trigger.created_at,
+      started_at: null, dispatched_at: null, completed_at: null, result: null, error: null,
+      trigger_comment_id: trigger.id, delivered_comment_ids: [],
+    }));
+    let timeline = [root, second, third];
+    mockApiObj.listTimeline.mockResolvedValue(timeline);
+    mockApiObj.listTasksByIssue.mockResolvedValue(tasks);
+    const client = createTestQueryClient();
+    const { container } = render(<I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <QueryClientProvider client={client}><IssueDetail issueId="issue-1" defaultSidebarOpen={false} /></QueryClientProvider>
+    </I18nProvider>);
+    await waitFor(() => expect(container.querySelectorAll('[data-run-slot-id]')).toHaveLength(3));
+    const slots = tasks.map((task) => container.querySelector(`[data-run-slot-id="${task.id}"]`)!);
+    fireEvent.click(within(slots[0] as HTMLElement).getByRole("button", { name: /View activity/ }));
+    await within(slots[0] as HTMLElement).findByText("No activity recorded yet.");
+    for (const index of [0, 1]) {
+      const reply: TimelineEntry = { ...mockTimeline[1]!, id: `answer-${index}`, parent_id: index === 0 ? null : root.id,
+        source_task_id: tasks[index]!.id, content: `Answer ${index}`, created_at: `2026-01-16T00:01:0${index}Z` };
+      tasks[index] = { ...tasks[index]!, status: "completed", completed_at: reply.created_at,
+        delivered_comment_ids: [tasks[index]!.trigger_comment_id!] };
+      timeline = [...timeline, reply];
+      mockApiObj.listTasksByIssue.mockResolvedValue([...tasks]);
+      mockApiObj.listTimeline.mockResolvedValue(timeline);
+      act(() => {
+        client.setQueryData(issueKeys.tasks("issue-1"), [...tasks]);
+        client.setQueryData(issueKeys.timeline("issue-1"), timeline);
+      });
+      await screen.findByText(reply.content!);
+      expect(container.querySelector(`[data-run-slot-id="${tasks[index]!.id}"]`)).toBe(slots[index]);
+      expect(slots[index]!.textContent).toContain(reply.content);
+      expect(container.querySelectorAll(`[data-run-id="${tasks[index]!.id}"]`)).toHaveLength(1);
+    }
+    expect(within(slots[0] as HTMLElement).getByRole("button", { name: /View activity/ })).toHaveAttribute("aria-expanded", "true");
+    expect(slots[0]!.nextElementSibling?.id).toBe("comment-request-two");
+    expect(slots[1]!.nextElementSibling?.id).toBe("comment-request-three");
+    expect(container.querySelector(`[data-run-slot-id="${tasks[2]!.id}"]`)).toBe(slots[2]);
+    expect(within(slots[2] as HTMLElement).getByText("Waiting for an available agent.")).toBeInTheDocument();
+  });
+
+  it.each(["failed", "cancelled"] as const)("keeps a %s run outside the user reply that triggered it", async (status) => {
+    const root = mockTimeline[0]!;
+    const trigger = { ...root, id: "user-reply", parent_id: root.id, content: "Please try this task" };
+    const task: AgentTask = {
+      id: "4a2e8d1c-7f9b-4e2a-9c1d-123456789abc", agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",
+      status, priority: 0, created_at: "2026-01-16T00:00:00Z",
+      started_at: null, dispatched_at: null, completed_at: "2026-01-16T00:01:00Z", result: null, error: null,
+      trigger_comment_id: trigger.id, delivered_comment_ids: [],
+    };
+    mockApiObj.listTimeline.mockResolvedValue([root, trigger]);
+    mockApiObj.listTasksByIssue.mockResolvedValue([task]);
+    const { container } = renderIssueDetail();
+    await screen.findByText(trigger.content);
+    await waitFor(() => expect(container.querySelector(`[data-run-comment-id="${task.id}"]`)).not.toBeNull());
+    const userReply = container.querySelector("#comment-user-reply")!;
+    const agentBlock = container.querySelector(`[data-run-comment-id="${task.id}"]`)!;
+    expect(userReply.contains(agentBlock)).toBe(false);
+    expect(userReply.nextElementSibling).toBe(agentBlock);
+    expect(within(agentBlock as HTMLElement).getByRole("button", { name: "Retry run" })).toBeInTheDocument();
+    expect(container.querySelectorAll(`[data-run-id="${task.id}"]`)).toHaveLength(1);
   });
 
   // Details is creator + immutable timestamps, so it ranks below the

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1265,14 +1265,15 @@ describe("IssueDetail (shared)", () => {
     expect(mockApiObj.listTaskMessages).toHaveBeenCalledWith(taskId);
   });
 
-  it("shows an assignment run without a trigger comment and moves its metadata to the agent reply", async () => {
+  it.each([null, "comment-1"])("shows an assignment reply once in its run slot when posted under %s", async (parentId) => {
     const task: AgentTask = {
       id: "ba2e8d1c-7f9b-4e2a-9c1d-123456789abc", agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",
       status: "queued", priority: 0, created_at: "2026-01-16T00:00:00Z",
       started_at: null, dispatched_at: null, completed_at: null, result: null, error: null,
       delivered_comment_ids: [],
     };
-    mockApiObj.listTimeline.mockResolvedValue([]);
+    const existing = { ...mockTimeline[0]!, id: "comment-1" };
+    mockApiObj.listTimeline.mockResolvedValue([existing]);
     mockApiObj.listTasksByIssue.mockResolvedValue([task]);
     mockApiObj.listTaskMessages.mockResolvedValue([
       { task_id: task.id, issue_id: "issue-1", seq: 1, type: "tool_use", tool: "exec_command", input: { command: "pnpm test" } },
@@ -1293,17 +1294,17 @@ describe("IssueDetail (shared)", () => {
     await screen.findByText("pnpm test");
     expect(container.querySelectorAll(`[data-run-id="${task.id}"]`)).toHaveLength(1);
     const reply: TimelineEntry = {
-      ...mockTimeline[1]!, id: "assignment-reply", parent_id: null, source_task_id: task.id,
+      ...mockTimeline[1]!, id: "assignment-reply", parent_id: parentId, source_task_id: task.id,
       content: "Assignment complete.", created_at: "2026-01-16T00:01:00Z",
     };
     const completed: AgentTask = { ...running, status: "completed", completed_at: reply.created_at };
     mockApiObj.listTasksByIssue.mockResolvedValue([completed]);
-    mockApiObj.listTimeline.mockResolvedValue([reply]);
+    mockApiObj.listTimeline.mockResolvedValue([existing, reply]);
     act(() => {
       queryClient.setQueryData(issueKeys.tasks("issue-1"), [completed]);
-      queryClient.setQueryData(issueKeys.timeline("issue-1"), [reply]);
+      queryClient.setQueryData(issueKeys.timeline("issue-1"), [existing, reply]);
     });
-    await screen.findByText(reply.content!);
+    await waitFor(() => expect(screen.getAllByText(reply.content!)).toHaveLength(1));
     await waitFor(() => expect(container.querySelector(`[data-run-comment-id="${task.id}"]`)).toBeNull());
     expect(container.querySelector(`[data-run-slot-id="${task.id}"]`)).toBe(assignmentSlot);
     const replyBlock = container.querySelector("#comment-assignment-reply")!;
@@ -1354,6 +1355,22 @@ describe("IssueDetail (shared)", () => {
     expect(slots[1]!.nextElementSibling?.id).toBe("comment-request-three");
     expect(container.querySelector(`[data-run-slot-id="${tasks[2]!.id}"]`)).toBe(slots[2]);
     expect(within(slots[2] as HTMLElement).getByText("Waiting for an available agent.")).toBeInTheDocument();
+  });
+
+  it("keeps a downstream run in the thread after its triggering agent reply is projected there", async () => {
+    const root = mockTimeline[0]!;
+    const first: AgentTask = { id: "ba2e8d1c-7f9b-4e2a-9c1d-123456789ab0", agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",
+      status: "completed", priority: 0, created_at: root.created_at, started_at: root.created_at, dispatched_at: null,
+      completed_at: "2026-01-16T00:01:00Z", result: null, error: null, trigger_comment_id: root.id };
+    const answer = { ...mockTimeline[1]!, id: "answer-a", parent_id: null, source_task_id: first.id, content: "Agent A response" };
+    const second: AgentTask = { ...first, id: "ba2e8d1c-7f9b-4e2a-9c1d-123456789ab1", agent_id: "agent-2", status: "queued",
+      started_at: null, completed_at: null, trigger_comment_id: answer.id };
+    mockApiObj.listTimeline.mockResolvedValue([root, answer]);
+    mockApiObj.listTasksByIssue.mockResolvedValue([first, second]);
+    const { container } = renderIssueDetail();
+    await screen.findByText(answer.content);
+    await waitFor(() => expect(container.querySelectorAll(`[data-run-id="${second.id}"]`)).toHaveLength(1));
+    expect(container.querySelector(`#comment-${root.id}`)?.querySelector(`[data-run-id="${second.id}"]`)).not.toBeNull();
   });
 
   it.each(["failed", "cancelled"] as const)("keeps a %s run outside the user reply that triggered it", async (status) => {
@@ -1869,6 +1886,20 @@ describe("IssueDetail (shared)", () => {
   });
 
   describe("highlightCommentId scroll-to-comment", () => {
+    it.each(["root", "reply"])("unfolds an assignment run with a resolved %s when a notification targets a hidden reply", async (resolved) => {
+      const run: AgentTask = { id: "ba2e8d1c-7f9b-4e2a-9c1d-123456789abc", agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",
+        status: "completed", priority: 0, created_at: "2026-01-16T00:00:00Z", started_at: null, dispatched_at: null,
+        completed_at: "2026-01-16T00:01:00Z", result: null, error: null, delivered_comment_ids: [] };
+      const root = { ...mockTimeline[1]!, id: "assigned-answer", parent_id: null, source_task_id: run.id,
+        content: "Assignment answer", resolved_at: resolved === "root" ? "2026-01-17T00:00:00Z" : null };
+      const target = { ...mockTimeline[0]!, id: "hidden-target", parent_id: root.id, content: "Hidden notification target" };
+      const resolution = { ...target, id: "resolution", content: "Resolved reply", resolved_at: "2026-01-17T00:00:00Z" };
+      mockApiObj.listTimeline.mockResolvedValue([root, target, ...(resolved === "reply" ? [resolution] : [])]);
+      mockApiObj.listTasksByIssue.mockResolvedValue([run]);
+      renderIssueDetailWithHighlight(target.id);
+      await waitFor(() => expect(document.getElementById(`comment-${target.id}`)).not.toBeNull());
+      await waitFor(() => expect(document.getElementById(`comment-${target.id}`)).toHaveClass(highlightedCommentBackgroundClass));
+    });
     it("scrolls to the highlighted comment after both issue and timeline finish loading", async () => {
       renderIssueDetailWithHighlight("comment-2");
 

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1253,15 +1253,15 @@ describe("IssueDetail (shared)", () => {
     const replyRow = container.querySelector("#comment-run-reply")!;
     await waitFor(() => expect(within(replyRow as HTMLElement).getByText("Completed")).toBeInTheDocument());
     const run = replyRow.querySelector(`[data-run-id="${taskId}"]`)!;
-    const metadata = run.querySelector('[data-slot="card"]')!;
+    expect(run.querySelector('[data-slot="card"]')).toBeNull();
     expect(container.querySelectorAll(`[data-run-id="${taskId}"]`)).toHaveLength(1);
-    expect(metadata.contains(body)).toBe(false);
+    expect(run.contains(body)).toBe(false);
     expect(replyRow.contains(body)).toBe(true);
     expect(container.querySelector(`[data-run-comment-id="${taskId}"]`)).toBeNull();
     expect(userBlock.querySelector("[data-run-id]")).toBeNull();
     expect(within(run as HTMLElement).queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
     fireEvent.click(within(run as HTMLElement).getByRole("button", { name: /View activity/ }));
-    await waitFor(() => expect(within(metadata as HTMLElement).getByText("pnpm test")).toBeInTheDocument());
+    await waitFor(() => expect(within(run as HTMLElement).getByText("pnpm test")).toBeInTheDocument());
     expect(mockApiObj.listTaskMessages).toHaveBeenCalledWith(taskId);
   });
 

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1240,15 +1240,17 @@ describe("IssueDetail (shared)", () => {
     expect(container.querySelector(`[data-run-comment-id="${taskId}"]`)).toBe(agentBlock);
     expect(userBlock.querySelector("[data-run-id]")).toBeNull();
 
+    fireEvent.click(within(agentBlock as HTMLElement).getByRole("button", { name: /View activity/ }));
+    await within(agentBlock as HTMLElement).findByRole("button", { name: "Open full log" });
+
     const reply: TimelineEntry = {
       ...mockTimeline[1]!, id: "run-reply", parent_id: root.id, source_task_id: taskId,
       content: "Review complete. The navigation is ready.",
     };
     const completed: AgentTask = { ...running, status: "completed", completed_at: "2026-01-16T00:01:00Z" };
-    mockApiObj.listTasksByIssue.mockResolvedValue([completed]);
+    mockApiObj.listTasksByIssue.mockResolvedValue([running]);
     mockApiObj.listTimeline.mockResolvedValue([root, reply]);
     act(() => {
-      client.setQueryData(issueKeys.tasks("issue-1"), [completed]);
       client.setQueryData(issueKeys.timeline("issue-1"), [root, reply]);
     });
     const body = await screen.findByText(reply.content!);
@@ -1262,7 +1264,14 @@ describe("IssueDetail (shared)", () => {
     expect(replyRow.contains(body)).toBe(true);
     expect(container.querySelector(`[data-run-comment-id="${taskId}"]`)).toBeNull();
     expect(userBlock.querySelector("[data-run-id]")).toBeNull();
-    expect(within(run as HTMLElement).queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    expect(within(replyRow as HTMLElement).queryByRole("button", { name: /View activity/ })).not.toBeInTheDocument();
+    expect(within(run as HTMLElement).getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    const logButton = within(run as HTMLElement).getByRole("button", { name: "Open full log" });
+    expect(logButton.closest("[data-comment-block]")?.querySelector("[data-run-summary-row]")).toBeNull();
+    mockApiObj.listTasksByIssue.mockResolvedValue([completed]);
+    act(() => client.setQueryData(issueKeys.tasks("issue-1"), [completed]));
+    await waitFor(() => expect(within(run as HTMLElement).queryByRole("button", { name: "Stop" })).not.toBeInTheDocument());
+    expect(within(run as HTMLElement).getByRole("button", { name: "Open full log" })).toBe(logButton);
     fireEvent.click(within(run as HTMLElement).getByRole("button", { name: "Open full log" }));
     await screen.findByRole("dialog");
     expect(mockApiObj.listTaskMessages).toHaveBeenCalledWith(taskId);
@@ -1301,10 +1310,9 @@ describe("IssueDetail (shared)", () => {
       content: "Assignment complete.", created_at: "2026-01-16T00:01:00Z",
     };
     const completed: AgentTask = { ...running, status: "completed", completed_at: reply.created_at };
-    mockApiObj.listTasksByIssue.mockResolvedValue([completed]);
+    mockApiObj.listTasksByIssue.mockResolvedValue([running]);
     mockApiObj.listTimeline.mockResolvedValue([existing, reply]);
     act(() => {
-      queryClient.setQueryData(issueKeys.tasks("issue-1"), [completed]);
       queryClient.setQueryData(issueKeys.timeline("issue-1"), [existing, reply]);
     });
     await waitFor(() => expect(screen.getAllByText(reply.content!)).toHaveLength(1));
@@ -1313,6 +1321,13 @@ describe("IssueDetail (shared)", () => {
     const replyBlock = container.querySelector("#comment-assignment-reply")!;
     expect(replyBlock.querySelector(`[data-run-id="${task.id}"]`)).not.toBeNull();
     expect(container.querySelectorAll(`[data-run-id="${task.id}"]`)).toHaveLength(1);
+    const headerLog = within(replyBlock as HTMLElement).getByRole("button", { name: "Open full log" });
+    expect(replyBlock.querySelector("[data-run-summary-row]")).toBeNull();
+    expect(within(replyBlock as HTMLElement).getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    mockApiObj.listTasksByIssue.mockResolvedValue([completed]);
+    act(() => queryClient.setQueryData(issueKeys.tasks("issue-1"), [completed]));
+    await waitFor(() => expect(within(replyBlock as HTMLElement).queryByRole("button", { name: "Stop" })).not.toBeInTheDocument());
+    expect(within(replyBlock as HTMLElement).getByRole("button", { name: "Open full log" })).toBe(headerLog);
   });
 
   it("replaces each queued run in place without moving replies behind later requests", async () => {

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1265,7 +1265,7 @@ describe("IssueDetail (shared)", () => {
     expect(container.querySelector(`[data-run-comment-id="${taskId}"]`)).toBeNull();
     expect(userBlock.querySelector("[data-run-id]")).toBeNull();
     expect(within(replyRow as HTMLElement).queryByRole("button", { name: /View activity/ })).not.toBeInTheDocument();
-    expect(within(run as HTMLElement).getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(within(run as HTMLElement).queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
     const logButton = within(run as HTMLElement).getByRole("button", { name: "Open full log" });
     expect(logButton.closest("[data-comment-block]")?.querySelector("[data-run-summary-row]")).toBeNull();
     mockApiObj.listTasksByIssue.mockResolvedValue([completed]);
@@ -1323,7 +1323,7 @@ describe("IssueDetail (shared)", () => {
     expect(container.querySelectorAll(`[data-run-id="${task.id}"]`)).toHaveLength(1);
     const headerLog = within(replyBlock as HTMLElement).getByRole("button", { name: "Open full log" });
     expect(replyBlock.querySelector("[data-run-summary-row]")).toBeNull();
-    expect(within(replyBlock as HTMLElement).getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(within(replyBlock as HTMLElement).queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
     mockApiObj.listTasksByIssue.mockResolvedValue([completed]);
     act(() => queryClient.setQueryData(issueKeys.tasks("issue-1"), [completed]));
     await waitFor(() => expect(within(replyBlock as HTMLElement).queryByRole("button", { name: "Stop" })).not.toBeInTheDocument());

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1214,7 +1214,7 @@ describe("IssueDetail (shared)", () => {
       trigger_comment_id: "comment-1", delivered_comment_ids: [],
     };
     const root = mockTimeline[0]!;
-    mockApiObj.listTimeline.mockResolvedValue([root]);
+    mockApiObj.listTimeline.mockResolvedValue([]);
     mockApiObj.listTasksByIssue.mockResolvedValue([task]);
     mockApiObj.listTaskMessages.mockResolvedValue([
       { task_id: taskId, issue_id: "issue-1", seq: 1, type: "tool_use", tool: "exec_command", input: { command: "pnpm test" } },
@@ -1227,6 +1227,11 @@ describe("IssueDetail (shared)", () => {
         </QueryClientProvider>
       </I18nProvider>,
     );
+    await waitFor(() => expect(client.getQueryData(issueKeys.tasks("issue-1"))).toEqual([task]));
+    await waitFor(() => expect(client.getQueryData(issueKeys.timeline("issue-1"))).toEqual([]));
+    expect(container.querySelector(`[data-run-id="${taskId}"]`)).toBeNull();
+    mockApiObj.listTimeline.mockResolvedValue([root]);
+    act(() => client.setQueryData(issueKeys.timeline("issue-1"), [root]));
     await screen.findByText("Waiting for an available agent.");
     const userBlock = container.querySelector(`#comment-body-${root.id}`)!.parentElement!;
     const agentBlock = container.querySelector(`[data-run-comment-id="${taskId}"]`)!;

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -80,7 +80,7 @@ import { ProjectPicker } from "../../projects/components/project-picker";
 import { LocalDirectoryHint } from "../../projects/components/local-directory-hint";
 import { useNewRunIds } from "./use-run-comment-motion";
 import { AgentRunComment, CommentCard } from "./comment-card";
-import { EMPTY_COMMENT_RUNS, buildCommentRunView, standaloneCommentRuns, type CommentRun } from "./comment-runs";
+import { EMPTY_COMMENT_RUNS, buildCommentRunView, type CommentRun } from "./comment-runs";
 import { issueTasksOptions } from "@multica/core/issues/queries";
 import { SourceContextBadge } from "./source-context-viewer";
 import { RevisionConflictCompare } from "./revision-conflict-compare";
@@ -1433,12 +1433,11 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const { data: commentTasks } = useQuery(issueTasksOptions(id));
   const enteringRunIds = useNewRunIds(id, commentTasks);
   const previousCommentRuns = useRef(new Map<string, CommentRun[]>());
-  const { runs: commentRuns, timeline: displayTimeline } = useMemo(() => {
+  const { runs: commentRuns, timeline: displayTimeline, standaloneRuns } = useMemo(() => {
     const next = buildCommentRunView(commentTasks ?? [], timeline, previousCommentRuns.current);
     previousCommentRuns.current = next.runs;
     return next;
   }, [commentTasks, timeline]);
-  const standaloneRuns = useMemo(() => standaloneCommentRuns(commentTasks ?? [], commentRuns), [commentTasks, commentRuns]);
 
   // Resolve / unresolve must always clear the per-session expand entry so
   // re-resolving an already-expanded thread folds it back to the bar (the

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -80,7 +80,7 @@ import { ProjectPicker } from "../../projects/components/project-picker";
 import { LocalDirectoryHint } from "../../projects/components/local-directory-hint";
 import { useNewRunIds } from "./use-run-comment-motion";
 import { AgentRunComment, CommentCard } from "./comment-card";
-import { EMPTY_COMMENT_RUNS, groupCommentRuns, standaloneCommentRuns, type CommentRun } from "./comment-runs";
+import { EMPTY_COMMENT_RUNS, buildCommentRunView, standaloneCommentRuns, type CommentRun } from "./comment-runs";
 import { issueTasksOptions } from "@multica/core/issues/queries";
 import { SourceContextBadge } from "./source-context-viewer";
 import { RevisionConflictCompare } from "./revision-conflict-compare";
@@ -1433,9 +1433,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const { data: commentTasks } = useQuery(issueTasksOptions(id));
   const enteringRunIds = useNewRunIds(id, commentTasks);
   const previousCommentRuns = useRef(new Map<string, CommentRun[]>());
-  const commentRuns = useMemo(() => {
-    const next = groupCommentRuns(commentTasks ?? [], timeline, previousCommentRuns.current);
-    previousCommentRuns.current = next;
+  const { runs: commentRuns, timeline: displayTimeline } = useMemo(() => {
+    const next = buildCommentRunView(commentTasks ?? [], timeline, previousCommentRuns.current);
+    previousCommentRuns.current = next.runs;
     return next;
   }, [commentTasks, timeline]);
   const standaloneRuns = useMemo(() => standaloneCommentRuns(commentTasks ?? [], commentRuns), [commentTasks, commentRuns]);
@@ -1450,13 +1450,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       // Fold the thread back on any resolve change: clear the thread ROOT's
       // expand entry (expand state is keyed on root id, but a resolve target
       // can be a reply). Walk parent_id up to the root.
-      const byId = new Map(timeline.map((e) => [e.id, e]));
+      const byId = new Map(displayTimeline.map((e) => [e.id, e]));
       let cur = byId.get(commentId);
       while (cur?.parent_id && byId.get(cur.parent_id)) cur = byId.get(cur.parent_id)!;
       clearResolvedExpand(cur?.id ?? commentId);
       toggleResolveComment(commentId, resolved);
     },
-    [timeline, clearResolvedExpand, toggleResolveComment],
+    [displayTimeline, clearResolvedExpand, toggleResolveComment],
   );
 
   // Memoized timeline grouping. Each render rebuilds the per-parent map from
@@ -1474,16 +1474,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     // bucketed under their parent's id and rendered nested inside CommentCard.
     // No orphan rescue needed: the timeline is fetched in full, so every
     // reply's parent is always in the same array.
-    // A task-owned reply occupies its run slot even if the agent posted it
-    // top-level instead of using the trigger's thread as its API parent.
-    const replyParents = new Map([...commentRuns.values()].flatMap((runs) => runs.flatMap((run) =>
-      run.hasReply && run.anchorCommentId && run.commentId && run.commentId !== run.anchorCommentId
-        ? [[run.commentId, run.anchorCommentId] as const] : [],
-    )));
-    const displayTimeline = timeline.map((entry) => {
-      const parentId = replyParents.get(entry.id);
-      return parentId && entry.parent_id !== parentId ? { ...entry, parent_id: parentId } : entry;
-    });
     const topLevel = displayTimeline.filter(
       (e) => e.type === "activity" || !e.parent_id,
     );
@@ -1554,7 +1544,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     const groups: RawTimelineGroup[] = [];
     for (const entry of coalesced) {
       if ("task" in entry) {
-        groups.push({ type: "run", run: entry, entry: entry.hasReply ? timeline.find((comment) => comment.id === entry.commentId) : undefined });
+        groups.push({ type: "run", run: entry, entry: entry.hasReply ? displayTimeline.find((comment) => comment.id === entry.commentId) : undefined });
       } else if (entry.type === "activity") {
         const last = groups[groups.length - 1];
         if (last?.type === "activities") {
@@ -1568,7 +1558,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     }
 
     return { threadReplies, groups };
-  }, [timeline, standaloneRuns, commentRuns]);
+  }, [displayTimeline, standaloneRuns]);
 
   // Flat array consumed by <Virtuoso>. Recomputed when timelineView.groups
   // changes (timeline events) or expandedResolved flips (user toggles a
@@ -1911,14 +1901,14 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     const rootId = replyToRoot.get(highlightCommentId);
     if (rootId && rootId !== highlightCommentId) {
       // Root resolved → the whole thread is a folded bar.
-      if (items[targetIdx]?.kind === "resolved-bar") {
+      const rootItem = items[targetIdx];
+      if (rootItem?.kind === "resolved-bar" || (rootItem?.kind === "run" && rootItem.entry?.resolved_at && !expandedResolved.has(rootId))) {
         toggleResolvedExpand(rootId, true);
         return;
       }
       // A reply is the resolution → the other replies fold behind the
       // "N comments" bar; expand if the target is one of those folded replies.
-      const rootItem = items[targetIdx];
-      if (rootItem?.kind === "comment" && !expandedResolved.has(rootId)) {
+      if ((rootItem?.kind === "comment" || rootItem?.kind === "run") && rootItem.entry && !expandedResolved.has(rootId)) {
         const resolution = deriveThreadResolution(
           rootItem.entry,
           timelineView.threadReplies.get(rootId) ?? EMPTY_REPLIES,

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -78,7 +78,10 @@ import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 import { SubIssuesAgentWorkingChip } from "./sub-issues-agent-working-chip";
 import { ProjectPicker } from "../../projects/components/project-picker";
 import { LocalDirectoryHint } from "../../projects/components/local-directory-hint";
-import { CommentCard } from "./comment-card";
+import { useNewRunIds } from "./use-run-comment-motion";
+import { AgentRunComment, CommentCard } from "./comment-card";
+import { EMPTY_COMMENT_RUNS, groupCommentRuns, standaloneCommentRuns, type CommentRun } from "./comment-runs";
+import { issueTasksOptions } from "@multica/core/issues/queries";
 import { SourceContextBadge } from "./source-context-viewer";
 import { RevisionConflictCompare } from "./revision-conflict-compare";
 import { CommentInput } from "./comment-input";
@@ -454,6 +457,7 @@ function shallowEqualEntries(a: TimelineEntry[], b: TimelineEntry[]): boolean {
 // into one activity-group row) but project it into a discriminated union
 // the itemContent dispatcher can switch on.
 type TimelineItem =
+  | { kind: "run"; id: string; run: CommentRun; entry?: TimelineEntry }
   | { kind: "comment"; id: string; entry: TimelineEntry }
   | { kind: "resolved-bar"; id: string; entry: TimelineEntry }
   | { kind: "activity-group"; id: string; entries: TimelineEntry[] };
@@ -461,7 +465,7 @@ type TimelineItem =
 type RawTimelineGroup = {
   type: "comment" | "activities";
   entries: TimelineEntry[];
-};
+} | { type: "run"; run: CommentRun; entry?: TimelineEntry };
 
 function flattenGroups(
   groups: ReadonlyArray<RawTimelineGroup>,
@@ -469,7 +473,9 @@ function flattenGroups(
 ): TimelineItem[] {
   const out: TimelineItem[] = [];
   for (const group of groups) {
-    if (group.type === "comment") {
+    if (group.type === "run") {
+      out.push({ kind: "run", id: group.entry?.id ?? group.run.task.id, run: group.run, entry: group.entry });
+    } else if (group.type === "comment") {
       const entry = group.entries[0]!;
       const isResolved = !!entry.resolved_at;
       const isExpanded = expandedResolved.has(entry.id);
@@ -1424,6 +1430,16 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     editComment, deleteComment, toggleResolveComment, toggleReaction: handleToggleReaction,
   } = useIssueTimeline(id, user?.id);
 
+  const { data: commentTasks } = useQuery(issueTasksOptions(id));
+  const enteringRunIds = useNewRunIds(id, commentTasks);
+  const previousCommentRuns = useRef(new Map<string, CommentRun[]>());
+  const commentRuns = useMemo(() => {
+    const next = groupCommentRuns(commentTasks ?? [], timeline, previousCommentRuns.current);
+    previousCommentRuns.current = next;
+    return next;
+  }, [commentTasks, timeline]);
+  const standaloneRuns = useMemo(() => standaloneCommentRuns(commentTasks ?? [], commentRuns), [commentTasks, commentRuns]);
+
   // Resolve / unresolve must always clear the per-session expand entry so
   // re-resolving an already-expanded thread folds it back to the bar (the
   // expand Set is keyed only on commentId, not on resolution state). Without
@@ -1458,11 +1474,21 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     // bucketed under their parent's id and rendered nested inside CommentCard.
     // No orphan rescue needed: the timeline is fetched in full, so every
     // reply's parent is always in the same array.
-    const topLevel = timeline.filter(
+    // A task-owned reply occupies its run slot even if the agent posted it
+    // top-level instead of using the trigger's thread as its API parent.
+    const replyParents = new Map([...commentRuns.values()].flatMap((runs) => runs.flatMap((run) =>
+      run.hasReply && run.anchorCommentId && run.commentId && run.commentId !== run.anchorCommentId
+        ? [[run.commentId, run.anchorCommentId] as const] : [],
+    )));
+    const displayTimeline = timeline.map((entry) => {
+      const parentId = replyParents.get(entry.id);
+      return parentId && entry.parent_id !== parentId ? { ...entry, parent_id: parentId } : entry;
+    });
+    const topLevel = displayTimeline.filter(
       (e) => e.type === "activity" || !e.parent_id,
     );
     const repliesByParent = new Map<string, TimelineEntry[]>();
-    for (const e of timeline) {
+    for (const e of displayTimeline) {
       if (e.type === "comment" && e.parent_id) {
         const list = repliesByParent.get(e.parent_id) ?? [];
         list.push(e);
@@ -1493,13 +1519,24 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     const COALESCE_MS = 2 * 60 * 1000;
     const NO_TIME_LIMIT_ACTIONS = new Set(["task_completed", "task_failed"]);
     const NEVER_COALESCE_ACTIONS = new Set(["squad_leader_evaluated"]);
-    const coalesced: TimelineEntry[] = [];
-    for (const entry of topLevel) {
+    // Unanchored runs separate activity groups at their actual start position.
+    const standaloneReplyIds = new Set(standaloneRuns.filter((run) => run.hasReply).map((run) => run.commentId));
+    const chronological = [...topLevel.filter((entry) => !standaloneReplyIds.has(entry.id)), ...standaloneRuns].sort((a, b) => {
+      const left = "task" in a ? a.task : a;
+      const right = "task" in b ? b.task : b;
+      return Date.parse(left.created_at) - Date.parse(right.created_at);
+    });
+    const coalesced: (TimelineEntry | CommentRun)[] = [];
+    for (const entry of chronological) {
+      if ("task" in entry) {
+        coalesced.push(entry);
+        continue;
+      }
       if (entry.type === "activity") {
         const prev = coalesced[coalesced.length - 1];
         if (
           !NEVER_COALESCE_ACTIONS.has(entry.action!) &&
-          prev?.type === "activity" &&
+          prev && !("task" in prev) && prev.type === "activity" &&
           prev.action === entry.action &&
           prev.actor_type === entry.actor_type &&
           prev.actor_id === entry.actor_id &&
@@ -1514,9 +1551,11 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     }
 
     // Group consecutive activities together so the connector line works
-    const groups: { type: "activities" | "comment"; entries: TimelineEntry[] }[] = [];
+    const groups: RawTimelineGroup[] = [];
     for (const entry of coalesced) {
-      if (entry.type === "activity") {
+      if ("task" in entry) {
+        groups.push({ type: "run", run: entry, entry: entry.hasReply ? timeline.find((comment) => comment.id === entry.commentId) : undefined });
+      } else if (entry.type === "activity") {
         const last = groups[groups.length - 1];
         if (last?.type === "activities") {
           last.entries.push(entry);
@@ -1529,7 +1568,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     }
 
     return { threadReplies, groups };
-  }, [timeline]);
+  }, [timeline, standaloneRuns, commentRuns]);
 
   // Flat array consumed by <Virtuoso>. Recomputed when timelineView.groups
   // changes (timeline events) or expandedResolved flips (user toggles a
@@ -1601,7 +1640,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const minimapThreads = useMemo<ThreadMinimapThread[]>(
     () =>
       items.flatMap((it) => {
-        if (it.kind !== "comment" && it.kind !== "resolved-bar") return [];
+        if (it.kind === "activity-group" || !it.entry) return [];
         const replies = timelineView.threadReplies.get(it.id) ?? EMPTY_REPLIES;
         return [
           {
@@ -2005,7 +2044,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       { content: issue?.description, attachments: descEditorAttachments },
     ];
     for (const item of items) {
-      if (item.kind === "activity-group") continue;
+      if (item.kind === "activity-group" || !item.entry) continue;
       blocks.push({
         content: item.entry.content,
         attachments: item.entry.attachments,
@@ -2587,6 +2626,25 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // The wrapper `id="comment-..."` is the deep-link target — equivalent to
   // a native `<a href="#comment-...">` anchor.
   const renderItem = (_i: number, item: TimelineItem): React.ReactElement => {
+    if (item.kind === "run") {
+      const reply = item.entry;
+      return <div className="pb-3" id={reply ? `comment-${reply.id}` : undefined}>
+        {reply?.resolved_at && !expandedResolved.has(reply.id) ? <ResolvedThreadBar
+          entry={reply} replies={timelineView.threadReplies.get(reply.id) ?? EMPTY_REPLIES}
+          onExpand={() => toggleResolvedExpand(reply.id, true)} /> : <AgentRunComment run={item.run} entering={enteringRunIds.has(item.run.task.id)} standalone
+          commentProps={reply ? {
+            issueId: id, entry: reply, replies: timelineView.threadReplies.get(reply.id) ?? EMPTY_REPLIES,
+            currentUserId: user?.id, canModerate: canModerateComments, onReply: submitReply,
+            onReplyAccepted: scrollToTimelineBottom, onEdit: editComment, onDelete: deleteComment,
+            onToggleReaction: handleToggleReaction, onCreateSubIssue: openCommentSubIssue,
+            onResolveToggle: handleResolveToggle,
+            onCollapseResolved: reply.resolved_at ? () => toggleResolvedExpand(reply.id, false) : undefined,
+            expandedResolvedIds: expandedResolved, onResolvedExpandChange: toggleResolvedExpand,
+            highlightedCommentId: highlightedId,
+            runs: commentRuns.get(reply.id) ?? EMPTY_COMMENT_RUNS, enteringRunIds,
+          } : undefined} />}
+      </div>;
+    }
     if (item.kind === "resolved-bar") {
       return (
         <div className="pb-3" id={`comment-${item.id}`}>
@@ -2604,6 +2662,8 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
         <div className="pb-3" id={`comment-${item.id}`}>
           <CommentCard
             issueId={id}
+            runs={commentRuns.get(item.id) ?? EMPTY_COMMENT_RUNS}
+            enteringRunIds={enteringRunIds}
             entry={item.entry}
             replies={timelineView.threadReplies.get(item.id) ?? EMPTY_REPLIES}
             currentUserId={user?.id}
@@ -3331,7 +3391,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       data={items}
                       initialScrollTop={restoredScrollTop}
                       increaseViewportBy={{ top: 800, bottom: 800 }}
-                      computeItemKey={(_i, item) => `${item.kind}:${item.id}`}
+                      computeItemKey={(_i, item) => `${item.kind}:${item.kind === "run" ? item.run.task.id : item.id}`}
                       skipAnimationFrameInResizeObserver
                       // followOutput intentionally NOT set. Virtuoso treats
                       // it as a sticky "is at bottom" flag and resets
@@ -3344,7 +3404,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               ) : (
                 <div className="mt-4">
                   {items.map((item, i) => (
-                    <Fragment key={`${item.kind}:${item.id}`}>
+                    <Fragment key={`${item.kind}:${item.kind === "run" ? item.run.task.id : item.id}`}>
                       {renderItem(i, item)}
                     </Fragment>
                   ))}

--- a/packages/views/issues/components/use-run-comment-motion.test.tsx
+++ b/packages/views/issues/components/use-run-comment-motion.test.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { cleanup, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentTask } from "@multica/core/types";
+import { useNewRunIds, useRunCommentMotion, useRunDisclosureMotion } from "./use-run-comment-motion";
+
+const animate = vi.fn((_frames: Keyframe[], _options: KeyframeAnimationOptions) => ({ cancel: vi.fn() }));
+const originalAnimate = Object.getOwnPropertyDescriptor(Element.prototype, "animate");
+let reduced = false;
+beforeEach(() => {
+  reduced = false;
+  animate.mockClear();
+  Object.defineProperty(Element.prototype, "animate", { configurable: true, value: animate });
+  vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: reduced })));
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  if (originalAnimate) Object.defineProperty(Element.prototype, "animate", originalAnimate);
+  else Reflect.deleteProperty(Element.prototype, "animate");
+  vi.unstubAllGlobals();
+});
+
+function task(id: string): AgentTask {
+  return { id, issue_id: "issue", agent_id: "agent", runtime_id: "runtime", status: "queued", priority: 0,
+    created_at: "2026-09-07T00:00:00Z", started_at: null, dispatched_at: null, completed_at: null, result: null, error: null };
+}
+
+function Slot({ entering = false, replyId, status = "queued" }: { entering?: boolean; replyId?: string; status?: string }) {
+  const ref = useRunCommentMotion(entering, replyId, status);
+  return <div ref={ref}><span data-run-status>{status}</span><div data-comment-content={replyId}>Reply</div></div>;
+}
+function Disclosure() {
+  const [open, setOpen] = useState(false);
+  const motion = useRunDisclosureMotion(open);
+  return <>
+    <button key={String(open)} onClick={(event) => { motion.onTrigger(event); setOpen(!open); }}>
+      <svg ref={motion.chevronRef} style={{ rotate: open ? "90deg" : "0deg" }} />Toggle
+    </button>
+    {open && <div ref={motion.contentRef}>Activity</div>}
+  </>;
+}
+
+describe("run comment motion", () => {
+  it("marks only runs added after the initial snapshot and resets across issues", async () => {
+    const old = task("old");
+    const added = task("new");
+    const { result, rerender } = renderHook(({ issueId, tasks }: { issueId: string; tasks?: AgentTask[] }) => useNewRunIds(issueId, tasks),
+      { initialProps: { issueId: "first", tasks: undefined } as { issueId: string; tasks?: AgentTask[] } });
+    rerender({ issueId: "first", tasks: [old] });
+    expect(result.current.size).toBe(0);
+    rerender({ issueId: "first", tasks: [old, added] });
+    await waitFor(() => expect([...result.current]).toEqual(["new"]));
+    const marked = result.current;
+    rerender({ issueId: "first", tasks: [old, { ...added, status: "running" }] });
+    expect(result.current).toBe(marked);
+    rerender({ issueId: "second", tasks: [task("other")] });
+    expect(result.current.size).toBe(0);
+  });
+
+  it("animates live arrival once and never replays on a virtualized remount", () => {
+    const view = render(<Slot />);
+    expect(animate).not.toHaveBeenCalled();
+    view.rerender(<Slot entering />);
+    expect(animate).toHaveBeenCalledWith(
+      [{ opacity: 0, transform: "translateY(4px)" }, { opacity: 1, transform: "translateY(0)" }],
+      expect.objectContaining({ duration: 160 }),
+    );
+    view.rerender(<Slot entering />);
+    expect(animate).toHaveBeenCalledTimes(1);
+    const animation = animate.mock.results[0]!.value;
+    view.unmount();
+    expect(animation.cancel).toHaveBeenCalled();
+    animate.mockClear();
+    render(<Slot entering />);
+    expect(animate).not.toHaveBeenCalled();
+  });
+
+  it("fades only the arriving reply and changed status, not routine rerenders", () => {
+    const view = render(<Slot status="running" />);
+    view.rerender(<Slot status="completed" replyId="reply" />);
+    expect(animate.mock.instances).toEqual([screen.getByText("Reply"), screen.getByText("completed")]);
+    expect(animate.mock.calls.map((call) => call[1].duration)).toEqual([160, 100]);
+    view.rerender(<Slot status="completed" replyId="reply" />);
+    expect(animate).toHaveBeenCalledTimes(2);
+    view.unmount();
+    animate.mockClear();
+    render(<Slot status="completed" replyId="reply" />);
+    expect(animate).not.toHaveBeenCalled();
+  });
+
+  it("keeps reduced motion to a short fade without displacement", () => {
+    reduced = true;
+    const view = render(<Slot />);
+    view.rerender(<Slot entering />);
+    expect(animate).toHaveBeenCalledWith([{ opacity: 0 }, { opacity: 1 }], expect.objectContaining({ duration: 60 }));
+  });
+
+  it("fades pointer disclosure once and keeps keyboard disclosure immediate", () => {
+    render(<Disclosure />);
+    const toggle = () => screen.getByRole("button", { name: "Toggle" });
+    fireEvent.click(toggle(), { detail: 1 });
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(animate).toHaveBeenCalledWith(
+      [{ opacity: 0, transform: "translateY(-4px)" }, { opacity: 1, transform: "translateY(0)" }],
+      expect.objectContaining({ duration: 180 }),
+    );
+    expect(animate).toHaveBeenCalledWith([{ rotate: "0deg" }, { rotate: "90deg" }], expect.objectContaining({ duration: 180 }));
+    fireEvent.click(toggle(), { detail: 1 });
+    expect(animate).toHaveBeenCalledWith([{ rotate: "90deg" }, { rotate: "0deg" }], expect.objectContaining({ duration: 120 }));
+    animate.mockClear();
+    fireEvent.click(toggle(), { detail: 0 });
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(animate).not.toHaveBeenCalled();
+  });
+
+  it("uses only a short content fade for reduced-motion disclosure", () => {
+    reduced = true;
+    render(<Disclosure />);
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }), { detail: 1 });
+    expect(animate).toHaveBeenCalledTimes(1);
+    expect(animate).toHaveBeenCalledWith([{ opacity: 0 }, { opacity: 1 }], expect.objectContaining({ duration: 60 }));
+  });
+
+  it("reverses a rapid toggle from the visible arrow angle and cancels stale motion", () => {
+    render(<Disclosure />);
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }), { detail: 1 });
+    const firstAnimations = animate.mock.results.map((result) => result.value);
+    const toggle = screen.getByRole("button", { name: "Toggle" });
+    const computed = getComputedStyle(toggle.querySelector("svg")!);
+    computed.rotate = "42deg";
+    const style = vi.spyOn(window, "getComputedStyle").mockReturnValue(computed);
+    fireEvent.click(toggle, { detail: 1 });
+    expect(animate).toHaveBeenLastCalledWith([{ rotate: "42deg" }, { rotate: "0deg" }], expect.objectContaining({ duration: 120 }));
+    for (const animation of firstAnimations) expect(animation.cancel).toHaveBeenCalled();
+    style.mockRestore();
+  });
+});

--- a/packages/views/issues/components/use-run-comment-motion.ts
+++ b/packages/views/issues/components/use-run-comment-motion.ts
@@ -62,10 +62,16 @@ export function useRunDisclosureMotion(open: boolean) {
   const contentRef = useRef<HTMLDivElement>(null);
   const chevronRef = useRef<SVGSVGElement>(null);
   const pending = useRef(false);
+  const focusedTrigger = useRef<HTMLElement | null>(null);
   const fromRotation = useRef("0deg");
   useLayoutEffect(() => {
     const requested = pending.current;
     pending.current = false;
+    const previousTrigger = focusedTrigger.current;
+    focusedTrigger.current = null;
+    if (previousTrigger && !previousTrigger.isConnected && document.activeElement === document.body) {
+      chevronRef.current?.closest<HTMLElement>("button, summary")?.focus({ preventScroll: true });
+    }
     if (!requested) return;
     const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
     const duration = open ? 180 : 120;
@@ -81,6 +87,7 @@ export function useRunDisclosureMotion(open: boolean) {
     chevronRef,
     onTrigger(event: MouseEvent<HTMLElement>) {
       pending.current = event.detail > 0;
+      focusedTrigger.current = event.detail === 0 && document.activeElement === event.currentTarget ? event.currentTarget : null;
       // Sample before React cancels the previous animation or replaces the
       // trigger, so rapid reversals start at the currently visible angle.
       const rotation = chevronRef.current ? getComputedStyle(chevronRef.current).rotate : undefined;

--- a/packages/views/issues/components/use-run-comment-motion.ts
+++ b/packages/views/issues/components/use-run-comment-motion.ts
@@ -1,0 +1,90 @@
+import { useEffect, useLayoutEffect, useRef, useState, type MouseEvent } from "react";
+import type { AgentTask } from "@multica/core/types";
+
+const EMPTY_IDS: ReadonlySet<string> = new Set();
+const EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+
+function reveal(element: HTMLElement | null, duration: number, translate = 0) {
+  if (!element?.animate) return;
+  const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+  return element.animate(
+    translate && !reduced
+      ? [{ opacity: 0, transform: `translateY(${translate}px)` }, { opacity: 1, transform: "translateY(0)" }]
+      : [{ opacity: 0 }, { opacity: 1 }],
+    { duration: reduced ? 60 : duration, easing: EASING },
+  );
+}
+
+/** Mark additions after the initial query, not existing history or route restoration. */
+export function useNewRunIds(issueId: string, tasks: readonly AgentTask[] | undefined) {
+  const known = useRef<{ issueId: string; ids: Set<string> } | null>(null);
+  const [arrivals, setArrivals] = useState<{ issueId: string; ids: ReadonlySet<string> }>({ issueId, ids: EMPTY_IDS });
+  useEffect(() => {
+    if (!tasks) return;
+    if (!known.current || known.current.issueId !== issueId) {
+      known.current = { issueId, ids: new Set(tasks.map((task) => task.id)) };
+      setArrivals((previous) => previous.issueId === issueId && previous.ids === EMPTY_IDS
+        ? previous : { issueId, ids: EMPTY_IDS });
+      return;
+    }
+    const added = tasks.filter((task) => !known.current!.ids.has(task.id));
+    if (added.length === 0) return;
+    for (const task of added) known.current.ids.add(task.id);
+    setArrivals((previous) => ({ issueId, ids: new Set([
+      ...(previous.issueId === issueId ? previous.ids : EMPTY_IDS), ...added.map((task) => task.id),
+    ]) }));
+  }, [issueId, tasks]);
+  return arrivals.issueId === issueId ? arrivals.ids : EMPTY_IDS;
+}
+
+/** Animate observed changes only. A virtualized row's first mount is always still. */
+export function useRunCommentMotion(entering: boolean, replyId: string | undefined, status: string) {
+  const ref = useRef<HTMLDivElement>(null);
+  const previous = useRef({ entering, replyId, status });
+  useLayoutEffect(() => {
+    const before = previous.current;
+    previous.current = { entering, replyId, status };
+    const animations: (Animation | undefined)[] = [];
+    if (entering && !before.entering) animations.push(reveal(ref.current, 160, 4));
+    if (replyId && replyId !== before.replyId) {
+      const body = Array.from(ref.current?.querySelectorAll<HTMLElement>("[data-comment-content]") ?? [])
+        .find((element) => element.dataset.commentContent === replyId);
+      animations.push(reveal(body ?? null, 160));
+    }
+    if (status !== before.status) animations.push(reveal(ref.current?.querySelector("[data-run-status]") ?? null, 100));
+    return () => { for (const animation of animations) animation?.cancel(); };
+  }, [entering, replyId, status]);
+  return ref;
+}
+
+/** Animate the toggle itself, including when historical runs mount a new trigger. */
+export function useRunDisclosureMotion(open: boolean) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const chevronRef = useRef<SVGSVGElement>(null);
+  const pending = useRef(false);
+  const fromRotation = useRef("0deg");
+  useLayoutEffect(() => {
+    const requested = pending.current;
+    pending.current = false;
+    if (!requested) return;
+    const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    const duration = open ? 180 : 120;
+    const arrow = !reduced ? chevronRef.current?.animate?.(
+      [{ rotate: fromRotation.current }, { rotate: open ? "90deg" : "0deg" }],
+      { duration, easing: EASING },
+    ) : undefined;
+    const content = open ? reveal(contentRef.current, duration, -4) : undefined;
+    return () => { arrow?.cancel(); content?.cancel(); };
+  }, [open]);
+  return {
+    contentRef,
+    chevronRef,
+    onTrigger(event: MouseEvent<HTMLElement>) {
+      pending.current = event.detail > 0;
+      // Sample before React cancels the previous animation or replaces the
+      // trigger, so rapid reversals start at the currently visible angle.
+      const rotation = chevronRef.current ? getComputedStyle(chevronRef.current).rotate : undefined;
+      fromRotation.current = rotation && rotation !== "none" ? rotation : open ? "90deg" : "0deg";
+    },
+  };
+}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -1,4 +1,26 @@
 {
+  "inline_run": {
+    "label": "{{name}} run",
+    "stop": "Stop",
+    "stopping": "Stopping...",
+    "queued": "Waiting for an available agent.",
+    "starting": "Preparing the agent session.",
+    "waiting_directory": "Waiting for another run to release the working directory.",
+    "thinking": "Thinking",
+    "waiting_response": "Waiting for the agent to respond.",
+    "view_activity": "View activity",
+    "steps_one": "{{count}} step",
+    "steps_other": "{{count}} steps",
+    "loading": "Loading activity...",
+    "load_failed": "Could not load activity.",
+    "try_again": "Try again",
+    "empty": "No activity recorded yet.",
+    "show_earlier": "Show {{count}} earlier steps",
+    "full_log": "Open full log",
+    "message": "Agent message",
+    "error": "Error",
+    "waiting_result": "Waiting for the tool result..."
+  },
   "status_catalog_error": {
     "title": "Couldn't load the status list",
     "hint": "Issues are hidden until it loads, because a status filter can't be applied without it.",

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -481,6 +481,7 @@
     "show_more_activities_other": "Show {{count}} more activities"
   },
   "comment": {
+    "add_reaction": "Add reaction",
     "collapse_thread": "Collapse thread",
     "expand_thread": "Expand thread",
     "delete_title": "Delete comment",

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -481,6 +481,8 @@
     "show_more_activities_other": "Show {{count}} more activities"
   },
   "comment": {
+    "collapse_thread": "Collapse thread",
+    "expand_thread": "Expand thread",
     "delete_title": "Delete comment",
     "delete_desc": "This comment will be permanently deleted. This cannot be undone.",
     "delete_desc_with_replies": "This comment and all its replies will be permanently deleted. This cannot be undone.",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -472,6 +472,7 @@
     "show_more_activities_other": "アクティビティをさらに {{count}} 件表示"
   },
   "comment": {
+    "add_reaction": "リアクションを追加",
     "collapse_thread": "スレッドを折りたたむ",
     "expand_thread": "スレッドを展開",
     "delete_title": "コメントを削除",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -472,6 +472,8 @@
     "show_more_activities_other": "アクティビティをさらに {{count}} 件表示"
   },
   "comment": {
+    "collapse_thread": "スレッドを折りたたむ",
+    "expand_thread": "スレッドを展開",
     "delete_title": "コメントを削除",
     "delete_desc": "このコメントは完全に削除されます。この操作は元に戻せません。",
     "delete_desc_with_replies": "このコメントとすべての返信が完全に削除されます。この操作は元に戻せません。",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -1,4 +1,25 @@
 {
+  "inline_run": {
+    "label": "{{name}} の実行",
+    "stop": "停止",
+    "stopping": "停止中...",
+    "queued": "利用可能なエージェントを待っています。",
+    "starting": "エージェントのセッションを準備しています。",
+    "waiting_directory": "別の実行が作業ディレクトリを解放するのを待っています。",
+    "thinking": "思考中",
+    "waiting_response": "エージェントの応答を待っています。",
+    "view_activity": "実行過程を表示",
+    "steps_other": "{{count}} ステップ",
+    "loading": "実行過程を読み込み中...",
+    "load_failed": "実行過程を読み込めませんでした。",
+    "try_again": "再試行",
+    "empty": "実行記録はまだありません。",
+    "show_earlier": "前の {{count}} ステップを表示",
+    "full_log": "完全なログを開く",
+    "message": "エージェントのメッセージ",
+    "error": "エラー",
+    "waiting_result": "ツールの結果を待っています..."
+  },
   "status_catalog_error": {
     "title": "ステータス一覧を読み込めませんでした",
     "hint": "これがないとステータスの絞り込みを適用できないため、タスクは表示されません。",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -1,4 +1,25 @@
 {
+  "inline_run": {
+    "label": "{{name}} 실행",
+    "stop": "중지",
+    "stopping": "중지 중...",
+    "queued": "사용 가능한 에이전트를 기다리고 있습니다.",
+    "starting": "에이전트 세션을 준비하고 있습니다.",
+    "waiting_directory": "다른 실행이 작업 디렉터리를 해제할 때까지 기다리고 있습니다.",
+    "thinking": "생각 중",
+    "waiting_response": "에이전트의 응답을 기다리고 있습니다.",
+    "view_activity": "실행 과정 보기",
+    "steps_other": "{{count}}단계",
+    "loading": "실행 과정 불러오는 중...",
+    "load_failed": "실행 과정을 불러올 수 없습니다.",
+    "try_again": "다시 시도",
+    "empty": "아직 실행 기록이 없습니다.",
+    "show_earlier": "이전 {{count}}단계 보기",
+    "full_log": "전체 로그 열기",
+    "message": "에이전트 메시지",
+    "error": "오류",
+    "waiting_result": "도구 결과를 기다리고 있습니다..."
+  },
   "status_catalog_error": {
     "title": "상태 목록을 불러오지 못했습니다",
     "hint": "이것 없이는 상태 필터를 적용할 수 없어 태스크를 표시하지 않습니다.",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -472,6 +472,7 @@
     "show_more_activities_other": "활동 {{count}}개 더 보기"
   },
   "comment": {
+    "add_reaction": "반응 추가",
     "collapse_thread": "스레드 접기",
     "expand_thread": "스레드 펼치기",
     "delete_title": "댓글 삭제",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -472,6 +472,8 @@
     "show_more_activities_other": "활동 {{count}}개 더 보기"
   },
   "comment": {
+    "collapse_thread": "스레드 접기",
+    "expand_thread": "스레드 펼치기",
     "delete_title": "댓글 삭제",
     "delete_desc": "이 댓글이 영구 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
     "delete_desc_with_replies": "이 댓글과 모든 답글이 영구 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -1,4 +1,25 @@
 {
+  "inline_run": {
+    "label": "{{name}} 的运行",
+    "stop": "停止",
+    "stopping": "正在停止...",
+    "queued": "等待可用的智能体。",
+    "starting": "正在准备智能体会话。",
+    "waiting_directory": "等待其他运行释放工作目录。",
+    "thinking": "思考中",
+    "waiting_response": "等待智能体响应。",
+    "view_activity": "查看执行过程",
+    "steps_other": "{{count}} 个步骤",
+    "loading": "正在加载执行过程...",
+    "load_failed": "无法加载执行过程。",
+    "try_again": "重试",
+    "empty": "暂无执行记录。",
+    "show_earlier": "显示前面的 {{count}} 个步骤",
+    "full_log": "打开完整日志",
+    "message": "智能体消息",
+    "error": "错误",
+    "waiting_result": "等待工具返回结果..."
+  },
   "status_catalog_error": {
     "title": "状态列表加载失败",
     "hint": "没有它就无法应用状态筛选，因此暂时不显示任务。",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -472,6 +472,8 @@
     "show_more_activities_other": "展开更早 {{count}} 条动态"
   },
   "comment": {
+    "collapse_thread": "收起讨论",
+    "expand_thread": "展开讨论",
     "delete_title": "删除评论",
     "delete_desc": "这条评论会被永久删除，无法撤销。",
     "delete_desc_with_replies": "这条评论及其全部回复会被永久删除，无法撤销。",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -472,6 +472,7 @@
     "show_more_activities_other": "展开更早 {{count}} 条动态"
   },
   "comment": {
+    "add_reaction": "添加表情回应",
     "collapse_thread": "收起讨论",
     "expand_thread": "展开讨论",
     "delete_title": "删除评论",

--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -298,6 +298,7 @@ var concurrentIndexCleanups = map[string]string{
 	"443_issue_project_status_index":                            "idx_issue_project_status",
 	"445_comment_delegated_failure_unsettled_index":             "idx_comment_delegated_failure_unsettled",
 	"446_issue_properties_bigm_index":                           "idx_issue_properties_bigm",
+	"452_agent_task_pending_thread_unique":                      "idx_one_pending_task_per_issue_agent_thread",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction
@@ -322,6 +323,7 @@ var concurrentDownIndexCleanups = map[string]string{
 	"391_drop_agent_task_queue_dispatched_prepare_index":    "idx_agent_task_queue_dispatched_prepare",
 	"437_drop_agent_runtime_last_seen_at_index":             "idx_agent_runtime_last_seen_at",
 	"450_drop_comment_delegated_failure_pending_index":      "idx_comment_delegated_failure_pending",
+	"453_drop_pending_issue_agent_unique":                   "idx_one_pending_task_per_issue_agent_v2",
 }
 
 var preMigrationHooks = func() map[string]preMigrationHook {

--- a/server/cmd/server/comment_at_least_once_test.go
+++ b/server/cmd/server/comment_at_least_once_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -65,12 +66,13 @@ func TestConsecutiveCommentsMergeNotDropped(t *testing.T) {
 		resp.Body.Close()
 	})
 
-	// Three deliberate comments in a row, before any run starts.
-	cidA := postComment(t, issueID, "First instruction", nil)
-	cidB := postComment(t, issueID, "Second, correcting the first", nil)
-	cidC := postComment(t, issueID, "Third, one more detail", nil)
+	// Three explicit instructions in the same thread, before any run starts.
+	mention := fmt.Sprintf("[@Agent](mention://agent/%s) ", agentID)
+	cidA := postComment(t, issueID, mention+"First instruction", nil)
+	cidB := postComment(t, issueID, mention+"Second, correcting the first", &cidA)
+	cidC := postComment(t, issueID, mention+"Third, one more detail", &cidA)
 
-	// Still exactly one task: we bound concurrency to one run per (issue,agent).
+	// Still exactly one pending task for this (issue, agent, thread).
 	if n := countPendingTasksForAgent(t, issueID, agentID); n != 1 {
 		t.Fatalf("expected exactly 1 pending task after 3 comments, got %d", n)
 	}
@@ -147,14 +149,18 @@ func TestGetLatestMemberCommentForIssueSince(t *testing.T) {
 
 // insertCommentAt inserts a comment with an explicit created_at and author, and
 // returns its id. Used to construct precise before/after-anchor scenarios.
-func insertCommentAt(t *testing.T, issueID, authorType, authorID, content string, at time.Time) string {
+func insertCommentAt(t *testing.T, issueID, authorType, authorID, content string, at time.Time, parentIDs ...string) string {
 	t.Helper()
 	var id string
+	var parentID *string
+	if len(parentIDs) > 0 {
+		parentID = &parentIDs[0]
+	}
 	err := testPool.QueryRow(context.Background(), `
-		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, 'comment', $6, $6)
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at, updated_at, parent_id)
+		VALUES ($1, $2, $3, $4, $5, 'comment', $6, $6, $7)
 		RETURNING id::text
-	`, issueID, testWorkspaceID, authorType, authorID, content, at).Scan(&id)
+	`, issueID, testWorkspaceID, authorType, authorID, content, at, parentID).Scan(&id)
 	if err != nil {
 		t.Fatalf("insertCommentAt: %v", err)
 	}
@@ -211,7 +217,7 @@ func TestMergeCommentIntoPendingTask_RecomputesOriginatorAndSkipsDispatched(t *t
 
 	now := time.Now()
 	cidA := insertCommentAt(t, issueID, "member", testUserID, "first, from originator A", now.Add(-2*time.Minute))
-	cidB := insertCommentAt(t, issueID, "member", testUserID, "second, folds in", now.Add(-1*time.Minute))
+	cidB := insertCommentAt(t, issueID, "member", testUserID, "second, folds in", now.Add(-1*time.Minute), cidA)
 
 	// A second member to act as a DIFFERENT originator.
 	otherUserID := createWorkspaceMember(t, "merge-recompute-other")
@@ -259,7 +265,7 @@ func TestMergeCommentIntoPendingTask_RecomputesOriginatorAndSkipsDispatched(t *t
 	if _, err := testPool.Exec(ctx, `UPDATE agent_task_queue SET status = 'dispatched', dispatched_at = now() WHERE issue_id = $1`, issueID); err != nil {
 		t.Fatalf("flip task to dispatched: %v", err)
 	}
-	cidC := insertCommentAt(t, issueID, "member", testUserID, "third, arrives after dispatch", now)
+	cidC := insertCommentAt(t, issueID, "member", testUserID, "third, arrives after dispatch", now, cidA)
 	if _, err := queries.MergeCommentIntoPendingTask(ctx, db.MergeCommentIntoPendingTaskParams{
 		IssueID:              pgIssue,
 		AgentID:              pgAgent,
@@ -339,8 +345,8 @@ func TestMergeCommentIntoPendingTask_TargetsQueuedNotDeferred(t *testing.T) {
 
 	now := time.Now()
 	cidQueued := insertCommentAt(t, issueID, "member", testUserID, "queued task trigger", now.Add(-3*time.Minute))
-	cidDeferred := insertCommentAt(t, issueID, "member", testUserID, "deferred fallback trigger", now.Add(-2*time.Minute))
-	cidNew := insertCommentAt(t, issueID, "member", testUserID, "new comment, must fold into queued", now.Add(-1*time.Minute))
+	cidDeferred := insertCommentAt(t, issueID, "member", testUserID, "deferred fallback trigger", now.Add(-2*time.Minute), cidQueued)
+	cidNew := insertCommentAt(t, issueID, "member", testUserID, "new comment, must fold into queued", now.Add(-1*time.Minute), cidQueued)
 
 	var runtimeID string
 	if err := testPool.QueryRow(ctx, `SELECT runtime_id FROM agent WHERE id = $1`, agentID).Scan(&runtimeID); err != nil {

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -671,9 +671,9 @@ func TestDeleteCommentCancelsTriggeredTasks(t *testing.T) {
 	})
 }
 
-// TestCommentTriggerCoalescing verifies that rapid-fire comments don't create
-// duplicate tasks (coalescing dedup).
-func TestCommentTriggerCoalescing(t *testing.T) {
+// TestCommentThreadsQueueSeparatelyFromAssignment verifies that each root
+// comment queues independently of other threads and the assignment task.
+func TestCommentThreadsQueueSeparatelyFromAssignment(t *testing.T) {
 	agentID := getAgentID(t)
 	issueID := createIssueAssignedToAgent(t, "Coalescing test", agentID)
 	t.Cleanup(func() {
@@ -682,12 +682,21 @@ func TestCommentTriggerCoalescing(t *testing.T) {
 		resp.Body.Close()
 	})
 
-	// Post two comments rapidly — only 1 task should be created (coalescing).
-	postComment(t, issueID, "First comment", nil)
-	postComment(t, issueID, "Second comment", nil)
+	// Distinct root comments must not merge with each other or the assignment.
+	first := postComment(t, issueID, "First comment", nil)
+	second := postComment(t, issueID, "Second comment", nil)
 
-	if n := countPendingTasks(t, issueID); n != 1 {
-		t.Errorf("expected 1 pending task (coalescing), got %d", n)
+	if n := countPendingTasks(t, issueID); n != 3 {
+		t.Fatalf("expected assignment plus two independent thread tasks, got %d", n)
+	}
+	for _, id := range []string{first, second} {
+		var count int
+		if err := testPool.QueryRow(context.Background(), `SELECT count(*) FROM agent_task_queue WHERE issue_id=$1 AND agent_id=$2 AND trigger_comment_id=$3 AND cardinality(coalesced_comment_ids)=0`, issueID, agentID, id).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("comment %s should own exactly one unmerged task, got %d", id, count)
+		}
 	}
 }
 

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -346,6 +346,8 @@ type TaskIssueStatusData struct {
 }
 
 type AgentTaskResponse struct {
+	CancelledByCommentChange bool `json:"cancelled_by_comment_change,omitempty"`
+
 	ID                   string                 `json:"id"`
 	AgentID              string                 `json:"agent_id"`
 	RuntimeID            string                 `json:"runtime_id"`
@@ -752,6 +754,10 @@ type TaskAgentData struct {
 // derivation; pass "" only on daemon-facing paths that genuinely don't have
 // it, in which case RelativeWorkDir falls back to the existing WorkDir.
 func taskToResponse(t db.AgentTaskQueue, workspaceID string) AgentTaskResponse {
+	var cancellation struct {
+		TaskID string `json:"comment_change_cancelled_task_id"`
+	}
+	_ = json.Unmarshal(t.Context, &cancellation)
 	var result any
 	if t.Result != nil {
 		json.Unmarshal(t.Result, &result)
@@ -777,6 +783,9 @@ func taskToResponse(t db.AgentTaskQueue, workspaceID string) AgentTaskResponse {
 		handoffNote = t.HandoffNote.String
 	}
 	return AgentTaskResponse{
+		// Task-scoped provenance must not transfer through copied retry context.
+		CancelledByCommentChange: t.Status == "cancelled" && cancellation.TaskID != "" && cancellation.TaskID == uuidToString(t.ID),
+
 		ID:                     uuidToString(t.ID),
 		AgentID:                uuidToString(t.AgentID),
 		RuntimeID:              uuidToString(t.RuntimeID),

--- a/server/internal/handler/attribution_response_test.go
+++ b/server/internal/handler/attribution_response_test.go
@@ -11,6 +11,26 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
+func TestTaskCommentChangeCancellation(t *testing.T) {
+	id := "11111111-1111-1111-1111-111111111111"
+	for _, tc := range []struct {
+		name, taskID, status, context string
+		want                          bool
+	}{
+		{"edited input", id, "cancelled", `{"comment_change_cancelled_task_id":"` + id + `"}`, true},
+		{"manual stop", id, "cancelled", `{}`, false},
+		{"retry inherits context", "22222222-2222-2222-2222-222222222222", "cancelled", `{"comment_change_cancelled_task_id":"` + id + `"}`, false},
+		{"not cancelled", id, "running", `{"comment_change_cancelled_task_id":"` + id + `"}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := taskToResponse(db.AgentTaskQueue{ID: parseUUID(tc.taskID), Status: tc.status, Context: []byte(tc.context)}, "")
+			if got.CancelledByCommentChange != tc.want {
+				t.Fatalf("cancelled_by_comment_change = %v, want %v", got.CancelledByCommentChange, tc.want)
+			}
+		})
+	}
+}
+
 // TestTaskAttributionBase covers the pure row→attribution mapping (MUL-4302 §9):
 // source label + precise flag, initiator/originator raw refs, evidence, lineage —
 // no DB, no name hydration.

--- a/server/internal/handler/autopilot_mention_authority_test.go
+++ b/server/internal/handler/autopilot_mention_authority_test.go
@@ -378,6 +378,8 @@ func TestReconcileCommentsOnCompletion_AutopilotDelegationRestoresAuthority(t *t
 		fx := newAutopilotDelegationFixture(t, workerID, creatorUserID, "autopilot")
 		issueID := uuidToString(fx.Issue.ID)
 		workerTaskID := seedCompletedTaskOnIssueBefore(t, workerID, issueID, fx.RuntimeID)
+		// Simulate a claim race that registered an undelivered thread input.
+		dbfx.Exec(t, `UPDATE agent_task_queue SET coalesced_comment_ids=ARRAY[$2::uuid] WHERE id=$1`, workerTaskID, fx.Comment.ID)
 		workerTask, err := testHandler.Queries.GetAgentTask(ctx, util.MustParseUUID(workerTaskID))
 		if err != nil {
 			t.Fatalf("load worker task: %v", err)
@@ -651,6 +653,8 @@ func TestUpdateComment_AdminEditOfAgentCommentClearsStaleLineage(t *testing.T) {
 	// lineage cleared it must NOT resurrect the creator authority or enqueue a
 	// follow-up. (Without the fix this reconcile would enqueue exactly one.)
 	workerTaskID := seedCompletedTaskOnIssueBefore(t, workerID, issueID, fx.RuntimeID)
+	// Simulate a claim race that registered an undelivered thread input.
+	dbfx.Exec(t, `UPDATE agent_task_queue SET coalesced_comment_ids=ARRAY[$2::uuid] WHERE id=$1`, workerTaskID, fx.Comment.ID)
 	workerTask, err := testHandler.Queries.GetAgentTask(ctx, util.MustParseUUID(workerTaskID))
 	if err != nil {
 		t.Fatalf("load worker task: %v", err)

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1535,6 +1535,7 @@ type commentAgentTrigger struct {
 }
 
 type commentTriggerComputeOptions struct {
+	ThreadCommentID         pgtype.UUID
 	ExcludeTriggerCommentID pgtype.UUID
 	// OriginatorUserID is the top-of-chain human user id for this trigger
 	// (MUL-3963). Only consulted for AGENT actors — canInvokeAgent judges A2A
@@ -2138,7 +2139,7 @@ func (h *Handler) resolveCommentTriggerEnqueue(ctx context.Context, issue db.Iss
 				// it is newer than the task and completion reconcile covers it by
 				// timestamp; MUL-4195 leaves the claimed task untouched. Defer to
 				// the active task, or enqueue fresh if it has since finished.
-				active, activeErr := h.hasActiveTaskForIssueAndAgent(ctx, issue.ID, trigger.Agent.ID)
+				active, activeErr := h.hasActiveTaskForIssueAndAgent(ctx, issue.ID, trigger.Agent.ID, triggerCommentID)
 				if status, reason, enqueueFresh := decidePostMergeMiss(active, activeErr); !enqueueFresh {
 					return status, reason
 				}
@@ -2270,10 +2271,11 @@ func commentEnqueueFailureReason(err error) DispatchReasonCode {
 // duplicate) AND must not report a success — "cannot confirm whether a run is
 // active" is never the same as "a run is active". See decidePostMergeMiss /
 // decideSuppressedLeaderOutcome for the two decisions.
-func (h *Handler) hasActiveTaskForIssueAndAgent(ctx context.Context, issueID, agentID pgtype.UUID) (bool, error) {
-	active, err := h.Queries.HasActiveTaskForIssueAndAgent(ctx, db.HasActiveTaskForIssueAndAgentParams{
-		IssueID: issueID,
-		AgentID: agentID,
+func (h *Handler) hasActiveTaskForIssueAndAgent(ctx context.Context, issueID, agentID, threadCommentID pgtype.UUID) (bool, error) {
+	active, err := h.Queries.HasActiveTaskForIssueAndAgentInThread(ctx, db.HasActiveTaskForIssueAndAgentInThreadParams{
+		ThreadCommentID: threadCommentID,
+		IssueID:         issueID,
+		AgentID:         agentID,
 	})
 	if err != nil {
 		slog.Warn("has active task for issue+agent check failed",
@@ -2625,6 +2627,13 @@ func (h *Handler) enqueueSingleCommentTrigger(ctx context.Context, issue db.Issu
 // — the implicit routing fallbacks (assignee, thread parent, conversation) were
 // never named by the user, so a no-route there is not a silent no-op.
 func (h *Handler) computeCommentAgentTriggers(ctx context.Context, issue db.Issue, content string, parentComment *db.Comment, actorType, actorID string, opts commentTriggerComputeOptions) ([]commentAgentTrigger, []commentMentionTarget) {
+	// A persisted comment determines its thread; previews use the parent.
+	// A new top-level preview has no thread yet and cannot merge with a queue.
+	opts.ThreadCommentID = opts.ExcludeTriggerCommentID
+	if !opts.ThreadCommentID.Valid && parentComment != nil {
+		opts.ThreadCommentID = parentComment.ID
+	}
+
 	if isNoteComment(content) {
 		return nil, nil
 	}
@@ -2989,21 +2998,26 @@ func (h *Handler) routeAssignedSquadLeaderFallback(ctx context.Context, issue db
 }
 
 func (h *Handler) hasPendingTaskForIssueAndAgent(ctx context.Context, issueID, agentID pgtype.UUID, opts commentTriggerComputeOptions) (bool, error) {
+	if !opts.ThreadCommentID.Valid {
+		return false, nil
+	}
 	// Key dedup on the reviewed head so re-pushing to the PR mid-review
 	// invalidates dedup and a fresh run enqueues against the new HEAD (TEN-356).
 	headSha := h.TaskService.ResolveIssueReviewSHAParam(ctx, issueID)
 	if opts.ExcludeTriggerCommentID.Valid {
-		return h.Queries.HasPendingTaskForIssueAndAgentExcludingTriggerComment(ctx, db.HasPendingTaskForIssueAndAgentExcludingTriggerCommentParams{
+		return h.Queries.HasPendingTaskForIssueAndAgentExcludingTriggerCommentInThread(ctx, db.HasPendingTaskForIssueAndAgentExcludingTriggerCommentInThreadParams{
+			ThreadCommentID:         opts.ThreadCommentID,
 			IssueID:                 issueID,
 			AgentID:                 agentID,
 			ExcludeTriggerCommentID: opts.ExcludeTriggerCommentID,
 			HeadSha:                 headSha,
 		})
 	}
-	return h.Queries.HasPendingTaskForIssueAndAgent(ctx, db.HasPendingTaskForIssueAndAgentParams{
-		IssueID: issueID,
-		AgentID: agentID,
-		HeadSha: headSha,
+	return h.Queries.HasPendingTaskForIssueAndAgentInThread(ctx, db.HasPendingTaskForIssueAndAgentInThreadParams{
+		ThreadCommentID: opts.ThreadCommentID,
+		IssueID:         issueID,
+		AgentID:         agentID,
+		HeadSha:         headSha,
 	})
 }
 
@@ -3139,7 +3153,7 @@ func (h *Handler) resolveMentionedAgentCommentTriggers(ctx context.Context, issu
 			// deferred; otherwise nothing runs → self_trigger_suppressed.
 			if authorType == "agent" && authorID == uuidToString(leaderID) &&
 				h.shouldSuppressSquadLeaderSelfTrigger(ctx, issue.ID, leaderID, squad.ID) {
-				active, activeErr := h.hasActiveTaskForIssueAndAgent(ctx, issue.ID, leaderID)
+				active, activeErr := h.hasActiveTaskForIssueAndAgent(ctx, issue.ID, leaderID, opts.ThreadCommentID)
 				status, reason := decideSuppressedLeaderOutcome(active, activeErr)
 				addTarget(commentMentionTarget{TargetType: "squad", TargetID: m.ID, Status: status, ReasonCode: reason})
 				continue

--- a/server/internal/handler/comment_duplicate_enqueue_race_test.go
+++ b/server/internal/handler/comment_duplicate_enqueue_race_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -43,14 +44,11 @@ func dupRaceFixture(t *testing.T, agentName string, issueNumber int) (agentID, i
 
 func insertDupRaceComment(t *testing.T, issueID, content, age string) string {
 	t.Helper()
-	var id string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at)
-		VALUES ($1, $2, 'member', $3, $4, 'comment', now() - $5::interval)
-		RETURNING id
-	`, issueID, testWorkspaceID, testUserID, content, age).Scan(&id); err != nil {
-		t.Fatalf("insert comment %q: %v", content, err)
-	}
+	// These race cases compete for the same thread slot.
+	var parentID *string
+	dbfx.QueryRow(t, `SELECT (SELECT id::text FROM comment WHERE issue_id=$1 AND parent_id IS NULL ORDER BY created_at, id LIMIT 1)`, issueID).Scan(&parentID)
+	id := dbfx.Comment(t, issueID, content, testutil.Cols{"parent_id": parentID})
+	dbfx.Exec(t, `UPDATE comment SET created_at=now()-$2::interval WHERE id=$1`, id, age)
 	return id
 }
 
@@ -396,7 +394,7 @@ func TestCommentEnqueueRaceQueuedWinnerReattributesOriginator(t *testing.T) {
 	if _, err := testHandler.TaskService.EnqueueTaskForMention(ctx, issue, agentUUID, util.MustParseUUID(winnerCommentID)); err != nil {
 		t.Fatalf("enqueue winning task: %v", err)
 	}
-	// Losing comment authored by M2.
+	// Losing comment authored by M2 in the same thread.
 	var loserCommentID string
 	if err := testPool.QueryRow(ctx, `
 		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at)
@@ -405,6 +403,8 @@ func TestCommentEnqueueRaceQueuedWinnerReattributesOriginator(t *testing.T) {
 	`, issueID, testWorkspaceID, m2).Scan(&loserCommentID); err != nil {
 		t.Fatalf("insert M2 loser comment: %v", err)
 	}
+
+	dbfx.Exec(t, `UPDATE comment SET parent_id=$2 WHERE id=$1`, loserCommentID, winnerCommentID)
 
 	trigger := commentAgentTrigger{Agent: agent, Source: commentTriggerSourceMentionAgent}
 	results := testHandler.enqueueCommentAgentTriggers(ctx, issue, util.MustParseUUID(loserCommentID), []commentAgentTrigger{trigger})

--- a/server/internal/handler/comment_merge_failclosed_test.go
+++ b/server/internal/handler/comment_merge_failclosed_test.go
@@ -50,6 +50,7 @@ func TestMergeCommentIntoPendingTask_FailClosedKeepsOriginalSnapshot(t *testing.
 		t.Fatalf("seed comment B: %v", err)
 	}
 
+	dbfx.Exec(t, `UPDATE comment SET parent_id=$2 WHERE id=$1`, cidB, cidA)
 	// A QUEUED task with a fully precise snapshot triggered by cidA.
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO agent_task_queue

--- a/server/internal/handler/comment_reconcile_test.go
+++ b/server/internal/handler/comment_reconcile_test.go
@@ -94,6 +94,8 @@ func TestCompleteTask_ReconcilesMemberCommentPostedDuringRun(t *testing.T) {
 		VALUES ($1, $2, 'member', $3, 'wait, also handle this', 'comment', now() - interval '1 minute')
 	`, issueID, testWorkspaceID, testUserID)
 
+	dbfx.Exec(t, `UPDATE comment SET parent_id=$2 WHERE issue_id=$1 AND id<>$2`, issueID, triggerCommentID)
+
 	if w := completeTaskViaHandler(t, taskID, "done"); w.Code != http.StatusOK {
 		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -287,6 +289,7 @@ func TestCompleteTask_ReconcilesAgentAuthoredMentionToCompletedAgent(t *testing.
 		VALUES ($1, $2, 'agent', $3, $4, 'comment')
 		RETURNING id
 	`, issueID, testWorkspaceID, agentA, mention).Scan(&mentionCommentID)
+	dbfx.Exec(t, `UPDATE comment SET parent_id=$2 WHERE id=$1`, mentionCommentID, triggerCommentID)
 	mentionComment, err := testHandler.Queries.GetComment(ctx, util.MustParseUUID(mentionCommentID))
 	if err != nil {
 		t.Fatalf("setup: load mention comment: %v", err)
@@ -500,6 +503,8 @@ func TestConsecutiveCommentsDifferentOriginatorsFullEnqueuePath(t *testing.T) {
 
 	// B's comment (different originator) before start → must fold in, NOT drop.
 	cB := insertMemberComment(userB, "second, from B — different user")
+	dbfx.Exec(t, `UPDATE comment SET parent_id=$2 WHERE id=$1`, cB.ID, cA.ID)
+	cB.ParentID = cA.ID
 	testHandler.triggerTasksForComment(ctx, issue, cB, nil, "member", userB, userB, nil)
 
 	// Still exactly one task (bounded concurrency, no unique-index collision).
@@ -563,6 +568,8 @@ func TestCompleteTask_ReconcilesDispatchedWindowComment(t *testing.T) {
 		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at)
 		VALUES ($1, $2, 'member', $3, 'squeezed in before start', 'comment', now() - interval '3 minutes')
 	`, issueID, testWorkspaceID, testUserID)
+
+	dbfx.Exec(t, `UPDATE comment SET parent_id=$2 WHERE issue_id=$1 AND id<>$2`, issueID, triggerCommentID)
 
 	if w := completeTaskViaHandler(t, taskID, "done"); w.Code != http.StatusOK {
 		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
@@ -655,6 +662,8 @@ func TestCompleteTask_ReconcilesPreDispatchMergeRaceComment(t *testing.T) {
 	`, agentID, runtimeID, issueID, triggerCommentID, deliveredCoalescedID).Scan(&taskID)
 	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID) })
 
+	dbfx.Exec(t, `UPDATE comment SET parent_id=$2 WHERE issue_id=$1 AND id<>$2`, issueID, triggerCommentID)
+
 	if w := completeTaskViaHandler(t, taskID, "done"); w.Code != http.StatusOK {
 		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -713,8 +722,9 @@ func TestCompleteTask_ReconcilesPlannedButUndeliveredComments(t *testing.T) {
 				return id
 			}
 			old1 := insertComment("planned old one", "10 minutes")
-			old2 := insertComment("planned old two", "9 minutes")
+			old2 := insertComment("[@Agent](mention://agent/"+agentID+") planned old two", "9 minutes")
 			trigger := insertComment("planned trigger", "8 minutes")
+			dbfx.Exec(t, `UPDATE comment SET parent_id=$2 WHERE issue_id=$1 AND id<>$2`, issueID, old1)
 			delivered := []string{trigger}
 			if tc.deliveredOldCount > 0 {
 				delivered = append([]string{old1}, delivered...)

--- a/server/internal/handler/comment_thread_queue_test.go
+++ b/server/internal/handler/comment_thread_queue_test.go
@@ -1,0 +1,144 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestCommentThreadQueuesMergeAndExecuteIndependently(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "thread queue runtime")
+	agentID := dbfx.Agent(t, "thread queue agent", runtimeID)
+	issueID := dbfx.Issue(t, "thread queue issue", testutil.Cols{"assignee_type": "agent", "assignee_id": agentID})
+	rootA := dbfx.Comment(t, issueID, "thread A")
+	rootB := dbfx.Comment(t, issueID, "thread B")
+	replyA := dbfx.Comment(t, issueID, "A supplement", testutil.Cols{"parent_id": rootA})
+	nestedA := dbfx.Comment(t, issueID, "A nested supplement", testutil.Cols{"parent_id": replyA})
+	t.Cleanup(func() { dbfx.Exec(t, "DELETE FROM agent_task_queue WHERE issue_id = $1", issueID) })
+	issue, err := testHandler.Queries.GetIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent, err := testHandler.Queries.GetAgent(ctx, parseUUID(agentID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	enqueue := func(commentID string, pending bool, want DispatchStatus) {
+		t.Helper()
+		result := testHandler.enqueueCommentAgentTriggers(ctx, issue, parseUUID(commentID),
+			[]commentAgentTrigger{{Agent: agent, Source: commentTriggerSourceMentionAgent, AlreadyPending: pending}})
+		if result[agentID].status != want {
+			t.Fatalf("enqueue %s: got %+v, want %s", commentID, result[agentID], want)
+		}
+	}
+	enqueue(rootA, false, DispatchQueued)
+	// Even a stale pending hint from another thread must not merge or defer B.
+	enqueue(rootB, true, DispatchQueued)
+	enqueue(replyA, true, DispatchCoalesced)
+	enqueue(nestedA, true, DispatchCoalesced)
+	tasks, err := testHandler.Queries.ListTasksByIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("got %d runs, want one per thread", len(tasks))
+	}
+	var a, b db.AgentTaskQueue
+	for _, task := range tasks {
+		switch uuidToString(task.CommentThreadID) {
+		case rootA:
+			a = task
+		case rootB:
+			b = task
+		default:
+			t.Fatalf("wrong thread scope: %s", uuidToString(task.CommentThreadID))
+		}
+	}
+	if uuidToString(a.TriggerCommentID) != nestedA || len(a.CoalescedCommentIds) != 2 || len(b.CoalescedCommentIds) != 0 {
+		t.Fatalf("wrong input batches: A=%+v B=%+v", a.TriggerCommentID, b.CoalescedCommentIds)
+	}
+	claim := db.ClaimAgentTaskParams{AgentID: parseUUID(agentID), RuntimeID: parseUUID(runtimeID), PrepareLeaseSecs: 60, RuntimeStaleSecs: 120}
+	claimed, err := testHandler.Queries.ClaimAgentTask(ctx, claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed.ID != a.ID {
+		t.Fatal("oldest thread should execute first")
+	}
+	if _, err := testHandler.Queries.ClaimAgentTask(ctx, claim); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("another thread ran concurrently on the same issue: %v", err)
+	}
+	// A new instruction after execution starts belongs to a successor run.
+	dbfx.Exec(t, "UPDATE agent_task_queue SET status='running', started_at=now(), delivered_comment_ids=ARRAY[$2::uuid,$3::uuid,$4::uuid] WHERE id=$1", uuidToString(a.ID), rootA, replyA, nestedA)
+	followupA := dbfx.Comment(t, issueID, "A follow-up", testutil.Cols{"parent_id": rootA})
+	enqueue(followupA, false, DispatchQueued)
+	dbfx.Exec(t, "UPDATE agent_task_queue SET status='completed', completed_at=now() WHERE id=$1", uuidToString(a.ID))
+	completed, err := testHandler.Queries.GetAgentTask(ctx, a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testHandler.reconcileCommentsOnCompletion(ctx, &completed)
+	tasks, err = testHandler.Queries.ListTasksByIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("completion duplicated another thread: got %d tasks", len(tasks))
+	}
+	// A row-specific rerun replaces only A's pending successor.
+	rerun, err := testHandler.TaskService.RerunIssue(ctx, issue.ID, a.ID, pgtype.UUID{}, parseUUID(testUserID), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := testHandler.Queries.GetAgentTask(ctx, b.ID)
+	if err != nil || other.Status != "queued" {
+		t.Fatalf("rerun disturbed thread B: %s / %v", other.Status, err)
+	}
+	if rerun.CommentThreadID != a.CommentThreadID {
+		t.Fatal("rerun lost thread scope")
+	}
+	if _, err := testHandler.TaskService.CancelTask(ctx, rerun.ID); err != nil {
+		t.Fatal(err)
+	}
+	other, err = testHandler.Queries.GetAgentTask(ctx, b.ID)
+	if err != nil || other.Status != "queued" {
+		t.Fatalf("stop disturbed thread B: %s / %v", other.Status, err)
+	}
+}
+
+func TestDeferredCommentThreadsPromoteIndependently(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "thread promotion runtime")
+	agentID := dbfx.Agent(t, "thread promotion agent", runtimeID)
+	issueID := dbfx.Issue(t, "thread promotion issue")
+	rootA := dbfx.Comment(t, issueID, "A")
+	rootB := dbfx.Comment(t, issueID, "B")
+	create := func(root string) string {
+		return dbfx.Task(t, agentID, testutil.Cols{"runtime_id": runtimeID, "issue_id": issueID, "trigger_comment_id": root, "status": "deferred", "fire_at": testutil.Raw("now()-interval '1 minute'")})
+	}
+	a, b := create(rootA), create(rootB)
+	anotherA := create(rootA)
+	promoted, err := testHandler.Queries.PromoteDueDeferredTasksForRuntime(ctx, db.PromoteDueDeferredTasksForRuntimeParams{RuntimeID: parseUUID(runtimeID), RuntimeStaleSecs: 120})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(promoted) != 2 {
+		t.Fatalf("promoted %d runs, want one per thread", len(promoted))
+	}
+	for _, id := range []string{a, b} {
+		row, err := testHandler.Queries.GetAgentTask(ctx, parseUUID(id))
+		if err != nil || row.Status != "queued" {
+			t.Fatalf("thread did not promote: %s / %v", row.Status, err)
+		}
+	}
+	row, err := testHandler.Queries.GetAgentTask(ctx, parseUUID(anotherA))
+	if err != nil || row.Status != "deferred" {
+		t.Fatalf("second run in A must stay deferred: %s / %v", row.Status, err)
+	}
+}

--- a/server/internal/handler/comment_trigger_preview_test.go
+++ b/server/internal/handler/comment_trigger_preview_test.go
@@ -466,7 +466,7 @@ func TestPreviewCommentTriggers_ExplicitMentionSuppressesAssigneeFallback(t *tes
 	}
 }
 
-func TestCreateComment_ExplicitMentionKeepsPendingRouteWithoutDuplicateTask(t *testing.T) {
+func TestCreateComment_ExplicitMentionQueuesDifferentThreadsIndependently(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
@@ -487,8 +487,8 @@ func TestCreateComment_ExplicitMentionKeepsPendingRouteWithoutDuplicateTask(t *t
 	}
 
 	postCommentForTriggerPreviewTest(t, issueID, map[string]any{"content": content + " again"})
-	if got := countQueuedCommentTriggerTasks(t, issueID, mentionedID); got != 1 {
-		t.Fatalf("duplicate pending mention queued tasks = %d, want 1", got)
+	if got := countQueuedCommentTriggerTasks(t, issueID, mentionedID); got != 2 {
+		t.Fatalf("separate thread queued tasks = %d, want 2", got)
 	}
 }
 
@@ -1277,7 +1277,7 @@ func TestPreviewCommentTriggers_MalformedMentionIDDoesNotPanic(t *testing.T) {
 	}
 }
 
-func TestPreviewCommentTriggers_AllSuppressesAssigneeAndPendingDedupes(t *testing.T) {
+func TestPreviewCommentTriggers_AllSuppressesAssigneeAndNewThreadQueuesSeparately(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
@@ -1311,8 +1311,8 @@ func TestPreviewCommentTriggers_AllSuppressesAssigneeAndPendingDedupes(t *testin
 	postCommentForTriggerPreviewTest(t, issueID, map[string]any{
 		"content": "can you continue here?",
 	})
-	if got := countQueuedCommentTriggerTasks(t, issueID, agentID); got != 1 {
-		t.Fatalf("pending assignee create queued tasks = %d, want 1", got)
+	if got := countQueuedCommentTriggerTasks(t, issueID, agentID); got != 2 {
+		t.Fatalf("assignment and new comment thread queued tasks = %d, want 2", got)
 	}
 }
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2560,7 +2560,9 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 				resp.TriggerCommentContent = comment.Content
 				resp.TriggerThreadID = uuidToString(comment.ID)
 				if comment.ParentID.Valid {
-					resp.TriggerThreadID = uuidToString(comment.ParentID)
+					if root, err := h.Queries.GetCommentThreadRootID(r.Context(), comment.ID); err == nil {
+						resp.TriggerThreadID = uuidToString(root)
+					}
 				}
 				resp.TriggerAuthorType = comment.AuthorType
 				// The triggering comment's author is the task initiator — the
@@ -4016,6 +4018,7 @@ func (h *Handler) reconcileCommentsOnCompletion(ctx context.Context, task *db.Ag
 		plannedCommentIDs = append(plannedCommentIDs, task.TriggerCommentID)
 	}
 	comments, err := h.Queries.ListReconcilableCommentsForIssueSince(ctx, db.ListReconcilableCommentsForIssueSinceParams{
+		CommentThreadID:   task.CommentThreadID,
 		IssueID:           task.IssueID,
 		Since:             task.CreatedAt,
 		PlannedCommentIds: plannedCommentIDs,
@@ -4223,7 +4226,11 @@ func (h *Handler) buildCoalescedCommentData(ctx context.Context, workspaceID pgt
 			CreatedAt:  timestampToString(comment.CreatedAt),
 		}
 		if comment.ParentID.Valid {
-			data.ThreadID = uuidToString(comment.ParentID)
+			root, err := h.Queries.GetCommentThreadRootID(ctx, comment.ID)
+			if err != nil {
+				continue
+			}
+			data.ThreadID = uuidToString(root)
 		}
 		if comment.AuthorID.Valid {
 			switch comment.AuthorType {

--- a/server/internal/handler/daemon_comment_delivery_test.go
+++ b/server/internal/handler/daemon_comment_delivery_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -233,6 +234,16 @@ func createCommentDeliveryFixture(t *testing.T, label string) commentDeliveryFix
 	}
 }
 
+func makeCommentDeliverySingleThread(t *testing.T, fixture commentDeliveryFixture) {
+	t.Helper()
+	root := dbfx.Comment(t, fixture.issueID, "thread root", testutil.Cols{"author_type": "agent", "author_id": fixture.agentID})
+	dbfx.Exec(t, `UPDATE comment SET created_at=now()-interval '10 minutes' WHERE id=$1`, root)
+	for _, id := range fixture.commentID {
+		dbfx.Exec(t, `UPDATE comment SET parent_id=$2 WHERE id=$1`, id, root)
+	}
+	dbfx.Exec(t, `UPDATE agent_task_queue SET trigger_comment_id=trigger_comment_id WHERE id=$1`, fixture.taskID)
+}
+
 func claimCommentDeliveryFixture(t *testing.T, fixture commentDeliveryFixture, capabilities string) AgentTaskResponse {
 	t.Helper()
 	w := httptest.NewRecorder()
@@ -353,6 +364,7 @@ func TestClaimTaskByRuntime_CoalescedOnlyStaleTaskDoesNotReuseDeletedTriggerCapa
 		t.Skip("database not available")
 	}
 	fixture := createCommentDeliveryFixture(t, "Deleted trigger stale claim")
+	makeCommentDeliverySingleThread(t, fixture)
 	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1`, fixture.issueID, fixture.agentID); err != nil {
 		t.Fatalf("assign stale-claim issue: %v", err)
 	}
@@ -386,6 +398,7 @@ func TestUpdateComment_RequeuesSurvivingCoalescedBatch(t *testing.T) {
 		t.Skip("database not available")
 	}
 	fixture := createCommentDeliveryFixture(t, "Edited trigger batch repair")
+	makeCommentDeliverySingleThread(t, fixture)
 	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1`, fixture.issueID, fixture.agentID); err != nil {
 		t.Fatalf("assign edited-trigger issue: %v", err)
 	}
@@ -408,6 +421,7 @@ func TestDeleteComment_RequeuesSurvivingCoalescedBatch(t *testing.T) {
 		t.Skip("database not available")
 	}
 	fixture := createCommentDeliveryFixture(t, "Deleted trigger batch repair")
+	makeCommentDeliverySingleThread(t, fixture)
 	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1`, fixture.issueID, fixture.agentID); err != nil {
 		t.Fatalf("assign deleted-trigger issue: %v", err)
 	}
@@ -435,6 +449,7 @@ func TestUpdateComment_CancelsAndRequeuesWhenEditedInputIsCoalesced(t *testing.T
 		t.Skip("database not available")
 	}
 	fixture := createCommentDeliveryFixture(t, "Edited coalesced input repair")
+	makeCommentDeliverySingleThread(t, fixture)
 	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1`, fixture.issueID, fixture.agentID); err != nil {
 		t.Fatalf("assign edited-coalesced issue: %v", err)
 	}
@@ -464,6 +479,7 @@ func TestDeleteComment_CancelsAndRequeuesWhenDeletedInputIsCoalesced(t *testing.
 		t.Skip("database not available")
 	}
 	fixture := createCommentDeliveryFixture(t, "Deleted coalesced input repair")
+	makeCommentDeliverySingleThread(t, fixture)
 	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1`, fixture.issueID, fixture.agentID); err != nil {
 		t.Fatalf("assign deleted-coalesced issue: %v", err)
 	}
@@ -484,6 +500,7 @@ func TestDeleteComment_FailureRestoresCancelledCompleteBatch(t *testing.T) {
 		t.Skip("database not available")
 	}
 	fixture := createCommentDeliveryFixture(t, "Failed deletion batch repair")
+	makeCommentDeliverySingleThread(t, fixture)
 	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1`, fixture.issueID, fixture.agentID); err != nil {
 		t.Fatalf("assign failed-delete issue: %v", err)
 	}
@@ -513,6 +530,7 @@ func TestDeleteComment_ConcurrentNoOpIsReportedAndRestoresCancelledBatch(t *test
 		t.Skip("database not available")
 	}
 	fixture := createCommentDeliveryFixture(t, "Concurrent deletion batch repair")
+	makeCommentDeliverySingleThread(t, fixture)
 	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1`, fixture.issueID, fixture.agentID); err != nil {
 		t.Fatalf("assign concurrent-delete issue: %v", err)
 	}
@@ -594,6 +612,7 @@ func TestClaimTaskByRuntime_PayloadOverflowReceiptsOnlyEmbeddedPrefix(t *testing
 		t.Skip("database not available")
 	}
 	fixture := createCommentDeliveryFixture(t, "Comment payload overflow")
+	makeCommentDeliverySingleThread(t, fixture)
 	oversized := strings.Repeat("x", maxClaimCommentPayloadBytes+1024)
 	if _, err := testPool.Exec(context.Background(), `UPDATE comment SET content = $2 WHERE id = $1`, fixture.commentID[0], oversized); err != nil {
 		t.Fatalf("make first coalesced comment oversized: %v", err)

--- a/server/internal/handler/daemon_comment_delivery_test.go
+++ b/server/internal/handler/daemon_comment_delivery_test.go
@@ -450,6 +450,13 @@ func TestUpdateComment_CancelsAndRequeuesWhenEditedInputIsCoalesced(t *testing.T
 	}
 
 	assertRepairedCommentBatch(t, fixture, fixture.commentID[0], fixture.commentID[1:])
+	original, err := testHandler.Queries.GetAgentTask(context.Background(), parseUUID(fixture.taskID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !taskToResponse(original, testWorkspaceID).CancelledByCommentChange {
+		t.Fatal("edited input must identify the cancelled run as invalidated by a comment change")
+	}
 }
 
 func TestDeleteComment_CancelsAndRequeuesWhenDeletedInputIsCoalesced(t *testing.T) {

--- a/server/internal/handler/delegated_failure_recovery_test.go
+++ b/server/internal/handler/delegated_failure_recovery_test.go
@@ -118,7 +118,8 @@ func TestUpdateComment_RequeuesDelegatedFailureRecoverySurvivor(t *testing.T) {
 		Scan(&activeTasks, &recoveryCovered); err != nil {
 		t.Fatalf("read rebuilt coordinator task: %v", err)
 	}
-	if activeTasks != 1 || !recoveryCovered {
-		t.Fatalf("rebuilt active tasks/recovery coverage = %d/%v, want 1/true", activeTasks, recoveryCovered)
+	// Rebuilding an old cross-thread batch preserves both independent runs.
+	if activeTasks != 2 || !recoveryCovered {
+		t.Fatalf("rebuilt active tasks/recovery coverage = %d/%v, want 2/true", activeTasks, recoveryCovered)
 	}
 }

--- a/server/internal/handler/issue_revision_test.go
+++ b/server/internal/handler/issue_revision_test.go
@@ -436,6 +436,7 @@ func TestConcurrentCommentRevisionConflictCancelsTaskBatchOnce(t *testing.T) {
 	}
 	ctx := context.Background()
 	fixture := createCommentDeliveryFixture(t, "revision task side effects")
+	makeCommentDeliverySingleThread(t, fixture)
 	if _, err := testPool.Exec(ctx, `
 		UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1
 	`, fixture.issueID, fixture.agentID); err != nil {

--- a/server/internal/handler/issue_trigger.go
+++ b/server/internal/handler/issue_trigger.go
@@ -72,7 +72,7 @@ func (h *Handler) shouldSuppressActiveSelfAssignment(ctx context.Context, actorT
 	if actorType != "agent" || actorID == "" || actorID != uuidToString(targetAgentID) {
 		return false
 	}
-	active, err := h.hasActiveTaskForIssueAndAgent(ctx, issueID, targetAgentID)
+	active, err := h.Queries.HasActiveTaskForIssueAndAgent(ctx, db.HasActiveTaskForIssueAndAgentParams{IssueID: issueID, AgentID: targetAgentID})
 	return active || err != nil
 }
 

--- a/server/internal/handler/mention_self_trigger_test.go
+++ b/server/internal/handler/mention_self_trigger_test.go
@@ -230,9 +230,9 @@ func TestEnqueueMentionedAgentTasks_SelfMentionDedupesAgainstPendingTask(t *test
 				t.Fatalf("reset tasks: %v", err)
 			}
 			if _, err := testPool.Exec(ctx, `
-				INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status)
-				VALUES ($1, $2, $3, $4)
-			`, fx.JID, fx.RuntimeID, fx.IssueAID, tc.status); err != nil {
+				INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, trigger_comment_id)
+				VALUES ($1, $2, $3, $4, $5)
+			`, fx.JID, fx.RuntimeID, fx.IssueAID, tc.status, fx.CommentA.ID); err != nil {
 				t.Fatalf("seed %s task: %v", tc.status, err)
 			}
 

--- a/server/internal/handler/squad_worker_comment_wakes_leader_test.go
+++ b/server/internal/handler/squad_worker_comment_wakes_leader_test.go
@@ -99,14 +99,14 @@ func TestCreateComment_WorkerAgentCommentWakesSquadLeader_MUL4015(t *testing.T) 
 	}
 }
 
-// TestCreateComment_WorkerAgentCommentDoesNotWakeLeader_WhenLeaderTaskPending
+// TestCreateComment_WorkerAgentCommentQueuesSeparatelyFromLeaderAssignment
 // pins the dedup behavior: when the squad leader ALREADY has a queued or
 // dispatched task on the issue, a worker's completion comment does not double-
 // enqueue a second leader task. This is the desired "coalescing" behavior in
 // production — the leader is going to run once and will observe the worker's
 // comment in that run. Regression coverage so nobody drops the dedup and
 // starts stacking duplicate leader runs.
-func TestCreateComment_WorkerAgentCommentDoesNotWakeLeader_WhenLeaderTaskPending(t *testing.T) {
+func TestCreateComment_WorkerAgentCommentQueuesSeparatelyFromLeaderAssignment(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
@@ -159,8 +159,7 @@ func TestCreateComment_WorkerAgentCommentDoesNotWakeLeader_WhenLeaderTaskPending
 		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// Expected: still exactly 1 queued leader task (the pre-seeded one) —
-	// no double enqueue.
+	// The new comment thread queues independently of the assignment run.
 	var leaderTasks int
 	if err := testPool.QueryRow(ctx, `
 		SELECT count(*) FROM agent_task_queue
@@ -168,8 +167,8 @@ func TestCreateComment_WorkerAgentCommentDoesNotWakeLeader_WhenLeaderTaskPending
 	`, issueID, fx.LeaderID).Scan(&leaderTasks); err != nil {
 		t.Fatalf("count leader tasks: %v", err)
 	}
-	if leaderTasks != 1 {
-		t.Fatalf("expected 1 queued leader task (dedup), got %d", leaderTasks)
+	if leaderTasks != 2 {
+		t.Fatalf("expected separate assignment and comment tasks, got %d", leaderTasks)
 	}
 }
 

--- a/server/internal/service/attribution_stamp_test.go
+++ b/server/internal/service/attribution_stamp_test.go
@@ -217,6 +217,10 @@ func TestMergeCommentIntoPendingTask_KeepsAccountableEqualsOriginator(t *testing
 		t.Fatalf("seed comment: %v", err)
 	}
 
+	// Bind this task's input to the thread whose attribution is being refreshed.
+	if _, err := pool.Exec(ctx, `UPDATE agent_task_queue SET trigger_comment_id=$2 WHERE id=$1`, taskID, commentID); err != nil {
+		t.Fatal(err)
+	}
 	// Re-stamp the FULL snapshot for B's member comment (direct_human + comment
 	// evidence), as the caller does.
 	if _, err := q.MergeCommentIntoPendingTask(ctx, db.MergeCommentIntoPendingTaskParams{

--- a/server/internal/service/builtin_skills/multica-platform/references/mentions.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/mentions.md
@@ -187,6 +187,12 @@ result comment on the autopilot issue can still wake the leader), and it survive
 a busy target: if the mentioned agent is already running, the delegation is
 replayed at that run's completion under the same authority, so it is never lost.
 
+Editing or deleting input cancels active runs that contain that comment and
+re-evaluates surviving inputs. These cancelled runs expose
+`cancelled_by_comment_change: true` in task responses. Unstarted runs without
+replies remain in execution history but do not create cancelled comment blocks;
+manual cancellations and runs that already executed remain visible.
+
 An edit is treated as a fresh action — it re-derives the comment's lineage from
 the editing action. Only the agent author editing its OWN comment re-stamps the
 lineage to the editing task; any other editor — including a workspace owner/admin

--- a/server/internal/service/builtin_skills/multica-platform/references/mentions.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/mentions.md
@@ -117,9 +117,9 @@ None of these start a fresh run, and none produce an error response — but they
 are three different things, and the response tells you which. A mention that
 never parsed is a truly silent no-op. One that parsed and was refused comes back
 in `trigger_outcomes` as `status: "blocked"` with a `reason_code`. One whose
-target is already busy comes back `coalesced` or `deferred`: no second run, but
-your comment IS folded into the task that is already running, so it still gets
-read. Read that array after posting — it is the only place any of this shows up.
+target has a queued task in the same comment thread can come back `coalesced`.
+A claim race can return `deferred`: the input is recorded for a follow-up run,
+not injected into an already running prompt. Different threads queue independently. Read that array after posting — it is the only place any of this shows up.
 
 - **A name where a UUID belongs.** `mention://member/Alice` is dead. The id
   group accepts only hex+dashes or `all`; the non-hex letters in a typical name
@@ -138,10 +138,15 @@ read. Read that array after posting — it is the only place any of this shows u
   with `target_unavailable` instead — a non-UUID names no entity anywhere, so
   it conceals nothing. Neither case is ever an error response.
 - **An already-pending task.** Even a correct `@agent`/`@squad` starts no second
-  run when the target already has a pending task on this issue. This is a fold,
-  not a drop: the comment merges into that task and the outcome is `coalesced`
-  (same reviewed head) or `deferred` (different head) — do NOT re-post it as
-  "the mention didn't work". Edit preview is the only exception:
+  run when the same target has a mergeable queued task in the **same thread**
+  (the root comment and all descendants), with the same reviewed head. The
+  outcome is `coalesced`; all covered instructions are delivered together.
+  Different root threads and assignment-triggered runs have separate queue
+  slots. Inputs received after execution starts belong to a successor run;
+  `deferred` means a claim race durably recorded the follow-up obligation.
+  Agent concurrency limits still apply, and runs for the same issue and agent
+  execute serially. Stopping or retrying one thread does not cancel another
+  thread's queue. Do not re-post a successfully queued/coalesced/deferred input. Edit preview is the only exception:
   `editing_comment_id` ignores pending tasks from the same comment being edited,
   because save cancels those old tasks before it re-computes triggers. It is
   still comment-scoped, not an agent-wide bypass.

--- a/server/internal/service/delegated_failure_recovery_settled_test.go
+++ b/server/internal/service/delegated_failure_recovery_settled_test.go
@@ -227,7 +227,7 @@ func TestManualRerunSettlesDeliveredRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse actor id: %v", err)
 	}
-	if _, err := svc.RerunIssue(ctx, issueID, pgtype.UUID{}, pgtype.UUID{}, actorID, func(db.Agent) bool { return true }); err != nil {
+	if _, err := svc.RerunIssue(ctx, issueID, recoveryTaskID, pgtype.UUID{}, actorID, func(db.Agent) bool { return true }); err != nil {
 		t.Fatalf("RerunIssue: %v", err)
 	}
 

--- a/server/internal/service/delegated_failure_recovery_test.go
+++ b/server/internal/service/delegated_failure_recovery_test.go
@@ -680,10 +680,10 @@ func TestFinalDelegatedFailureMergesIntoPendingCoordinatorTask(t *testing.T) {
 		INSERT INTO agent_task_queue (
 			agent_id, runtime_id, issue_id, status, priority,
 			originator_user_id, accountable_user_id, originator_source,
-			trigger_evidence_kind, trigger_evidence_ref_id
+			trigger_evidence_kind, trigger_evidence_ref_id, trigger_comment_id
 		)
-		VALUES ($1, $2, $3, 'queued', 0, $4, $4, 'direct_human', 'issue_assignment', $3)
-		RETURNING id`, f.coordinator, f.runtimeID, f.issueID, f.userID).Scan(&pendingID); err != nil {
+		VALUES ($1, $2, $3, 'queued', 0, $4, $4, 'direct_human', 'issue_assignment', $3, $5)
+		RETURNING id`, f.coordinator, f.runtimeID, f.issueID, f.userID, f.sourceTrigger).Scan(&pendingID); err != nil {
 		t.Fatalf("seed pending coordinator task: %v", err)
 	}
 
@@ -741,10 +741,10 @@ func TestDelegatedFailurePlannedBehindDispatchedCoordinatorGetsFollowUp(t *testi
 	if err := f.pool.QueryRow(ctx, `
 		INSERT INTO agent_task_queue (
 			agent_id, runtime_id, issue_id, status, priority, dispatched_at,
-			originator_user_id, accountable_user_id, originator_source
+			originator_user_id, accountable_user_id, originator_source, trigger_comment_id
 		)
-		VALUES ($1, $2, $3, 'dispatched', 0, now(), $4, $4, 'direct_human')
-		RETURNING id`, f.coordinator, f.runtimeID, f.issueID, f.userID).Scan(&activeID); err != nil {
+		VALUES ($1, $2, $3, 'dispatched', 0, now(), $4, $4, 'direct_human', $5)
+		RETURNING id`, f.coordinator, f.runtimeID, f.issueID, f.userID, f.sourceTrigger).Scan(&activeID); err != nil {
 		t.Fatalf("seed active coordinator task: %v", err)
 	}
 

--- a/server/internal/service/issue_channel_media_test.go
+++ b/server/internal/service/issue_channel_media_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -226,8 +227,8 @@ func TestCreateMediaGatedIssueCommitsDeferredTaskAtomicallyBeforeCreatedEvent(t 
 			NewOriginatorSource:     pgtype.Text{String: "direct_human", Valid: true},
 			NewTriggerEvidenceKind:  pgtype.Text{String: "comment", Valid: true},
 			NewTriggerEvidenceRefID: mergedCommentID,
-		}); err != nil {
-			callbackErr = fmt.Errorf("merge immediate comment into deferred task: %w", err)
+		}); !errors.Is(err, pgx.ErrNoRows) {
+			callbackErr = fmt.Errorf("new comment thread must not merge into the assignment: %v", err)
 		}
 	})
 
@@ -272,8 +273,8 @@ func TestCreateMediaGatedIssueCommitsDeferredTaskAtomicallyBeforeCreatedEvent(t 
 		Scan(&taskID, &triggerCommentID, &runtimeID, &taskCount); err != nil {
 		t.Fatalf("load final pending task: %v", err)
 	}
-	if taskCount != 1 || taskID != result.AssignedTaskID || triggerCommentID != mergedCommentID {
-		t.Fatalf("pending task = count %d id %v trigger %v, want one task %v with trigger %v", taskCount, taskID, triggerCommentID, result.AssignedTaskID, mergedCommentID)
+	if taskCount != 1 || taskID != result.AssignedTaskID || triggerCommentID.Valid {
+		t.Fatalf("pending task = count %d id %v trigger %v, want one assignment task %v without a comment trigger", taskCount, taskID, triggerCommentID, result.AssignedTaskID)
 	}
 	if wakeup.calls[0].runtimeID != util.UUIDToString(runtimeID) {
 		t.Fatalf("schedule wakeup runtime = %q, want %q", wakeup.calls[0].runtimeID, util.UUIDToString(runtimeID))
@@ -307,6 +308,9 @@ func TestHydrateDeferredChannelIssueTaskOverlayDoesNotOverwriteMergedCommentPlan
 		VALUES ($1, $2, 'member', $3, 'New effective trigger')
 		RETURNING id`, task.IssueID, workspaceID, userID).Scan(&commentID); err != nil {
 		t.Fatalf("seed merged comment: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE agent_task_queue SET trigger_comment_id=$2 WHERE id=$1`, task.ID, commentID); err != nil {
+		t.Fatal(err)
 	}
 	mergedOverlay := json.RawMessage(`{"mcpServers":{"merged":{"url":"https://merged.example"}}}`)
 	if _, err := q.MergeCommentIntoPendingTask(ctx, db.MergeCommentIntoPendingTaskParams{

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -716,7 +716,7 @@ func isDuplicatePendingTaskErr(err error) bool {
 		return false
 	}
 	switch pgErr.ConstraintName {
-	case "idx_one_pending_task_per_issue_agent", "idx_one_pending_task_per_issue_agent_v2":
+	case "idx_one_pending_task_per_issue_agent", "idx_one_pending_task_per_issue_agent_v2", "idx_one_pending_task_per_issue_agent_thread":
 		return true
 	default:
 		return false
@@ -5295,9 +5295,10 @@ func hasRunnableSuccessor(ctx context.Context, q *db.Queries, task db.AgentTaskQ
 	if !task.IssueID.Valid {
 		return false, nil
 	}
-	return q.HasPendingTaskForIssueAndAgent(ctx, db.HasPendingTaskForIssueAndAgentParams{
-		IssueID: task.IssueID,
-		AgentID: task.AgentID,
+	return q.HasPendingTaskForIssueAndAgentInThread(ctx, db.HasPendingTaskForIssueAndAgentInThreadParams{
+		ThreadCommentID: task.TriggerCommentID,
+		IssueID:         task.IssueID,
+		AgentID:         task.AgentID,
 	})
 }
 
@@ -5621,9 +5622,10 @@ func (s *TaskService) RerunIssue(ctx context.Context, issueID pgtype.UUID, sourc
 		// that failed after this committed.
 		cerr := s.runInTx(ctx, func(qtx *db.Queries) error {
 			var err error
-			cancelled, err = qtx.CancelPendingTasksByIssueAndAgent(ctx, db.CancelPendingTasksByIssueAndAgentParams{
-				IssueID: issueID,
-				AgentID: agentID,
+			cancelled, err = qtx.CancelPendingTasksByIssueAndAgentInThread(ctx, db.CancelPendingTasksByIssueAndAgentInThreadParams{
+				ThreadCommentID: triggerCommentID,
+				IssueID:         issueID,
+				AgentID:         agentID,
 			})
 			if err != nil {
 				return err

--- a/server/internal/service/task_channel_media_race_test.go
+++ b/server/internal/service/task_channel_media_race_test.go
@@ -535,6 +535,9 @@ func TestDeferredChannelIssueTaskPromotesAfterMediaSettlement(t *testing.T) {
 		VALUES ($1, $2, 'member', $3, 'More context') RETURNING id`, issueID, workspaceID, userID).Scan(&commentID); err != nil {
 		t.Fatalf("seed comment: %v", err)
 	}
+	if _, err := pool.Exec(ctx, `UPDATE agent_task_queue SET trigger_comment_id=$2 WHERE id=$1`, task.ID, commentID); err != nil {
+		t.Fatal(err)
+	}
 	merged, err := q.MergeCommentIntoPendingTask(ctx, db.MergeCommentIntoPendingTaskParams{
 		IssueID:                 issueID,
 		AgentID:                 util.MustParseUUID(agentID),
@@ -579,7 +582,7 @@ func TestDeferredChannelIssueTaskConflictsWithQueuedSiblingAtDatabase(t *testing
 	ctx := context.Background()
 
 	var indexDefinition string
-	if err := pool.QueryRow(ctx, `SELECT pg_get_indexdef('idx_one_pending_task_per_issue_agent_v2'::regclass)`).Scan(&indexDefinition); err != nil {
+	if err := pool.QueryRow(ctx, `SELECT pg_get_indexdef('idx_one_pending_task_per_issue_agent_thread'::regclass)`).Scan(&indexDefinition); err != nil {
 		t.Fatalf("load pending-task index: %v", err)
 	}
 	if !strings.Contains(indexDefinition, "channel_issue_media_pending") {
@@ -614,7 +617,7 @@ func TestDeferredChannelIssueTaskConflictsWithQueuedSiblingAtDatabase(t *testing
 		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
 		VALUES ($1, $2, $3, 'queued', 0)`, task.AgentID, task.RuntimeID, issueID)
 	var pgErr *pgconn.PgError
-	if !errors.As(err, &pgErr) || pgErr.Code != "23505" || pgErr.ConstraintName != "idx_one_pending_task_per_issue_agent_v2" {
+	if !errors.As(err, &pgErr) || pgErr.Code != "23505" || pgErr.ConstraintName != "idx_one_pending_task_per_issue_agent_thread" {
 		t.Fatalf("queued sibling insert error = %v, want unique violation on pending-task index", err)
 	}
 }

--- a/server/migrations/451_agent_task_comment_thread.down.sql
+++ b/server/migrations/451_agent_task_comment_thread.down.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER agent_task_comment_thread ON agent_task_queue;
+DROP FUNCTION set_agent_task_comment_thread();
+ALTER TABLE agent_task_queue DROP COLUMN comment_thread_id;
+DROP FUNCTION comment_thread_root_id(uuid);

--- a/server/migrations/451_agent_task_comment_thread.up.sql
+++ b/server/migrations/451_agent_task_comment_thread.up.sql
@@ -1,0 +1,35 @@
+-- Persist the queue's thread scope so uniqueness remains atomic for every
+-- writer, including retries and older clients. This is derived data, not a FK.
+ALTER TABLE agent_task_queue ADD COLUMN comment_thread_id uuid;
+
+CREATE FUNCTION comment_thread_root_id(comment_id uuid) RETURNS uuid
+LANGUAGE sql STABLE STRICT AS $$
+    WITH RECURSIVE ancestors AS (
+        SELECT c.id, c.parent_id, c.issue_id, ARRAY[c.id] AS path
+        FROM comment c WHERE c.id = comment_id
+        UNION ALL
+        SELECT p.id, p.parent_id, p.issue_id, a.path || p.id
+        FROM ancestors a JOIN comment p ON p.id = a.parent_id AND p.issue_id = a.issue_id
+        WHERE NOT p.id = ANY(a.path)
+    )
+    SELECT COALESCE(
+        (SELECT id FROM ancestors ORDER BY cardinality(path) DESC LIMIT 1),
+        comment_id
+    )
+$$;
+
+CREATE FUNCTION set_agent_task_comment_thread() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.comment_thread_id := comment_thread_root_id(NEW.trigger_comment_id);
+    RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER agent_task_comment_thread
+BEFORE INSERT OR UPDATE OF trigger_comment_id ON agent_task_queue
+FOR EACH ROW EXECUTE FUNCTION set_agent_task_comment_thread();
+
+UPDATE agent_task_queue
+SET comment_thread_id = comment_thread_root_id(trigger_comment_id)
+WHERE trigger_comment_id IS NOT NULL;

--- a/server/migrations/452_agent_task_pending_thread_unique.down.sql
+++ b/server/migrations/452_agent_task_pending_thread_unique.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_one_pending_task_per_issue_agent_thread;

--- a/server/migrations/452_agent_task_pending_thread_unique.up.sql
+++ b/server/migrations/452_agent_task_pending_thread_unique.up.sql
@@ -1,0 +1,5 @@
+-- Build the new guard before retiring the issue-wide guard.
+CREATE UNIQUE INDEX CONCURRENTLY idx_one_pending_task_per_issue_agent_thread
+    ON agent_task_queue (issue_id, agent_id, COALESCE(comment_thread_id, '00000000-0000-0000-0000-000000000000'::uuid))
+    WHERE status IN ('queued', 'dispatched')
+       OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true');

--- a/server/migrations/453_drop_pending_issue_agent_unique.down.sql
+++ b/server/migrations/453_drop_pending_issue_agent_unique.down.sql
@@ -1,0 +1,6 @@
+-- Drain per-thread pending queues before downgrading; never discard requests
+-- merely to recreate the older, narrower uniqueness constraint.
+CREATE UNIQUE INDEX CONCURRENTLY idx_one_pending_task_per_issue_agent_v2
+    ON agent_task_queue (issue_id, agent_id)
+    WHERE status IN ('queued', 'dispatched')
+       OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true');

--- a/server/migrations/453_drop_pending_issue_agent_unique.up.sql
+++ b/server/migrations/453_drop_pending_issue_agent_unique.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_one_pending_task_per_issue_agent_v2;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -32,7 +32,7 @@ WHERE acknowledged.id = (
       WHERE attempt_count.trigger_evidence_kind = 'delegated_failure'
         AND attempt_count.trigger_evidence_ref_id = $2
   ) >= $3::int
-RETURNING acknowledged.id, acknowledged.agent_id, acknowledged.issue_id, acknowledged.status, acknowledged.priority, acknowledged.dispatched_at, acknowledged.started_at, acknowledged.completed_at, acknowledged.result, acknowledged.error, acknowledged.created_at, acknowledged.context, acknowledged.runtime_id, acknowledged.session_id, acknowledged.work_dir, acknowledged.trigger_comment_id, acknowledged.chat_session_id, acknowledged.autopilot_run_id, acknowledged.attempt, acknowledged.max_attempts, acknowledged.parent_task_id, acknowledged.failure_reason, acknowledged.trigger_summary, acknowledged.force_fresh_session, acknowledged.is_leader_task, acknowledged.wait_reason, acknowledged.initiator_user_id, acknowledged.handoff_note, acknowledged.prepare_lease_expires_at, acknowledged.squad_id, acknowledged.runtime_mcp_overlay, acknowledged.escalation_for_task_id, acknowledged.fire_at, acknowledged.originator_user_id, acknowledged.runtime_connected_apps, acknowledged.coalesced_comment_ids, acknowledged.delivered_comment_ids, acknowledged.chat_input_task_id, acknowledged.chat_finalize_deferred_at, acknowledged.originator_source, acknowledged.delegated_from_task_id, acknowledged.retry_of_task_id, acknowledged.rerun_of_task_id, acknowledged.rule_version_id, acknowledged.trigger_evidence_kind, acknowledged.trigger_evidence_ref_id, acknowledged.accountable_user_id, acknowledged.session_rollout_missing, acknowledged.retired_session_id, acknowledged.quick_actions_disabled, acknowledged.regenerate_quick_actions_for, acknowledged.branch_name, acknowledged.durable_work_dir, acknowledged.channel_context_revision
+RETURNING acknowledged.id, acknowledged.agent_id, acknowledged.issue_id, acknowledged.status, acknowledged.priority, acknowledged.dispatched_at, acknowledged.started_at, acknowledged.completed_at, acknowledged.result, acknowledged.error, acknowledged.created_at, acknowledged.context, acknowledged.runtime_id, acknowledged.session_id, acknowledged.work_dir, acknowledged.trigger_comment_id, acknowledged.chat_session_id, acknowledged.autopilot_run_id, acknowledged.attempt, acknowledged.max_attempts, acknowledged.parent_task_id, acknowledged.failure_reason, acknowledged.trigger_summary, acknowledged.force_fresh_session, acknowledged.is_leader_task, acknowledged.wait_reason, acknowledged.initiator_user_id, acknowledged.handoff_note, acknowledged.prepare_lease_expires_at, acknowledged.squad_id, acknowledged.runtime_mcp_overlay, acknowledged.escalation_for_task_id, acknowledged.fire_at, acknowledged.originator_user_id, acknowledged.runtime_connected_apps, acknowledged.coalesced_comment_ids, acknowledged.delivered_comment_ids, acknowledged.chat_input_task_id, acknowledged.chat_finalize_deferred_at, acknowledged.originator_source, acknowledged.delegated_from_task_id, acknowledged.retry_of_task_id, acknowledged.rerun_of_task_id, acknowledged.rule_version_id, acknowledged.trigger_evidence_kind, acknowledged.trigger_evidence_ref_id, acknowledged.accountable_user_id, acknowledged.session_rollout_missing, acknowledged.retired_session_id, acknowledged.quick_actions_disabled, acknowledged.regenerate_quick_actions_for, acknowledged.branch_name, acknowledged.durable_work_dir, acknowledged.channel_context_revision, acknowledged.comment_thread_id
 `
 
 type AcknowledgeExhaustedDelegatedFailureRecoveryParams struct {
@@ -103,6 +103,7 @@ func (q *Queries) AcknowledgeExhaustedDelegatedFailureRecovery(ctx context.Conte
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -303,7 +304,7 @@ const cancelAgentTask = `-- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Automatic cancellation without an explicit persisted failure reason. Unlike
@@ -366,6 +367,7 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -424,7 +426,7 @@ SET status = 'cancelled',
     END
 WHERE task.id = $1
   AND task.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING task.id, task.agent_id, task.issue_id, task.status, task.priority, task.dispatched_at, task.started_at, task.completed_at, task.result, task.error, task.created_at, task.context, task.runtime_id, task.session_id, task.work_dir, task.trigger_comment_id, task.chat_session_id, task.autopilot_run_id, task.attempt, task.max_attempts, task.parent_task_id, task.failure_reason, task.trigger_summary, task.force_fresh_session, task.is_leader_task, task.wait_reason, task.initiator_user_id, task.handoff_note, task.prepare_lease_expires_at, task.squad_id, task.runtime_mcp_overlay, task.escalation_for_task_id, task.fire_at, task.originator_user_id, task.runtime_connected_apps, task.coalesced_comment_ids, task.delivered_comment_ids, task.chat_input_task_id, task.chat_finalize_deferred_at, task.originator_source, task.delegated_from_task_id, task.retry_of_task_id, task.rerun_of_task_id, task.rule_version_id, task.trigger_evidence_kind, task.trigger_evidence_ref_id, task.accountable_user_id, task.session_rollout_missing, task.retired_session_id, task.quick_actions_disabled, task.regenerate_quick_actions_for, task.branch_name, task.durable_work_dir, task.channel_context_revision
+RETURNING task.id, task.agent_id, task.issue_id, task.status, task.priority, task.dispatched_at, task.started_at, task.completed_at, task.result, task.error, task.created_at, task.context, task.runtime_id, task.session_id, task.work_dir, task.trigger_comment_id, task.chat_session_id, task.autopilot_run_id, task.attempt, task.max_attempts, task.parent_task_id, task.failure_reason, task.trigger_summary, task.force_fresh_session, task.is_leader_task, task.wait_reason, task.initiator_user_id, task.handoff_note, task.prepare_lease_expires_at, task.squad_id, task.runtime_mcp_overlay, task.escalation_for_task_id, task.fire_at, task.originator_user_id, task.runtime_connected_apps, task.coalesced_comment_ids, task.delivered_comment_ids, task.chat_input_task_id, task.chat_finalize_deferred_at, task.originator_source, task.delegated_from_task_id, task.retry_of_task_id, task.rerun_of_task_id, task.rule_version_id, task.trigger_evidence_kind, task.trigger_evidence_ref_id, task.accountable_user_id, task.session_rollout_missing, task.retired_session_id, task.quick_actions_disabled, task.regenerate_quick_actions_for, task.branch_name, task.durable_work_dir, task.channel_context_revision, task.comment_thread_id
 `
 
 // An explicit user cancellation is a terminal acknowledgement for any
@@ -489,6 +491,7 @@ func (q *Queries) CancelAgentTaskByUser(ctx context.Context, id pgtype.UUID) (Ag
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -501,7 +504,7 @@ SET status = 'cancelled',
     failure_reason = $2,
     prepare_lease_expires_at = NULL
 WHERE id = $3 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CancelAgentTaskWithReasonParams struct {
@@ -575,6 +578,7 @@ func (q *Queries) CancelAgentTaskWithReason(ctx context.Context, arg CancelAgent
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -583,7 +587,7 @@ const cancelAgentTasksByAgent = `-- name: CancelAgentTasksByAgent :many
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE agent_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Bulk-cancel every active (queued/dispatched/running) task for an agent.
@@ -655,6 +659,7 @@ func (q *Queries) CancelAgentTasksByAgent(ctx context.Context, agentID pgtype.UU
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -670,7 +675,7 @@ const cancelAgentTasksByChatSession = `-- name: CancelAgentTasksByChatSession :m
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE chat_session_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Cancels active tasks belonging to a chat session. Called from
@@ -742,6 +747,7 @@ func (q *Queries) CancelAgentTasksByChatSession(ctx context.Context, chatSession
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -757,7 +763,7 @@ const cancelAgentTasksByIssue = `-- name: CancelAgentTasksByIssue :many
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Cancels every active task on the issue and returns the affected rows so the
@@ -829,6 +835,7 @@ func (q *Queries) CancelAgentTasksByIssue(ctx context.Context, issueID pgtype.UU
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -846,7 +853,7 @@ SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL,
     context = COALESCE(context, '{}'::jsonb) || jsonb_build_object('comment_change_cancelled_task_id', id::text)
 WHERE (trigger_comment_id = $1 OR $1 = ANY(coalesced_comment_ids))
   AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Cancels active tasks whose planned batch contains the edited/deleted comment.
@@ -917,6 +924,7 @@ func (q *Queries) CancelAgentTasksByTriggerComment(ctx context.Context, triggerC
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -937,9 +945,9 @@ WITH cancelled AS (
       AND fallback.status IN ('deferred', 'queued', 'dispatched', 'waiting_local_directory')
       AND primary_task.issue_id = $1
       AND primary_task.agent_id = $2
-    RETURNING fallback.id, fallback.agent_id, fallback.issue_id, fallback.status, fallback.priority, fallback.dispatched_at, fallback.started_at, fallback.completed_at, fallback.result, fallback.error, fallback.created_at, fallback.context, fallback.runtime_id, fallback.session_id, fallback.work_dir, fallback.trigger_comment_id, fallback.chat_session_id, fallback.autopilot_run_id, fallback.attempt, fallback.max_attempts, fallback.parent_task_id, fallback.failure_reason, fallback.trigger_summary, fallback.force_fresh_session, fallback.is_leader_task, fallback.wait_reason, fallback.initiator_user_id, fallback.handoff_note, fallback.prepare_lease_expires_at, fallback.squad_id, fallback.runtime_mcp_overlay, fallback.escalation_for_task_id, fallback.fire_at, fallback.originator_user_id, fallback.runtime_connected_apps, fallback.coalesced_comment_ids, fallback.delivered_comment_ids, fallback.chat_input_task_id, fallback.chat_finalize_deferred_at, fallback.originator_source, fallback.delegated_from_task_id, fallback.retry_of_task_id, fallback.rerun_of_task_id, fallback.rule_version_id, fallback.trigger_evidence_kind, fallback.trigger_evidence_ref_id, fallback.accountable_user_id, fallback.session_rollout_missing, fallback.retired_session_id, fallback.quick_actions_disabled, fallback.regenerate_quick_actions_for, fallback.branch_name, fallback.durable_work_dir, fallback.channel_context_revision
+    RETURNING fallback.id, fallback.agent_id, fallback.issue_id, fallback.status, fallback.priority, fallback.dispatched_at, fallback.started_at, fallback.completed_at, fallback.result, fallback.error, fallback.created_at, fallback.context, fallback.runtime_id, fallback.session_id, fallback.work_dir, fallback.trigger_comment_id, fallback.chat_session_id, fallback.autopilot_run_id, fallback.attempt, fallback.max_attempts, fallback.parent_task_id, fallback.failure_reason, fallback.trigger_summary, fallback.force_fresh_session, fallback.is_leader_task, fallback.wait_reason, fallback.initiator_user_id, fallback.handoff_note, fallback.prepare_lease_expires_at, fallback.squad_id, fallback.runtime_mcp_overlay, fallback.escalation_for_task_id, fallback.fire_at, fallback.originator_user_id, fallback.runtime_connected_apps, fallback.coalesced_comment_ids, fallback.delivered_comment_ids, fallback.chat_input_task_id, fallback.chat_finalize_deferred_at, fallback.originator_source, fallback.delegated_from_task_id, fallback.retry_of_task_id, fallback.rerun_of_task_id, fallback.rule_version_id, fallback.trigger_evidence_kind, fallback.trigger_evidence_ref_id, fallback.accountable_user_id, fallback.session_rollout_missing, fallback.retired_session_id, fallback.quick_actions_disabled, fallback.regenerate_quick_actions_for, fallback.branch_name, fallback.durable_work_dir, fallback.channel_context_revision, fallback.comment_thread_id
 )
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM cancelled
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM cancelled
 `
 
 type CancelDeferredEscalationsForIssueAgentParams struct {
@@ -1002,6 +1010,7 @@ type CancelDeferredEscalationsForIssueAgentRow struct {
 	BranchName                pgtype.Text        `json:"branch_name"`
 	DurableWorkDir            pgtype.Text        `json:"durable_work_dir"`
 	ChannelContextRevision    pgtype.Int8        `json:"channel_context_revision"`
+	CommentThreadID           pgtype.UUID        `json:"comment_thread_id"`
 }
 
 func (q *Queries) CancelDeferredEscalationsForIssueAgent(ctx context.Context, arg CancelDeferredEscalationsForIssueAgentParams) ([]CancelDeferredEscalationsForIssueAgentRow, error) {
@@ -1068,6 +1077,7 @@ func (q *Queries) CancelDeferredEscalationsForIssueAgent(ctx context.Context, ar
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -1084,7 +1094,7 @@ UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE escalation_for_task_id = $1
   AND status IN ('deferred', 'queued', 'dispatched', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 func (q *Queries) CancelDeferredEscalationsForTask(ctx context.Context, escalationForTaskID pgtype.UUID) ([]AgentTaskQueue, error) {
@@ -1151,6 +1161,7 @@ func (q *Queries) CancelDeferredEscalationsForTask(ctx context.Context, escalati
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -1167,7 +1178,7 @@ UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE issue_id = $1 AND agent_id = $2
   AND status IN ('queued', 'dispatched', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CancelPendingTasksByIssueAndAgentParams struct {
@@ -1255,6 +1266,100 @@ func (q *Queries) CancelPendingTasksByIssueAndAgent(ctx context.Context, arg Can
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const cancelPendingTasksByIssueAndAgentInThread = `-- name: CancelPendingTasksByIssueAndAgentInThread :many
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE issue_id = $1 AND agent_id = $2
+  AND status IN ('queued', 'dispatched', 'deferred')
+  AND comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id($3::uuid)
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
+`
+
+type CancelPendingTasksByIssueAndAgentInThreadParams struct {
+	IssueID         pgtype.UUID `json:"issue_id"`
+	AgentID         pgtype.UUID `json:"agent_id"`
+	ThreadCommentID pgtype.UUID `json:"thread_comment_id"`
+}
+
+// Cancel only the not-yet-started plan in the selected thread. Other threads
+// retain their queues; running tasks are stopped explicitly through CancelTask.
+func (q *Queries) CancelPendingTasksByIssueAndAgentInThread(ctx context.Context, arg CancelPendingTasksByIssueAndAgentInThreadParams) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, cancelPendingTasksByIssueAndAgentInThread, arg.IssueID, arg.AgentID, arg.ThreadCommentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.TriggerSummary,
+			&i.ForceFreshSession,
+			&i.IsLeaderTask,
+			&i.WaitReason,
+			&i.InitiatorUserID,
+			&i.HandoffNote,
+			&i.PrepareLeaseExpiresAt,
+			&i.SquadID,
+			&i.RuntimeMcpOverlay,
+			&i.EscalationForTaskID,
+			&i.FireAt,
+			&i.OriginatorUserID,
+			&i.RuntimeConnectedApps,
+			&i.CoalescedCommentIds,
+			&i.DeliveredCommentIds,
+			&i.ChatInputTaskID,
+			&i.ChatFinalizeDeferredAt,
+			&i.OriginatorSource,
+			&i.DelegatedFromTaskID,
+			&i.RetryOfTaskID,
+			&i.RerunOfTaskID,
+			&i.RuleVersionID,
+			&i.TriggerEvidenceKind,
+			&i.TriggerEvidenceRefID,
+			&i.AccountableUserID,
+			&i.SessionRolloutMissing,
+			&i.RetiredSessionID,
+			&i.QuickActionsDisabled,
+			&i.RegenerateQuickActionsFor,
+			&i.BranchName,
+			&i.DurableWorkDir,
+			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -1272,7 +1377,7 @@ SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE id = $1
   AND chat_session_id = $2
   AND status = 'queued'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CancelQueuedAgentTaskParams struct {
@@ -1340,6 +1445,7 @@ func (q *Queries) CancelQueuedAgentTask(ctx context.Context, arg CancelQueuedAge
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -1367,7 +1473,7 @@ SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE queued.chat_session_id = $1
   AND queued.status = 'queued'
   AND queued.id IS DISTINCT FROM (SELECT id FROM head)
-RETURNING queued.id, queued.agent_id, queued.issue_id, queued.status, queued.priority, queued.dispatched_at, queued.started_at, queued.completed_at, queued.result, queued.error, queued.created_at, queued.context, queued.runtime_id, queued.session_id, queued.work_dir, queued.trigger_comment_id, queued.chat_session_id, queued.autopilot_run_id, queued.attempt, queued.max_attempts, queued.parent_task_id, queued.failure_reason, queued.trigger_summary, queued.force_fresh_session, queued.is_leader_task, queued.wait_reason, queued.initiator_user_id, queued.handoff_note, queued.prepare_lease_expires_at, queued.squad_id, queued.runtime_mcp_overlay, queued.escalation_for_task_id, queued.fire_at, queued.originator_user_id, queued.runtime_connected_apps, queued.coalesced_comment_ids, queued.delivered_comment_ids, queued.chat_input_task_id, queued.chat_finalize_deferred_at, queued.originator_source, queued.delegated_from_task_id, queued.retry_of_task_id, queued.rerun_of_task_id, queued.rule_version_id, queued.trigger_evidence_kind, queued.trigger_evidence_ref_id, queued.accountable_user_id, queued.session_rollout_missing, queued.retired_session_id, queued.quick_actions_disabled, queued.regenerate_quick_actions_for, queued.branch_name, queued.durable_work_dir, queued.channel_context_revision
+RETURNING queued.id, queued.agent_id, queued.issue_id, queued.status, queued.priority, queued.dispatched_at, queued.started_at, queued.completed_at, queued.result, queued.error, queued.created_at, queued.context, queued.runtime_id, queued.session_id, queued.work_dir, queued.trigger_comment_id, queued.chat_session_id, queued.autopilot_run_id, queued.attempt, queued.max_attempts, queued.parent_task_id, queued.failure_reason, queued.trigger_summary, queued.force_fresh_session, queued.is_leader_task, queued.wait_reason, queued.initiator_user_id, queued.handoff_note, queued.prepare_lease_expires_at, queued.squad_id, queued.runtime_mcp_overlay, queued.escalation_for_task_id, queued.fire_at, queued.originator_user_id, queued.runtime_connected_apps, queued.coalesced_comment_ids, queued.delivered_comment_ids, queued.chat_input_task_id, queued.chat_finalize_deferred_at, queued.originator_source, queued.delegated_from_task_id, queued.retry_of_task_id, queued.rerun_of_task_id, queued.rule_version_id, queued.trigger_evidence_kind, queued.trigger_evidence_ref_id, queued.accountable_user_id, queued.session_rollout_missing, queued.retired_session_id, queued.quick_actions_disabled, queued.regenerate_quick_actions_for, queued.branch_name, queued.durable_work_dir, queued.channel_context_revision, queued.comment_thread_id
 `
 
 // Clear only positional follow-ups. The first visible task is current even
@@ -1438,6 +1544,7 @@ func (q *Queries) CancelQueuedAgentTasksForSession(ctx context.Context, chatSess
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -1462,10 +1569,11 @@ WHERE r.runtime_id = ANY($1::uuid[])
     SELECT 1 FROM agent_task_queue successor
     WHERE successor.issue_id = r.issue_id
       AND successor.agent_id = r.agent_id
+      AND successor.comment_thread_id IS NOT DISTINCT FROM r.comment_thread_id
       AND successor.id <> r.id
       AND successor.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
   )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Cancels deferred auto-retry rows that a newer active task has already
@@ -1556,6 +1664,7 @@ func (q *Queries) CancelSupersededDeferredRetriesForRuntimes(ctx context.Context
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -1625,7 +1734,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type ClaimAgentTaskParams struct {
@@ -1708,6 +1817,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, arg ClaimAgentTaskParams) 
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -1716,7 +1826,7 @@ const claimChatFinalizeDeferred = `-- name: ClaimChatFinalizeDeferred :one
 UPDATE agent_task_queue
 SET chat_finalize_deferred_at = NULL
 WHERE id = $1 AND chat_finalize_deferred_at IS NOT NULL
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Atomically claims the deferred marker so the daemon ack and the sweeper
@@ -1779,6 +1889,7 @@ func (q *Queries) ClaimChatFinalizeDeferred(ctx context.Context, id pgtype.UUID)
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -1977,7 +2088,7 @@ SET status = 'completed', completed_at = now(), result = $2,
     retired_session_id = COALESCE($8, retired_session_id),
     prepare_lease_expires_at = NULL
 WHERE id = $1 AND status = 'running'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CompleteAgentTaskParams struct {
@@ -2069,6 +2180,7 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -2312,7 +2424,7 @@ SELECT
     $22,
     COALESCE($23::uuid, gen_random_uuid())
 WHERE lock_task_owner_rows($1, $3, $2)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CreateAgentTaskParams struct {
@@ -2441,6 +2553,7 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -2469,7 +2582,7 @@ SELECT
     $19,
     COALESCE($20::uuid, gen_random_uuid())
 WHERE lock_task_owner_rows($1, $3, $2)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CreateDeferredAgentTaskParams struct {
@@ -2585,6 +2698,7 @@ func (q *Queries) CreateDeferredAgentTask(ctx context.Context, arg CreateDeferre
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -2623,7 +2737,7 @@ SELECT
     $23,
     COALESCE($24::uuid, gen_random_uuid())
 WHERE lock_task_owner_rows($1, $3, $2)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CreateDeferredChannelIssueTaskParams struct {
@@ -2743,6 +2857,7 @@ func (q *Queries) CreateDeferredChannelIssueTask(ctx context.Context, arg Create
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -2768,7 +2883,7 @@ WHERE p.id = $5
   AND p.chat_session_id IS NULL
   AND p.autopilot_run_id IS NULL
   AND lock_task_owner_rows(p.agent_id, p.issue_id, p.runtime_id)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CreateManualQuickCreateRetryTaskParams struct {
@@ -2852,6 +2967,7 @@ func (q *Queries) CreateManualQuickCreateRetryTask(ctx context.Context, arg Crea
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -2874,7 +2990,7 @@ SELECT
     $11,
     COALESCE($12::uuid, gen_random_uuid())
 WHERE lock_task_owner_rows($1, NULL, $2)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CreateQuickCreateTaskParams struct {
@@ -2973,6 +3089,7 @@ func (q *Queries) CreateQuickCreateTask(ctx context.Context, arg CreateQuickCrea
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -3013,10 +3130,10 @@ SELECT
 FROM agent_task_queue p
 WHERE p.id = $1
   AND lock_task_owner_rows(p.agent_id, p.issue_id, p.runtime_id)
-ON CONFLICT (issue_id, agent_id) WHERE status IN ('queued', 'dispatched')
+ON CONFLICT (issue_id, agent_id, (COALESCE(comment_thread_id, '00000000-0000-0000-0000-000000000000'::uuid))) WHERE status IN ('queued', 'dispatched')
        OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true')
 DO NOTHING
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CreateRetryTaskParams struct {
@@ -3166,6 +3283,7 @@ func (q *Queries) CreateRetryTask(ctx context.Context, arg CreateRetryTaskParams
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -3346,7 +3464,7 @@ WHERE t.id = v.id
       WHERE retry_parent.id = t.parent_task_id
         AND retry_parent.failure_reason = 'runtime_offline'
   )
-RETURNING t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.squad_id, t.runtime_mcp_overlay, t.escalation_for_task_id, t.fire_at, t.originator_user_id, t.runtime_connected_apps, t.coalesced_comment_ids, t.delivered_comment_ids, t.chat_input_task_id, t.chat_finalize_deferred_at, t.originator_source, t.delegated_from_task_id, t.retry_of_task_id, t.rerun_of_task_id, t.rule_version_id, t.trigger_evidence_kind, t.trigger_evidence_ref_id, t.accountable_user_id, t.session_rollout_missing, t.retired_session_id, t.quick_actions_disabled, t.regenerate_quick_actions_for, t.branch_name, t.durable_work_dir, t.channel_context_revision
+RETURNING t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.squad_id, t.runtime_mcp_overlay, t.escalation_for_task_id, t.fire_at, t.originator_user_id, t.runtime_connected_apps, t.coalesced_comment_ids, t.delivered_comment_ids, t.chat_input_task_id, t.chat_finalize_deferred_at, t.originator_source, t.delegated_from_task_id, t.retry_of_task_id, t.rerun_of_task_id, t.rule_version_id, t.trigger_evidence_kind, t.trigger_evidence_ref_id, t.accountable_user_id, t.session_rollout_missing, t.retired_session_id, t.quick_actions_disabled, t.regenerate_quick_actions_for, t.branch_name, t.durable_work_dir, t.channel_context_revision, t.comment_thread_id
 `
 
 type ExpireStaleQueuedTasksParams struct {
@@ -3480,6 +3598,7 @@ func (q *Queries) ExpireStaleQueuedTasks(ctx context.Context, arg ExpireStaleQue
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -3498,7 +3617,7 @@ WHERE id = $1
   AND runtime_id = $2
   AND status IN ('dispatched', 'waiting_local_directory')
   AND started_at IS NULL
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type ExtendAgentTaskPrepareLeaseParams struct {
@@ -3569,6 +3688,7 @@ func (q *Queries) ExtendAgentTaskPrepareLease(ctx context.Context, arg ExtendAge
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -3587,7 +3707,7 @@ SET status = 'failed',
     retired_session_id = COALESCE($9, retired_session_id),
     prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type FailAgentTaskParams struct {
@@ -3685,6 +3805,7 @@ func (q *Queries) FailAgentTask(ctx context.Context, arg FailAgentTaskParams) (A
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -3731,7 +3852,7 @@ WHERE retry.id = victims.id
         AND COALESCE(runtime.last_seen_at, runtime.updated_at) >=
             now() - make_interval(secs => $2::double precision)
   )
-RETURNING retry.id, retry.agent_id, retry.issue_id, retry.status, retry.priority, retry.dispatched_at, retry.started_at, retry.completed_at, retry.result, retry.error, retry.created_at, retry.context, retry.runtime_id, retry.session_id, retry.work_dir, retry.trigger_comment_id, retry.chat_session_id, retry.autopilot_run_id, retry.attempt, retry.max_attempts, retry.parent_task_id, retry.failure_reason, retry.trigger_summary, retry.force_fresh_session, retry.is_leader_task, retry.wait_reason, retry.initiator_user_id, retry.handoff_note, retry.prepare_lease_expires_at, retry.squad_id, retry.runtime_mcp_overlay, retry.escalation_for_task_id, retry.fire_at, retry.originator_user_id, retry.runtime_connected_apps, retry.coalesced_comment_ids, retry.delivered_comment_ids, retry.chat_input_task_id, retry.chat_finalize_deferred_at, retry.originator_source, retry.delegated_from_task_id, retry.retry_of_task_id, retry.rerun_of_task_id, retry.rule_version_id, retry.trigger_evidence_kind, retry.trigger_evidence_ref_id, retry.accountable_user_id, retry.session_rollout_missing, retry.retired_session_id, retry.quick_actions_disabled, retry.regenerate_quick_actions_for, retry.branch_name, retry.durable_work_dir, retry.channel_context_revision
+RETURNING retry.id, retry.agent_id, retry.issue_id, retry.status, retry.priority, retry.dispatched_at, retry.started_at, retry.completed_at, retry.result, retry.error, retry.created_at, retry.context, retry.runtime_id, retry.session_id, retry.work_dir, retry.trigger_comment_id, retry.chat_session_id, retry.autopilot_run_id, retry.attempt, retry.max_attempts, retry.parent_task_id, retry.failure_reason, retry.trigger_summary, retry.force_fresh_session, retry.is_leader_task, retry.wait_reason, retry.initiator_user_id, retry.handoff_note, retry.prepare_lease_expires_at, retry.squad_id, retry.runtime_mcp_overlay, retry.escalation_for_task_id, retry.fire_at, retry.originator_user_id, retry.runtime_connected_apps, retry.coalesced_comment_ids, retry.delivered_comment_ids, retry.chat_input_task_id, retry.chat_finalize_deferred_at, retry.originator_source, retry.delegated_from_task_id, retry.retry_of_task_id, retry.rerun_of_task_id, retry.rule_version_id, retry.trigger_evidence_kind, retry.trigger_evidence_ref_id, retry.accountable_user_id, retry.session_rollout_missing, retry.retired_session_id, retry.quick_actions_disabled, retry.regenerate_quick_actions_for, retry.branch_name, retry.durable_work_dir, retry.channel_context_revision, retry.comment_thread_id
 `
 
 type FailExpiredRuntimeReconnectRetriesParams struct {
@@ -3811,6 +3932,7 @@ func (q *Queries) FailExpiredRuntimeReconnectRetries(ctx context.Context, arg Fa
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -3865,7 +3987,7 @@ WHERE (
       )
     )
   )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type FailStaleTasksParams struct {
@@ -3976,6 +4098,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -4217,7 +4340,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM agent_task_queue
 WHERE id = $1
 `
 
@@ -4279,12 +4402,13 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
 
 const getAgentTaskForDelegatedFailureUpdate = `-- name: GetAgentTaskForDelegatedFailureUpdate :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM agent_task_queue
 WHERE id = $1
 FOR UPDATE
 `
@@ -4350,12 +4474,13 @@ func (q *Queries) GetAgentTaskForDelegatedFailureUpdate(ctx context.Context, id 
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
 
 const getAgentTaskInWorkspace = `-- name: GetAgentTaskInWorkspace :one
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision, atq.comment_thread_id FROM agent_task_queue atq
 JOIN agent a ON a.id = atq.agent_id
 WHERE atq.id = $1 AND a.workspace_id = $2
 `
@@ -4430,8 +4555,20 @@ func (q *Queries) GetAgentTaskInWorkspace(ctx context.Context, arg GetAgentTaskI
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
+}
+
+const getCommentThreadRootID = `-- name: GetCommentThreadRootID :one
+SELECT comment_thread_root_id($1::uuid)::uuid AS id
+`
+
+func (q *Queries) GetCommentThreadRootID(ctx context.Context, commentID pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, getCommentThreadRootID, commentID)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const getLastTaskSession = `-- name: GetLastTaskSession :one
@@ -4873,6 +5010,30 @@ func (q *Queries) HasActiveTaskForIssueAndAgent(ctx context.Context, arg HasActi
 	return has_active, err
 }
 
+const hasActiveTaskForIssueAndAgentInThread = `-- name: HasActiveTaskForIssueAndAgentInThread :one
+SELECT count(*) > 0 AS has_active FROM agent_task_queue
+WHERE issue_id = $1 AND agent_id = $2
+  AND (
+    status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+    OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true')
+  )
+  AND comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id($3::uuid)
+`
+
+type HasActiveTaskForIssueAndAgentInThreadParams struct {
+	IssueID         pgtype.UUID `json:"issue_id"`
+	AgentID         pgtype.UUID `json:"agent_id"`
+	ThreadCommentID pgtype.UUID `json:"thread_comment_id"`
+}
+
+// Active execution and pending work in this comment thread only.
+func (q *Queries) HasActiveTaskForIssueAndAgentInThread(ctx context.Context, arg HasActiveTaskForIssueAndAgentInThreadParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasActiveTaskForIssueAndAgentInThread, arg.IssueID, arg.AgentID, arg.ThreadCommentID)
+	var has_active bool
+	err := row.Scan(&has_active)
+	return has_active, err
+}
+
 const hasPendingTaskForIssue = `-- name: HasPendingTaskForIssue :one
 SELECT count(*) > 0 AS has_pending FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched')
@@ -4958,6 +5119,79 @@ func (q *Queries) HasPendingTaskForIssueAndAgentExcludingTriggerComment(ctx cont
 		arg.AgentID,
 		arg.ExcludeTriggerCommentID,
 		arg.HeadSha,
+	)
+	var has_pending bool
+	err := row.Scan(&has_pending)
+	return has_pending, err
+}
+
+const hasPendingTaskForIssueAndAgentExcludingTriggerCommentInThread = `-- name: HasPendingTaskForIssueAndAgentExcludingTriggerCommentInThread :one
+SELECT count(*) > 0 AS has_pending FROM agent_task_queue
+WHERE issue_id = $1
+  AND agent_id = $2
+  AND (
+    status IN ('queued', 'dispatched')
+    OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true')
+  )
+  AND trigger_comment_id IS DISTINCT FROM $3::uuid
+  AND (
+    COALESCE($4::text, '') = ''
+    OR context->>'head_sha' = $4::text
+  )
+  AND comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id($5::uuid)
+`
+
+type HasPendingTaskForIssueAndAgentExcludingTriggerCommentInThreadParams struct {
+	IssueID                 pgtype.UUID `json:"issue_id"`
+	AgentID                 pgtype.UUID `json:"agent_id"`
+	ExcludeTriggerCommentID pgtype.UUID `json:"exclude_trigger_comment_id"`
+	HeadSha                 pgtype.Text `json:"head_sha"`
+	ThreadCommentID         pgtype.UUID `json:"thread_comment_id"`
+}
+
+// Thread-scoped edit preview: ignore the comment whose old run save replaces.
+func (q *Queries) HasPendingTaskForIssueAndAgentExcludingTriggerCommentInThread(ctx context.Context, arg HasPendingTaskForIssueAndAgentExcludingTriggerCommentInThreadParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasPendingTaskForIssueAndAgentExcludingTriggerCommentInThread,
+		arg.IssueID,
+		arg.AgentID,
+		arg.ExcludeTriggerCommentID,
+		arg.HeadSha,
+		arg.ThreadCommentID,
+	)
+	var has_pending bool
+	err := row.Scan(&has_pending)
+	return has_pending, err
+}
+
+const hasPendingTaskForIssueAndAgentInThread = `-- name: HasPendingTaskForIssueAndAgentInThread :one
+SELECT count(*) > 0 AS has_pending FROM agent_task_queue
+WHERE issue_id = $1 AND agent_id = $2
+  AND (
+    status IN ('queued', 'dispatched')
+    OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true')
+  )
+  AND (
+    COALESCE($3::text, '') = ''
+    OR context->>'head_sha' = $3::text
+  )
+  AND comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id($4::uuid)
+`
+
+type HasPendingTaskForIssueAndAgentInThreadParams struct {
+	IssueID         pgtype.UUID `json:"issue_id"`
+	AgentID         pgtype.UUID `json:"agent_id"`
+	HeadSha         pgtype.Text `json:"head_sha"`
+	ThreadCommentID pgtype.UUID `json:"thread_comment_id"`
+}
+
+// Same pending/head rules as HasPendingTaskForIssueAndAgent, scoped to one
+// root comment and all descendants. NULL selects assignment-level work.
+func (q *Queries) HasPendingTaskForIssueAndAgentInThread(ctx context.Context, arg HasPendingTaskForIssueAndAgentInThreadParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasPendingTaskForIssueAndAgentInThread,
+		arg.IssueID,
+		arg.AgentID,
+		arg.HeadSha,
+		arg.ThreadCommentID,
 	)
 	var has_pending bool
 	err := row.Scan(&has_pending)
@@ -5176,7 +5410,7 @@ func (q *Queries) ListActiveAgentsByRuntimeForUpdate(ctx context.Context, runtim
 }
 
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
 ORDER BY created_at DESC
 `
@@ -5250,6 +5484,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -5364,7 +5599,7 @@ func (q *Queries) ListActiveTasksByIssueFamily(ctx context.Context, arg ListActi
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM agent_task_queue
 WHERE agent_id = $1
 ORDER BY created_at DESC
 `
@@ -5433,6 +5668,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -5623,7 +5859,7 @@ func (q *Queries) ListAllAgentsAnyKind(ctx context.Context, workspaceID pgtype.U
 }
 
 const listChatFinalizeDeferredExpired = `-- name: ListChatFinalizeDeferredExpired :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM agent_task_queue
 WHERE chat_finalize_deferred_at IS NOT NULL
   AND chat_finalize_deferred_at < now() - make_interval(secs => $1::double precision)
 ORDER BY chat_finalize_deferred_at
@@ -5702,6 +5938,7 @@ func (q *Queries) ListChatFinalizeDeferredExpired(ctx context.Context, arg ListC
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -5826,7 +6063,7 @@ func (q *Queries) ListPendingDelegatedFailureRecoveries(ctx context.Context, max
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC
 `
@@ -5895,6 +6132,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -5907,7 +6145,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listQueuedClaimCandidatesByRuntime = `-- name: ListQueuedClaimCandidatesByRuntime :many
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision, atq.comment_thread_id FROM agent_task_queue atq
 WHERE atq.runtime_id = $1
   AND atq.status = 'queued'
   AND EXISTS (
@@ -6004,6 +6242,7 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtim
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -6016,7 +6255,7 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtim
 }
 
 const listQueuedClaimCandidatesByRuntimes = `-- name: ListQueuedClaimCandidatesByRuntimes :many
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision, atq.comment_thread_id FROM agent_task_queue atq
 WHERE atq.runtime_id = ANY($1::uuid[])
   AND atq.status = 'queued'
   AND EXISTS (
@@ -6115,6 +6354,7 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntimes(ctx context.Context, runti
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -6127,7 +6367,7 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntimes(ctx context.Context, runti
 }
 
 const listTasksByIssue = `-- name: ListTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC
 `
@@ -6196,6 +6436,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -6270,16 +6511,16 @@ func (q *Queries) ListUserAgentsByRuntimeForUpdate(ctx context.Context, runtimeI
 }
 
 const listWorkspaceAgentTaskSnapshot = `-- name: ListWorkspaceAgentTaskSnapshot :many
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision, atq.comment_thread_id FROM agent_task_queue atq
 JOIN agent a ON a.id = atq.agent_id
 WHERE a.workspace_id = $1
   AND atq.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
 
 UNION ALL
 
-SELECT latest.id, latest.agent_id, latest.issue_id, latest.status, latest.priority, latest.dispatched_at, latest.started_at, latest.completed_at, latest.result, latest.error, latest.created_at, latest.context, latest.runtime_id, latest.session_id, latest.work_dir, latest.trigger_comment_id, latest.chat_session_id, latest.autopilot_run_id, latest.attempt, latest.max_attempts, latest.parent_task_id, latest.failure_reason, latest.trigger_summary, latest.force_fresh_session, latest.is_leader_task, latest.wait_reason, latest.initiator_user_id, latest.handoff_note, latest.prepare_lease_expires_at, latest.squad_id, latest.runtime_mcp_overlay, latest.escalation_for_task_id, latest.fire_at, latest.originator_user_id, latest.runtime_connected_apps, latest.coalesced_comment_ids, latest.delivered_comment_ids, latest.chat_input_task_id, latest.chat_finalize_deferred_at, latest.originator_source, latest.delegated_from_task_id, latest.retry_of_task_id, latest.rerun_of_task_id, latest.rule_version_id, latest.trigger_evidence_kind, latest.trigger_evidence_ref_id, latest.accountable_user_id, latest.session_rollout_missing, latest.retired_session_id, latest.quick_actions_disabled, latest.regenerate_quick_actions_for, latest.branch_name, latest.durable_work_dir, latest.channel_context_revision FROM agent a
+SELECT latest.id, latest.agent_id, latest.issue_id, latest.status, latest.priority, latest.dispatched_at, latest.started_at, latest.completed_at, latest.result, latest.error, latest.created_at, latest.context, latest.runtime_id, latest.session_id, latest.work_dir, latest.trigger_comment_id, latest.chat_session_id, latest.autopilot_run_id, latest.attempt, latest.max_attempts, latest.parent_task_id, latest.failure_reason, latest.trigger_summary, latest.force_fresh_session, latest.is_leader_task, latest.wait_reason, latest.initiator_user_id, latest.handoff_note, latest.prepare_lease_expires_at, latest.squad_id, latest.runtime_mcp_overlay, latest.escalation_for_task_id, latest.fire_at, latest.originator_user_id, latest.runtime_connected_apps, latest.coalesced_comment_ids, latest.delivered_comment_ids, latest.chat_input_task_id, latest.chat_finalize_deferred_at, latest.originator_source, latest.delegated_from_task_id, latest.retry_of_task_id, latest.rerun_of_task_id, latest.rule_version_id, latest.trigger_evidence_kind, latest.trigger_evidence_ref_id, latest.accountable_user_id, latest.session_rollout_missing, latest.retired_session_id, latest.quick_actions_disabled, latest.regenerate_quick_actions_for, latest.branch_name, latest.durable_work_dir, latest.channel_context_revision, latest.comment_thread_id FROM agent a
 JOIN LATERAL (
-  SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision
+  SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision, atq.comment_thread_id
   FROM agent_task_queue atq
   WHERE atq.agent_id = a.id
     AND atq.status IN ('completed', 'failed')
@@ -6378,6 +6619,7 @@ func (q *Queries) ListWorkspaceAgentTaskSnapshot(ctx context.Context, workspaceI
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -6628,7 +6870,7 @@ SET status = 'waiting_local_directory',
     wait_reason = $2,
     prepare_lease_expires_at = now() + make_interval(secs => $3::double precision)
 WHERE id = $1 AND status = 'dispatched'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type MarkAgentTaskWaitingLocalDirectoryParams struct {
@@ -6704,6 +6946,7 @@ func (q *Queries) MarkAgentTaskWaitingLocalDirectory(ctx context.Context, arg Ma
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -6712,7 +6955,7 @@ const markChatFinalizeDeferred = `-- name: MarkChatFinalizeDeferred :one
 UPDATE agent_task_queue
 SET chat_finalize_deferred_at = now()
 WHERE id = $1
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Arms the deferred chat-finalize marker for a cancelled chat task whose
@@ -6775,6 +7018,7 @@ func (q *Queries) MarkChatFinalizeDeferred(ctx context.Context, id pgtype.UUID) 
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -6808,12 +7052,13 @@ WHERE id = (
     SELECT t.id FROM agent_task_queue t
     WHERE t.issue_id = $12
       AND t.agent_id = $13
+      AND t.comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id($1::uuid)
       AND (
           t.status = 'queued'
           OR (t.status = 'deferred' AND t.context->>'channel_issue_media_pending' = 'true')
       )
       -- Head-scoped (TEN-356, #5914): never fold across HEADs. The physical
-      -- unique index is only (issue_id, agent_id), so an insert-race loser can
+      -- unique index is per (issue_id, agent_id, thread), so an insert-race loser can
       -- collide with a pending task stamped for a DIFFERENT head_sha; merging
       -- into it would give a new-HEAD comment old-HEAD review coverage. Empty/
       -- absent head_sha (no linked PR) matches any task, preserving coalescing.
@@ -6926,6 +7171,7 @@ WHERE id = (
     SELECT t.id FROM agent_task_queue t
     WHERE t.issue_id = $3
       AND t.agent_id = $4
+      AND t.comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id($1::uuid)
       AND (
           t.status = 'queued'
           OR (t.status = 'deferred' AND t.context->>'channel_issue_media_pending' = 'true')
@@ -6935,7 +7181,7 @@ WHERE id = (
     ORDER BY t.created_at DESC
     LIMIT 1
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type MergeDelegatedFailureCommentIntoPendingTaskParams struct {
@@ -7014,6 +7260,7 @@ func (q *Queries) MergeDelegatedFailureCommentIntoPendingTask(ctx context.Contex
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -7036,6 +7283,7 @@ WHERE t.runtime_id = ANY($1::uuid[])
       SELECT 1 FROM agent_task_queue occupant
       WHERE occupant.issue_id = t.issue_id
         AND occupant.agent_id = t.agent_id
+          AND occupant.comment_thread_id IS NOT DISTINCT FROM t.comment_thread_id
         AND occupant.id <> t.id
         AND (
           occupant.status IN ('queued', 'dispatched')
@@ -7069,7 +7317,7 @@ const promoteDeferredChannelIssueTask = `-- name: PromoteDeferredChannelIssueTas
 UPDATE agent_task_queue
 SET status = 'queued', fire_at = NULL
 WHERE id = $1 AND issue_id IS NOT NULL AND status = 'deferred'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Early promotion is idempotent at the service layer: a task already promoted
@@ -7132,6 +7380,7 @@ func (q *Queries) PromoteDeferredChannelIssueTask(ctx context.Context, id pgtype
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -7141,7 +7390,7 @@ WITH due AS (
     SELECT t.id,
            t.issue_id,
            row_number() OVER (
-               PARTITION BY t.issue_id, t.agent_id
+               PARTITION BY t.issue_id, t.agent_id, t.comment_thread_id
                ORDER BY t.priority DESC, t.created_at ASC, t.id
            ) AS rn
     FROM agent_task_queue t
@@ -7159,6 +7408,7 @@ WITH due AS (
         SELECT 1 FROM agent_task_queue occupant
         WHERE occupant.issue_id = t.issue_id
           AND occupant.agent_id = t.agent_id
+          AND occupant.comment_thread_id IS NOT DISTINCT FROM t.comment_thread_id
           AND occupant.id <> t.id
           AND (
             occupant.status IN ('queued', 'dispatched')
@@ -7169,7 +7419,7 @@ WITH due AS (
 UPDATE agent_task_queue
 SET status = 'queued'
 WHERE id IN (SELECT id FROM due WHERE issue_id IS NULL OR rn = 1)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type PromoteDueDeferredTasksForRuntimeParams struct {
@@ -7178,7 +7428,7 @@ type PromoteDueDeferredTasksForRuntimeParams struct {
 }
 
 // Promotion is fenced against the single queued/dispatched slot
-// idx_one_pending_task_per_issue_agent_v2 allows per (issue, agent). A deferred
+// idx_one_pending_task_per_issue_agent_thread allows per (issue, agent, thread). A deferred
 // row is NOT covered by that index, so it can legitimately coexist with a queued
 // one — a manual rerun enqueued behind a running task, plus the deferred retry
 // that task's failure armed (runtime_offline, provider_network's final attempt).
@@ -7186,8 +7436,8 @@ type PromoteDueDeferredTasksForRuntimeParams struct {
 // the claim loop promotes before it claims, that error blocked every claim on the
 // runtime — including the rerun the operator was waiting for.
 //
-// Two fences: skip a row whose (issue, agent) slot is already occupied, and
-// promote at most ONE row per (issue, agent) so a single statement cannot collide
+// Two fences: skip a row whose (issue, agent, thread) slot is already occupied, and
+// promote at most ONE row per (issue, agent, thread) so a single statement cannot collide
 // with itself. A skipped row stays deferred with fire_at in the past and is
 // promoted by a later tick once the slot frees, so nothing is lost — the human's
 // rerun simply goes first. Chat / quick-create rows (issue_id NULL) are outside
@@ -7256,6 +7506,7 @@ func (q *Queries) PromoteDueDeferredTasksForRuntime(ctx context.Context, arg Pro
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -7272,7 +7523,7 @@ WITH due AS (
     SELECT t.id,
            t.issue_id,
            row_number() OVER (
-               PARTITION BY t.issue_id, t.agent_id
+               PARTITION BY t.issue_id, t.agent_id, t.comment_thread_id
                ORDER BY t.priority DESC, t.created_at ASC, t.id
            ) AS rn
     FROM agent_task_queue t
@@ -7290,6 +7541,7 @@ WITH due AS (
         SELECT 1 FROM agent_task_queue occupant
         WHERE occupant.issue_id = t.issue_id
           AND occupant.agent_id = t.agent_id
+          AND occupant.comment_thread_id IS NOT DISTINCT FROM t.comment_thread_id
           AND occupant.id <> t.id
           AND (
             occupant.status IN ('queued', 'dispatched')
@@ -7300,7 +7552,7 @@ WITH due AS (
 UPDATE agent_task_queue
 SET status = 'queued'
 WHERE id IN (SELECT id FROM due WHERE issue_id IS NULL OR rn = 1)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type PromoteDueDeferredTasksForRuntimesParams struct {
@@ -7375,6 +7627,7 @@ func (q *Queries) PromoteDueDeferredTasksForRuntimes(ctx context.Context, arg Pr
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -7498,7 +7751,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type ReclaimStaleDispatchedTaskForRuntimeParams struct {
@@ -7576,6 +7829,7 @@ func (q *Queries) ReclaimStaleDispatchedTaskForRuntime(ctx context.Context, arg 
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -7617,7 +7871,7 @@ WHERE id IN (
     LIMIT $5::int
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type ReclaimStaleDispatchedTasksForRuntimesParams struct {
@@ -7705,6 +7959,7 @@ func (q *Queries) ReclaimStaleDispatchedTasksForRuntimes(ctx context.Context, ar
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -7725,7 +7980,7 @@ SET status = 'failed',
     wait_reason = NULL,
     prepare_lease_expires_at = NULL
 WHERE runtime_id = $1 AND status IN ('dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Called by the daemon at startup. Atomically fails any dispatched/running/
@@ -7798,6 +8053,7 @@ func (q *Queries) RecoverOrphanedTasksForRuntime(ctx context.Context, runtimeID 
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -7877,6 +8133,7 @@ WHERE id = (
     SELECT t.id FROM agent_task_queue t
     WHERE t.issue_id = $2
       AND t.agent_id = $3
+      AND t.comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id($1::uuid)
       AND t.status IN ('dispatched', 'running', 'waiting_local_directory')
       AND (
           COALESCE($4::text, '') = ''
@@ -7946,7 +8203,7 @@ WHERE id = $1
   AND status = 'dispatched'
   AND started_at IS NULL
   AND dispatched_at = $3
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type RequeueAgentTaskAfterClaimFailureParams struct {
@@ -8018,6 +8275,7 @@ func (q *Queries) RequeueAgentTaskAfterClaimFailure(ctx context.Context, arg Req
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -8291,7 +8549,7 @@ SET status = 'running',
     wait_reason = NULL,
     prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('dispatched', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Transitions a task to running. Accepts either 'dispatched' (the normal
@@ -8358,6 +8616,7 @@ func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTask
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -842,7 +842,8 @@ func (q *Queries) CancelAgentTasksByIssue(ctx context.Context, issueID pgtype.UU
 
 const cancelAgentTasksByTriggerComment = `-- name: CancelAgentTasksByTriggerComment :many
 UPDATE agent_task_queue
-SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL,
+    context = COALESCE(context, '{}'::jsonb) || jsonb_build_object('comment_change_cancelled_task_id', id::text)
 WHERE (trigger_comment_id = $1 OR $1 = ANY(coalesced_comment_ids))
   AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -300,7 +300,7 @@ SELECT
     $11,
     COALESCE($12::uuid, gen_random_uuid())
 WHERE lock_task_owner_rows($1, NULL, $2)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CreateAutopilotTaskParams struct {
@@ -408,6 +408,7 @@ func (q *Queries) CreateAutopilotTask(ctx context.Context, arg CreateAutopilotTa
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -933,7 +934,7 @@ func (q *Queries) GetAutopilotRunByWebhookDelivery(ctx context.Context, webhookD
 }
 
 const getAutopilotTaskByRun = `-- name: GetAutopilotTaskByRun :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM agent_task_queue
 WHERE autopilot_run_id = $1
 ORDER BY created_at
 LIMIT 1
@@ -999,6 +1000,7 @@ func (q *Queries) GetAutopilotTaskByRun(ctx context.Context, autopilotRunID pgty
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -387,7 +387,7 @@ SELECT
     $15::bigint,
     COALESCE($16::uuid, gen_random_uuid())
 WHERE lock_task_owner_rows($1, NULL, $2)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CreateChatTaskParams struct {
@@ -491,6 +491,7 @@ func (q *Queries) CreateChatTask(ctx context.Context, arg CreateChatTaskParams) 
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -570,7 +571,7 @@ FROM (
 WHERE task.id = $1
   AND pending.max_until IS NOT NULL
   AND (task.fire_at IS NULL OR task.fire_at < pending.max_until)
-RETURNING task.id, task.agent_id, task.issue_id, task.status, task.priority, task.dispatched_at, task.started_at, task.completed_at, task.result, task.error, task.created_at, task.context, task.runtime_id, task.session_id, task.work_dir, task.trigger_comment_id, task.chat_session_id, task.autopilot_run_id, task.attempt, task.max_attempts, task.parent_task_id, task.failure_reason, task.trigger_summary, task.force_fresh_session, task.is_leader_task, task.wait_reason, task.initiator_user_id, task.handoff_note, task.prepare_lease_expires_at, task.squad_id, task.runtime_mcp_overlay, task.escalation_for_task_id, task.fire_at, task.originator_user_id, task.runtime_connected_apps, task.coalesced_comment_ids, task.delivered_comment_ids, task.chat_input_task_id, task.chat_finalize_deferred_at, task.originator_source, task.delegated_from_task_id, task.retry_of_task_id, task.rerun_of_task_id, task.rule_version_id, task.trigger_evidence_kind, task.trigger_evidence_ref_id, task.accountable_user_id, task.session_rollout_missing, task.retired_session_id, task.quick_actions_disabled, task.regenerate_quick_actions_for, task.branch_name, task.durable_work_dir, task.channel_context_revision
+RETURNING task.id, task.agent_id, task.issue_id, task.status, task.priority, task.dispatched_at, task.started_at, task.completed_at, task.result, task.error, task.created_at, task.context, task.runtime_id, task.session_id, task.work_dir, task.trigger_comment_id, task.chat_session_id, task.autopilot_run_id, task.attempt, task.max_attempts, task.parent_task_id, task.failure_reason, task.trigger_summary, task.force_fresh_session, task.is_leader_task, task.wait_reason, task.initiator_user_id, task.handoff_note, task.prepare_lease_expires_at, task.squad_id, task.runtime_mcp_overlay, task.escalation_for_task_id, task.fire_at, task.originator_user_id, task.runtime_connected_apps, task.coalesced_comment_ids, task.delivered_comment_ids, task.chat_input_task_id, task.chat_finalize_deferred_at, task.originator_source, task.delegated_from_task_id, task.retry_of_task_id, task.rerun_of_task_id, task.rule_version_id, task.trigger_evidence_kind, task.trigger_evidence_ref_id, task.accountable_user_id, task.session_rollout_missing, task.retired_session_id, task.quick_actions_disabled, task.regenerate_quick_actions_for, task.branch_name, task.durable_work_dir, task.channel_context_revision, task.comment_thread_id
 `
 
 // Closes the enqueue-vs-append race: under READ COMMITTED a media message can
@@ -637,6 +638,7 @@ func (q *Queries) DeferChatTaskForSealedPendingMedia(ctx context.Context, taskID
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }
@@ -2880,7 +2882,7 @@ WHERE task.chat_session_id = $1
         AND message.role = 'user'
         AND message.channel_media_pending_until > now()
   )
-RETURNING task.id, task.agent_id, task.issue_id, task.status, task.priority, task.dispatched_at, task.started_at, task.completed_at, task.result, task.error, task.created_at, task.context, task.runtime_id, task.session_id, task.work_dir, task.trigger_comment_id, task.chat_session_id, task.autopilot_run_id, task.attempt, task.max_attempts, task.parent_task_id, task.failure_reason, task.trigger_summary, task.force_fresh_session, task.is_leader_task, task.wait_reason, task.initiator_user_id, task.handoff_note, task.prepare_lease_expires_at, task.squad_id, task.runtime_mcp_overlay, task.escalation_for_task_id, task.fire_at, task.originator_user_id, task.runtime_connected_apps, task.coalesced_comment_ids, task.delivered_comment_ids, task.chat_input_task_id, task.chat_finalize_deferred_at, task.originator_source, task.delegated_from_task_id, task.retry_of_task_id, task.rerun_of_task_id, task.rule_version_id, task.trigger_evidence_kind, task.trigger_evidence_ref_id, task.accountable_user_id, task.session_rollout_missing, task.retired_session_id, task.quick_actions_disabled, task.regenerate_quick_actions_for, task.branch_name, task.durable_work_dir, task.channel_context_revision
+RETURNING task.id, task.agent_id, task.issue_id, task.status, task.priority, task.dispatched_at, task.started_at, task.completed_at, task.result, task.error, task.created_at, task.context, task.runtime_id, task.session_id, task.work_dir, task.trigger_comment_id, task.chat_session_id, task.autopilot_run_id, task.attempt, task.max_attempts, task.parent_task_id, task.failure_reason, task.trigger_summary, task.force_fresh_session, task.is_leader_task, task.wait_reason, task.initiator_user_id, task.handoff_note, task.prepare_lease_expires_at, task.squad_id, task.runtime_mcp_overlay, task.escalation_for_task_id, task.fire_at, task.originator_user_id, task.runtime_connected_apps, task.coalesced_comment_ids, task.delivered_comment_ids, task.chat_input_task_id, task.chat_finalize_deferred_at, task.originator_source, task.delegated_from_task_id, task.retry_of_task_id, task.rerun_of_task_id, task.rule_version_id, task.trigger_evidence_kind, task.trigger_evidence_ref_id, task.accountable_user_id, task.session_rollout_missing, task.retired_session_id, task.quick_actions_disabled, task.regenerate_quick_actions_for, task.branch_name, task.durable_work_dir, task.channel_context_revision, task.comment_thread_id
 `
 
 // Media completion may race with the 3s run batcher. Promote every original
@@ -2953,6 +2955,7 @@ func (q *Queries) PromoteChannelChatTasksIfMediaReady(ctx context.Context, chatS
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -3383,7 +3386,7 @@ const setChatTaskInputOwnerSelf = `-- name: SetChatTaskInputOwnerSelf :one
 UPDATE agent_task_queue
 SET chat_input_task_id = id
 WHERE id = $1
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 // Stamps a freshly-created direct-chat task as the owner of its own input batch
@@ -3451,6 +3454,7 @@ func (q *Queries) SetChatTaskInputOwnerSelf(ctx context.Context, id pgtype.UUID)
 		&i.BranchName,
 		&i.DurableWorkDir,
 		&i.ChannelContextRevision,
+		&i.CommentThreadID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -1289,16 +1289,18 @@ func (q *Queries) ListRecentThreadCommentsForIssue(ctx context.Context, arg List
 const listReconcilableCommentsForIssueSince = `-- name: ListReconcilableCommentsForIssueSince :many
 SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, via_plugin_id, revision, recovery_settled_at FROM comment
 WHERE issue_id = $1
+  AND (id = ANY($2::uuid[])
+       OR comment_thread_root_id(id) = $3::uuid)
   AND (
       (
           author_type IN ('member', 'agent')
-          AND (created_at > $2 OR id = ANY($3::uuid[]))
+          AND (created_at > $4 OR id = ANY($2::uuid[]))
       )
       OR (
           author_type = 'system'
           AND type = 'progress_update'
           AND source_task_id IS NOT NULL
-          AND id = ANY($3::uuid[])
+          AND id = ANY($2::uuid[])
       )
   )
 ORDER BY created_at ASC, id ASC
@@ -1306,8 +1308,9 @@ ORDER BY created_at ASC, id ASC
 
 type ListReconcilableCommentsForIssueSinceParams struct {
 	IssueID           pgtype.UUID        `json:"issue_id"`
-	Since             pgtype.Timestamptz `json:"since"`
 	PlannedCommentIds []pgtype.UUID      `json:"planned_comment_ids"`
+	CommentThreadID   pgtype.UUID        `json:"comment_thread_id"`
+	Since             pgtype.Timestamptz `json:"since"`
 }
 
 // MUL-4195 / MUL-4304 completion reconciliation: every MEMBER- or AGENT-authored
@@ -1343,7 +1346,12 @@ type ListReconcilableCommentsForIssueSinceParams struct {
 // replaying in order lets later comments coalesce onto the follow-up created by
 // the first.
 func (q *Queries) ListReconcilableCommentsForIssueSince(ctx context.Context, arg ListReconcilableCommentsForIssueSinceParams) ([]Comment, error) {
-	rows, err := q.db.Query(ctx, listReconcilableCommentsForIssueSince, arg.IssueID, arg.Since, arg.PlannedCommentIds)
+	rows, err := q.db.Query(ctx, listReconcilableCommentsForIssueSince,
+		arg.IssueID,
+		arg.PlannedCommentIds,
+		arg.CommentThreadID,
+		arg.Since,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -172,6 +172,7 @@ type AgentTaskQueue struct {
 	BranchName                pgtype.Text `json:"branch_name"`
 	DurableWorkDir            pgtype.Text `json:"durable_work_dir"`
 	ChannelContextRevision    pgtype.Int8 `json:"channel_context_revision"`
+	CommentThreadID           pgtype.UUID `json:"comment_thread_id"`
 }
 
 type AgentToLabel struct {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -16,7 +16,7 @@ UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
 WHERE (runtime_id = ANY($1::uuid[]) OR agent_id = ANY($2::uuid[]))
   AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id
 `
 
 type CancelAgentTasksByRuntimeOrAgentParams struct {
@@ -110,6 +110,7 @@ func (q *Queries) CancelAgentTasksByRuntimeOrAgent(ctx context.Context, arg Canc
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -212,7 +213,7 @@ SET status = 'failed', completed_at = now(), error = 'runtime went offline',
 FROM victims
 WHERE task.id = victims.id
   AND task.status IN ('dispatched', 'running', 'waiting_local_directory')
-RETURNING task.id, task.agent_id, task.issue_id, task.status, task.priority, task.dispatched_at, task.started_at, task.completed_at, task.result, task.error, task.created_at, task.context, task.runtime_id, task.session_id, task.work_dir, task.trigger_comment_id, task.chat_session_id, task.autopilot_run_id, task.attempt, task.max_attempts, task.parent_task_id, task.failure_reason, task.trigger_summary, task.force_fresh_session, task.is_leader_task, task.wait_reason, task.initiator_user_id, task.handoff_note, task.prepare_lease_expires_at, task.squad_id, task.runtime_mcp_overlay, task.escalation_for_task_id, task.fire_at, task.originator_user_id, task.runtime_connected_apps, task.coalesced_comment_ids, task.delivered_comment_ids, task.chat_input_task_id, task.chat_finalize_deferred_at, task.originator_source, task.delegated_from_task_id, task.retry_of_task_id, task.rerun_of_task_id, task.rule_version_id, task.trigger_evidence_kind, task.trigger_evidence_ref_id, task.accountable_user_id, task.session_rollout_missing, task.retired_session_id, task.quick_actions_disabled, task.regenerate_quick_actions_for, task.branch_name, task.durable_work_dir, task.channel_context_revision
+RETURNING task.id, task.agent_id, task.issue_id, task.status, task.priority, task.dispatched_at, task.started_at, task.completed_at, task.result, task.error, task.created_at, task.context, task.runtime_id, task.session_id, task.work_dir, task.trigger_comment_id, task.chat_session_id, task.autopilot_run_id, task.attempt, task.max_attempts, task.parent_task_id, task.failure_reason, task.trigger_summary, task.force_fresh_session, task.is_leader_task, task.wait_reason, task.initiator_user_id, task.handoff_note, task.prepare_lease_expires_at, task.squad_id, task.runtime_mcp_overlay, task.escalation_for_task_id, task.fire_at, task.originator_user_id, task.runtime_connected_apps, task.coalesced_comment_ids, task.delivered_comment_ids, task.chat_input_task_id, task.chat_finalize_deferred_at, task.originator_source, task.delegated_from_task_id, task.retry_of_task_id, task.rerun_of_task_id, task.rule_version_id, task.trigger_evidence_kind, task.trigger_evidence_ref_id, task.accountable_user_id, task.session_rollout_missing, task.retired_session_id, task.quick_actions_disabled, task.regenerate_quick_actions_for, task.branch_name, task.durable_work_dir, task.channel_context_revision, task.comment_thread_id
 `
 
 type FailTasksForOfflineRuntimesParams struct {
@@ -292,6 +293,7 @@ func (q *Queries) FailTasksForOfflineRuntimes(ctx context.Context, arg FailTasks
 			&i.BranchName,
 			&i.DurableWorkDir,
 			&i.ChannelContextRevision,
+			&i.CommentThreadID,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -586,7 +586,7 @@ SELECT
 FROM agent_task_queue p
 WHERE p.id = $1
   AND lock_task_owner_rows(p.agent_id, p.issue_id, p.runtime_id)
-ON CONFLICT (issue_id, agent_id) WHERE status IN ('queued', 'dispatched')
+ON CONFLICT (issue_id, agent_id, (COALESCE(comment_thread_id, '00000000-0000-0000-0000-000000000000'::uuid))) WHERE status IN ('queued', 'dispatched')
        OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true')
 DO NOTHING
 RETURNING *;
@@ -668,6 +668,16 @@ UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE issue_id = $1 AND agent_id = $2
   AND status IN ('queued', 'dispatched', 'deferred')
+RETURNING *;
+
+-- name: CancelPendingTasksByIssueAndAgentInThread :many
+-- Cancel only the not-yet-started plan in the selected thread. Other threads
+-- retain their queues; running tasks are stopped explicitly through CancelTask.
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE issue_id = $1 AND agent_id = $2
+  AND status IN ('queued', 'dispatched', 'deferred')
+  AND comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id(sqlc.narg('thread_comment_id')::uuid)
 RETURNING *;
 
 -- name: CancelAgentTasksByAgent :many
@@ -1768,6 +1778,21 @@ WHERE issue_id = $1 AND agent_id = $2
     OR context->>'head_sha' = sqlc.narg('head_sha')::text
   );
 
+-- name: HasPendingTaskForIssueAndAgentInThread :one
+-- Same pending/head rules as HasPendingTaskForIssueAndAgent, scoped to one
+-- root comment and all descendants. NULL selects assignment-level work.
+SELECT count(*) > 0 AS has_pending FROM agent_task_queue
+WHERE issue_id = $1 AND agent_id = $2
+  AND (
+    status IN ('queued', 'dispatched')
+    OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true')
+  )
+  AND (
+    COALESCE(sqlc.narg('head_sha')::text, '') = ''
+    OR context->>'head_sha' = sqlc.narg('head_sha')::text
+  )
+  AND comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id(sqlc.narg('thread_comment_id')::uuid);
+
 -- name: HasPendingTaskForIssueAndAgentExcludingTriggerComment :one
 -- Same as HasPendingTaskForIssueAndAgent, but ignores tasks triggered by the
 -- current comment being edited. Edit preview needs this because save cancels
@@ -1785,6 +1810,22 @@ WHERE issue_id = @issue_id
     COALESCE(sqlc.narg('head_sha')::text, '') = ''
     OR context->>'head_sha' = sqlc.narg('head_sha')::text
   );
+
+-- name: HasPendingTaskForIssueAndAgentExcludingTriggerCommentInThread :one
+-- Thread-scoped edit preview: ignore the comment whose old run save replaces.
+SELECT count(*) > 0 AS has_pending FROM agent_task_queue
+WHERE issue_id = @issue_id
+  AND agent_id = @agent_id
+  AND (
+    status IN ('queued', 'dispatched')
+    OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true')
+  )
+  AND trigger_comment_id IS DISTINCT FROM @exclude_trigger_comment_id::uuid
+  AND (
+    COALESCE(sqlc.narg('head_sha')::text, '') = ''
+    OR context->>'head_sha' = sqlc.narg('head_sha')::text
+  )
+  AND comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id(sqlc.narg('thread_comment_id')::uuid);
 
 -- name: MergeCommentIntoPendingTask :one
 -- MUL-4195: fold a newly-arrived comment into an existing task for (issue,
@@ -1857,12 +1898,13 @@ WHERE id = (
     SELECT t.id FROM agent_task_queue t
     WHERE t.issue_id = @issue_id
       AND t.agent_id = @agent_id
+      AND t.comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id(@new_trigger_comment_id::uuid)
       AND (
           t.status = 'queued'
           OR (t.status = 'deferred' AND t.context->>'channel_issue_media_pending' = 'true')
       )
       -- Head-scoped (TEN-356, #5914): never fold across HEADs. The physical
-      -- unique index is only (issue_id, agent_id), so an insert-race loser can
+      -- unique index is per (issue_id, agent_id, thread), so an insert-race loser can
       -- collide with a pending task stamped for a DIFFERENT head_sha; merging
       -- into it would give a new-HEAD comment old-HEAD review coverage. Empty/
       -- absent head_sha (no linked PR) matches any task, preserving coalescing.
@@ -1909,6 +1951,7 @@ WHERE id = (
     SELECT t.id FROM agent_task_queue t
     WHERE t.issue_id = @issue_id
       AND t.agent_id = @agent_id
+      AND t.comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id(@comment_id::uuid)
       AND t.status IN ('dispatched', 'running', 'waiting_local_directory')
       AND (
           COALESCE(sqlc.narg('head_sha')::text, '') = ''
@@ -1938,6 +1981,7 @@ WHERE id = (
     SELECT t.id FROM agent_task_queue t
     WHERE t.issue_id = @issue_id
       AND t.agent_id = @agent_id
+      AND t.comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id(@comment_id::uuid)
       AND (
           t.status = 'queued'
           OR (t.status = 'deferred' AND t.context->>'channel_issue_media_pending' = 'true')
@@ -2144,6 +2188,16 @@ WHERE issue_id = $1 AND agent_id = $2
     OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true')
   );
 
+-- name: HasActiveTaskForIssueAndAgentInThread :one
+-- Active execution and pending work in this comment thread only.
+SELECT count(*) > 0 AS has_active FROM agent_task_queue
+WHERE issue_id = $1 AND agent_id = $2
+  AND (
+    status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+    OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true')
+  )
+  AND comment_thread_id IS NOT DISTINCT FROM comment_thread_root_id(sqlc.narg('thread_comment_id')::uuid);
+
 -- name: GetLatestTaskRoleForIssueAndAgent :one
 -- Returns the role markers from the agent's most recent task on this issue.
 -- Used by the squad-leader self-trigger guard to tell apart leader tasks,
@@ -2229,6 +2283,7 @@ WHERE r.runtime_id = ANY(@runtime_ids::uuid[])
     SELECT 1 FROM agent_task_queue successor
     WHERE successor.issue_id = r.issue_id
       AND successor.agent_id = r.agent_id
+      AND successor.comment_thread_id IS NOT DISTINCT FROM r.comment_thread_id
       AND successor.id <> r.id
       AND successor.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
   )
@@ -2236,7 +2291,7 @@ RETURNING *;
 
 -- name: PromoteDueDeferredTasksForRuntime :many
 -- Promotion is fenced against the single queued/dispatched slot
--- idx_one_pending_task_per_issue_agent_v2 allows per (issue, agent). A deferred
+-- idx_one_pending_task_per_issue_agent_thread allows per (issue, agent, thread). A deferred
 -- row is NOT covered by that index, so it can legitimately coexist with a queued
 -- one — a manual rerun enqueued behind a running task, plus the deferred retry
 -- that task's failure armed (runtime_offline, provider_network's final attempt).
@@ -2244,8 +2299,8 @@ RETURNING *;
 -- the claim loop promotes before it claims, that error blocked every claim on the
 -- runtime — including the rerun the operator was waiting for.
 --
--- Two fences: skip a row whose (issue, agent) slot is already occupied, and
--- promote at most ONE row per (issue, agent) so a single statement cannot collide
+-- Two fences: skip a row whose (issue, agent, thread) slot is already occupied, and
+-- promote at most ONE row per (issue, agent, thread) so a single statement cannot collide
 -- with itself. A skipped row stays deferred with fire_at in the past and is
 -- promoted by a later tick once the slot frees, so nothing is lost — the human's
 -- rerun simply goes first. Chat / quick-create rows (issue_id NULL) are outside
@@ -2254,7 +2309,7 @@ WITH due AS (
     SELECT t.id,
            t.issue_id,
            row_number() OVER (
-               PARTITION BY t.issue_id, t.agent_id
+               PARTITION BY t.issue_id, t.agent_id, t.comment_thread_id
                ORDER BY t.priority DESC, t.created_at ASC, t.id
            ) AS rn
     FROM agent_task_queue t
@@ -2272,6 +2327,7 @@ WITH due AS (
         SELECT 1 FROM agent_task_queue occupant
         WHERE occupant.issue_id = t.issue_id
           AND occupant.agent_id = t.agent_id
+          AND occupant.comment_thread_id IS NOT DISTINCT FROM t.comment_thread_id
           AND occupant.id <> t.id
           AND (
             occupant.status IN ('queued', 'dispatched')
@@ -2345,6 +2401,7 @@ WHERE t.runtime_id = ANY(@runtime_ids::uuid[])
       SELECT 1 FROM agent_task_queue occupant
       WHERE occupant.issue_id = t.issue_id
         AND occupant.agent_id = t.agent_id
+          AND occupant.comment_thread_id IS NOT DISTINCT FROM t.comment_thread_id
         AND occupant.id <> t.id
         AND (
           occupant.status IN ('queued', 'dispatched')
@@ -2361,7 +2418,7 @@ WITH due AS (
     SELECT t.id,
            t.issue_id,
            row_number() OVER (
-               PARTITION BY t.issue_id, t.agent_id
+               PARTITION BY t.issue_id, t.agent_id, t.comment_thread_id
                ORDER BY t.priority DESC, t.created_at ASC, t.id
            ) AS rn
     FROM agent_task_queue t
@@ -2379,6 +2436,7 @@ WITH due AS (
         SELECT 1 FROM agent_task_queue occupant
         WHERE occupant.issue_id = t.issue_id
           AND occupant.agent_id = t.agent_id
+          AND occupant.comment_thread_id IS NOT DISTINCT FROM t.comment_thread_id
           AND occupant.id <> t.id
           AND (
             occupant.status IN ('queued', 'dispatched')
@@ -2747,3 +2805,6 @@ INSERT INTO agent (
     @owner_id, '', '{}'::jsonb, '[]'::jsonb, 'user', @system_key
 )
 RETURNING *;
+
+-- name: GetCommentThreadRootID :one
+SELECT comment_thread_root_id(@comment_id::uuid)::uuid AS id;

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -687,7 +687,8 @@ RETURNING *;
 -- coalesced input; cancellation prevents an agent from acting on a stale or
 -- deleted version. Must run before deletion clears trigger_comment_id.
 UPDATE agent_task_queue
-SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL,
+    context = COALESCE(context, '{}'::jsonb) || jsonb_build_object('comment_change_cancelled_task_id', id::text)
 WHERE (trigger_comment_id = $1 OR $1 = ANY(coalesced_comment_ids))
   AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
 RETURNING *;

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -381,6 +381,8 @@ LIMIT 1;
 -- the first.
 SELECT * FROM comment
 WHERE issue_id = @issue_id
+  AND (id = ANY(@planned_comment_ids::uuid[])
+       OR comment_thread_root_id(id) = sqlc.narg('comment_thread_id')::uuid)
   AND (
       (
           author_type IN ('member', 'agent')


### PR DESCRIPTION
## What does this PR do?

Show agent execution inside issue comment threads so users can follow progress without opening a separate window. Each run starts as a lightweight agent row; its persisted reply replaces that row in place. Replies remain ordinary comment content, with a compact log button beside the author instead of a nested metadata card.

Queue merging now follows the same thread boundary as the UI. Two root comments mentioning the same agent create separate runs; additional instructions in one thread can coalesce while that thread's run is queued. This prevents one thread's run from absorbing another thread's instructions and leaving its UI without an execution state or answer.

## Related Issue

No linked issue; developed through local product acceptance testing.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Tests

## Changes Made

- Place runs by task identity and planned/delivered comment coverage. Project agent answers, group runs, and resolve notification targets using the same comment tree. Assignment answers render once, including answers originally posted inside another thread.
- Preserve the earliest covered input's position for same-thread batches. Retain an established anchor while a new coalesced comment is still loading; wait for unknown triggers rather than briefly showing standalone blocks. Historical cross-thread batches retain their original trigger placement.
- Top-header and right-panel active lists show running/claimed work first, then pending runs by priority descending and original enqueue time ascending, matching queue selection instead of the history endpoint's newest-first order. Coalescing does not change queue age.
- Before a reply arrives, show identity, one-line activity, duration, Stop, and expandable steps. Retain the latest meaningful activity between tool events. After a reply is published, move logs to its header immediately, even if the run is still finishing; issue-level Working remains available.
- Fit terminal run actions to the actual comment column with container queries, keeping disclosure and retry reachable beside an open sidebar. Align root/reply content and place comment actions on the right. Reveal actions and the log button on the current block's hover or keyboard focus; preserve visibility for open menus and touch devices. Add restrained motion and text shimmer, with reduced-motion support and stable keyboard focus.
- Show verified issue identifiers in execution summaries, preserving raw evidence and copied commands. Keep the full-log timing timeline whenever timing data exists.
- Hide only cancelled runs explicitly invalidated by queued-comment edits and never dispatched/delivered. Preserve actual failures, manual cancellations, retries, and full execution history.
- Scope pending-task uniqueness, merge/claim-race obligations, completion reconciliation, automatic retries, deferred promotion, and manual rerun replacement to the root comment thread. Assignment tasks retain a separate queue slot. Existing agent concurrency limits and per-issue/agent execution serialization remain in force.
- Update built-in mention documentation, translations, generated sqlc code, and regression coverage.

## How to Test

1. Mention an agent in two separate root comments while it is busy. Both threads should show independent queued rows. Add a reply in thread A: only A's queued batch should coalesce.
2. Let the runs finish. A should receive its combined answer, B its own answer, each once and in its original run slot. Open their header log buttons and verify full execution details and timing.
3. Stop or retry one thread's task while another is pending. The other thread's queue must remain intact. Inputs posted after execution starts belong to a follow-up run.
4. Assign an issue directly to an agent; verify its independent run and single persisted answer. Edit a queued comment; confirm obsolete cancelled placeholders disappear while execution history remains accessible.
5. Exercise activity disclosure, keyboard focus, notification navigation into resolved threads, long summaries, and hover actions on individual blocks.

## Validation

Latest local verification:

- Final review (2026-09-08): 344 views/transcript tests, 154 core tests, views typecheck, and the full guarded backend race suite passed again. Real DEV-25/26 runs verified independent thread queues, same-thread coalescing, edit replacement, UI Stop/Retry, assignment reply replacement before completion, header logs, and terminal delivery. DEV-13 notification navigation into a resolved assignment thread was rechecked. Narrow-column overflow was reproduced and fixed; browser measurements are now 380px content in a 380px row, with 28px icon buttons; wide columns retain full labels. The 13 inline-run tests and affected-file ESLint passed after the fix.

- CI follow-up: registered interrupted concurrent-index cleanup for migration 452 up and 453 down; aligned server integration fixtures with same-thread coalescing and added explicit assignment/root-thread isolation assertions. The full guarded `bash scripts/test-go.sh --race` suite passed against the isolated migrated database, along with `go build ./...`, `go vet -tags agentintegration ./...`, and the test-wrapper self-tests. Local Redis-backed cases were skipped because `REDIS_TEST_URL` was unset; the remote backend job covers Redis.

- Full database-backed `go test ./internal/handler ./internal/service -count=1` passed using a separately migrated PostgreSQL test database. Coverage includes thread isolation, nested replies, same-thread merging, claim serialization, independent deferred promotion, retries, cancellation, comment editing, attribution, and delegated recovery. The final media-assignment boundary assertion also passed in a targeted rerun.
- 124 views tests passed across run grouping, comment cards, inline controls, and issue detail. Views typecheck, affected-file ESLint, and `git diff --check` passed.
- Real local agent execution in **DEV-23**: with a holding run active, A and B returned `queued`; A's supplement returned `coalesced`. The three runs completed serially. Delivery receipts contained exactly A + its supplement for A, and only B for B. Browser checks confirmed one answer per run, stable placement, and a working full-log dialog with its timing timeline.
- Queue-order regression reproduced the DEV-24 reversal before the fix. All 33 focused ordering/header/execution-log tests passed, along with views typecheck and affected-file ESLint (one existing pricing dependency warning).
- Earlier local acceptance covered assignment, chained agent replies, resolved-thread notification navigation, Stop/Retry, queued edits, reply-before-completion, and keyboard disclosure. Core API-schema and transcript-backfill suites passed during implementation.

Remote CI passed for `7b6125693`: backend race tests (including Redis-backed cases), frontend build/test shards, SQLC, vulnerability scan, Windows execenv, installers, and mobile checks. Image-budget was skipped by its path filter. Native desktop/mobile product acceptance has not been run locally.

## Migrations and rollout

Migrations **451–453** add a derived `comment_thread_id`, backfill existing tasks, and replace issue/agent pending uniqueness with issue/agent/thread uniqueness. A database trigger derives the scope from the comment ancestry for all task writers. Concurrent index creation is in a separate single-statement migration, with interrupted-build cleanup registered for both upgrade and downgrade; no foreign keys are added.

Deploy the migrations with the updated API/queue queries: the new retry conflict target requires the new index. Existing cross-thread input batches are preserved; if rebuilt after a comment edit, their surviving inputs are queued by thread. Before downgrading, drain pending queues so the old issue/agent unique index can be recreated without discarding requests.

## Checklist

- [x] Added regression tests and relevant documentation
- [x] Verified local behavior with actual agent runs
- [x] Documented database migration and validation limits
- [x] Checked Chinese product copy against repository conventions

## AI Disclosure

Implemented with Codex, guided by product feedback and local acceptance. Tests focus on task/reply identity, comment-thread queue isolation, durable input delivery, cancellation, transcript recovery, and accessible interaction.


