### PR TITLE
fix(settings): report clipboard results through the shared helper

### DIFF
--- a/packages/views/settings/components/clipboard-copy.test.tsx
+++ b/packages/views/settings/components/clipboard-copy.test.tsx
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { renderWithI18n } from "../../test/i18n";
+import { NavigationProvider } from "../../navigation";
+
+const mocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  connectVCS: vi.fn(),
+  invalidateQueries: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: mocks.success, error: mocks.error },
+}));
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "workspace-1" }));
+vi.mock("@multica/core/paths", () => ({
+  useCurrentWorkspace: () => ({ id: "workspace-1", name: "Workspace" }),
+}));
+vi.mock("@multica/core/auth", () => {
+  const state = { user: { id: "user-1" } };
+  return {
+    useAuthStore: Object.assign(
+      (selector: (value: typeof state) => unknown) => selector(state),
+      { getState: () => state },
+    ),
+  };
+});
+vi.mock("@multica/core/api", () => ({ api: { connectVCS: mocks.connectVCS } }));
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({ queryKey: ["members"] }),
+  invitationListOptions: () => ({ queryKey: ["invitations"] }),
+  shareLinkListOptions: () => ({ queryKey: ["share-links"] }),
+  workspaceKeys: { all: ["workspaces"] },
+}));
+vi.mock("@multica/core/billing", () => ({
+  workspaceSubscriptionSummaryOptions: () => ({ queryKey: ["billing"] }),
+  usePreviewWorkspaceSeatPurchase: () => ({}),
+  usePurchaseWorkspaceSeats: () => ({}),
+}));
+vi.mock("@multica/core/vcs", () => ({
+  vcsConnectionsOptions: () => ({ queryKey: ["vcs"] }),
+}));
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+  useQuery: ({ queryKey }: { queryKey: string[] }) => {
+    switch (queryKey[0]) {
+      case "members":
+        return {
+          data: [
+            { id: "member-1", user_id: "user-1", role: "owner", name: "Owner" },
+          ],
+        };
+      case "share-links":
+        return {
+          data: [
+            { id: "link-1", code: "invite-code", role: "member", use_count: 0 },
+          ],
+        };
+
+      case "vcs":
+        return {
+          data: { connections: [], configured: true, can_manage: true },
+        };
+      default:
+        return { data: [] };
+    }
+  },
+}));
+vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => null }));
+
+import { MembersTab } from "./members-tab";
+import { VCSTab } from "./vcs-tab";
+
+const secureContextDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "isSecureContext",
+);
+const clipboardDescriptor = Object.getOwnPropertyDescriptor(
+  navigator,
+  "clipboard",
+);
+const execCommandDescriptor = Object.getOwnPropertyDescriptor(
+  document,
+  "execCommand",
+);
+
+function setClipboard(writeText?: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  });
+}
+
+function setLegacyCopy(result: boolean) {
+  const copy = vi.fn(() => result);
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: copy,
+  });
+  return copy;
+}
+
+function renderMembers() {
+  renderWithI18n(
+    <NavigationProvider
+      value={{
+        push: vi.fn(),
+        replace: vi.fn(),
+        back: vi.fn(),
+        pathname: "/settings",
+        searchParams: new URLSearchParams(),
+        hash: "",
+        getShareableUrl: (path) => `https://public.example${path}`,
+      }}
+    >
+      <MembersTab />
+    </NavigationProvider>,
+  );
+}
+
+async function connectVCS() {
+  mocks.connectVCS.mockResolvedValue({
+    id: "connection-1",
+    webhook_url: "https://public.example/webhook",
+    webhook_path: "/webhook",
+    webhook_secret: "test-only-secret",
+  });
+  renderWithI18n(<VCSTab />);
+  fireEvent.change(screen.getByLabelText("Instance URL"), {
+    target: { value: "https://forgejo.example" },
+  });
+  fireEvent.change(screen.getByLabelText("Access token"), {
+    target: { value: "test-only-token" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+  await screen.findByDisplayValue("https://public.example/webhook");
+  mocks.success.mockClear();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, "isSecureContext", {
+    configurable: true,
+    value: true,
+  });
+  setClipboard();
+});
+
+afterEach(() => {
+  if (secureContextDescriptor)
+    Object.defineProperty(window, "isSecureContext", secureContextDescriptor);
+  else Reflect.deleteProperty(window, "isSecureContext");
+  if (clipboardDescriptor)
+    Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+  else Reflect.deleteProperty(navigator, "clipboard");
+  if (execCommandDescriptor)
+    Object.defineProperty(document, "execCommand", execCommandDescriptor);
+  else Reflect.deleteProperty(document, "execCommand");
+});
+
+// The clipboard API matrix lives in editor/utils/clipboard.test.ts; these cover settings wiring.
+describe("settings clipboard feedback", () => {
+  it("does not report an invite link copied when legacy copying returns false", async () => {
+    const legacyCopy = setLegacyCopy(false);
+    renderMembers();
+    fireEvent.click(screen.getByTitle("Copy link"));
+    await waitFor(() =>
+      expect(mocks.error).toHaveBeenCalledWith("Failed to copy link"),
+    );
+    expect(legacyCopy).toHaveBeenCalledWith("copy");
+    expect(mocks.success).not.toHaveBeenCalled();
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("copies the public invite URL through the navigation adapter", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard(writeText);
+    renderMembers();
+    fireEvent.click(screen.getByTitle("Copy link"));
+    await waitFor(() =>
+      expect(mocks.success).toHaveBeenCalledWith("Link copied"),
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      "https://public.example/join?code=invite-code",
+    );
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("copies a VCS webhook when the Clipboard API is unavailable", async () => {
+    setClipboard();
+    const legacyCopy = setLegacyCopy(true);
+    await connectVCS();
+    fireEvent.click(screen.getAllByTitle("Copy")[0]!);
+    await waitFor(() =>
+      expect(mocks.success).toHaveBeenCalledWith("Copied to clipboard"),
+    );
+
+    expect(legacyCopy).toHaveBeenCalledWith("copy");
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("reports a VCS copy failure when clipboard permission and the legacy fallback both fail", async () => {
+    setClipboard(vi.fn().mockRejectedValue(new Error("Permission denied")));
+    const legacyCopy = setLegacyCopy(false);
+    await connectVCS();
+    fireEvent.click(screen.getAllByTitle("Copy")[1]!);
+    await waitFor(() =>
+      expect(mocks.error).toHaveBeenCalledWith("Could not copy"),
+    );
+    expect(legacyCopy).toHaveBeenCalledWith("copy");
+    expect(mocks.success).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/settings/components/members-tab.tsx
+++ b/packages/views/settings/components/members-tab.tsx
@@ -58,6 +58,7 @@ import {
   DropdownMenuSubContent,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { toast } from "sonner";
+import { copyText } from "@multica/ui/lib/clipboard";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@multica/core/auth";
 import {
@@ -758,27 +759,12 @@ export function MembersTab() {
       .finally(() => setShareLinkActionId(null));
   };
 
-  const handleCopyShareLink = (link: ShareLink) => {
+  const handleCopyShareLink = async (link: ShareLink) => {
     const joinUrl = buildShareLinkUrl(navigation, link.code);
-    if (navigator.clipboard && window.isSecureContext) {
-      navigator.clipboard.writeText(joinUrl).then(
-        () => toast.success(t(($) => $.members.toast_share_link_copied)),
-        () => toast.error(t(($) => $.members.toast_share_link_copy_failed)),
-      );
+    if (await copyText(joinUrl)) {
+      toast.success(t(($) => $.members.toast_share_link_copied));
     } else {
-      const textArea = document.createElement("textarea");
-      textArea.value = joinUrl;
-      textArea.style.position = "fixed";
-      textArea.style.left = "-9999px";
-      document.body.appendChild(textArea);
-      textArea.select();
-      try {
-        document.execCommand("copy");
-        toast.success(t(($) => $.members.toast_share_link_copied));
-      } catch {
-        toast.error(t(($) => $.members.toast_share_link_copy_failed));
-      }
-      document.body.removeChild(textArea);
+      toast.error(t(($) => $.members.toast_share_link_copy_failed));
     }
   };
 

--- a/packages/views/settings/components/vcs-tab.tsx
+++ b/packages/views/settings/components/vcs-tab.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { copyText } from "@multica/ui/lib/clipboard";
 import { Copy, GitBranch, RefreshCw, Trash2 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
@@ -117,10 +118,9 @@ export function VCSTab() {
   }
 
   async function copy(value: string) {
-    try {
-      await navigator.clipboard.writeText(value);
+    if (await copyText(value)) {
       toast.success(t(($) => $.vcs.copied));
-    } catch {
+    } else {
       toast.error(t(($) => $.vcs.copy_failed));
     }
   }


### PR DESCRIPTION
## What does this PR do?

Makes the two remaining settings copy handlers use the existing `copyText` helper and report its result.

In Members → Share links, the inline fallback ignores a `false` return from `document.execCommand("copy")` and reports **Link copied** even though copying failed. The VCS webhook URL/secret fields call `navigator.clipboard.writeText` directly, so they report failure when the Clipboard API is unavailable, even if legacy copying would work.

Multica already centralizes this behavior in `@multica/ui/lib/clipboard`. Reusing it removes the duplicate fallback, preserves navigation-adapter share URLs, and keeps the existing translated success/error messages. No new clipboard implementation or dependency is introduced.

## Related Issue

Follow-up to #3810, which introduced `copyText` for self-hosted HTTP deployments. These settings call sites still bypass it on current `main`. No separate GitHub issue was opened for these two omissions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/settings/components/members-tab.tsx`: await `copyText(joinUrl)` and select the toast from its boolean result.
- `packages/views/settings/components/vcs-tab.tsx`: use the same helper for both webhook fields.
- `packages/views/settings/components/clipboard-copy.test.tsx`: cover failed legacy share-link copying, navigation-adapter URLs, unavailable Clipboard API in VCS, and failure of both copy mechanisms.

## How to Test

1. Run `pnpm --filter @multica/views exec vitest run settings/components/clipboard-copy.test.tsx editor/utils/clipboard.test.ts`.
2. With the Clipboard API unavailable and legacy copying returning `false`, click a share link's copy button. Expect **Failed to copy link**, never a success toast.
3. In the VCS connection setup result, make the Clipboard API unavailable while legacy copying returns `true`. Copy the webhook URL; expect **Copied to clipboard**.
4. With both mechanisms failing, copying the webhook secret must show **Could not copy**.

Validation: the component regression suite produced **3 failures / 1 pass** against unmodified upstream handlers; after this patch it and the existing helper suite pass (**8 tests**). Views TypeScript checking and ESLint on the three changed files pass. The four browser captures below also assert the toast and legacy API calls.

Local environment: Windows, Node 24.20.0, pnpm 10.28.2. Full `make check-worktree` (Go/database/E2E) was not run; `make` is unavailable in this shell. Browser captures use fixture API responses and controlled clipboard APIs, not a full-stack deployment or an actual OS clipboard write.

Risk: the VCS fields now use the same legacy fallback already used elsewhere in Multica when modern copying is unavailable or rejects. The shared helper and URL construction are unchanged.

Official [CI run 34182574780](https://github.com/multica-ai/multica/actions/runs/34182574780) has passed for head `0a9a7f040a4904dd30e94eca25b29f58e340f5b4`: 14 successful checks and the conditional `image-budget` check skipped.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Local test scope and full-stack validation limits are stated above. Documentation, landing copy, and Chinese product copy are not applicable: this patch restores existing behavior and changes no documented interface, new capability, or product text.

## AI Disclosure

**AI tool used:** OpenAI Codex.

**Prompt / approach:** Verify the settings copy failures on current upstream main, reuse the existing clipboard helper, write failing component regressions, validate the patch, and capture production components with synthetic fixtures. The contribution was kept independent of other fixes and audited for unrelated changes.

## Screenshots (optional)

Real Multica components and styles in a local fixture host. Headers identify the controlled conditions. Before is upstream `d8fa885d26acbdecde49010276e905cc9de5a056`; after is `0a9a7f040a4904dd30e94eca25b29f58e340f5b4`. [Capture provenance and recorded calls](https://github.com/sooodasama/multica/tree/ad77284050ae993e28d8338be8f154baa4e3aec0).

| Scenario | Before | After |
| --- | --- | --- |
| Share link: legacy copy returns false | ![Incorrect success](https://raw.githubusercontent.com/sooodasama/multica/ad77284050ae993e28d8338be8f154baa4e3aec0/members-before.png) | ![Failure feedback](https://raw.githubusercontent.com/sooodasama/multica/ad77284050ae993e28d8338be8f154baa4e3aec0/members-after.png) |
| VCS: Clipboard API unavailable, legacy copy returns true | ![Fallback not attempted](https://raw.githubusercontent.com/sooodasama/multica/ad77284050ae993e28d8338be8f154baa4e3aec0/vcs-before.png) | ![Successful fallback](https://raw.githubusercontent.com/sooodasama/multica/ad77284050ae993e28d8338be8f154baa4e3aec0/vcs-after.png) |
