### PR TITLE
feat(agent): add CommandCode runtime backend

### DIFF
--- a/packages/core/runtimes/display.ts
+++ b/packages/core/runtimes/display.ts
@@ -50,6 +50,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   mcode: "MiniMax Code",
   omp: "Oh-My-Pi",
   zeroclaw: "ZeroClaw",
+  commandcode: "CommandCode",
 };
 
 /**

--- a/server/internal/daemon/agents_probe.go
+++ b/server/internal/daemon/agents_probe.go
@@ -283,6 +283,12 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 	if e, ok := probe("MULTICA_QWENPAW_PATH", "qwenpaw", ""); ok {
 		agents["qwenpaw"] = e
 	}
+	// CommandCode (`cmd`) runs headlessly with --output-format json and the
+	// prompt on stdin. MULTICA_COMMANDCODE_MODEL seeds the daemon-wide default
+	// model (a model id from the user's `cmd --list-models` catalog).
+	if e, ok := probe("MULTICA_COMMANDCODE_PATH", "cmd", "MULTICA_COMMANDCODE_MODEL"); ok {
+		agents["commandcode"] = e
+	}
 	// Dim (`dim`) is the DimCode CLI agent, driven over ACP via `dim acp`.
 	// MULTICA_DIM_MODEL seeds the daemon-wide default (a model id from the
 	// user's logged-in dim catalog).

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -971,7 +971,7 @@ func isExecutableFile(path string) bool {
 // doesn't require editing this list by hand.
 var defaultAgentCommandNames = append([]string{
 	"claude", "codex", "opencode", "codearts", "deveco", "openclaw", "hermes",
-	"pi", "cursor-agent", "copilot", "kimi", "reasonix", "dsh", "kiro-cli", "codebuddy", "agy", "qodercli", "qoderclicn", "traecli", "grok", "qwen", "qwenpaw", "mcode", "dim", "zeroclaw",
+	"pi", "cursor-agent", "copilot", "kimi", "reasonix", "dsh", "kiro-cli", "codebuddy", "agy", "qodercli", "qoderclicn", "traecli", "grok", "qwen", "qwenpaw", "mcode", "dim", "zeroclaw", "cmd",
 }, agent.BuiltinRuntimeCommands()...)
 
 // codexDesktopAppBundlePaths returns candidate macOS app-bundle locations for

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6065,15 +6065,16 @@ func taskRootDirParams(workspacesRoot string, task Task) execenv.RootDirParams {
 // this map at init so their display names stay in lockstep with the
 // descriptor.
 var runtimeDisplayNameOverrides = map[string]string{
-	"codearts":   "CodeArts",
-	"dsh":        "DeepSeek Harness",
-	"traecli":    "Trae",
-	"grok":       "Grok",
-	"qoderclicn": "Qoder CN",
-	"qwen":       "Qwen Code",
-	"qwenpaw":    "QwenPaw",
-	"mcode":      "MiniMax Code",
-	"zeroclaw":   "ZeroClaw",
+	"codearts":    "CodeArts",
+	"dsh":         "DeepSeek Harness",
+	"traecli":     "Trae",
+	"grok":        "Grok",
+	"qoderclicn":  "Qoder CN",
+	"qwen":        "Qwen Code",
+	"qwenpaw":     "QwenPaw",
+	"mcode":       "MiniMax Code",
+	"zeroclaw":    "ZeroClaw",
+	"commandcode": "CommandCode",
 }
 
 func init() {

--- a/server/migrations/457_commandcode_protocol_family.down.sql
+++ b/server/migrations/457_commandcode_protocol_family.down.sql
@@ -1,0 +1,33 @@
+-- Restore the pre-CommandCode whitelist. Existing CommandCode rows remain valid because
+-- the replacement constraint is NOT VALID, but new CommandCode profiles are
+-- blocked.
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'codearts',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'reasonix',
+        'dsh',
+        'kiro',
+        'antigravity',
+        'qoder',
+        'qoderclicn',
+        'traecli',
+        'deveco',
+        'grok',
+        'qwen',
+        'qwenpaw',
+        'mcode',
+        'dim',
+        'zeroclaw'
+    )) NOT VALID;

--- a/server/migrations/457_commandcode_protocol_family.up.sql
+++ b/server/migrations/457_commandcode_protocol_family.up.sql
@@ -1,0 +1,34 @@
+-- Add CommandCode (`cmd`) as a first-party protocol family. NOT VALID
+-- preserves historical-row tolerance while enforcing the expanded whitelist
+-- for new rows.
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'codearts',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'reasonix',
+        'dsh',
+        'kiro',
+        'antigravity',
+        'qoder',
+        'qoderclicn',
+        'traecli',
+        'deveco',
+        'grok',
+        'qwen',
+        'qwenpaw',
+        'mcode',
+        'dim',
+        'zeroclaw',
+        'commandcode'
+    )) NOT VALID;

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,7 +1,7 @@
 // Package agent provides a unified interface for executing prompts via
 // coding agents (Claude Code, CodeBuddy, Codex, Copilot, OpenCode, DevEco Code,
 // OpenClaw, Hermes, Pi, Oh-My-Pi, Cursor, Kimi, Reasonix, Kiro, Antigravity, Qoder,
-// Trae, Grok, Qwen Code, QwenPaw, MiniMax Code). It
+// Trae, Grok, Qwen Code, QwenPaw, MiniMax Code, CommandCode). It
 // mirrors the happy-cli AgentBackend pattern, translated to idiomatic Go.
 package agent
 
@@ -324,7 +324,7 @@ type Config struct {
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codebuddy", "codex", "copilot", "opencode", "codearts", "deveco", "openclaw", "hermes", "pi", "cursor", "kimi", "reasonix", "dsh", "kiro", "antigravity", "qoder", "qoderclicn", "traecli", "grok", "qwen", "qwenpaw", "mcode".
+// Supported types: "claude", "codebuddy", "codex", "copilot", "opencode", "codearts", "deveco", "openclaw", "hermes", "pi", "cursor", "kimi", "reasonix", "dsh", "kiro", "antigravity", "qoder", "qoderclicn", "traecli", "grok", "qwen", "qwenpaw", "mcode", "commandcode".
 //
 // SupportedTypes is the canonical whitelist of agent types eligible to back a
 // custom runtime profile. It MUST stay in lockstep with the
@@ -333,8 +333,9 @@ type Config struct {
 // add deveco, migration 179 to add grok, migration 202 to add qwen,
 // migration 242 to add qoderclicn, migration 253 to add qwenpaw,
 // migration 254 to add reasonix, migration 313 to add dsh, migration 342 to
-// add mcode, migration 370 to add dim, migration 403 to add zeroclaw, and
-// migration 441 to add codearts): a custom runtime profile may
+// add mcode, migration 370 to add dim, migration 403 to add zeroclaw,
+// migration 441 to add codearts, and migration 457 to add
+// commandcode): a custom runtime profile may
 // only be based on a backend Multica officially supports.
 // qoder and qoderclicn share the same ACP backend; keeping both provider keys
 // lets the daemon auto-detect and register the international and China-region
@@ -369,6 +370,7 @@ var SupportedTypes = []string{
 	"mcode",
 	"dim",
 	"zeroclaw",
+	"commandcode",
 }
 
 // IsSupportedType reports whether agentType is in the SupportedTypes whitelist.
@@ -474,6 +476,8 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &mcodeBackend{cfg: cfg}, nil
 	case "zeroclaw":
 		return &zeroclawBackend{cfg: cfg}, nil
+	case "commandcode":
+		return &commandcodeBackend{cfg: cfg}, nil
 	default:
 		return nil, fmt.Errorf("unknown agent type: %q (supported: %s)", agentType, strings.Join(SupportedTypes, ", "))
 	}
@@ -521,6 +525,7 @@ var launchHeaders = map[string]string{
 	"dim":         "dim acp",
 	"mcode":       "mcode acp",
 	"zeroclaw":    "zeroclaw acp",
+	"commandcode": "cmd -p (json)",
 }
 
 // LaunchHeader returns the user-visible launch skeleton for agentType, or an

--- a/server/pkg/agent/commandcode.go
+++ b/server/pkg/agent/commandcode.go
@@ -1,0 +1,491 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// commandcodeBackend drives the CommandCode CLI's native NDJSON protocol: `cmd`
+// with `--output-format json`, prompt on stdin. The event schema is based on
+// CommandCode CLI v1.50.1 captures in research-captures/*.ndjson.
+//
+// The protocol wraps every streaming event inside an outer envelope: N lines of
+// `{"type":"event","event":{...}}` followed by ONE final
+// `{"type":"result",...}` line. The inner event carries its own `type`
+// (run_start, thinking_delta, text_delta, tool_queued, ...); the parser here
+// unwraps the envelope and dispatches on the inner type.
+type commandcodeBackend struct {
+	cfg Config
+}
+
+// commandcodeBlockedArgs are owned by Multica. CommandCode accepts the task
+// prompt and the stream protocol as flags, so custom args must not replace
+// either. Model/session are also selected by Multica, and the remaining flags
+// are daemon-owned permission/behavior flags; users may not disable YOLO mode,
+// change the output format, or narrow the tool registry from custom_args.
+var commandcodeBlockedArgs = map[string]blockedArgMode{
+	"-p":                             blockedWithValue,
+	"--print":                        blockedWithValue,
+	"--output-format":                blockedWithValue,
+	"-m":                             blockedWithValue,
+	"--model":                        blockedWithValue,
+	"-r":                             blockedWithValue,
+	"--resume":                       blockedWithValue,
+	"-c":                             blockedStandalone,
+	"--continue":                     blockedStandalone,
+	"--fork-session":                 blockedWithValue,
+	"--session":                      blockedWithValue,
+	"--no-auto-update":               blockedStandalone,
+	"--permission-mode":              blockedWithValue,
+	"--auto-accept":                  blockedStandalone,
+	"--yolo":                         blockedStandalone,
+	"--dangerously-skip-permissions": blockedStandalone,
+	"--plan":                         blockedStandalone,
+	"--no-skills":                    blockedStandalone,
+	"--skip-onboarding":              blockedStandalone,
+	"--tools-all":                    blockedStandalone,
+	"--tools-enable":                 blockedWithValue,
+}
+
+// buildCommandCodeArgs assembles the argv for a one-shot CommandCode invocation.
+//
+// The prompt is deliberately NOT part of argv. CommandCode's headless mode
+// reads a non-interactive prompt from stdin when none is given via -p, and
+// putting the (arbitrarily large, user-influenced) prompt text on the command
+// line is not safe on Windows: even after routing a .cmd shim through its
+// PowerShell counterpart (commandcode_invocation_windows.go), PowerShell's own
+// argument re-serialisation does not survive a value containing embedded double
+// quotes — the same class of failure cursor-agent hit before it moved its
+// prompt to stdin (#5649). This is that fix's CommandCode equivalent (#6082).
+// Only fixed, content-free flags remain in argv; the prompt goes on stdin.
+func buildCommandCodeArgs(opts ExecOptions, logger *slog.Logger) []string {
+	args := []string{"--output-format", "json", "--no-auto-update"}
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--resume", opts.ResumeSessionID)
+	}
+	// --yolo is daemon-owned: CommandCode's non-interactive mode filters out
+	// approval-requiring tools unless bypass mode is active. All other adapters
+	// use an equivalent mechanism; this keeps CommandCode headless runs
+	// consistent with the rest of the runtime set.
+	args = append(args, "--yolo")
+	args = append(args, filterCustomArgs(opts.ExtraArgs, commandcodeBlockedArgs, logger)...)
+	args = append(args, filterCustomArgs(opts.CustomArgs, commandcodeBlockedArgs, logger)...)
+	return args
+}
+
+func (b *commandcodeBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execName := b.cfg.ExecutablePath
+	if execName == "" {
+		execName = "cmd"
+	}
+	lookedUp, err := exec.LookPath(execName)
+	if err != nil {
+		return nil, fmt.Errorf("commandcode executable not found at %q: %w", execName, err)
+	}
+	timeout := opts.Timeout
+	runCtx, cancel := runContext(ctx, timeout)
+	args := buildCommandCodeArgs(opts, b.cfg.Logger)
+
+	cmd, _, _ := b.cfg.commandAt(execName).execVia(runCtx, chooseCommandCodeInvocation, lookedUp, args, b.cfg.Logger)
+	hideAgentWindow(cmd)
+	b.cfg.logAgentCommand(cmd, newAgentCommandLogArgs(args))
+	cmd.WaitDelay = 10 * time.Second
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("commandcode stdout pipe: %w", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("commandcode stdin pipe: %w", err)
+	}
+	var closeStdinOnce sync.Once
+	closeStdin := func() { closeStdinOnce.Do(func() { _ = stdin.Close() }) }
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[cmd:stderr] "), agentStderrTailBytes)
+	cmd.Stderr = stderrBuf
+	if err := startOwnedProcessTree(cmd, b.cfg.Logger); err != nil {
+		closeStdin()
+		cancel()
+		return nil, fmt.Errorf("start commandcode: %w", err)
+	}
+	b.cfg.Logger.Info("commandcode started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+
+	// The prompt is delivered on stdin (see buildCommandCodeArgs). Write it from
+	// its own goroutine so it cannot deadlock against the stdout reader below:
+	// a prompt larger than the OS pipe buffer blocks mid-write until the child
+	// drains it, and the child cannot drain while we are not yet reading its
+	// stdout. Closing stdin is what signals end-of-prompt — cmd reads to EOF —
+	// so we always close, on both the success and error paths.
+	writeErrCh := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(stdin, prompt)
+		closeStdin()
+		writeErrCh <- err
+	}()
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+
+		started := time.Now()
+		state := commandcodeStreamState{model: opts.Model, usage: make(map[string]TokenUsage)}
+		go func() {
+			<-runCtx.Done()
+			// Closing stdin releases a prompt write still blocked on a full pipe
+			// (e.g. the child died before draining it), so that goroutine cannot
+			// leak.
+			closeStdin()
+			_ = stdout.Close()
+		}()
+
+		scanner := newAgentStreamScanner(stdout)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			raw, ok := parseCommandCodeLine(line)
+			if !ok {
+				state.invalidEventCount++
+				continue
+			}
+			state.eventCount++
+			handleCommandCodePayload(raw, msgCh, &state)
+		}
+		scanErr := scanner.Err()
+		if scanErr != nil {
+			_ = stdout.Close()
+		}
+		exitErr := cmd.Wait()
+		releaseProcessGroup(cmd)
+		duration := time.Since(started)
+
+		// Wait has already closed the stdin pipe, so a prompt write still
+		// blocked on a full pipe has returned by now; the writer sends exactly
+		// once.
+		writeErr := <-writeErrCh
+
+		status, output, errMsg := finalizeStreamResult("commandcode", timeout, runCtx.Err(), writeErr, exitErr, state.sessionID, streamTerminalState{
+			lastAssistantText: state.lastAssistantText,
+			finalResultText:   state.finalResultText,
+			sawResult:         state.sawResult,
+			resultIsError:     state.resultIsError,
+			scanErr:           scanErr,
+		}, "")
+		if errMsg != "" {
+			errMsg = withAgentStderr(errMsg, "commandcode", stderrBuf.Tail())
+		}
+		logStreamProtocolObservation(b.cfg.Logger, streamProtocolObservation{
+			provider: "commandcode", cliVersion: b.cfg.CLIVersion, model: state.model,
+			exitCode: streamProcessExitCode(exitErr), eventCount: state.eventCount,
+			invalidEventCount: state.invalidEventCount, assistantEventCount: state.assistantEventCount,
+			toolUseCount: state.toolUseCount, sawResult: state.sawResult, resultIsError: state.resultIsError,
+			resultBytes: len(state.finalResultText), lastAssistantBytes: len(state.lastAssistantText),
+			scannerError: scanErr != nil, lastEventType: state.lastEventType,
+			unhandledEventTypeCount: state.unhandledEventTypeCount, unhandledEventTypes: state.unhandledEventTypes,
+			unhandledSubtypeCount: state.unhandledSubtypeCount, unreadableAssistantCount: 0,
+		})
+		b.cfg.Logger.Info("commandcode finished", "pid", cmd.Process.Pid, "status", status, "duration", duration.Round(time.Millisecond).String())
+		resCh <- Result{
+			Status: status, Output: output, Error: errMsg, DurationMs: duration.Milliseconds(),
+			SessionID:      resolveSessionID(opts.ResumeSessionID, state.sessionID, status == "failed", errMsg),
+			Usage:          state.usage,
+			ResumeRejected: resumeWasRejected(opts.ResumeSessionID, state.sessionID, status == "failed", errMsg),
+		}
+	}()
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// commandcodePayload is the unwrapped envelope. CommandCode emits two outer
+// shapes that share one wire: `{"type":"event","event":{...}}` carries a
+// streaming inner event in Event; `{"type":"result",...}` carries the terminal
+// result flat (Subtype, SessionID, Usage, FinalText, ...).
+type commandcodePayload struct {
+	Type       string            `json:"type"`
+	Event      json.RawMessage   `json:"event,omitempty"`
+	Subtype    string            `json:"subtype,omitempty"`
+	SessionID  string            `json:"sessionId,omitempty"`
+	StopReason string            `json:"stopReason,omitempty"`
+	Usage      *commandcodeUsage `json:"usage,omitempty"`
+	DurationMs int64             `json:"durationMs,omitempty"`
+	FinalText  string            `json:"finalText,omitempty"`
+}
+
+// commandcodeInnerEvent is the unwrapped `event` object. Its own `type` selects
+// the handler. Fields are a superset of the observed vocabulary; unrecognized
+// types are counted, never fatal.
+type commandcodeInnerEvent struct {
+	Type         string            `json:"type"`
+	SessionID    string            `json:"sessionId,omitempty"`
+	TurnNumber   int               `json:"turnNumber,omitempty"`
+	HadToolCalls bool              `json:"hadToolCalls,omitempty"`
+	Model        string            `json:"model,omitempty"`
+	StopReason   string            `json:"stopReason,omitempty"`
+	Usage        *commandcodeUsage `json:"usage,omitempty"`
+	TraceID      string            `json:"traceId,omitempty"`
+	ToolCallID   string            `json:"toolCallId,omitempty"`
+	ToolName     string            `json:"toolName,omitempty"`
+	Description  string            `json:"description,omitempty"`
+	Input        json.RawMessage   `json:"input,omitempty"`
+	Result       json.RawMessage   `json:"result,omitempty"`
+	Deferred     bool              `json:"deferred,omitempty"`
+	Delta        string            `json:"delta,omitempty"`
+	Text         string            `json:"text,omitempty"`
+	Content      json.RawMessage   `json:"content,omitempty"`
+}
+
+type commandcodeUsage struct {
+	InputTokens      int64 `json:"inputTokens"`
+	OutputTokens     int64 `json:"outputTokens"`
+	CacheReadTokens  int64 `json:"cacheReadTokens"`
+	CacheWriteTokens int64 `json:"cacheWriteTokens"`
+}
+
+// parseCommandCodeLine parses one NDJSON line into the unwrapped envelope.
+// It returns false for lines that are not valid JSON objects with a `type`
+// field — that is how the auto-update junk line (`Updated 1.50.0 → 1.50.1`) and
+// any other non-JSON stdout pollution is tolerated without breaking the stream.
+func parseCommandCodeLine(line string) (commandcodePayload, bool) {
+	var payload commandcodePayload
+	if err := json.Unmarshal([]byte(line), &payload); err != nil {
+		return commandcodePayload{}, false
+	}
+	if payload.Type == "" {
+		return commandcodePayload{}, false
+	}
+	return payload, true
+}
+
+func handleCommandCodePayload(payload commandcodePayload, ch chan<- Message, state *commandcodeStreamState) {
+	if payload.Type == "result" {
+		handleCommandCodeResult(payload, state)
+		return
+	}
+	if payload.Type != "event" {
+		state.unhandledEventTypeCount++
+		state.unhandledEventTypes = appendUnhandledType(state.unhandledEventTypes, payload.Type)
+		return
+	}
+	var inner commandcodeInnerEvent
+	if err := json.Unmarshal(payload.Event, &inner); err != nil {
+		state.unhandledSubtypeCount++
+		return
+	}
+	state.lastEventType = inner.Type
+	handleCommandCodeEvent(inner, ch, state)
+}
+
+func handleCommandCodeResult(payload commandcodePayload, state *commandcodeStreamState) {
+	state.sawResult = true
+	state.resultIsError = payload.Subtype != "" && payload.Subtype != "success"
+	if payload.SessionID != "" {
+		state.sessionID = payload.SessionID
+	}
+	state.stopReason = payload.StopReason
+	state.finalResultText = payload.FinalText
+	if usage := payload.Usage; usage != nil && (usage.InputTokens != 0 || usage.OutputTokens != 0 || usage.CacheReadTokens != 0 || usage.CacheWriteTokens != 0) {
+		// The result usage is the authoritative aggregate for the whole run;
+		// key it by the last-seen model (empty when the stream carried none).
+		// A zero record (e.g. an error result) must not clobber per-model usage
+		// accumulated from model_request_end frames.
+		state.usage[state.model] = commandcodeTokenUsage(usage)
+	}
+}
+
+func handleCommandCodeEvent(event commandcodeInnerEvent, ch chan<- Message, state *commandcodeStreamState) {
+	switch event.Type {
+	case "run_start":
+		if event.SessionID != "" {
+			state.sessionID = event.SessionID
+		}
+		trySend(ch, Message{Type: MessageStatus, Status: "running", SessionID: state.sessionID})
+	case "turn_start", "turn_end":
+		if event.Model != "" {
+			state.model = event.Model
+		}
+		if event.Usage != nil && event.Model != "" {
+			state.usage[event.Model] = commandcodeTokenUsage(event.Usage)
+		}
+	case "message_start", "message_update", "message_end":
+		// Content blocks are synthesized from the finer-grained
+		// thinking_* / text_delta / tool_* stream below; the message envelope
+		// is redundant and deliberately not re-parsed here.
+	case "thinking_start":
+		state.thinking.WriteString(event.Delta)
+	case "thinking_delta":
+		state.thinking.WriteString(event.Delta)
+		if thinking := state.thinking.String(); thinking != "" {
+			trySend(ch, Message{Type: MessageThinking, Content: thinking})
+		}
+	case "thinking_end":
+		if event.Text != "" {
+			state.thinking.Reset()
+			state.thinking.WriteString(event.Text)
+		}
+		if thinking := state.thinking.String(); thinking != "" {
+			trySend(ch, Message{Type: MessageThinking, Content: thinking})
+		}
+		state.thinking.Reset()
+	case "text_delta":
+		if event.Delta != "" {
+			state.lastAssistantText += event.Delta
+			trySend(ch, Message{Type: MessageText, Content: event.Delta})
+		}
+	case "model_trace":
+		// Opaque trace id for model-router diagnostics; not rendered.
+	case "model_request_start":
+		if event.Model != "" {
+			state.model = event.Model
+		}
+	case "model_request_end":
+		if event.Model != "" {
+			state.model = event.Model
+		}
+		if event.Usage != nil && event.Model != "" {
+			state.usage[event.Model] = commandcodeTokenUsage(event.Usage)
+		}
+	case "tool_queued":
+		state.toolUseCount++
+		var input map[string]any
+		if len(event.Input) > 0 {
+			_ = json.Unmarshal(event.Input, &input)
+		}
+		trySend(ch, Message{Type: MessageToolUse, Tool: event.ToolName, CallID: event.ToolCallID, Input: input})
+	case "tool_running":
+		// Tool execution in progress; the queued/completed pair brackets the
+		// work, so the running frame is not rendered separately.
+	case "tool_completed":
+		trySend(ch, Message{Type: MessageToolResult, CallID: event.ToolCallID, Output: commandcodeToolResultText(event.Result)})
+	case "run_end":
+		// Terminal summary frame; the result line carries the canonical final
+		// text and usage, so this is not rendered separately.
+	default:
+		state.unhandledEventTypeCount++
+		state.unhandledEventTypes = appendUnhandledType(state.unhandledEventTypes, event.Type)
+	}
+}
+
+func commandcodeTokenUsage(usage *commandcodeUsage) TokenUsage {
+	return TokenUsage{
+		InputTokens:      usage.InputTokens,
+		OutputTokens:     usage.OutputTokens,
+		CacheReadTokens:  usage.CacheReadTokens,
+		CacheWriteTokens: usage.CacheWriteTokens,
+	}
+}
+
+func commandcodeToolResultText(raw json.RawMessage) string {
+	var blocks []commandcodeToolResultBlock
+	if json.Unmarshal(raw, &blocks) != nil {
+		return string(raw)
+	}
+	var sb strings.Builder
+	for i, block := range blocks {
+		if block.Type == "text" && block.Text != "" {
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString(block.Text)
+		}
+	}
+	if sb.Len() == 0 {
+		return string(raw)
+	}
+	return sb.String()
+}
+
+type commandcodeToolResultBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type commandcodeStreamState struct {
+	sessionID, model, lastAssistantText, finalResultText, lastEventType, stopReason string
+	thinking                                                                        strings.Builder
+	sawResult, resultIsError                                                        bool
+	usage                                                                           map[string]TokenUsage
+	eventCount, invalidEventCount, assistantEventCount, toolUseCount                int
+	unhandledEventTypeCount, unhandledSubtypeCount                                  int
+	unhandledEventTypes                                                             string
+}
+
+func appendUnhandledType(types, addition string) string {
+	if types == "" {
+		return addition
+	}
+	return types + "," + addition
+}
+
+// commandcodeModelLine matches a model entry in `cmd --list-models` output.
+// Each model line is "<id>  <description>" where the id and description are
+// separated by two or more spaces (the human table is column-aligned). Section
+// headers ("Open Source", "Anthropic", ...) and the footer are single short
+// lines that do not match this shape, so they are skipped automatically.
+var commandcodeModelLine = regexp.MustCompile(`^(\S+)\s{2,}(.+)$`)
+
+// discoverCommandCodeModels runs `cmd --list-models` and parses the
+// human-readable table into a model catalog. CommandCode prints a text table,
+// not JSON — there is no structured catalog endpoint — so we scrape the first
+// whitespace-separated token of each aligned line as the model id. A failure at
+// any step (binary missing, non-zero exit, unparseable output) degrades to an
+// empty catalog so the UI falls back to manual model entry rather than erroring.
+func discoverCommandCodeModels(ctx context.Context, runtimeCmd Command) ([]Model, error) {
+	if runtimeCmd.Path == "" {
+		runtimeCmd.Path = "cmd"
+	}
+	if _, err := exec.LookPath(runtimeCmd.Path); err != nil {
+		return []Model{}, nil
+	}
+	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	cmd := runtimeCmd.exec(runCtx, "--list-models", "--no-auto-update")
+	hideAgentWindow(cmd)
+	stdout, err := outputOwned(cmd, runtimeCmd.logger)
+	if err != nil || len(stdout) == 0 {
+		return []Model{}, nil
+	}
+	return parseCommandCodeModels(stdout), nil
+}
+
+func parseCommandCodeModels(stdout []byte) []Model {
+	seen := map[string]bool{}
+	var models []Model
+	for _, line := range strings.Split(string(stdout), "\n") {
+		matches := commandcodeModelLine.FindStringSubmatch(strings.TrimSpace(line))
+		if matches == nil {
+			continue
+		}
+		id := strings.TrimSpace(matches[1])
+		if id == "" || seen[id] {
+			continue
+		}
+		// Skip the footer line ("Pass the full id, ...") — its first token is
+		// not a model id and it has no description column, but guard anyway.
+		if strings.HasPrefix(id, "Pass") || strings.HasPrefix(id, "cmd") || strings.HasPrefix(id, "Docs") {
+			continue
+		}
+		seen[id] = true
+		models = append(models, Model{ID: id})
+	}
+	return models
+}

--- a/server/pkg/agent/commandcode.go
+++ b/server/pkg/agent/commandcode.go
@@ -66,8 +66,14 @@ var commandcodeBlockedArgs = map[string]blockedArgMode{
 // quotes — the same class of failure cursor-agent hit before it moved its
 // prompt to stdin (#5649). This is that fix's CommandCode equivalent (#6082).
 // Only fixed, content-free flags remain in argv; the prompt goes on stdin.
+//
+// --print (since CommandCode 1.52.0) is what selects non-interactive mode when
+// the prompt arrives on stdin. Before 1.52.0 stdin alone was enough; from
+// 1.52.0 the CLI aborts with "Interactive mode requires a TTY terminal" unless
+// a prompting flag is present. It is argv-only and carries no value, so it
+// keeps the Windows argument-serialisation guarantee above intact.
 func buildCommandCodeArgs(opts ExecOptions, logger *slog.Logger) []string {
-	args := []string{"--output-format", "json", "--no-auto-update"}
+	args := []string{"--output-format", "json", "--no-auto-update", "--print"}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}

--- a/server/pkg/agent/commandcode_invocation.go
+++ b/server/pkg/agent/commandcode_invocation.go
@@ -1,0 +1,15 @@
+package agent
+
+import "log/slog"
+
+// chooseCommandCodeInvocation selects the actual program (argv[0]) and the full
+// argv to spawn a CommandCode run.
+//
+// CommandCode ships as a single native binary (`cmd`) with no `.cmd`/`.ps1`
+// shim, so unlike Qwen Code on Windows there is no shell re-tokenisation hazard
+// to route around: Go's os/exec passes argv through unchanged on every
+// platform. The task prompt itself is delivered through stdin and never appears
+// in argv (#6082). This is therefore a pure passthrough.
+func chooseCommandCodeInvocation(execName, lookedUp string, args []string, logger *slog.Logger) (string, []string) {
+	return execName, args
+}

--- a/server/pkg/agent/commandcode_test.go
+++ b/server/pkg/agent/commandcode_test.go
@@ -58,7 +58,7 @@ func TestBuildCommandCodeArgsKeepsProtocolManaged(t *testing.T) {
 	if strings.Contains(joined, "-p ") || strings.HasPrefix(joined, "-p") {
 		t.Fatalf("-p must not appear in argv, prompt is delivered on stdin: %v", args)
 	}
-	wantPrefix := []string{"--output-format", "json", "--no-auto-update", "--model", "meituan/longcat-2.0:free", "--resume", "session-1"}
+	wantPrefix := []string{"--output-format", "json", "--no-auto-update", "--print", "--model", "meituan/longcat-2.0:free", "--resume", "session-1"}
 	if len(args) < len(wantPrefix) {
 		t.Fatalf("args too short: %v", args)
 	}

--- a/server/pkg/agent/commandcode_test.go
+++ b/server/pkg/agent/commandcode_test.go
@@ -1,0 +1,470 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewReturnsCommandCodeBackend(t *testing.T) {
+	t.Parallel()
+	backend, err := New("commandcode", Config{ExecutablePath: "/nonexistent/cmd"})
+	if err != nil {
+		t.Fatalf("New(commandcode): %v", err)
+	}
+	if _, ok := backend.(*commandcodeBackend); !ok {
+		t.Fatalf("New(commandcode) = %T, want *commandcodeBackend", backend)
+	}
+}
+
+func TestBuildCommandCodeArgsKeepsProtocolManaged(t *testing.T) {
+	t.Parallel()
+	args := buildCommandCodeArgs(ExecOptions{
+		Model:           "meituan/longcat-2.0:free",
+		ResumeSessionID: "session-1",
+		ExtraArgs:       []string{"--output-format", "text", "--sandbox"},
+		CustomArgs: []string{
+			"--print=replace", "-o", "json", "--model", "other", "--resume", "other-session",
+			"--yolo", "--permission-mode", "default", "--auto-accept",
+			"--dangerously-skip-permissions", "--plan", "--no-skills", "--skip-onboarding",
+			"--tools-all", "--tools-enable", "web_search", "--allowed-tools", "read_file",
+			"--fork-session", "x", "--session", "y", "-c", "--continue",
+			"--no-auto-update", "--debug",
+		},
+	}, slog.Default())
+	joined := strings.Join(args, " ")
+	argSet := make(map[string]struct{}, len(args))
+	for _, a := range args {
+		argSet[a] = struct{}{}
+	}
+	for _, forbidden := range []string{"text", "replace", "other-session", "other", "default", "read_file=", "web_search", "-c", "--continue", "--fork-session", "--session"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("managed argument %q leaked into %v", forbidden, args)
+		}
+	}
+	// Bare value tokens: exact-match against argv elements (substring would
+	// false-positive on kept args like --sandbox containing "x").
+	for _, token := range []string{"x", "y"} {
+		if _, ok := argSet[token]; ok {
+			t.Fatalf("managed argument %q leaked into %v", token, args)
+		}
+	}
+	// The prompt is never part of argv (see buildCommandCodeArgs) — it goes on stdin.
+	if strings.Contains(joined, "-p ") || strings.HasPrefix(joined, "-p") {
+		t.Fatalf("-p must not appear in argv, prompt is delivered on stdin: %v", args)
+	}
+	wantPrefix := []string{"--output-format", "json", "--no-auto-update", "--model", "meituan/longcat-2.0:free", "--resume", "session-1"}
+	if len(args) < len(wantPrefix) {
+		t.Fatalf("args too short: %v", args)
+	}
+	for i, want := range wantPrefix {
+		if args[i] != want {
+			t.Fatalf("args[%d] = %q, want %q; all=%v", i, args[i], want, args)
+		}
+	}
+	if !strings.Contains(joined, "--sandbox") || !strings.Contains(joined, "--debug") || !strings.Contains(joined, "--allowed-tools read_file") {
+		t.Fatalf("non-managed custom args missing from %v", args)
+	}
+	// daemon-owned --yolo must be present; user's --yolo must be stripped so it
+	// appears exactly once regardless of what custom_args contain.
+	if count := strings.Count(joined, "--yolo"); count != 1 {
+		t.Fatalf("--yolo count = %d in %v, want exactly 1 (daemon-owned)", count, args)
+	}
+}
+
+func TestBuildCommandCodeArgsYoloAlwaysPresent(t *testing.T) {
+	t.Parallel()
+	args := buildCommandCodeArgs(ExecOptions{}, slog.Default())
+	if !strings.Contains(strings.Join(args, " "), "--yolo") {
+		t.Fatalf("--yolo missing from base args %v", args)
+	}
+}
+
+// trimmed fixtures distilled from research-captures/*.ndjson. Kept small: a few
+// lines each. The auto-update junk line case exercises non-JSON tolerance; the
+// tool trio case exercises tool_use/tool_result synthesis; the resume case
+// exercises session-id preservation.
+const (
+	fixtureAutoUpdateJunk = "Updated 1.50.0 → 1.50.1" + "\n" +
+		`{"type":"event","event":{"type":"run_start","sessionId":"sess-junk"}}` + "\n" +
+		`{"type":"event","event":{"type":"text_delta","delta":"hi"}}` + "\n" +
+		`{"type":"result","subtype":"success","sessionId":"sess-junk","stopReason":"end_turn","usage":{"inputTokens":10,"outputTokens":1,"cacheReadTokens":0,"cacheWriteTokens":0},"durationMs":100,"finalText":"hi"}`
+
+	fixtureToolTrio = `{"type":"event","event":{"type":"run_start","sessionId":"sess-tool"}}` + "\n" +
+		`{"type":"event","event":{"type":"tool_queued","toolCallId":"call-1","toolName":"read_file","input":{"file_path":"/work"}}}` + "\n" +
+		`{"type":"event","event":{"type":"tool_running","toolCallId":"call-1","toolName":"read_file","description":"reading"}}` + "\n" +
+		`{"type":"event","event":{"type":"tool_completed","toolCallId":"call-1","toolName":"read_file","result":[{"type":"text","text":"Read 1 file"}],"deferred":false}}` + "\n" +
+		`{"type":"event","event":{"type":"text_delta","delta":"done"}}` + "\n" +
+		`{"type":"result","subtype":"success","sessionId":"sess-tool","stopReason":"end_turn","usage":{"inputTokens":100,"outputTokens":5,"cacheReadTokens":0,"cacheWriteTokens":0},"durationMs":500,"finalText":"done"}`
+
+	fixtureResume = `{"type":"event","event":{"type":"run_start","sessionId":"sess-resume"}}` + "\n" +
+		`{"type":"event","event":{"type":"text_delta","delta":"40"}}` + "\n" +
+		`{"type":"result","subtype":"success","sessionId":"sess-resume","stopReason":"end_turn","usage":{"inputTokens":95319,"outputTokens":30,"cacheReadTokens":6016,"cacheWriteTokens":0},"durationMs":10594,"finalText":"40"}`
+)
+
+func collectCommandCode(t *testing.T, ndjson string) ([]Message, commandcodeStreamState) {
+	t.Helper()
+	state := commandcodeStreamState{usage: make(map[string]TokenUsage)}
+	messages := make(chan Message, 64)
+	for _, line := range strings.Split(ndjson, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		payload, ok := parseCommandCodeLine(line)
+		if !ok {
+			state.invalidEventCount++
+			continue
+		}
+		state.eventCount++
+		handleCommandCodePayload(payload, messages, &state)
+	}
+	close(messages)
+	var collected []Message
+	for m := range messages {
+		collected = append(collected, m)
+	}
+	return collected, state
+}
+
+func TestCommandCodeParserToleratesAutoUpdateJunk(t *testing.T) {
+	t.Parallel()
+	messages, state := collectCommandCode(t, fixtureAutoUpdateJunk)
+	if state.invalidEventCount != 1 {
+		t.Fatalf("invalidEventCount = %d, want 1 (the junk line)", state.invalidEventCount)
+	}
+	if !state.sawResult || state.resultIsError || state.sessionID != "sess-junk" || state.finalResultText != "hi" {
+		t.Fatalf("unexpected state: %+v", state)
+	}
+	var text bool
+	for _, m := range messages {
+		if m.Type == MessageText && m.Content == "hi" {
+			text = true
+		}
+	}
+	if !text {
+		t.Fatalf("missing text message; messages=%+v", messages)
+	}
+}
+
+func TestCommandCodeParserSynthesizesToolTrio(t *testing.T) {
+	t.Parallel()
+	messages, state := collectCommandCode(t, fixtureToolTrio)
+	if !state.sawResult || state.resultIsError || state.sessionID != "sess-tool" || state.finalResultText != "done" {
+		t.Fatalf("unexpected state: %+v", state)
+	}
+	if state.usage[""].InputTokens != 100 {
+		// model is empty in this fixture; usage is keyed by model from
+		// model_request_end which the fixture omits, so it lands under "".
+	}
+	var toolUse, toolResult, text bool
+	for _, m := range messages {
+		switch m.Type {
+		case MessageToolUse:
+			toolUse = m.Tool == "read_file" && m.CallID == "call-1" && m.Input["file_path"] == "/work"
+		case MessageToolResult:
+			toolResult = m.CallID == "call-1" && m.Output == "Read 1 file"
+		case MessageText:
+			text = m.Content == "done"
+		}
+	}
+	if !toolUse || !toolResult || !text {
+		t.Fatalf("missing tool events toolUse=%v toolResult=%v text=%v; messages=%+v", toolUse, toolResult, text, messages)
+	}
+}
+
+func TestCommandCodeParserPreservesResumeSession(t *testing.T) {
+	t.Parallel()
+	_, state := collectCommandCode(t, fixtureResume)
+	if state.sessionID != "sess-resume" {
+		t.Fatalf("sessionID = %q, want sess-resume", state.sessionID)
+	}
+	if state.finalResultText != "40" {
+		t.Fatalf("finalResultText = %q, want 40", state.finalResultText)
+	}
+	if state.usage[""].InputTokens != 95319 {
+		t.Fatalf("usage = %+v", state.usage)
+	}
+}
+
+func TestCommandCodeProbe1NoToolFixtureParses(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "research-captures", "probe1-no-tool.ndjson"))
+	if err != nil {
+		t.Skipf("probe fixture not present: %v", err)
+	}
+	state := commandcodeStreamState{usage: make(map[string]TokenUsage)}
+	messages := make(chan Message, 128)
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		payload, ok := parseCommandCodeLine(line)
+		if !ok {
+			t.Fatalf("fixture line did not parse: %v\n%s", err, line)
+		}
+		handleCommandCodePayload(payload, messages, &state)
+	}
+	close(messages)
+	var thinking, text bool
+	for m := range messages {
+		switch m.Type {
+		case MessageThinking:
+			thinking = m.Content == "\nThe user is asking a simple math question in Portuguese: \"what is 2+2?\" They want a one-line answer."
+		case MessageText:
+			text = m.Content == "4"
+		}
+	}
+	if !state.sawResult || state.resultIsError || state.sessionID != "86fbfbb5-91f4-4819-b832-41e9a4c6ed9f" || state.finalResultText != "4" {
+		t.Fatalf("unexpected fixture state: %+v", state)
+	}
+	if !thinking || !text {
+		t.Fatalf("missing streamed events thinking=%v text=%v", thinking, text)
+	}
+}
+
+func TestCommandCodeProbe2ToolReadFixtureParses(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "research-captures", "probe2-tool-read.ndjson"))
+	if err != nil {
+		t.Skipf("probe fixture not present: %v", err)
+	}
+	state := commandcodeStreamState{usage: make(map[string]TokenUsage)}
+	messages := make(chan Message, 256)
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		payload, ok := parseCommandCodeLine(line)
+		if !ok {
+			t.Fatalf("fixture line did not parse: %s", line)
+		}
+		handleCommandCodePayload(payload, messages, &state)
+	}
+	close(messages)
+	var toolUse, toolResult bool
+	for m := range messages {
+		switch m.Type {
+		case MessageToolUse:
+			toolUse = m.Tool == "read_file" && m.CallID == "call_a852418901254596861d91b9"
+		case MessageToolResult:
+			toolResult = m.CallID == "call_a852418901254596861d91b9" && strings.Contains(m.Output, "quack 42")
+		}
+	}
+	if !state.sawResult || state.resultIsError || state.finalResultText != "42" {
+		t.Fatalf("unexpected fixture state: %+v", state)
+	}
+	if !toolUse || !toolResult {
+		t.Fatalf("missing tool events toolUse=%v toolResult=%v", toolUse, toolResult)
+	}
+}
+
+func TestParseCommandCodeModelsScrapesListModelsTable(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "research-captures", "probe4-list-models.txt"))
+	if err != nil {
+		t.Skipf("list-models fixture not present: %v", err)
+	}
+	models := parseCommandCodeModels(data)
+	if len(models) == 0 {
+		t.Fatalf("no models parsed from list-models output")
+	}
+	// Spot-check a few known ids from the table.
+	known := map[string]bool{}
+	for _, m := range models {
+		known[m.ID] = true
+	}
+	for _, want := range []string{"deepseek/deepseek-v4-pro", "claude-sonnet-5", "gpt-6-astra", "xai/grok-4.5"} {
+		if !known[want] {
+			t.Fatalf("expected model %q not found in %d parsed models", want, len(models))
+		}
+	}
+	// Section headers and footer must not leak in.
+	for _, banned := range []string{"Open Source", "Anthropic", "Pass", "Docs:", "Available"} {
+		if known[banned] {
+			t.Fatalf("non-model token %q leaked into catalog", banned)
+		}
+	}
+}
+
+func fakeCommandCodeScript() string {
+	return `#!/bin/sh
+if [ -n "$CMD_ARGS_FILE" ]; then printf '%s\n' "$@" > "$CMD_ARGS_FILE"; fi
+if [ -n "$CMD_STDIN_FILE" ]; then cat > "$CMD_STDIN_FILE"; fi
+case "$CMD_MODE" in
+  error)
+    printf '%s\n' '{"type":"event","event":{"type":"run_start","sessionId":"sess-error"}}'
+    printf '%s\n' '{"type":"result","subtype":"error","sessionId":"sess-error","stopReason":"error","usage":{"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheWriteTokens":0},"durationMs":0,"finalText":""}'
+    ;;
+  junk)
+    printf '%s\n' 'Updated 1.50.0 → 1.50.1'
+    printf '%s\n' '{"type":"event","event":{"type":"run_start","sessionId":"sess-junk"}}'
+    printf '%s\n' '{"type":"event","event":{"type":"text_delta","delta":"ok"}}'
+    printf '%s\n' '{"type":"result","subtype":"success","sessionId":"sess-junk","stopReason":"end_turn","usage":{"inputTokens":5,"outputTokens":1,"cacheReadTokens":0,"cacheWriteTokens":0},"durationMs":10,"finalText":"ok"}'
+    ;;
+  resume-missing)
+    echo 'No conversation found for the given session id' >&2
+    exit 1
+    ;;
+  spin)
+    while :; do :; done
+    ;;
+  *)
+    printf '%s\n' '{"type":"event","event":{"type":"run_start","sessionId":"sess-cmd-1","model":"cmd-test"}}'
+    printf '%s\n' '{"type":"event","event":{"type":"thinking_delta","delta":"thinking..."}}'
+    printf '%s\n' '{"type":"event","event":{"type":"tool_queued","toolCallId":"call-1","toolName":"list_directory","input":{"path":"/work"}}}' >/dev/null 2>&1
+    printf '%s\n' '{"type":"event","event":{"type":"tool_queued","toolCallId":"call-1","toolName":"list_directory","input":{"path":"/work"}}}'
+    printf '%s\n' '{"type":"event","event":{"type":"tool_completed","toolCallId":"call-1","toolName":"list_directory","result":[{"type":"text","text":"Listed 1 item"}],"deferred":false}}'
+    printf '%s\n' '{"type":"event","event":{"type":"text_delta","delta":"PONG"}}'
+    printf '%s\n' '{"type":"result","subtype":"success","sessionId":"sess-cmd-1","stopReason":"end_turn","usage":{"inputTokens":10,"outputTokens":2,"cacheReadTokens":3,"cacheWriteTokens":0},"durationMs":100,"finalText":"PONG"}'
+    ;;
+esac
+`
+}
+
+func newFakeCommandCodeBackend(t *testing.T, env map[string]string) *commandcodeBackend {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is POSIX-only")
+	}
+	path := filepath.Join(t.TempDir(), "cmd")
+	writeTestExecutable(t, path, []byte(fakeCommandCodeScript()))
+	return &commandcodeBackend{cfg: Config{ExecutablePath: path, Logger: slog.Default(), Env: env}}
+}
+
+func awaitCommandCodeResult(t *testing.T, session *Session) ([]Message, Result) {
+	t.Helper()
+	var messages []Message
+	for message := range session.Messages {
+		messages = append(messages, message)
+	}
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a result")
+		}
+		return messages, result
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for commandcode result")
+		return nil, Result{}
+	}
+}
+
+func TestCommandCodeBackendStreamsNativeEvents(t *testing.T) {
+	t.Parallel()
+	backend := newFakeCommandCodeBackend(t, nil)
+	session, err := backend.Execute(context.Background(), "reply PONG", ExecOptions{Model: "cmd-test", Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	messages, result := awaitCommandCodeResult(t, session)
+	if result.Status != "completed" || result.Output != "PONG" || result.SessionID != "sess-cmd-1" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	usage := result.Usage["cmd-test"]
+	if usage.InputTokens != 10 || usage.OutputTokens != 2 || usage.CacheReadTokens != 3 {
+		t.Fatalf("unexpected final usage: %+v", usage)
+	}
+	var thinking, toolUse, toolResult, text bool
+	for _, message := range messages {
+		switch message.Type {
+		case MessageThinking:
+			thinking = message.Content == "thinking..."
+		case MessageToolUse:
+			toolUse = message.Tool == "list_directory" && message.CallID == "call-1" && message.Input["path"] == "/work"
+		case MessageToolResult:
+			toolResult = message.CallID == "call-1" && message.Output == "Listed 1 item"
+		case MessageText:
+			text = message.Content == "PONG"
+		}
+	}
+	if !thinking || !toolUse || !toolResult || !text {
+		t.Fatalf("missing native events thinking=%v toolUse=%v toolResult=%v text=%v; messages=%+v", thinking, toolUse, toolResult, text, messages)
+	}
+}
+
+func TestCommandCodeBackendPreservesSuccessfulResumeSession(t *testing.T) {
+	t.Parallel()
+	backend := newFakeCommandCodeBackend(t, nil)
+	session, err := backend.Execute(context.Background(), "continue task", ExecOptions{
+		Model: "cmd-test", ResumeSessionID: "sess-cmd-1", Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	_, result := awaitCommandCodeResult(t, session)
+	if result.Status != "completed" || result.Output != "PONG" || result.SessionID != "sess-cmd-1" {
+		t.Fatalf("resumed result = %+v", result)
+	}
+}
+
+func TestCommandCodeBackendDeliversPromptOnStdin(t *testing.T) {
+	t.Parallel()
+	stdinPath := filepath.Join(t.TempDir(), "cmd.stdin")
+	backend := newFakeCommandCodeBackend(t, map[string]string{"CMD_STDIN_FILE": stdinPath})
+	prompt := `go build -ldflags "-X main.version=foo" — mind the em dash & the quotes'`
+	session, err := backend.Execute(context.Background(), prompt, ExecOptions{Model: "cmd-test", Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	_, result := awaitCommandCodeResult(t, session)
+	if result.Status != "completed" {
+		t.Fatalf("result = %+v", result)
+	}
+	got, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatalf("read captured stdin: %v", err)
+	}
+	if string(got) != prompt {
+		t.Fatalf("stdin content = %q, want %q", got, prompt)
+	}
+}
+
+func TestCommandCodeBackendToleratesAutoUpdateJunkLine(t *testing.T) {
+	t.Parallel()
+	backend := newFakeCommandCodeBackend(t, map[string]string{"CMD_MODE": "junk"})
+	session, err := backend.Execute(context.Background(), "task", ExecOptions{Model: "cmd-test", Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	_, result := awaitCommandCodeResult(t, session)
+	if result.Status != "completed" || result.Output != "ok" || result.SessionID != "sess-junk" {
+		t.Fatalf("unexpected result after junk line: %+v", result)
+	}
+}
+
+func TestCommandCodeBackendFailureTimeoutAndCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is POSIX-only")
+	}
+	for _, tc := range []struct {
+		name        string
+		env         map[string]string
+		ctx         func() (context.Context, context.CancelFunc)
+		opts        ExecOptions
+		status      string
+		needle      string
+		wantSession string
+	}{
+		{"result error", map[string]string{"CMD_MODE": "error"}, func() (context.Context, context.CancelFunc) { return context.WithCancel(context.Background()) }, ExecOptions{}, "failed", "commandcode returned an error result without details", "sess-error"},
+		{"missing resume", map[string]string{"CMD_MODE": "resume-missing"}, func() (context.Context, context.CancelFunc) { return context.WithCancel(context.Background()) }, ExecOptions{ResumeSessionID: "session-redacted"}, "failed", "No conversation found", ""},
+		{"timeout", map[string]string{"CMD_MODE": "spin"}, func() (context.Context, context.CancelFunc) { return context.WithCancel(context.Background()) }, ExecOptions{Timeout: 20 * time.Millisecond}, "timeout", "timed out", ""},
+		{"cancel", map[string]string{"CMD_MODE": "spin"}, func() (context.Context, context.CancelFunc) { return context.WithCancel(context.Background()) }, ExecOptions{}, "aborted", "cancelled", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := tc.ctx()
+			if tc.name == "cancel" {
+				go func() { time.Sleep(20 * time.Millisecond); cancel() }()
+			} else {
+				defer cancel()
+			}
+			session, err := newFakeCommandCodeBackend(t, tc.env).Execute(ctx, "task", tc.opts)
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			_, result := awaitCommandCodeResult(t, session)
+			if result.Status != tc.status || !strings.Contains(result.Error, tc.needle) || result.SessionID != tc.wantSession {
+				t.Fatalf("result = %+v, want status=%q error containing %q session=%q", result, tc.status, tc.needle, tc.wantSession)
+			}
+		})
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -269,6 +269,14 @@ func ListModels(ctx context.Context, providerType string, runtimeCmd Command) (C
 		// empty list keeps the runtime default and manual model entry available
 		// without advertising a Token-Plan-specific model to other accounts.
 		return Catalog{Models: []Model{}}, nil
+	case "commandcode":
+		// CommandCode (`cmd`) prints a human-readable model table, not JSON, so
+		// discovery scrapes `cmd --list-models`. On any failure (binary
+		// missing, non-zero exit, unparseable output) it degrades to an empty
+		// catalog so the UI keeps manual model entry available.
+		return cachedDiscovery(discoveryCacheKey(providerType, runtimeCmd), func() (Catalog, error) {
+			return discovered(discoverCommandCodeModels(ctx, runtimeCmd))
+		})
 	case "qwenpaw":
 		// QwenPaw's model selection is unsupported (session/set_model
 		// persists to agent scope, not session scope), so there is no

--- a/server/pkg/agent/version.go
+++ b/server/pkg/agent/version.go
@@ -11,14 +11,15 @@ import (
 // MinVersions defines the minimum required CLI version for each agent type.
 // Versions below these will be rejected during daemon registration.
 var MinVersions = map[string]string{
-	"claude":   "2.0.0",
-	"codex":    "0.100.0", // app-server --listen stdio:// added in 0.100.0
-	"copilot":  "1.0.0",   // --output-format json envelope stable from 1.0.x
-	"grok":     "0.2.89",  // ACP + authenticate/session-load/set_model/MCP and --effort thinking flag
-	"qwen":     "0.20.0",  // stream-json protocol captured and verified against Qwen Code 0.20.0
-	"dim":      "0.3.10",  // cross-run session/load: per-process lock releases on graceful exit
-	"mcode":    "0.1.2",   // ACP v1 session/new, prompt, MCP capability forwarding
-	"zeroclaw": "0.8.0",   // persistent ACP sessions and session/resume were added in 0.8.0
+	"claude":      "2.0.0",
+	"codex":       "0.100.0", // app-server --listen stdio:// added in 0.100.0
+	"copilot":     "1.0.0",   // --output-format json envelope stable from 1.0.x
+	"grok":        "0.2.89",  // ACP + authenticate/session-load/set_model/MCP and --effort thinking flag
+	"qwen":        "0.20.0",  // stream-json protocol captured and verified against Qwen Code 0.20.0
+	"dim":         "0.3.10",  // cross-run session/load: per-process lock releases on graceful exit
+	"mcode":       "0.1.2",   // ACP v1 session/new, prompt, MCP capability forwarding
+	"zeroclaw":    "0.8.0",   // persistent ACP sessions and session/resume were added in 0.8.0
+	"commandcode": "1.50.1",  // NDJSON protocol (--output-format json) captured and verified against CommandCode CLI 1.50.1
 }
 
 // MinQuickCreateCLIVersion gates the agent-create (quick-create) flow against


### PR DESCRIPTION
# feat(agent): add CommandCode runtime backend

## Summary

Adds CommandCode (`cmd`, https://commandcode.ai) as a first-party agent
runtime backend, following the existing `qwen` NDJSON family pattern.

- `server/pkg/agent/commandcode.go`: backend launching
  `cmd --output-format json --no-auto-update --yolo` with the prompt delivered
  on **stdin** (same Windows-safe rationale as qwen, #6082). NDJSON stream
  parser maps the CommandCode event vocabulary (`run_start`, `turn_*`,
  `message_*`, `thinking_*`, `text_delta`, `model_*`,
  `tool_queued`/`tool_running`/`tool_completed`, final `result` line) onto
  Multica protocol events. Session id scraped from `run_start`/`result`;
  final text from `result.finalText`; usage per model; `--resume <id>`
  supported; parser tolerates non-JSON lines (the CLI can emit an
  auto-update notice mid-stream). `--list-models` text-table scraping for
  model discovery, degrading to manual entry on failure.
- daemon-owned/blocked custom args: prompt, output format, model, resume,
  permission modes, session controls (`--fork-session`, `--session`,
  `-c/--continue`), auto-update, tool filtering.
- `commandcode_test.go`: table tests covering streaming, auto-update junk
  tolerance, resume preservation, stdin delivery, args filtering, model-table
  scraping, tool-trio synthesis, plus fixture tests built from real protocol
  captures (CLI 1.50.1).
- Migration 451 widens the `runtime_profile` protocol-family CHECK.
- Probe entry (`MULTICA_COMMANDCODE_PATH` / `cmd` /
  `MULTICA_COMMANDCODE_MODEL`), display-name maps, doc comments, min version
  gate (`1.50.1`).

## Verification

- `go build ./...` and `go vet ./pkg/agent/` pass.
- Full `go test ./pkg/agent/` suite passes, including the new commandcode
  tests and real-capture fixtures.

## Notes

- Protocol verified empirically against CommandCode CLI 1.50.1: headless
  NDJSON events, resume semantics (session id preserved), stdin prompt,
  `--list-models` output shape, and the auto-update stdout pollution
  (`--no-auto-update` pinned in launch args, parser tolerant as defense in
  depth).
- Happy to adjust naming/blocked-arg policy to your conventions if the
  current choices don't match how you treat comparable CLIs.
