### PR TITLE
[MUL-7136] fix(lark): include workspace slug in issue links

### DIFF
--- a/server/internal/integrations/channel/engine/resolvers.go
+++ b/server/internal/integrations/channel/engine/resolvers.go
@@ -58,11 +58,12 @@ type Result struct {
 	ChannelRouteRevision int64
 	// Sender is the platform-native sender id (e.g. Lark open_id), so the
 	// replier can target a binding prompt back to the sender.
-	Sender          string
-	IssueID         pgtype.UUID
-	IssueNumber     int32
-	IssueIdentifier string
-	IssueTitle      string
+	Sender             string
+	IssueID            pgtype.UUID
+	IssueNumber        int32
+	IssueIdentifier    string
+	IssueWorkspaceSlug string
+	IssueTitle         string
 	// IssueDuplicate marks an /issue command that did not create a new issue
 	// because the shared duplicate guard found the active IssueID above.
 	// Repliers render this as a business conflict, never as an internal error.

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -576,8 +576,8 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 			)
 		}
 		// One lookup feeds both the broadcast payload's identifier and the
-		// chat reply's.
-		prefix := r.issuePrefix(ctx, inst.WorkspaceID)
+		// chat reply's deep link.
+		prefix, workspaceSlug := r.issueWorkspaceIdentity(ctx, inst.WorkspaceID)
 		var assignedRunFireAt time.Time
 		if resolveMedia {
 			// The generic deferred-task sweeper is the crash fallback. Leave room
@@ -592,6 +592,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 			res.IssueNumber = duplicate.Number
 			res.IssueTitle = duplicate.Title
 			res.IssueIdentifier = service.IssueIdentifier(prefix, duplicate.Number)
+			res.IssueWorkspaceSlug = workspaceSlug
 			res.IssueDuplicate = true
 			// A duplicate is a terminal product outcome, not an infrastructure
 			// failure and not a chat prompt. Finalize the durable chat message's
@@ -614,6 +615,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 		// Same renderer the broadcast payload uses, so a degraded prefix can't
 		// show the chat "#42" while the realtime list shows "-42".
 		res.IssueIdentifier = service.IssueIdentifier(prefix, issueRes.Issue.Number)
+		res.IssueWorkspaceSlug = workspaceSlug
 		// IssueService.Create already enqueues the assigned agent's issue task.
 		// Scheduling the command as a chat run too makes the agent execute the
 		// same /issue input again. A synchronous issue command is terminal.
@@ -1102,17 +1104,17 @@ func (r *Router) createIssue(ctx context.Context, inst ResolvedInstallation, ori
 	return r.issues.Create(ctx, params, opts)
 }
 
-// issuePrefix reads the workspace's issue key (the "MUL" in MUL-42). A read
-// failure is not worth failing issue creation over, so it degrades to empty
-// and only the rendered identifier suffers.
-func (r *Router) issuePrefix(ctx context.Context, workspaceID pgtype.UUID) string {
+// issueWorkspaceIdentity reads the workspace slug and issue key prefix. A read
+// failure is not worth failing issue creation over, so it degrades to empty and
+// only the rendered identifier/link suffers.
+func (r *Router) issueWorkspaceIdentity(ctx context.Context, workspaceID pgtype.UUID) (prefix, slug string) {
 	ws, err := r.reader.GetWorkspace(ctx, workspaceID)
 	if err != nil {
-		r.logger.Warn("channel engine: workspace lookup for issue prefix failed",
+		r.logger.Warn("channel engine: workspace lookup for issue identity failed",
 			"workspace_id", util.UUIDToString(workspaceID), "error", err)
-		return ""
+		return "", ""
 	}
-	return ws.IssuePrefix
+	return ws.IssuePrefix, ws.Slug
 }
 
 // ErrEmptyIssueTitle is a defensive invariant error. Router handles a

--- a/server/internal/integrations/channel/engine/router_test.go
+++ b/server/internal/integrations/channel/engine/router_test.go
@@ -517,7 +517,7 @@ func newHarness(t *testing.T) *harness {
 		media:     &fakeMedia{},
 		issues:    &fakeIssues{},
 		tasks:     &fakeTasks{},
-		reader:    &fakeReader{ws: db.Workspace{IssuePrefix: "MUL"}},
+		reader:    &fakeReader{ws: db.Workspace{IssuePrefix: "MUL", Slug: "demo-web"}},
 		lifecycle: &fakeChannelChatLifecycle{},
 	}
 	h.router = NewRouter(h.issues, h.tasks, h.reader, RouterConfig{Logger: discardLogger(), Lifecycle: h.lifecycle})
@@ -1074,7 +1074,7 @@ func TestRouter_IssueCommand_Creates(t *testing.T) {
 	}
 	if !waitFor(time.Second, func() bool {
 		for _, r := range h.replier.calls() {
-			if r.IssueIdentifier == "MUL-42" && r.IssueTitle == "Fix login" {
+			if r.IssueIdentifier == "MUL-42" && r.IssueWorkspaceSlug == "demo-web" && r.IssueTitle == "Fix login" {
 				return true
 			}
 		}
@@ -1142,7 +1142,7 @@ func TestRouter_IssueCommand_ActiveDuplicateIsTerminalProductOutcome(t *testing.
 	}
 	if !waitFor(time.Second, func() bool {
 		for _, result := range h.replier.calls() {
-			if result.IssueDuplicate && result.IssueID == duplicate.ID && result.IssueIdentifier == "MUL-44" && result.IssueTitle == duplicate.Title {
+			if result.IssueDuplicate && result.IssueID == duplicate.ID && result.IssueIdentifier == "MUL-44" && result.IssueWorkspaceSlug == "demo-web" && result.IssueTitle == duplicate.Title {
 				return true
 			}
 		}

--- a/server/internal/integrations/channel/issue_link.go
+++ b/server/internal/integrations/channel/issue_link.go
@@ -1,0 +1,23 @@
+package channel
+
+import (
+	"net/url"
+	"strings"
+)
+
+// IssueWebLink builds the Multica web deep link for a channel issue result.
+// Current web routes are workspace-scoped: /{workspaceSlug}/issues/{identifier}.
+// When the slug is unavailable, keep the legacy /issues/{identifier} fallback so
+// older or partially-populated dispatch results still produce a usable best-effort URL.
+func IssueWebLink(appURL, workspaceSlug, identifier string) string {
+	if appURL == "" || identifier == "" {
+		return ""
+	}
+	base := strings.TrimRight(appURL, "/")
+	issuePath := "/issues/" + url.PathEscape(identifier)
+	workspaceSlug = strings.Trim(strings.TrimSpace(workspaceSlug), "/")
+	if workspaceSlug == "" {
+		return base + issuePath
+	}
+	return base + "/" + url.PathEscape(workspaceSlug) + issuePath
+}

--- a/server/internal/integrations/channel/issue_link.go
+++ b/server/internal/integrations/channel/issue_link.go
@@ -6,18 +6,16 @@ import (
 )
 
 // IssueWebLink builds the Multica web deep link for a channel issue result.
-// Current web routes are workspace-scoped: /{workspaceSlug}/issues/{identifier}.
-// When the slug is unavailable, keep the legacy /issues/{identifier} fallback so
-// older or partially-populated dispatch results still produce a usable best-effort URL.
+// Web routes are workspace-scoped — /{workspaceSlug}/issues/{identifier} — so a
+// link missing the slug cannot resolve to the issue and is not worth sending;
+// any empty part yields an empty string and the caller replies without a link.
+// That is deliberate for the adapters that will reuse this helper: an adapter
+// that forgets to plumb the slug through loses its link loudly, instead of
+// silently shipping the unroutable legacy /issues/{identifier} form again.
 func IssueWebLink(appURL, workspaceSlug, identifier string) string {
-	if appURL == "" || identifier == "" {
+	if appURL == "" || workspaceSlug == "" || identifier == "" {
 		return ""
 	}
-	base := strings.TrimRight(appURL, "/")
-	issuePath := "/issues/" + url.PathEscape(identifier)
-	workspaceSlug = strings.Trim(strings.TrimSpace(workspaceSlug), "/")
-	if workspaceSlug == "" {
-		return base + issuePath
-	}
-	return base + "/" + url.PathEscape(workspaceSlug) + issuePath
+	return strings.TrimRight(appURL, "/") + "/" + url.PathEscape(workspaceSlug) +
+		"/issues/" + url.PathEscape(identifier)
 }

--- a/server/internal/integrations/channel/issue_link_test.go
+++ b/server/internal/integrations/channel/issue_link_test.go
@@ -1,0 +1,20 @@
+package channel
+
+import "testing"
+
+func TestIssueWebLink(t *testing.T) {
+	t.Parallel()
+
+	if got, want := IssueWebLink("https://app.multica.test/", "demo-web", "MUL-42"), "https://app.multica.test/demo-web/issues/MUL-42"; got != want {
+		t.Fatalf("IssueWebLink with workspace slug = %q, want %q", got, want)
+	}
+	if got, want := IssueWebLink("https://app.multica.test", "", "MUL-42"), "https://app.multica.test/issues/MUL-42"; got != want {
+		t.Fatalf("IssueWebLink without workspace slug = %q, want %q", got, want)
+	}
+	if got := IssueWebLink("", "demo-web", "MUL-42"); got != "" {
+		t.Fatalf("IssueWebLink without app URL = %q, want empty", got)
+	}
+	if got := IssueWebLink("https://app.multica.test", "demo-web", ""); got != "" {
+		t.Fatalf("IssueWebLink without identifier = %q, want empty", got)
+	}
+}

--- a/server/internal/integrations/channel/issue_link_test.go
+++ b/server/internal/integrations/channel/issue_link_test.go
@@ -8,8 +8,8 @@ func TestIssueWebLink(t *testing.T) {
 	if got, want := IssueWebLink("https://app.multica.test/", "demo-web", "MUL-42"), "https://app.multica.test/demo-web/issues/MUL-42"; got != want {
 		t.Fatalf("IssueWebLink with workspace slug = %q, want %q", got, want)
 	}
-	if got, want := IssueWebLink("https://app.multica.test", "", "MUL-42"), "https://app.multica.test/issues/MUL-42"; got != want {
-		t.Fatalf("IssueWebLink without workspace slug = %q, want %q", got, want)
+	if got := IssueWebLink("https://app.multica.test", "", "MUL-42"); got != "" {
+		t.Fatalf("IssueWebLink without workspace slug = %q, want empty: a workspace-less path cannot route to the issue", got)
 	}
 	if got := IssueWebLink("", "demo-web", "MUL-42"); got != "" {
 		t.Fatalf("IssueWebLink without app URL = %q, want empty", got)

--- a/server/internal/integrations/lark/feishu_resolvers.go
+++ b/server/internal/integrations/lark/feishu_resolvers.go
@@ -307,6 +307,7 @@ func dispatchResultFromEngine(res engine.Result) DispatchResult {
 		IssueID:            res.IssueID,
 		IssueNumber:        res.IssueNumber,
 		IssueIdentifier:    res.IssueIdentifier,
+		IssueWorkspaceSlug: res.IssueWorkspaceSlug,
 		IssueTitle:         res.IssueTitle,
 		IssueDuplicate:     res.IssueDuplicate,
 		IssueUsageHadMedia: res.IssueUsageHadMedia,

--- a/server/internal/integrations/lark/feishu_types.go
+++ b/server/internal/integrations/lark/feishu_types.go
@@ -102,6 +102,8 @@ type DispatchResult struct {
 	// IssueIdentifier is the workspace-qualified key ("MUL-42") for the
 	// created issue, used verbatim in the confirmation message.
 	IssueIdentifier string
+	// IssueWorkspaceSlug is the workspace route segment used in deep links.
+	IssueWorkspaceSlug string
 	// IssueTitle is the title supplied on /issue, echoed in the confirmation.
 	IssueTitle string
 	// IssueDuplicate distinguishes an active-issue conflict from a successful

--- a/server/internal/integrations/lark/outcome_replier.go
+++ b/server/internal/integrations/lark/outcome_replier.go
@@ -320,7 +320,9 @@ func issueCreatedText(res DispatchResult, appURL string) string {
 	} else {
 		line = fmt.Sprintf("Created %s — %s", identifier, title)
 	}
-	if link := channel.IssueWebLink(appURL, res.IssueWorkspaceSlug, identifier); link != "" {
+	// Link off IssueIdentifier, not the local display value: the "#42" fallback
+	// above is a degraded label, never a routable identifier.
+	if link := channel.IssueWebLink(appURL, res.IssueWorkspaceSlug, res.IssueIdentifier); link != "" {
 		return line + "\n" + link
 	}
 	return line
@@ -338,7 +340,9 @@ func issueDuplicateText(res DispatchResult, appURL string) string {
 	} else {
 		line = fmt.Sprintf("Not created — active issue %s already exists: %s", identifier, title)
 	}
-	if link := channel.IssueWebLink(appURL, res.IssueWorkspaceSlug, identifier); link != "" {
+	// Link off IssueIdentifier, not the local display value: the "#42" fallback
+	// above is a degraded label, never a routable identifier.
+	if link := channel.IssueWebLink(appURL, res.IssueWorkspaceSlug, res.IssueIdentifier); link != "" {
 		return line + "\n" + link
 	}
 	return line

--- a/server/internal/integrations/lark/outcome_replier.go
+++ b/server/internal/integrations/lark/outcome_replier.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -319,10 +320,10 @@ func issueCreatedText(res DispatchResult, appURL string) string {
 	} else {
 		line = fmt.Sprintf("Created %s — %s", identifier, title)
 	}
-	if appURL == "" {
-		return line
+	if link := channel.IssueWebLink(appURL, res.IssueWorkspaceSlug, identifier); link != "" {
+		return line + "\n" + link
 	}
-	return line + "\n" + strings.TrimRight(appURL, "/") + "/issues/" + identifier
+	return line
 }
 
 func issueDuplicateText(res DispatchResult, appURL string) string {
@@ -337,10 +338,10 @@ func issueDuplicateText(res DispatchResult, appURL string) string {
 	} else {
 		line = fmt.Sprintf("Not created — active issue %s already exists: %s", identifier, title)
 	}
-	if appURL == "" {
-		return line
+	if link := channel.IssueWebLink(appURL, res.IssueWorkspaceSlug, identifier); link != "" {
+		return line + "\n" + link
 	}
-	return line + "\n" + strings.TrimRight(appURL, "/") + "/issues/" + identifier
+	return line
 }
 
 func (r *LarkOutcomeReplier) sendChatNotice(ctx context.Context, inst Installation, msg InboundMessage, body string) error {

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -338,10 +338,11 @@ func TestLarkOutcomeReplierUsesAppURLForWebLinks(t *testing.T) {
 		DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
 	rep.Reply(context.Background(), inst, InboundMessage{ChatID: "oc_chat", SenderOpenID: "ou_user"},
 		DispatchResult{
-			Outcome:         OutcomeIngested,
-			IssueID:         mustUUID("22222222-2222-2222-2222-222222222222"),
-			IssueNumber:     42,
-			IssueIdentifier: "MUL-42",
+			Outcome:            OutcomeIngested,
+			IssueID:            mustUUID("22222222-2222-2222-2222-222222222222"),
+			IssueNumber:        42,
+			IssueIdentifier:    "MUL-42",
+			IssueWorkspaceSlug: "demo-web",
 		})
 
 	stub.mu.Lock()
@@ -355,8 +356,8 @@ func TestLarkOutcomeReplierUsesAppURLForWebLinks(t *testing.T) {
 	if len(stub.textOut) != 1 {
 		t.Fatalf("expected one issue-created text, got %d", len(stub.textOut))
 	}
-	if !strings.Contains(stub.textOut[0].Text, "https://app.multica.test/issues/MUL-42") {
-		t.Fatalf("issue-created text should use AppURL; got %q", stub.textOut[0].Text)
+	if !strings.Contains(stub.textOut[0].Text, "https://app.multica.test/demo-web/issues/MUL-42") {
+		t.Fatalf("issue-created text should use AppURL and workspace slug; got %q", stub.textOut[0].Text)
 	}
 }
 
@@ -607,11 +608,12 @@ func TestLarkOutcomeReplierIssueCreatedSendsConfirmation(t *testing.T) {
 	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
 	msg := InboundMessage{ChatID: "oc_chat_42", SenderOpenID: "ou_user"}
 	rep.Reply(context.Background(), inst, msg, DispatchResult{
-		Outcome:         OutcomeIngested,
-		IssueID:         mustUUID("22222222-2222-2222-2222-222222222222"),
-		IssueNumber:     42,
-		IssueIdentifier: "MUL-42",
-		IssueTitle:      "fix login bug",
+		Outcome:            OutcomeIngested,
+		IssueID:            mustUUID("22222222-2222-2222-2222-222222222222"),
+		IssueNumber:        42,
+		IssueIdentifier:    "MUL-42",
+		IssueWorkspaceSlug: "demo-web",
+		IssueTitle:         "fix login bug",
 	})
 
 	stub.mu.Lock()
@@ -629,8 +631,8 @@ func TestLarkOutcomeReplierIssueCreatedSendsConfirmation(t *testing.T) {
 	if !strings.Contains(got.Text, "fix login bug") {
 		t.Errorf("text should embed the issue title; got %q", got.Text)
 	}
-	if !strings.Contains(got.Text, "https://multica.test/issues/MUL-42") {
-		t.Errorf("text should embed the deep link back to Multica; got %q", got.Text)
+	if !strings.Contains(got.Text, "https://multica.test/demo-web/issues/MUL-42") {
+		t.Errorf("text should embed the workspace issue deep link back to Multica; got %q", got.Text)
 	}
 	// No interactive card on this path — the confirmation must be
 	// plain text, matching how chat replies render.
@@ -655,12 +657,13 @@ func TestLarkOutcomeReplierIssueDuplicateSendsConflict(t *testing.T) {
 	inst := Installation{AppID: "cli_x"}
 	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
 	rep.Reply(context.Background(), inst, InboundMessage{ChatID: "oc_chat_42"}, DispatchResult{
-		Outcome:         OutcomeIngested,
-		IssueID:         mustUUID("22222222-2222-2222-2222-222222222222"),
-		IssueNumber:     42,
-		IssueIdentifier: "MUL-42",
-		IssueTitle:      "fix login bug",
-		IssueDuplicate:  true,
+		Outcome:            OutcomeIngested,
+		IssueID:            mustUUID("22222222-2222-2222-2222-222222222222"),
+		IssueNumber:        42,
+		IssueIdentifier:    "MUL-42",
+		IssueWorkspaceSlug: "demo-web",
+		IssueTitle:         "fix login bug",
+		IssueDuplicate:     true,
 	})
 
 	stub.mu.Lock()
@@ -674,6 +677,9 @@ func TestLarkOutcomeReplierIssueDuplicateSendsConflict(t *testing.T) {
 	}
 	if strings.Contains(text, "Created MUL-42") {
 		t.Fatalf("duplicate reply falsely claimed creation: %q", text)
+	}
+	if !strings.Contains(text, "https://multica.test/demo-web/issues/MUL-42") {
+		t.Fatalf("duplicate reply should embed the workspace issue deep link; got %q", text)
 	}
 }
 

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -683,6 +683,48 @@ func TestLarkOutcomeReplierIssueDuplicateSendsConflict(t *testing.T) {
 	}
 }
 
+// TestLarkOutcomeReplierIssueLinkOmittedOnDegradedWorkspaceRead pins the only
+// production path that leaves the slug empty: the workspace lookup behind
+// /issue failed, which zeroes the issue prefix and the slug together. The reply
+// must still confirm the issue with the degraded "#42" label, and must send no
+// link at all — neither the workspace-less path nor a URL built from "#42"
+// routes anywhere.
+func TestLarkOutcomeReplierIssueLinkOmittedOnDegradedWorkspaceRead(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	stub := &stubAPIClientWithRecorder{configured: true}
+	rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+		APIClient:   stub,
+		BindingSvc:  &BindingTokenService{},
+		Credentials: stubCredentialsResolver{secret: "s"},
+		Queries:     stubReplierQueries{},
+		AppURL:      "https://multica.test",
+		Logger:      log,
+	})
+
+	inst := Installation{AppID: "cli_x"}
+	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
+	rep.Reply(context.Background(), inst, InboundMessage{ChatID: "oc_chat_42"}, DispatchResult{
+		Outcome:     OutcomeIngested,
+		IssueID:     mustUUID("22222222-2222-2222-2222-222222222222"),
+		IssueNumber: 42,
+		IssueTitle:  "fix login bug",
+	})
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.textOut) != 1 {
+		t.Fatalf("expected one reply, got %d", len(stub.textOut))
+	}
+	text := stub.textOut[0].Text
+	if !strings.Contains(text, "Created #42") {
+		t.Fatalf("degraded reply should still confirm with the #42 label; got %q", text)
+	}
+	if strings.Contains(text, "https://multica.test") {
+		t.Fatalf("degraded reply must omit the link entirely; got %q", text)
+	}
+}
+
 // TestLarkOutcomeReplierOutcomeIngestedSilentWithoutIssue pins the
 // silent-by-default behaviour for plain chat messages. The "Created"
 // text is gated on IssueID.Valid; a chat that didn't include /issue


### PR DESCRIPTION
## Summary

Fix Lark issue creation replies to generate workspace-scoped issue links.

Previously the reply linked to:

```text
/issues/{identifier}
```

Current web routes are workspace-scoped, so the correct path is:

```text
/{workspaceSlug}/issues/{identifier}
```

This change carries the workspace slug in the channel engine issue result and uses a shared channel helper to render Lark issue-created and duplicate replies. If the slug is unavailable, the previous `/issues/{identifier}` path is retained as a fallback.

Fixes #8146

## Tests

```bash
cd server
go test ./internal/integrations/channel ./internal/integrations/lark ./internal/integrations/channel/engine
```