### PR TITLE
fix(issues): resolve comment trigger avatar URLs

### DIFF
--- a/packages/views/issues/components/comment-trigger-chips.test.tsx
+++ b/packages/views/issues/components/comment-trigger-chips.test.tsx
@@ -8,6 +8,10 @@ vi.mock("@multica/core/agents", () => ({
   useAgentPresenceDetail: () => ({ availability: "online", workload: "idle" }),
 }));
 
+vi.mock("@multica/core/api", () => ({
+  api: { getBaseUrl: () => "https://api.example.test" },
+}));
+
 vi.mock("@multica/core/paths", () => ({
   useCurrentWorkspace: () => ({ id: "ws-1" }),
 }));
@@ -50,6 +54,23 @@ describe("CommentTriggerChips", () => {
 
     fireEvent.click(chip);
     expect(onToggle).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("resolves a single agent's uploaded avatar against the API origin", () => {
+    // URL edge cases belong to core/workspace/avatar-url.test.ts; this guards
+    // the trigger preview's wiring to the real avatar and URL resolver.
+    renderWithI18n(
+      <CommentTriggerChips
+        agents={[{ ...walt, avatar_url: "/uploads/agent-custom-avatar.png" }]}
+        suppressedAgentIds={new Set()}
+        onToggle={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Walt" })).toHaveAttribute(
+      "src",
+      "https://api.example.test/uploads/agent-custom-avatar.png",
+    );
   });
 
   it("dims a suppressed single agent into the skip state", () => {

--- a/packages/views/issues/components/comment-trigger-chips.tsx
+++ b/packages/views/issues/components/comment-trigger-chips.tsx
@@ -5,6 +5,7 @@ import { TriangleAlert } from "lucide-react";
 import type { CommentTriggerPreviewAgent, CommentTriggerOutcome } from "@multica/core/types";
 import { useAgentPresenceDetail } from "@multica/core/agents";
 import { mentionLabelsByTarget } from "@multica/core/issues/comment-trigger-outcomes";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import { AVATAR_SIZE_PX } from "@multica/ui/lib/avatar-size";
@@ -413,7 +414,7 @@ function TriggerAgentAvatar({
       <ActorAvatarBase
         name={agent.name}
         initials=""
-        avatarUrl={agent.avatar_url}
+        avatarUrl={resolvePublicFileUrl(agent.avatar_url)}
         isAgent
         size="xs"
       />


### PR DESCRIPTION
## What does this PR do?

Fix custom agent avatars in the pre-send comment/reply trigger preview when the API returns a root-relative URL and the frontend uses a different origin. The preview currently requests `/uploads/...` from the frontend, fails to load it, and shows the generic Bot fallback even though the image is available from the API.

`TriggerAgentAvatar` passes the raw URL to the UI avatar, whereas the shared views avatar already calls `resolvePublicFileUrl`. Apply that same existing helper here. This restores the configured image without changing the fallback policy.

The response is valid upstream behavior: `LocalStorage.ObjectURL` returns `/uploads/<key>` when `LOCAL_UPLOAD_BASE_URL` is unset, and the avatar resolver preserves publicly readable local-storage URLs. The comment-trigger preview handler uses that resolver.

## Related Issue

No separate GitHub issue. This is a small regression fix with a focused reproduction.

## Type of Change

- [x] Bug fix
- [ ] New feature (non-breaking)
- [ ] Refactor / code improvement
- [ ] Documentation update
- [x] Tests
- [ ] CI / infrastructure

## Changes Made

- Resolve `agent.avatar_url` before passing it to `ActorAvatarBase` in the shared trigger preview.
- Add a component regression using the real avatar and URL resolver with different frontend/API origins. URL edge cases remain covered by the existing core helper suite.

## How to Test

1. Use a split-origin frontend/API setup whose agent avatar response is a root-relative `/uploads/...` URL, with the file served by the API.
2. Open an issue assigned to that agent and enter a new comment or a reply that previews the agent being triggered.
3. Before this patch, the preview requests the frontend origin and falls back to Bot. After this patch, it requests the API origin and displays the custom image.

Local validation:

- Component regression: failed on unmodified production code (10 existing tests passed); all 11 pass after the fix.
- Existing `workspace/avatar-url.test.ts`: 5 passed.
- Views TypeScript check, ESLint on both changed files, and `git diff --check` passed.
- Browser component reproduction: new-comment and reply previews, with one and two agents, changed from real frontend-origin HTTP 404/Bot fallbacks to API-origin HTTP 200/decoded images. An absolute-URL control works on the original code; an emoji control works after the patch. No page errors in these captures.
- Full `make check-worktree` was not run: `make` is unavailable in this Windows shell. No Go/database integration, real avatar upload, full-app E2E or installed Desktop run is claimed.

Scope/risk: this only changes URL resolution in the shared preview avatar. Absolute URLs and emoji values retain the existing helper behavior. Posted comment author avatars are a separate surface. Edit composers reuse this component but were not browser-tested here.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run the relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes (no documented interface changed)
- [ ] If I added a new runtime / coding tool / UI tab, I synced landing copy and relevant docs (not applicable)
- [ ] If this PR touches Chinese product copy, I checked the terminology conventions (not applicable)
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex.

**Prompt / approach:** Reproduce the comment-trigger custom-avatar failure on current upstream code, confirm the backend response contract, reuse the existing URL helper, add a regression that fails before the change, and capture the same component fixture before and after. Independently review the patch and document the limits of the reproduction.

## Screenshots

Real upstream components and production styles, mounted with a **synthetic local HTTP API and fictional data**. The fixture represents an already saved custom image using Multica's bundled `icon-192.png`; it does not exercise the upload flow or the complete application. The control image loads directly from the API in both screenshots.

Before: upstream `d8fa885d26`. After: `584ea2dbf4`. Same data, 1280×1050 CSS viewport, light theme, and device scale factor 2; unedited browser captures.

| Before: generic Bot after frontend-origin 404 | After: custom image from API origin |
| --- | --- |
| ![Before: comment and reply previews fall back to Bot](https://raw.githubusercontent.com/sooodasama/multica/e3e0c7b92a1aa520c65a774f2c4dab3f1273f508/before-relative-1.png) | ![After: both previews show the configured image](https://raw.githubusercontent.com/sooodasama/multica/e3e0c7b92a1aa520c65a774f2c4dab3f1273f508/after-relative-1.png) |

[Capture provenance and network/DOM evidence](https://github.com/sooodasama/multica/tree/e3e0c7b92a1aa520c65a774f2c4dab3f1273f508).
