### PR TITLE
MUL-7145: perf(realtime): stop task:progress ticks from invalidating task caches

### DIFF
--- a/packages/core/realtime/use-realtime-sync-task-progress.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-task-progress.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { agentTaskSnapshotKeys } from "../agents/queries";
+import type { WSMessage } from "../types/events";
+import type { WSClient } from "../api/ws-client";
+import { useRealtimeSync, type RealtimeSyncStores } from "./use-realtime-sync";
+
+vi.mock("../platform/workspace-storage", () => ({
+  getCurrentWsId: () => "ws-1",
+  getCurrentSlug: () => "test-ws",
+  createWorkspaceAwareStorage: (adapter: unknown) => adapter,
+  registerForWorkspaceRehydration: () => {},
+}));
+
+vi.mock("../paths", () => ({
+  useHasOnboarded: () => true,
+  resolvePostAuthDestination: () => "/",
+}));
+
+const FLUSH_MS = 200;
+
+function createMockWs(anyHandlers: ((msg: WSMessage) => void)[]): WSClient {
+  return {
+    on: vi.fn(() => () => {}),
+    onAny: vi.fn((handler: (msg: WSMessage) => void) => {
+      anyHandlers.push(handler);
+      return () => {};
+    }),
+    onReconnect: vi.fn(() => () => {}),
+    getLastSyncId: vi.fn(() => null),
+    dispatch: vi.fn(),
+  } as unknown as WSClient;
+}
+
+function createStores(): RealtimeSyncStores {
+  return {
+    authStore: Object.assign(() => ({}), {
+      getState: () => ({ user: { id: "u1" } }),
+      subscribe: () => () => {},
+      setState: () => {},
+      destroy: () => {},
+    }),
+  } as unknown as RealtimeSyncStores;
+}
+
+function createWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useRealtimeSync — task:progress does not trigger the task-prefix invalidation", () => {
+  let qc: QueryClient;
+  let anyHandlers: ((msg: WSMessage) => void)[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    anyHandlers = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function mount() {
+    renderHook(() => useRealtimeSync(createMockWs(anyHandlers), createStores()), {
+      wrapper: createWrapper(qc),
+    });
+    if (anyHandlers.length === 0) throw new Error("onAny handler was not registered");
+  }
+
+  function fire(type: string) {
+    for (const h of anyHandlers) h({ type, payload: {} } as WSMessage);
+  }
+
+  function snapshotInvalidated(spy: { mock: { calls: unknown[][] } }) {
+    return spy.mock.calls.some(([f]) => {
+      const key = (f as { queryKey?: unknown[] })?.queryKey;
+      return JSON.stringify(key) === JSON.stringify(agentTaskSnapshotKeys.list("ws-1"));
+    });
+  }
+
+  it("ignores progress ticks: broadcast-only payload, no cache changed", () => {
+    mount();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    // A long run's steady progress stream — this used to refetch eight query
+    // families every debounce window for data that never changed.
+    for (let i = 0; i < 10; i++) fire("task:progress");
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    expect(snapshotInvalidated(spy)).toBe(false);
+  });
+
+  it("still refreshes the snapshot on real lifecycle transitions", () => {
+    mount();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    fire("task:running");
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    expect(snapshotInvalidated(spy)).toBe(true);
+  });
+});

--- a/packages/core/realtime/use-realtime-sync-task-progress.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-task-progress.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { agentTaskSnapshotKeys } from "../agents/queries";
@@ -106,5 +106,55 @@ describe("useRealtimeSync — task:progress does not trigger the task-prefix inv
     vi.advanceTimersByTime(FLUSH_MS);
 
     expect(snapshotInvalidated(spy)).toBe(true);
+  });
+
+  // The documented cost of this change: on main, a task:progress tick would
+  // re-fetch the task caches and thereby repair a previously LOST lifecycle
+  // event (cross-node publication can fail and the broadcaster ignores the
+  // error, without disconnecting the browser). With progress ticks skipped,
+  // a mounted view that missed task:running stays on its stale status until
+  // the next event that still invalidates the task prefix — the run's own
+  // completed/failed/cancelled transition. This test pins BOTH halves so the
+  // tradeoff stays visible: the tick no longer fetches, the next lifecycle
+  // event does.
+  it("tradeoff: a dropped task:running is healed by the next lifecycle event, no longer by progress ticks", async () => {
+    mount();
+    let serverStatus = "queued";
+    const queryFn = vi.fn(async () => ({ status: serverStatus }));
+    const { result } = renderHook(
+      () =>
+        useQuery({
+          queryKey: agentTaskSnapshotKeys.list("ws-1"),
+          queryFn,
+          staleTime: 30_000,
+        }),
+      { wrapper: createWrapper(qc) },
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.data).toEqual({ status: "queued" });
+    expect(queryFn).toHaveBeenCalledTimes(1);
+
+    // The task starts server-side, but the task:running event never reaches
+    // this client. The next progress tick used to trigger the repair fetch;
+    // now it must not fetch at all.
+    serverStatus = "running";
+    fire("task:progress");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FLUSH_MS);
+    });
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual({ status: "queued" });
+
+    // Recovery now waits for the next event that still hits the task-prefix
+    // invalidation: the run's own terminal transition.
+    serverStatus = "completed";
+    fire("task:completed");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FLUSH_MS);
+    });
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toEqual({ status: "completed" });
   });
 });

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -975,13 +975,20 @@ export function useRealtimeSync(
       // every message would flood the network. Specific chat handlers below
       // still receive it via ws.on() (a separate subscription channel).
       "task:message",
-      // task:progress likewise: it fires every few seconds for the whole
-      // lifetime of an agent run, and its payload (summary/step/total) is
-      // broadcast-only — ReportProgress writes nothing to the DB, so none of
-      // the eight caches the task-prefix invalidation refreshes can have
-      // changed. The real lifecycle transitions (queued / dispatch / running
-      // / completed / failed / cancelled) keep flowing through the prefix
-      // invalidation.
+      // task:progress is broadcast-only narration: ReportProgress persists
+      // nothing, so the tick itself never signals that a task cache changed.
+      // The upstream daemon reports it twice per run — at launch and at the
+      // successful wrap-up — where the 100ms debounce coalesces it with the
+      // adjacent lifecycle invalidation, so skipping it changes little
+      // upstream. The savings come from runtimes that stream progress
+      // continuously during a run (observed on a self-hosted deployment
+      // reporting every few seconds): each tick refetched eight query
+      // families whose data had not changed. The cost: a progress tick no
+      // longer repairs a previously LOST lifecycle event for a mounted view;
+      // the run's own terminal transition still does — see the tradeoff test
+      // in use-realtime-sync-task-progress.test.tsx. Lifecycle transitions
+      // (queued / dispatch / running / completed / failed / cancelled) keep
+      // flowing through the prefix invalidation.
       "task:progress",
       // task:completed / task:failed deliberately NOT here. They go through
       // both the task-prefix invalidate (refreshes the agent-task-snapshot

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -975,6 +975,14 @@ export function useRealtimeSync(
       // every message would flood the network. Specific chat handlers below
       // still receive it via ws.on() (a separate subscription channel).
       "task:message",
+      // task:progress likewise: it fires every few seconds for the whole
+      // lifetime of an agent run, and its payload (summary/step/total) is
+      // broadcast-only — ReportProgress writes nothing to the DB, so none of
+      // the eight caches the task-prefix invalidation refreshes can have
+      // changed. The real lifecycle transitions (queued / dispatch / running
+      // / completed / failed / cancelled) keep flowing through the prefix
+      // invalidation.
+      "task:progress",
       // task:completed / task:failed deliberately NOT here. They go through
       // both the task-prefix invalidate (refreshes the agent-task-snapshot
       // cache) AND the chat-specific ws.on() handlers below. The two


### PR DESCRIPTION
## Problem

`task:progress` is broadcast-only narration: `ReportProgress` persists nothing, so the tick itself never signals that any of the eight task-prefix query families changed. Yet every tick fell through to the task-prefix invalidation in `useRealtimeSync` and marked those families stale per debounce window, refetching data that had not changed.

How often that costs anything depends on the runtime. The upstream daemon reports progress twice per run — at launch (`daemon.go` "Launching %s") and at the successful wrap-up ("Finishing task") — so on upstream the 100ms debounce coalesces most of it with the adjacent lifecycle invalidation and the waste is small (measured below). The every-few-seconds stream described in the first version of this PR is an observation from our self-hosted deployment, whose runtime reports progress continuously during a run; there, each tick used to refetch the task families for every viewer with the workspace open.

## Change

Add `task:progress` to `specificEvents` next to `task:message`, which was excluded for the same reason (MUL-6396). Real lifecycle transitions (`queued` / `dispatch` / `running` / `completed` / `failed` / `cancelled`) keep flowing through the prefix invalidation unchanged — a test pins both behaviors.

## Upstream before/after measurement

Setup: this branch's checkout (`ca83809` + review follow-ups, base `028f3b4`), single-node dev server, one viewer with `MEAS-1`'s issue detail (execution log visible) open and settled. The task run replays the exact report sequence the upstream daemon emits for one successful run — `start` → `ReportProgress("Launching claudecode", 1, 2)` → three message batches → `ReportProgress("Finishing task", 2, 2)` → `complete` over ~6.5s — via the daemon HTTP API. Requests counted from the browser's network capture, window = run start until 5s after `complete`, initial page load excluded, preflights excluded. "Before" is the same checkout with the one-line `specificEvents` entry commented out, full page reload between variants.

| Endpoint (GET) | before (main behavior) | after (this PR) |
|---|---|---|
| `/api/agent-task-snapshot` | 3 | 2 |
| `/api/issues/{id}/task-runs` | 3 | 2 |
| `/api/agents?workspace_id=…` | 2 | 2 |
| `/api/issues?limit=50` | 7 | 7 |
| `/api/issues/{id}` | 1 | 1 |
| `/api/inbox`, `/api/inbox/unread-summary`, `/api/notification-preferences` | 3 | 3 |
| **total** | **19** | **17** |

Reading of the delta: the launch report lands ~50ms after `task:running`, inside the debounce window, and coalesces in both variants — exactly as the review predicted. The "Finishing task" report, however, precedes `task:completed` by more than the 100ms debounce (upstream inserts a `GetTaskStatus` round-trip between them), so on main it produces one extra mid-run flush; only the actively observed families actually refetch (snapshot + task-runs here), which is why the saving is 2 requests and not 8 — counting actual requests, not invalidations, as requested. So the upstream saving is small and bounded (~2 requests per run per viewer), and the change is primarily about runtimes that stream progress continuously.

Status promptness and log delivery were checked in the same session: the "agent working" indicator and the running entry in the execution log appeared immediately on `task:running`, message batches arrived live (`task:message` has its own subscription channel, untouched by this PR), and the completed state rendered immediately on `task:completed`.

## Recovery tradeoff (documented, tested)

On main, a `task:progress` tick doubles as a repair signal: a mounted view that missed `task:running` (cross-node publication can fail and the broadcaster drops the error without disconnecting the browser) would be healed by the next tick's refetch within ~100ms. With this change that repair channel is gone: the view stays on its stale status until the next event that still hits the task-prefix invalidation — in the common case the run's own `completed`/`failed`/`cancelled` transition, otherwise a user-driven refetch (remount, window focus). `staleTime: 30s` does not schedule anything by itself.

A new test (`use-realtime-sync-task-progress.test.tsx`, mounted query with a fetching `queryFn`) pins both halves: the tick no longer fetches after a suppressed `task:running`, and the terminal transition still restores the displayed state. Verified in both directions — with the entry removed, the same test fails because the tick does refetch. For upstream's two-report sequence the exposure window is one run's duration; for continuously-reporting runtimes it is the same window this PR removes the traffic from, which is the tradeoff to weigh.
