### PR TITLE
fix(inbox): remove duplicate sidebar toggle in split view

### DIFF
--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -698,7 +698,9 @@ export function InboxPage() {
         layoutId="multica_inbox_issue_detail_layout"
         highlightCommentId={detailItem.details?.comment_id ?? undefined}
         highlightRequestToken={highlightRequestToken}
-        leadingAction={compactBackAction}
+        // The split layout already has a nav trigger in the list header.
+        // Explicit false suppresses the detail header's fallback trigger.
+        leadingAction={compactBackAction ?? false}
         onDelete={() => {
           // Issue deletion CASCADE-deletes the inbox item server-side, and the
           // issue:deleted WS event prunes it from the inbox cache. Just clear


### PR DESCRIPTION
## What does this PR do?

Fixes two global sidebar toggle buttons appearing when Web Inbox shows the list and issue detail side by side below the `xl` breakpoint. The list header retains the toggle; the embedded detail suppresses its fallback toggle through the existing leading-action slot.

Compact layouts keep their back button, and standalone issue details retain their sidebar toggle.

## Related Issue

Reported with a screenshot; no linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- In `packages/views/inbox/components/inbox-page.tsx`, pass explicit `false` when there is no compact back action. The shared header uses a nullish fallback, so this prevents a duplicate trigger without adding another prop.
- Scope and risk: one Inbox call site changes; no shared header behavior changes.

## How to Test

Verified locally:

- `pnpm --filter @multica/views test inbox/components/inbox-page.test.tsx layout/page-header.test.tsx` — 45 tests passed.
- `pnpm --filter @multica/views typecheck` — passed.
- `pnpm --filter @multica/views exec eslint inbox/components/inbox-page.tsx` — passed.
- `git diff --check` — passed.

Manual verification steps (not run):

1. At a viewport between 1024px and 1279px, open a Web Inbox item. Only the list header should show the global sidebar toggle.
2. Below 1024px, open an item and confirm its back button returns to the list.
3. Open a standalone issue below 1280px and confirm its sidebar toggle remains.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above

No new tests or documentation were added for this small change to an existing slot. Browser verification and after screenshots were not performed.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Investigated the two sidebar toggles in the supplied Web Inbox screenshot, traced both to the shared page header, and reused the existing leading-action slot to suppress the embedded copy. Ran focused tests, TypeScript, and ESLint checks.
