### PR TITLE
Add CLI support for explicit agent avatar emoji selection

### DIFF
--- a/apps/docs/content/docs/cli.ja.mdx
+++ b/apps/docs/content/docs/cli.ja.mdx
@@ -178,6 +178,17 @@ multica runtime activity <runtime-id>
 
 `multica chat` が読み取るのは、**エージェントが現在処理している外部チャットセッション**です。主にチャット統合の中のエージェントが使うもので、任意のワークスペースの会話を閲覧するための汎用コマンドではありません。
 
+## エージェントのアバター
+
+エージェント作成時にアバターを設定するか、後から `--avatar-emoji` で更新します:
+
+```bash
+multica agent create --name Fox --runtime-id <runtime-id> --avatar-emoji '🦊'
+multica agent update <agent-id> --avatar-emoji '🦊'
+```
+
+このオプションは絵文字を受け付け、空文字列や空白のみの文字列には設定できません。作成時に省略するとランダムなデフォルトアバターのまま、更新時に省略すると現在のアバターのままになります。ローカル画像をアップロードするには `multica agent avatar <agent-id> --file <image>` を使用します。
+
 ## ID と出力形式
 
 タスクには `MUL-123` のようなキーまたは完全な UUID を使います。UUID の短いプレフィックスは受け付けません。
@@ -249,7 +260,7 @@ CLI の設定ファイルには、あなたとして Multica にアクセスで�
 | | `resource list/add/update/remove` | プロジェクトの追加リソースを管理 | `--type`、`--url`、`--local-path`、`--daemon-id`、`--execution-mode`（ローカルディレクトリの `in_place` / `worktree`） |
 | `label` | `list/get/create/update/delete` | ワークスペースのラベルを管理 | |
 | `property` | `list/get/create/update/archive/unarchive` | ワークスペースのカスタムプロパティを管理 | `create`: `--name`、`--type`（`text`、`number`、`select`、`multi_select`、`date`、`checkbox`、`url`、`actor`、`multi_actor`）、`--option`（繰り返し可、select 系のみ）；`list`: `--include-archived`；タイプは作成後に変更できません |
-| `agent` | `list/get/create/update/archive/restore` | エージェントを管理 | `--name`、`--runtime-id`（`create` では必須）、`--instructions`、`--conversation-starters`、`--model`、`--thinking-level`、`--mcp-config`、`--permission-mode`、`--max-concurrent-tasks` |
+| `agent` | `list/get/create/update/archive/restore` | エージェントを管理 | `--name`、`--avatar-emoji`（絵文字）、`--runtime-id`（`create` では必須）、`--instructions`、`--conversation-starters`、`--model`、`--thinking-level`、`--mcp-config`、`--permission-mode`、`--max-concurrent-tasks` |
 | | `copy <agent-id>` | 新しいエージェントとして複製。元のエージェントは変更されません | `--name`（デフォルトは元の名前 + ` (copy)`）、`--runtime-id`（別のランタイムへ複製する場合は `--model` の同時指定が必須）、`--no-skills`；`custom_env`、`mcp_config`、`runtime_config` などの機密設定は複製されないため、`create` と同じフラグで再指定してください |
 | | `tasks <id>` | エージェントの実行を表示 | |
 | | `avatar <id>` | アバターをアップロード | |

--- a/apps/docs/content/docs/cli.ko.mdx
+++ b/apps/docs/content/docs/cli.ko.mdx
@@ -178,6 +178,17 @@ multica runtime activity <runtime-id>
 
 `multica chat`은 **에이전트가 현재 처리 중인 외부 채팅 대화**를 읽으며 주로 채팅 연동의 에이전트가 사용합니다. 워크스페이스의 임의 대화를 탐색하는 일반 명령이 아닙니다.
 
+## 에이전트 아바타
+
+에이전트를 생성할 때 아바타를 설정하거나 이후 `--avatar-emoji`로 업데이트합니다:
+
+```bash
+multica agent create --name Fox --runtime-id <runtime-id> --avatar-emoji '🦊'
+multica agent update <agent-id> --avatar-emoji '🦊'
+```
+
+이 옵션은 이모지를 받으며 빈 문자열이나 공백만으로는 설정할 수 없습니다. 생성 시 생략하면 무작위 기본 아바타가 유지되고, 업데이트 시 생략하면 현재 아바타가 유지됩니다. 로컬 이미지를 업로드하려면 `multica agent avatar <agent-id> --file <image>`를 사용하세요.
+
 ## ID와 출력 형식
 
 태스크에는 `MUL-123` 같은 key 또는 전체 UUID를 사용하며 UUID 짧은 접두사는 허용하지 않습니다.
@@ -249,7 +260,7 @@ CLI 설정 파일에는 사용자를 대신해 Multica에 접근할 수 있는 t
 | | `resource list/add/update/remove` | 프로젝트 추가 리소스 관리 | `--type`, `--url`, `--local-path`, `--daemon-id`, `--execution-mode`(로컬 디렉터리의 `in_place` / `worktree`) |
 | `label` | `list/get/create/update/delete` | 워크스페이스 라벨 관리 | |
 | `property` | `list/get/create/update/archive/unarchive` | 워크스페이스 사용자 지정 속성 관리 | `create`: `--name`, `--type`(`text`, `number`, `select`, `multi_select`, `date`, `checkbox`, `url`, `actor`, `multi_actor`), `--option`(반복 가능, select 유형만). `list`: `--include-archived`. 유형은 생성 후 변경 불가 |
-| `agent` | `list/get/create/update/archive/restore` | 에이전트 관리 | `--name`, `--runtime-id`(`create`에서 필수), `--instructions`, `--conversation-starters`, `--model`, `--thinking-level`, `--mcp-config`, `--permission-mode`, `--max-concurrent-tasks` |
+| `agent` | `list/get/create/update/archive/restore` | 에이전트 관리 | `--name`, `--avatar-emoji`(이모지), `--runtime-id`(`create`에서 필수), `--instructions`, `--conversation-starters`, `--model`, `--thinking-level`, `--mcp-config`, `--permission-mode`, `--max-concurrent-tasks` |
 | | `copy <agent-id>` | 원래 에이전트에 영향 없이 새 에이전트로 복사 | `--name`(기본값은 원래 이름 + ` (copy)`), `--runtime-id`(다른 런타임으로 복사할 때 `--model`도 필수), `--no-skills`. `custom_env`, `mcp_config`, `runtime_config` 같은 기밀 설정은 복사되지 않으며 `create`와 같은 flag로 다시 제공해야 함 |
 | | `tasks <id>` | 에이전트 실행 확인 | |
 | | `avatar <id>` | 아바타 업로드 | |

--- a/apps/docs/content/docs/cli.mdx
+++ b/apps/docs/content/docs/cli.mdx
@@ -178,6 +178,20 @@ See [Daemon and runtimes](/daemon-runtimes) for how it works and for custom prof
 
 `multica chat` reads **the external chat session an agent is currently handling**; it is mainly for agents in chat integrations, not a general command for browsing arbitrary workspace conversations.
 
+## Agent avatars
+
+Set an agent avatar at creation or update it later with `--avatar-emoji`:
+
+```bash
+multica agent create --name Fox --runtime-id <runtime-id> --avatar-emoji '🦊'
+multica agent update <agent-id> --avatar-emoji '🦊'
+```
+
+The option accepts an emoji glyph; it cannot be set to an empty or
+whitespace-only string. Omitting it on creation keeps the random default
+avatar; omitting it on update keeps the current avatar. To upload a local
+image, use `multica agent avatar <agent-id> --file <image>`.
+
 ## IDs and output formats
 
 Issues use keys like `MUL-123` or full UUIDs; short UUID prefixes are not accepted.
@@ -257,7 +271,7 @@ The tables below cover every current top-level command, grouped the way the CLI 
 | | `resource list/add/update/remove` | Manage project resources | `--type`, `--url`, `--local-path`, `--daemon-id`, `--execution-mode` (`in_place` / `worktree` for a local directory) |
 | `label` | `list/get/create/update/delete` | Manage workspace labels | |
 | `property` | `list/get/create/update/archive/unarchive` | Manage workspace custom properties | `create`: `--name`, `--type` (`text`, `number`, `select`, `multi_select`, `date`, `checkbox`, `url`, `actor`, `multi_actor`), `--option` (repeatable, select types only); `list`: `--include-archived`; the type cannot be changed after creation |
-| `agent` | `list/get/create/update/archive/restore` | Manage agents | `--name`, `--runtime-id` (required for `create`), `--instructions`, `--conversation-starters`, `--model`, `--thinking-level`, `--mcp-config`, `--permission-mode`, `--max-concurrent-tasks` |
+| `agent` | `list/get/create/update/archive/restore` | Manage agents | `--name`, `--avatar-emoji` (glyph), `--runtime-id` (required for `create`), `--instructions`, `--conversation-starters`, `--model`, `--thinking-level`, `--mcp-config`, `--permission-mode`, `--max-concurrent-tasks` |
 | | `copy <agent-id>` | Copy into a new agent; the original is untouched | `--name` (defaults to the original name plus ` (copy)`), `--runtime-id` (copying to another runtime also requires `--model`), `--no-skills`; secret configuration such as `custom_env`, `mcp_config`, and `runtime_config` is not copied — re-provide it with the same flags as `create` |
 | | `tasks <id>` | View an agent's runs | |
 | | `avatar <id>` | Upload an avatar | |

--- a/apps/docs/content/docs/cli.zh.mdx
+++ b/apps/docs/content/docs/cli.zh.mdx
@@ -178,6 +178,17 @@ multica runtime activity <runtime-id>
 
 `multica chat` 读取的是**智能体当前正在处理的外部聊天会话**，主要供聊天集成中的智能体使用；它不是用于浏览任意工作区对话的通用命令。
 
+## 智能体头像
+
+在创建智能体时设置头像，或之后用 `--avatar-emoji` 更新：
+
+```bash
+multica agent create --name Fox --runtime-id <runtime-id> --avatar-emoji '🦊'
+multica agent update <agent-id> --avatar-emoji '🦊'
+```
+
+该选项接受表情符号，不能设置为空字符串或仅含空白的字符串。创建时省略该选项会保留随机生成的默认头像；更新时省略会保留当前头像。要上传本地图片，使用 `multica agent avatar <agent-id> --file <image>`。
+
 ## ID 和输出格式
 
 任务使用 `MUL-123` 这样的 key 或完整 UUID，不接受 UUID 短前缀。
@@ -249,7 +260,7 @@ CLI 配置文件包含可代表你访问 Multica 的令牌。不要提交到仓�
 | | `resource list/add/update/remove` | 管理项目附加资源 | `--type`、`--url`、`--local-path`、`--daemon-id`、`--execution-mode`（本地目录的 `in_place` / `worktree`） |
 | `label` | `list/get/create/update/delete` | 管理工作区标签 | |
 | `property` | `list/get/create/update/archive/unarchive` | 管理工作区自定义属性 | `create`：`--name`、`--type`（`text`、`number`、`select`、`multi_select`、`date`、`checkbox`、`url`、`actor`、`multi_actor`）、`--option`（可重复，仅 select 类型）；`list`：`--include-archived`；类型创建后不可修改 |
-| `agent` | `list/get/create/update/archive/restore` | 管理智能体 | `--name`、`--runtime-id`（`create` 必填）、`--instructions`、`--conversation-starters`、`--model`、`--thinking-level`、`--mcp-config`、`--permission-mode`、`--max-concurrent-tasks` |
+| `agent` | `list/get/create/update/archive/restore` | 管理智能体 | `--name`、`--avatar-emoji`（表情符号）、`--runtime-id`（`create` 必填）、`--instructions`、`--conversation-starters`、`--model`、`--thinking-level`、`--mcp-config`、`--permission-mode`、`--max-concurrent-tasks` |
 | | `copy <agent-id>` | 复制为新智能体，原智能体不受影响 | `--name`（默认为原名加 ` (copy)`）、`--runtime-id`（复制到其他运行时时必须同时指定 `--model`）、`--no-skills`；`custom_env`、`mcp_config`、`runtime_config` 等机密配置不会复制，需用与 `create` 相同的 flag 重新提供 |
 | | `tasks <id>` | 查看智能体的运行 | |
 | | `avatar <id>` | 上传头像 | |

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -18,6 +18,10 @@ import (
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
 
+// agentEmojiAvatarPrefix mirrors handler.agentEmojiAvatarPrefix: the marker the
+// server persists for an emoji avatar. The CLI only ever sends this form.
+const agentEmojiAvatarPrefix = "emoji:"
+
 var agentCmd = &cobra.Command{
 	Use:   "agent",
 	Short: "Work with agents",
@@ -158,6 +162,7 @@ func init() {
 
 	// agent create
 	agentCreateCmd.Flags().String("name", "", "Agent name (required)")
+	agentCreateCmd.Flags().String("avatar-emoji", "", "Avatar emoji glyph (e.g. 🦊), not empty/whitespace-only; omitted = random avatar")
 	agentCreateCmd.Flags().String("description", "", "Agent description")
 	agentCreateCmd.Flags().String("instructions", "", "Agent instructions")
 	agentCreateCmd.Flags().String("conversation-starters", "", "Conversation starters as a JSON array of {\"label\",\"prompt\"} objects (at most 3; label ≤80, prompt ≤4000). Shown above the Chat composer; selecting one fills the composer and does not start a run. Omit to default to none.")
@@ -182,6 +187,7 @@ func init() {
 
 	// agent update
 	agentUpdateCmd.Flags().String("name", "", "New name")
+	agentUpdateCmd.Flags().String("avatar-emoji", "", "Avatar emoji glyph (e.g. 🦊), not empty/whitespace-only; omitted = keep current avatar")
 	agentUpdateCmd.Flags().String("description", "", "New description")
 	agentUpdateCmd.Flags().String("instructions", "", "New instructions")
 	agentUpdateCmd.Flags().String("conversation-starters", "", "New conversation starters as a JSON array of {\"label\",\"prompt\"} objects (at most 3; label ≤80, prompt ≤4000). Pass '[]' to clear. Omit to leave the stored value unchanged.")
@@ -658,6 +664,13 @@ func runAgentCreate(cmd *cobra.Command, _ []string) error {
 	if err := applyConversationStartersFlag(cmd, body); err != nil {
 		return err
 	}
+	if cmd.Flags().Changed("avatar-emoji") {
+		v, _ := cmd.Flags().GetString("avatar-emoji")
+		if strings.TrimSpace(v) == "" {
+			return fmt.Errorf("--avatar-emoji must not be empty or whitespace-only; omit the flag to use the random default avatar")
+		}
+		body["avatar_url"] = agentEmojiAvatarPrefix + v
+	}
 	if cmd.Flags().Changed("runtime-config") {
 		v, _ := cmd.Flags().GetString("runtime-config")
 		var rc any
@@ -756,6 +769,13 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("runtime-id")
 		body["runtime_id"] = v
 	}
+	if cmd.Flags().Changed("avatar-emoji") {
+		v, _ := cmd.Flags().GetString("avatar-emoji")
+		if strings.TrimSpace(v) == "" {
+			return fmt.Errorf("--avatar-emoji must not be empty or whitespace-only; omit the flag to keep the current avatar")
+		}
+		body["avatar_url"] = agentEmojiAvatarPrefix + v
+	}
 	if cmd.Flags().Changed("runtime-config") {
 		v, _ := cmd.Flags().GetString("runtime-config")
 		var rc any
@@ -810,7 +830,7 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --conversation-starters, --runtime-id, --runtime-config, --model, --thinking-level, --service-tier, --custom-args, --mcp-config, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
+		return fmt.Errorf("no fields to update; use --name, --avatar-emoji, --description, --instructions, --conversation-starters, --runtime-id, --runtime-config, --model, --thinking-level, --service-tier, --custom-args, --mcp-config, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
 	}
 
 	ctx, cancel := cli.APIContext(context.Background())

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -2212,6 +2212,94 @@ func TestAgentUpdateSendsConversationStarters(t *testing.T) {
 	}
 }
 
+func TestAgentAvatarEmojiRequests(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "")
+	for _, operation := range []struct {
+		name, method, path string
+		registered         *cobra.Command
+		run                func(*cobra.Command, []string) error
+	}{
+		{"create", http.MethodPost, "/api/agents", agentCreateCmd, runAgentCreate},
+		{"update", http.MethodPut, "/api/agents/agent-123", agentUpdateCmd, runAgentUpdate},
+	} {
+		t.Run(operation.name, func(t *testing.T) {
+			flag := operation.registered.Flags().Lookup("avatar-emoji")
+			if flag == nil {
+				t.Fatal("--avatar-emoji is not registered")
+			}
+			if strings.Contains(flag.Usage, "emoji:") {
+				t.Fatal("help must not expose the internal emoji: marker")
+			}
+			for _, tc := range []struct {
+				name, value, wantBody string
+				supplied              bool
+				wantErr               bool
+			}{
+				{"emoji", "🦊", "emoji:🦊", true, false},
+				{"empty", "", "", true, true},
+				{"whitespace", "   ", "", true, true},
+				{"omitted", "", "", false, false},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					var got map[string]any
+					requested := false
+					srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						requested = true
+						if r.Method != operation.method || r.URL.Path != operation.path {
+							t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+						}
+						if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+							t.Error(err)
+						}
+						if err := json.NewEncoder(w).Encode(map[string]any{"id": "agent-123"}); err != nil {
+							t.Error(err)
+						}
+					}))
+					defer srv.Close()
+					setCLITestServerEnv(t, srv.URL)
+					cmd := &cobra.Command{Use: operation.name}
+					cmd.Flags().String("avatar-emoji", flag.DefValue, flag.Usage)
+					cmd.Flags().String("name", "TestAgent", "")
+					cmd.Flags().String("runtime-id", "runtime-1", "")
+					cmd.Flags().String("output", "json", "")
+					if tc.supplied {
+						if err := cmd.ParseFlags([]string{"--avatar-emoji", tc.value}); err != nil {
+							t.Fatal(err)
+						}
+					} else if operation.name == "update" {
+						if err := cmd.Flags().Set("name", "Renamed"); err != nil {
+							t.Fatal(err)
+						}
+					}
+					_, err := captureStdout(t, func() error { return operation.run(cmd, []string{"agent-123"}) })
+					if tc.wantErr {
+						if err == nil {
+							t.Fatal("expected error for empty/whitespace-only --avatar-emoji, got nil")
+						}
+						if !strings.Contains(err.Error(), "--avatar-emoji must not be empty or whitespace-only") {
+							t.Fatalf("error = %v, want a message about --avatar-emoji must not be empty or whitespace-only", err)
+						}
+						if requested {
+							t.Fatal("empty/whitespace-only --avatar-emoji must be rejected before any HTTP request")
+						}
+						return
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					value, present := got["avatar_url"]
+					if present != tc.supplied || (present && value != tc.wantBody) {
+						t.Fatalf("avatar_url = %#v (present %v), want %q (present %v)", value, present, tc.wantBody, tc.supplied)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestAgentCreateAndUpdateExposeConversationStartersFlag(t *testing.T) {
 	if agentCreateCmd.Flag("conversation-starters") == nil {
 		t.Error("agent create must expose --conversation-starters")

--- a/server/internal/service/builtin_skills/multica-platform/references/agents.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/agents.md
@@ -72,6 +72,13 @@ empty strings. `--max-concurrent-tasks` is validated as 1–50 before the
 request is sent. `--conversation-starters` is a JSON array of `{label, prompt}`
 objects (at most 3); pass `'[]'` on update to clear.
 
+Set `--avatar-emoji '🦊'` on `agent create` or `agent update <id>` to choose
+an emoji avatar. The CLI prefixes the glyph with the internal `emoji:` marker
+before sending `avatar_url`, only when the flag is supplied, and rejects an
+empty or whitespace-only value before making a request: omission preserves
+the random default on create and the current avatar on update. Local image
+uploads remain available through `multica agent avatar <id> --file <image>`.
+
 The HTTP body accepts: `name`, `description`, `instructions`,
 `conversation_starters`, `avatar_url`, `runtime_id`, `runtime_config`,
 `custom_env`, `custom_args`, `model`, `thinking_level`, `service_tier`,


### PR DESCRIPTION
## What does this PR do?

Adds `--avatar-emoji` to `agent create` and `agent update`, accepting a bare emoji glyph. The CLI prefixes the internal `emoji:` marker before sending `avatar_url`; empty and whitespace-only values are rejected before any request is made. Omitting the flag preserves the random default on creation and the current avatar on updates. Existing local-image upload remains available.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- `server/cmd/multica/cmd_agent.go`: register `--avatar-emoji` flag, forward its value with `emoji:` prefix, add whitespace validation, and update help.
- `server/cmd/multica/cmd_agent_test.go`: cover create/update requests with emoji glyph, empty string, whitespace-only, and omitted values; verify error messages for empty/whitespace.
- `apps/docs/content/docs/cli.mdx`, `cli.zh.mdx`, `cli.ja.mdx`, `cli.ko.mdx`: document emoji syntax, omission behavior, and the upload command.
- `server/internal/service/builtin_skills/multica-platform/references/agents.md`: document emoji syntax and omission behavior.

## How to Test

From `server/`:

```sh
go test ./cmd/multica -run '^TestAgentAvatarEmojiRequests$' -count=1
go vet ./cmd/multica
```

Both passed locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above