### PR TITLE
fix(mcp): refresh workspace configuration caches on reconnect

### DIFF
--- a/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { WSClient } from "../api/ws-client";
@@ -11,7 +11,7 @@ import { issueKeys } from "../issues/queries";
 import { chatKeys } from "../chat/queries";
 import { runtimeKeys } from "../runtimes/queries";
 import { workspaceWorkingAgentsKeys } from "../agents/queries";
-import { workspaceKeys } from "../workspace/queries";
+import { agentMcpServersOptions, workspaceKeys } from "../workspace/queries";
 import { issueStatusKeys } from "../issue-statuses/queries";
 import {
   markWorkspaceDeletePending,
@@ -88,6 +88,39 @@ describe("useRealtimeSync — ws instance change", () => {
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
+  it.each(["reconnect", "replacement"])(
+    "invalidates cached MCP configuration on socket %s",
+    async (recovery) => {
+      const libraryKey = workspaceKeys.mcpServers("ws-1");
+      const assignmentKey = agentMcpServersOptions("ws-1", "agent-1").queryKey;
+      const otherLibraryKey = workspaceKeys.mcpServers("ws-2");
+      qc.setQueryData(libraryKey, []);
+      qc.setQueryData(assignmentKey, []);
+      qc.setQueryData(otherLibraryKey, []);
+      const ws = createMockWs();
+      const { rerender } = renderHook(
+        ({ socket }) => useRealtimeSync(socket, stores),
+        {
+          initialProps: { socket: ws as WSClient | null },
+          wrapper: createWrapper(qc),
+        },
+      );
+
+      await act(async () => {
+        if (recovery === "reconnect") {
+          await vi.mocked(ws.onReconnect).mock.calls[0]![0]();
+        } else {
+          rerender({ socket: null });
+        }
+      });
+      if (recovery === "replacement") rerender({ socket: createMockWs() });
+
+      expect(qc.getQueryState(libraryKey)?.isInvalidated).toBe(true);
+      expect(qc.getQueryState(assignmentKey)?.isInvalidated).toBe(true);
+      expect(qc.getQueryState(otherLibraryKey)?.isInvalidated).toBe(false);
+    },
+  );
+
   it("does not invalidate when ws goes from instance to null", () => {
     const ws1 = createMockWs();
     const { rerender } = renderHook(
@@ -117,11 +150,11 @@ describe("useRealtimeSync — ws instance change", () => {
     rerender({ ws: ws2 });
 
     // Should have called invalidateQueries for all workspace-scoped keys
-    // (16 workspace-scoped [incl. property definitions] + 6 per-issue
+    // (17 workspace-scoped [incl. property definitions] + 6 per-issue
     // prefixes + the workspace working-agents projection + 5 per-chat
     // prefixes + 1 workspaceKeys.list() + 1 cross-workspace inbox unread
-    // summary = 31 calls)
-    expect(invalidateSpy).toHaveBeenCalledTimes(31);
+    // summary = 32 calls)
+    expect(invalidateSpy).toHaveBeenCalledTimes(32);
   });
 
   it("does not re-invalidate when rerendered with the same ws instance", () => {

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -648,6 +648,7 @@ function invalidateWorkspaceScopedQueries(qc: QueryClient): void {
     qc.invalidateQueries({ queryKey: workspaceKeys.members(wsId) });
     qc.invalidateQueries({ queryKey: workspaceKeys.squads(wsId) });
     qc.invalidateQueries({ queryKey: workspaceKeys.skills(wsId) });
+    qc.invalidateQueries({ queryKey: workspaceKeys.mcpServers(wsId) });
     qc.invalidateQueries({ queryKey: workspaceKeys.invitations(wsId) });
     qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
     qc.invalidateQueries({ queryKey: runtimeKeys.all(wsId) });

--- a/packages/core/workspace/mutations.test.tsx
+++ b/packages/core/workspace/mutations.test.tsx
@@ -13,6 +13,10 @@ import {
   useCreateWorkspace,
   useDeleteWorkspace,
   useUpdateWorkspaceMcpServer,
+  useDeleteWorkspaceMcpServer,
+  useAddAgentMcpServer,
+  useSetAgentMcpServerEnabled,
+  useRemoveAgentMcpServer,
 } from "./mutations";
 import { agentMcpServersOptions, workspaceKeys } from "./queries";
 import {
@@ -284,14 +288,16 @@ describe("useUpdateWorkspaceMcpServer", () => {
       .mockImplementation(async () => [{ ...current, enabled: true }]);
     setApiInstance({ updateWorkspaceMcpServer, listAgentMcpServers } as unknown as ApiClient);
 
-    const activeKey = agentMcpServersOptions("agent-1").queryKey;
-    const inactiveKey = agentMcpServersOptions("agent-2").queryKey;
+    const activeKey = agentMcpServersOptions("ws-1", "agent-1").queryKey;
+    const inactiveKey = agentMcpServersOptions("ws-1", "agent-2").queryKey;
+    const otherWorkspaceKey = agentMcpServersOptions("ws-2", "agent-3").queryKey;
     qc.setQueryData(workspaceKeys.mcpServers("ws-1"), [original]);
     qc.setQueryData(activeKey, [{ ...original, enabled: true }]);
     qc.setQueryData(inactiveKey, [{ ...original, enabled: false }]);
+    qc.setQueryData(otherWorkspaceKey, []);
 
     const { result } = renderHook(() => ({
-      assignment: useQuery(agentMcpServersOptions("agent-1")),
+      assignment: useQuery(agentMcpServersOptions("ws-1", "agent-1")),
       updateServer: useUpdateWorkspaceMcpServer("ws-1"),
     }), { wrapper: createWrapper(qc) });
 
@@ -307,6 +313,7 @@ describe("useUpdateWorkspaceMcpServer", () => {
     expect(updateWorkspaceMcpServer).toHaveBeenCalledWith("ws-1", "server-1", update);
     expect(qc.getQueryState(workspaceKeys.mcpServers("ws-1"))?.isInvalidated).toBe(true);
     expect(qc.getQueryState(inactiveKey)?.isInvalidated).toBe(true);
+    expect(qc.getQueryState(otherWorkspaceKey)?.isInvalidated).toBe(false);
     await waitFor(() => {
       expect(result.current.assignment.data).toEqual([{ ...original, ...expected, enabled: true }]);
     });
@@ -331,11 +338,11 @@ describe("useUpdateWorkspaceMcpServer", () => {
     setApiInstance({ updateWorkspaceMcpServer, listAgentMcpServers } as unknown as ApiClient);
 
     qc.setQueryData(workspaceKeys.mcpServers("ws-1"), [original]);
-    qc.setQueryData(agentMcpServersOptions("agent-1").queryKey, [
+    qc.setQueryData(agentMcpServersOptions("ws-1", "agent-1").queryKey, [
       { ...original, enabled: true },
     ]);
     const { result } = renderHook(() => ({
-      assignment: useQuery(agentMcpServersOptions("agent-1")),
+      assignment: useQuery(agentMcpServersOptions("ws-1", "agent-1")),
       updateServer: useUpdateWorkspaceMcpServer("ws-1"),
     }), { wrapper: createWrapper(qc) });
 
@@ -353,5 +360,87 @@ describe("useUpdateWorkspaceMcpServer", () => {
       expect(result.current.updateServer.error).toBe(responseLost);
     });
     expect(listAgentMcpServers).toHaveBeenCalledWith("agent-1");
+  });
+});
+
+describe("MCP mutation cache scope", () => {
+  it.each(["add", "toggle", "remove", "failed remove"])(
+    "refreshes only the target assignment after %s",
+    async (operation) => {
+      const qc = new QueryClient({
+        defaultOptions: { queries: { staleTime: Infinity } },
+      });
+      const write = vi.fn().mockResolvedValue([]);
+      const failure = new Error("response lost");
+      if (operation === "failed remove") write.mockRejectedValue(failure);
+      setApiInstance({
+        addAgentMcpServer: write,
+        setAgentMcpServerEnabled: write,
+        removeAgentMcpServer: write,
+      } as unknown as ApiClient);
+      const target = agentMcpServersOptions("ws-1", "agent-1").queryKey;
+      const sibling = agentMcpServersOptions("ws-1", "agent-2").queryKey;
+      const other = agentMcpServersOptions("ws-2", "agent-3").queryKey;
+      for (const key of [target, sibling, other]) qc.setQueryData(key, []);
+      const { result, unmount } = renderHook(
+        () => ({
+          add: useAddAgentMcpServer("ws-1", "agent-1"),
+          toggle: useSetAgentMcpServerEnabled("ws-1", "agent-1"),
+          remove: useRemoveAgentMcpServer("ws-1", "agent-1"),
+        }),
+        { wrapper: createWrapper(qc) },
+      );
+      await act(async () => {
+        if (operation === "add")
+          await result.current.add.mutateAsync("server-1");
+        else if (operation === "toggle")
+          await result.current.toggle.mutateAsync({
+            serverId: "server-1",
+            enabled: false,
+          });
+        else if (operation === "failed remove")
+          await expect(
+            result.current.remove.mutateAsync("server-1"),
+          ).rejects.toBe(failure);
+        else await result.current.remove.mutateAsync("server-1");
+      });
+      expect(write).toHaveBeenCalledWith(
+        ...(operation === "toggle"
+          ? ["agent-1", "server-1", false]
+          : ["agent-1", "server-1"]),
+      );
+      expect(qc.getQueryState(target)?.isInvalidated).toBe(true);
+      expect(qc.getQueryState(sibling)?.isInvalidated).toBe(false);
+      expect(qc.getQueryState(other)?.isInvalidated).toBe(false);
+      unmount();
+      qc.clear();
+    },
+  );
+
+  it("invalidates the library and its assignments after deleting a server", async () => {
+    const qc = new QueryClient();
+    const remove = vi.fn().mockResolvedValue(undefined);
+    setApiInstance({
+      deleteWorkspaceMcpServer: remove,
+    } as unknown as ApiClient);
+    const keys = [
+      workspaceKeys.mcpServers("ws-1"),
+      agentMcpServersOptions("ws-1", "agent-1").queryKey,
+    ];
+    const other = agentMcpServersOptions("ws-2", "agent-2").queryKey;
+    for (const key of [...keys, other]) qc.setQueryData(key, []);
+    const { result, unmount } = renderHook(
+      () => useDeleteWorkspaceMcpServer("ws-1"),
+      { wrapper: createWrapper(qc) },
+    );
+    await act(async () => {
+      await result.current.mutateAsync("server-1");
+    });
+    expect(remove).toHaveBeenCalledWith("ws-1", "server-1");
+    for (const key of keys)
+      expect(qc.getQueryState(key)?.isInvalidated).toBe(true);
+    expect(qc.getQueryState(other)?.isInvalidated).toBe(false);
+    unmount();
+    qc.clear();
   });
 });

--- a/packages/core/workspace/mutations.ts
+++ b/packages/core/workspace/mutations.ts
@@ -115,7 +115,7 @@ export function useUpdateWorkspaceMcpServer(wsId: string) {
         queryClient.invalidateQueries({ queryKey: workspaceKeys.mcpServers(wsId) }),
         // Assignments include the library entry's name and transport, so every
         // agent's cached projection may change when the entry is updated.
-        queryClient.invalidateQueries({ queryKey: ["agents"] }),
+        queryClient.invalidateQueries({ queryKey: workspaceKeys.agentMcpServersAll(wsId) }),
       ]),
   });
 }
@@ -128,16 +128,16 @@ export function useDeleteWorkspaceMcpServer(wsId: string) {
       queryClient.invalidateQueries({ queryKey: workspaceKeys.mcpServers(wsId) });
       // Deleting a library entry drops it from every agent that had it, so
       // no agent's assignment list can be trusted afterwards.
-      queryClient.invalidateQueries({ queryKey: ["agents"] });
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.agentMcpServersAll(wsId) });
     },
   });
 }
 
 /**
- * Assignment writes all return the agent's resulting list, so the cache is
- * updated from the server's answer rather than a guess.
+ * Refetch the agent's assignments after a write, including ambiguous failures.
  */
 function useAgentMcpMutation<TVariables>(
+  wsId: string,
   agentId: string,
   mutationFn: (variables: TVariables) => Promise<unknown>,
 ) {
@@ -145,21 +145,21 @@ function useAgentMcpMutation<TVariables>(
   return useMutation({
     mutationFn,
     onSettled: () =>
-      queryClient.invalidateQueries({ queryKey: ["agents", agentId, "mcp-servers"] }),
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.agentMcpServers(wsId, agentId) }),
   });
 }
 
-export function useAddAgentMcpServer(agentId: string) {
-  return useAgentMcpMutation(agentId, (serverId: string) =>
+export function useAddAgentMcpServer(wsId: string, agentId: string) {
+  return useAgentMcpMutation(wsId, agentId, (serverId: string) =>
     api.addAgentMcpServer(agentId, serverId));
 }
 
-export function useSetAgentMcpServerEnabled(agentId: string) {
-  return useAgentMcpMutation(agentId, ({ serverId, enabled }: { serverId: string; enabled: boolean }) =>
+export function useSetAgentMcpServerEnabled(wsId: string, agentId: string) {
+  return useAgentMcpMutation(wsId, agentId, ({ serverId, enabled }: { serverId: string; enabled: boolean }) =>
     api.setAgentMcpServerEnabled(agentId, serverId, enabled));
 }
 
-export function useRemoveAgentMcpServer(agentId: string) {
-  return useAgentMcpMutation(agentId, (serverId: string) =>
+export function useRemoveAgentMcpServer(wsId: string, agentId: string) {
+  return useAgentMcpMutation(wsId, agentId, (serverId: string) =>
     api.removeAgentMcpServer(agentId, serverId));
 }

--- a/packages/core/workspace/queries.ts
+++ b/packages/core/workspace/queries.ts
@@ -21,6 +21,11 @@ export const workspaceKeys = {
   skills: (wsId: string) => ["workspaces", wsId, "skills"] as const,
   assigneeFrequency: (wsId: string) => ["workspaces", wsId, "assignee-frequency"] as const,
   mcpServers: (wsId: string) => ["workspaces", wsId, "mcp-servers"] as const,
+  // Nested under agents so agent events and reconnects also refresh assignments.
+  agentMcpServersAll: (wsId: string) =>
+    ["workspaces", wsId, "agents", "mcp-servers"] as const,
+  agentMcpServers: (wsId: string, agentId: string) =>
+    ["workspaces", wsId, "agents", "mcp-servers", agentId] as const,
 };
 
 export function workspaceListOptions() {
@@ -205,10 +210,10 @@ export function workspaceMcpServersOptions(wsId: string) {
 }
 
 /** The workspace MCP servers assigned to one agent, with their toggles. */
-export function agentMcpServersOptions(agentId: string) {
+export function agentMcpServersOptions(wsId: string, agentId: string) {
   return queryOptions({
-    queryKey: ["agents", agentId, "mcp-servers"] as const,
+    queryKey: workspaceKeys.agentMcpServers(wsId, agentId),
     queryFn: () => api.listAgentMcpServers(agentId),
-    enabled: agentId !== "",
+    enabled: wsId !== "" && agentId !== "",
   });
 }

--- a/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
@@ -28,10 +28,10 @@ const workspaceMcp = vi.hoisted(() => ({
 // Stubbing the query options keeps this a pure render test — the real ones
 // would hit fetch.
 vi.mock("@multica/core/workspace/queries", () => ({
-  agentMcpServersOptions: (agentId: string) => ({
-    queryKey: ["agents", agentId, "mcp-servers"],
+  agentMcpServersOptions: (wsId: string, agentId: string) => ({
+    queryKey: ["workspaces", wsId, "agents", "mcp-servers", agentId],
     queryFn: () => Promise.resolve(workspaceMcp.assigned),
-    enabled: agentId !== "",
+    enabled: wsId !== "" && agentId !== "",
   }),
   workspaceMcpServersOptions: (wsId: string) => ({
     queryKey: ["workspaces", wsId, "mcp-servers"],

--- a/packages/views/agents/components/tabs/mcp-config-tab.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.tsx
@@ -94,13 +94,12 @@ export function McpConfigTab({
   // from (GH #6062). A library entry does nothing until it is added here, and
   // each assignment carries its own toggle. The API returns names and
   // transports only — never the stored credentials.
-  const assignedQuery = useQuery(agentMcpServersOptions(agent.id));
-  const libraryQuery = useQuery(
-    workspaceMcpServersOptions(agent.workspace_id ?? ""),
-  );
-  const addServer = useAddAgentMcpServer(agent.id);
-  const setServerEnabled = useSetAgentMcpServerEnabled(agent.id);
-  const removeServer = useRemoveAgentMcpServer(agent.id);
+  const wsId = agent.workspace_id ?? "";
+  const assignedQuery = useQuery(agentMcpServersOptions(wsId, agent.id));
+  const libraryQuery = useQuery(workspaceMcpServersOptions(wsId));
+  const addServer = useAddAgentMcpServer(wsId, agent.id);
+  const setServerEnabled = useSetAgentMcpServerEnabled(wsId, agent.id);
+  const removeServer = useRemoveAgentMcpServer(wsId, agent.id);
   const redacted = agent.mcp_config_redacted === true;
   const managedServers = useMemo(
     () => listManagedMcpServers(agent.mcp_config),


### PR DESCRIPTION
## What does this PR do?

Refreshes the workspace MCP library and agent assignments when the client reconnects after missing configuration changes.

The query client uses `staleTime: Infinity`. Recovery invalidates workspace-scoped agents, but agent MCP assignments currently live at `["agents", agentId, "mcp-servers"]`, outside that prefix. The workspace MCP library is also absent from recovery invalidation. A client that cached either list before losing its connection can therefore keep displaying old names, assignments, or toggles after reconnecting.

The fix places assignment keys under the existing workspace agents prefix and includes the library in workspace recovery. All assignment mutations and their shared view caller use the same key factories; library edits/deletions invalidate assignments only in their workspace. This follows the existing workspace-scoped query convention without adding another refresh mechanism.

## Related Issue

No separate GitHub issue was opened. The per-agent assignment feature was introduced in #6976. The open daemon probe/tool-listing work in #7243 is complementary; this patch only addresses client query-cache freshness.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/workspace/queries.ts`: add workspace-scoped agent MCP key factories; require workspace and agent identity for the query.
- `packages/core/workspace/mutations.ts`: align assignment writes and library edit/delete invalidation with those factories, retaining invalidation on settled writes.
- `packages/core/realtime/use-realtime-sync.ts`: include the MCP library when recovering a connection.
- `packages/views/agents/components/tabs/mcp-config-tab.tsx`: pass the agent's workspace ID to the query and three mutation hooks.
- Update the adjacent mutation, realtime, and view tests, including reconnect/socket replacement, successful and failed writes, and preservation of other workspaces' caches.

## How to Test

Suggested full-app reproduction:

1. Visit Settings → MCP Servers and an agent's MCP tab so both queries are cached.
2. Disconnect that client. From another client or the CLI, rename a workspace MCP server or change the agent's assignments.
3. Restore the first client's connection without reloading the application.
4. Active configuration queries should refresh; previously visited inactive queries should refetch on their next mount instead of retaining the pre-disconnect data.

Executed locally:

```sh
pnpm --filter @multica/core exec vitest run workspace/mutations.test.tsx workspace/queries.test.ts realtime/use-realtime-sync-ws-instance.test.tsx
pnpm --filter @multica/views exec vitest run agents/components/tabs/mcp-config-tab.test.tsx
pnpm --filter @multica/core typecheck
pnpm --filter @multica/views typecheck
```

Both new recovery regressions failed on the unmodified upstream implementation because the MCP cache was not invalidated. After the patch, the related core tests pass (**38 tests**) and the MCP tab suite passes (**39 tests**). Both package typechecks pass. ESLint reports no errors in the changed files; the MCP tab retains its two pre-existing `assignedServers` dependency warnings.

Local environment: Windows, Node 24.20.0, pnpm 10.28.2. Full `make check-worktree` and the full-app steps above were not run; `make` is unavailable in this shell. Regressions exercise the real query client and recovery hook with controlled socket/API fixtures.

Risk: existing agent-prefix invalidations now also reach active assignment queries. Inactive queries are marked stale for the next mount. No server API, stored MCP configuration, credentials, daemon behavior, or database schema changes.

Official [CI run 34182605671](https://github.com/multica-ai/multica/actions/runs/34182605671) and [Mobile Verify run 34182605695](https://github.com/multica-ai/multica/actions/runs/34182605695) have passed for head `b76fb7b3b10db04171d45dcf1f71ddcec2b5de59`: 15 successful checks and the conditional `image-budget` check skipped.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Local test scope and full-stack validation limits are stated above. Documentation, landing copy, and Chinese product copy are not applicable: this patch restores existing behavior and changes no documented interface, new capability, or product text.

## AI Disclosure

**AI tool used:** OpenAI Codex.

**Prompt / approach:** Reproduce MCP cache recovery gaps on current upstream main, trace query keys and mutation/realtime invalidation, implement a minimal workspace-scoped fix, and verify the existing MCP view alongside focused hook regressions. Unrelated state refactoring and runtime features were excluded.

## Screenshots (optional)

Not applicable: this patch changes query-cache invalidation, with no layout or product-copy changes. The recovery and mutation regressions verify the stale-cache behavior; the suggested full-app reproduction has not been run locally.
