### PR TITLE
MUL-7140: hide quick-create run blocks from Activity

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -350,9 +350,9 @@ export interface AgentTask {
    */
   trigger_summary?: string;
   /**
-   * Server-computed source discriminator used by the activity row to label
-   * tasks that have no linked issue (so e.g. quick-create tasks render
-   * with a meaningful title instead of falling through to "Untracked").
+   * Server-computed source discriminator used by task surfaces. Quick-create
+   * remains quick_create after its result issue is linked, so consumers can
+   * distinguish creation work from later direct runs on that issue.
    */
   kind?: "comment" | "autopilot" | "chat" | "quick_create" | "direct";
   /**

--- a/packages/views/issues/components/comment-runs.test.ts
+++ b/packages/views/issues/components/comment-runs.test.ts
@@ -200,6 +200,13 @@ describe("standaloneCommentRuns", () => {
       .toEqual([{ task: run, hasReply: false }]);
   });
 
+  it("omits the issue-producing quick-create run from Activity", () => {
+    const quickCreate = task("quick-create", { kind: "quick_create", status: "completed" });
+    const assignment = task("assignment", { kind: "direct", status: "completed" });
+    expect(buildCommentRunView([quickCreate, assignment], []).standaloneRuns)
+      .toEqual([{ task: assignment, hasReply: false }]);
+  });
+
   it("keeps assignment slots after replies arrive and excludes comment-triggered slots", () => {
     const assigned = task("assignment");
     const triggered = task("comment-run", { trigger_comment_id: "trigger" });

--- a/packages/views/issues/components/comment-runs.ts
+++ b/packages/views/issues/components/comment-runs.ts
@@ -39,6 +39,10 @@ export function buildCommentRunView(
   timeline: readonly TimelineEntry[],
   previous = new Map<string, CommentRun[]>(),
 ): { timeline: readonly TimelineEntry[]; runs: Map<string, CommentRun[]>; standaloneRuns: CommentRun[] } {
+  // Quick create owns the issue's creation, not a turn inside the issue. The
+  // backend links that task to the issue after success so it remains available
+  // in Execution history, but it must not become an unanchored Activity block.
+  const inlineTasks = tasks.filter((task) => task.kind !== "quick_create");
   const comments = new Map(timeline.filter((entry) => entry.type === "comment").map((entry) => [entry.id, entry]));
   const threadRoot = (id: string): string | undefined => {
     const seen = new Set<string>();
@@ -58,10 +62,10 @@ export function buildCommentRunView(
       replies.set(entry.source_task_id, entry);
     }
   }
-  const byTask = new Map(tasks.map((task) => [task.id, task]));
+  const byTask = new Map(inlineTasks.map((task) => [task.id, task]));
   const priorAnchors = new Map([...previous.values()].flatMap((runs) => runs.map((run) => [run.task.id, run.anchorCommentId] as const)));
   const placements: CommentRun[] = [];
-  for (const task of [...tasks].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))) {
+  for (const task of [...inlineTasks].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))) {
     const reply = replies.get(task.id);
     if (isObsoleteCommentRun(task) && !reply) continue;
     let anchorId: string | undefined;

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -508,7 +508,7 @@ type AgentTaskResponse struct {
 	InitiatorID    string `json:"initiator_id,omitempty"`    // user UUID (member) or agent UUID
 	InitiatorName  string `json:"initiator_name,omitempty"`  // display name of the initiator
 	InitiatorEmail string `json:"initiator_email,omitempty"` // member email; empty for agent initiators
-	Kind           string `json:"kind"`                      // discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — used by the activity row to label tasks that have no linked issue
+	Kind           string `json:"kind"`                      // source discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — quick-create remains stable after its result issue is linked
 	// Attribution is the resolved accountable-human provenance for this run
 	// (MUL-4302 §9): the source label + precise flag, the initiator (accountable)
 	// and originator refs, the evidence pointer, and lineage. Always present (the
@@ -814,9 +814,8 @@ func taskToResponse(t db.AgentTaskQueue, workspaceID string) AgentTaskResponse {
 		RelativeWorkDir:        relativeWorkDir(workDir, workspaceID, uuidToString(t.ID)),
 		DurableWorkDir:         durableWorkDir,
 		RelativeDurableWorkDir: relativeWorkDir(durableWorkDir, "", ""),
-		// Surface task source so the UI can distinguish issue-linked tasks
-		// from chat-spawned or autopilot-spawned ones; all three may arrive
-		// with issue_id = "" once a task has no linked issue.
+		// Surface the stable task source. A successful quick-create gains an
+		// issue link for navigation but retains its quick_create kind.
 		ChatSessionID:  uuidToString(t.ChatSessionID),
 		AutopilotRunID: uuidToString(t.AutopilotRunID),
 		Kind:           computeTaskKind(t),
@@ -963,12 +962,10 @@ func basename(p string) string {
 	return p
 }
 
-// computeTaskKind picks the source-discriminator string the activity UI uses
-// to choose how to render a task row. Computed from the existing FK shape so
-// no extra DB lookup is needed: chat / autopilot / comment-on-issue (any
-// triggered task with both an issue_id and trigger_comment_id) / quick_create
-// (no linked source — the agent is creating the issue itself) / direct
-// (assignee-driven task on an existing issue).
+// computeTaskKind picks the stable source-discriminator string task UIs use.
+// Chat and autopilot have dedicated FKs; quick-create must inspect its context
+// because completion links the newly created issue back onto the task. The
+// remaining issue tasks split into comment-triggered and direct runs.
 func computeTaskKind(t db.AgentTaskQueue) string {
 	if uuidToString(t.ChatSessionID) != "" {
 		return "chat"
@@ -976,6 +973,14 @@ func computeTaskKind(t db.AgentTaskQueue) string {
 	if uuidToString(t.AutopilotRunID) != "" {
 		return "autopilot"
 	}
+	var contextKind struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(t.Context, &contextKind) == nil && contextKind.Type == service.QuickCreateContextType {
+		return "quick_create"
+	}
+	// Preserve the historical classification for issue-less rows from before
+	// quick-create stored a typed context.
 	if uuidToString(t.IssueID) == "" {
 		return "quick_create"
 	}

--- a/server/internal/handler/attribution_response_test.go
+++ b/server/internal/handler/attribution_response_test.go
@@ -31,6 +31,22 @@ func TestTaskCommentChangeCancellation(t *testing.T) {
 	}
 }
 
+func TestComputeTaskKindPreservesLinkedQuickCreateOrigin(t *testing.T) {
+	issueID := parseUUID("11111111-1111-1111-1111-111111111111")
+	if got := computeTaskKind(db.AgentTaskQueue{
+		IssueID: issueID,
+		Context: []byte(`{"type":"quick_create","prompt":"Create an issue"}`),
+	}); got != "quick_create" {
+		t.Fatalf("linked quick-create kind = %q, want quick_create", got)
+	}
+	if got := computeTaskKind(db.AgentTaskQueue{
+		IssueID: issueID,
+		Context: []byte(`{"head_sha":"abc123"}`),
+	}); got != "direct" {
+		t.Fatalf("ordinary linked task kind = %q, want direct", got)
+	}
+}
+
 // TestTaskAttributionBase covers the pure row→attribution mapping (MUL-4302 §9):
 // source label + precise flag, initiator/originator raw refs, evidence, lineage —
 // no DB, no name hydration.

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -7537,11 +7537,12 @@ func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.Ag
 		return
 	}
 
-	// Link the new issue back to this task so subsequent reads of the task
-	// (Activity tab, Recent work, etc.) render it as a normal issue task
-	// (kind = "direct") instead of staying on the "Creating issue" active-
-	// wording label. Best-effort: a write failure here doesn't block the
-	// inbox notification, which is the more important signal to the user.
+	// Link the new issue back to this task so subsequent reads (Activity tab,
+	// Recent work, etc.) can navigate to the result instead of leaving it on
+	// the "Creating issue" active wording. The task's source kind remains
+	// quick_create, derived from its typed context. Best-effort: a write failure
+	// here doesn't block the inbox notification, which is the more important
+	// signal to the user.
 	if err := s.Queries.LinkTaskToIssue(ctx, db.LinkTaskToIssueParams{
 		ID:      task.ID,
 		IssueID: issue.ID,


### PR DESCRIPTION
## Summary

- preserve `quick_create` as the task source after the created issue is linked
- exclude quick-create tasks from inline issue Activity blocks while retaining them in execution history
- add backend and frontend regression coverage

## Verification

- `go test ./internal/handler -count=1`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint issues/components/comment-runs.ts issues/components/comment-runs.test.ts`
- `pnpm --filter @multica/views exec vitest run issues/components/comment-runs.test.ts`
- full `@multica/views` suite: 4,961 passed; one unrelated existing `layout/sidebar-resize.test.tsx` assertion fails under local Node 25.4 because its localStorage spy is bypassed

Closes MUL-7140
