### PR TITLE
MUL-7120 fix(agent): stop ACP ghost sessions from wedging a conversation forever

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2939,6 +2939,36 @@ func TestShouldRetryWithFreshSession(t *testing.T) {
 			want:           true,
 		},
 		{
+			// GH #8116 end to end. A qoder chat pinned to a session the CLI
+			// never persisted used to reach this gate with ResumeRejected
+			// false, because the adapter returned a bare failed Result from
+			// session/resume — so the gate read "checked, not a rejection",
+			// declined to retry, and the conversation replayed the same dead
+			// id on every later message. The adapters now flag it, and this is
+			// what that flag has to buy.
+			name: "ghost session rejected at session/resume retries",
+			result: agent.Result{
+				Status:         "failed",
+				Error:          `qoder session/resume failed: session/resume: Invalid session identifier "27d8031c-9fea-4bda-9d42-37c36fa9aebf". (code=-32602)`,
+				ResumeRejected: true,
+			},
+			priorSessionID: "27d8031c-9fea-4bda-9d42-37c36fa9aebf",
+			provider:       "qoder",
+			want:           true,
+		},
+		{
+			// The other half of the same contract: an unrecognised resume
+			// failure must NOT retry. The adapters answer "not a rejection" by
+			// leaving the flag false, and a capable backend's false is an
+			// answer, not an absence — retrying here would fork a healthy
+			// conversation over a transient MCP or network fault.
+			name:           "unflagged resume failure does not retry",
+			result:         agent.Result{Status: "failed", Error: "qoder session/resume failed: session/resume: Invalid params: mcpServers[0] transport unreachable (code=-32602)"},
+			priorSessionID: "27d8031c-9fea-4bda-9d42-37c36fa9aebf",
+			provider:       "qoder",
+			want:           false,
+		},
+		{
 			name:           "temporarily busy resume retries without declaring the session dead",
 			result:         agent.Result{Status: "failed", Error: "session already in use", ResumeRejectedTransient: true},
 			priorSessionID: "healthy-id",

--- a/server/pkg/agent/acp_session.go
+++ b/server/pkg/agent/acp_session.go
@@ -34,9 +34,6 @@ import (
 // no literal in the original set matched, so a conversation pinned to a dead
 // id retried it forever.
 func isACPResumeRejected(err error) bool {
-	if isACPSessionNotFound(err) {
-		return true
-	}
 	var rpcErr *acpRPCError
 	if !errors.As(err, &rpcErr) {
 		return false
@@ -58,7 +55,19 @@ func isACPResumeRejected(err error) bool {
 	// own "session" would otherwise satisfy the noun half of every error this
 	// RPC can produce and quietly turn the predicate into the exclusion rule
 	// the doc above rejects.
-	return acpSessionUnusableRe.MatchString(strings.ToLower(rpcErr.Message + " " + rpcErr.Data))
+	text := strings.ToLower(rpcErr.Message + " " + rpcErr.Data)
+	// Delete request-shaped complaints before matching rather than returning
+	// false on sight of one. A message can carry both — "invalid session
+	// request: session not found" — and vetoing the whole string would throw
+	// away a real rejection sitting next to a complaint about our own call.
+	//
+	// This runs BEFORE both wording checks, which is why the isACPSessionNotFound
+	// literals are consulted through acpSessionNotFoundWording rather than by
+	// calling the helper on the raw error: "unknown session" is one of those
+	// literals, so "unknown session capability requested" would otherwise be
+	// answered true before the scrub ever ran.
+	text = acpSessionRequestComplaintRe.ReplaceAllString(text, " ")
+	return acpSessionNotFoundWording(text) || acpSessionUnusableRe.MatchString(text)
 }
 
 // acpSessionUnusableRe matches a runtime saying the session id itself is no
@@ -68,6 +77,7 @@ func isACPResumeRejected(err error) bool {
 //	unknown session <id>                         (Reasonix — verdict, then noun)
 //	Session not found                            (Hermes — noun, then verdict)
 //	session ses_abc does not exist               (noun, id, then verdict)
+//	No session found with id ses_abc             (Kiro — the "no <noun> found" shape)
 //
 // The verdict-first form demands the noun IMMEDIATELY after the verdict, and the
 // noun-first form allows only an "id"/"identifier" word and one id-shaped token
@@ -80,9 +90,28 @@ func isACPResumeRejected(err error) bool {
 // is explicitly documented never to flag, and matching one does not merely waste
 // a retry: it retires a live conversation's pointer and forks it irreversibly.
 // TestIsACPResumeRejected pins every one of them as a negative.
+//
+// The "no <noun> found" alternative is deliberately spelled out here even
+// though isACPSessionNotFound already matches that literal: that helper keeps
+// its error-code gate, so relying on it for this shape would quietly reinstate
+// the code dependency this predicate exists without. Kiro's real frame is
+// -32603 and would pass the gate anyway; the point is that the wording alone
+// decides, for every shape and not just the ones in the regex.
 var acpSessionUnusableRe = regexp.MustCompile(
 	`(no such|unknown|invalid|expired|unrecogni[sz]ed|nonexistent|missing)\s+(session|conversation|thread)` +
+		`|no\s+(session|conversation|thread)\s+found` +
 		`|(session|conversation|thread)(\s+(id|identifier))?(\s+"?[\w-]+"?)?\s+(is\s+)?(not found|does not exist|doesn't exist|no longer exists|expired|invalid|unknown|unrecogni[sz]ed)`)
+
+// acpSessionRequestComplaintRe matches the one verdict-first shape that is NOT
+// about the recorded session: a generic noun after it turns the phrase into a
+// complaint about the call we just made. "Invalid session parameters: cwd must
+// be absolute", "invalid session request" and "unknown session capability
+// requested" all say our request was malformed, not that the transcript is
+// gone — and a fresh session would fail identically, after the pointer had
+// already been retired. Reaching one of these needs a client-side bug first,
+// which is why it is a stop-list rather than a redesign.
+var acpSessionRequestComplaintRe = regexp.MustCompile(
+	`(no such|unknown|invalid|expired|unrecogni[sz]ed|nonexistent|missing)\s+(session|conversation|thread)\s+(params?|parameters?|request|requests|config|configuration|option|options|capability|capabilities|mode|setup)`)
 
 // setupFailureWithholdsSessionID reports whether a run that failed during setup
 // — after session/new, before session/prompt — must report an empty SessionID

--- a/server/pkg/agent/acp_session.go
+++ b/server/pkg/agent/acp_session.go
@@ -41,9 +41,19 @@ func isACPResumeRejected(err error) bool {
 	if !errors.As(err, &rpcErr) {
 		return false
 	}
-	if !isACPSessionErrorCode(rpcErr.Code) {
-		return false
-	}
+	// No isACPSessionErrorCode gate here, unlike isACPSessionNotFound, and that
+	// is a deliberate narrowing of what this fix depends on. The reported
+	// qodercli frame is invalid_params (-32602) — inside the accepted set — but
+	// that rests on the reporter's capture rather than anything we can
+	// re-derive: a qodercli without a login answers session/resume with an auth
+	// error long before it ever looks the id up, so the rejection path is
+	// unreachable locally. Gating on the code would make the whole fix miss its
+	// own bug if a runtime picks a code outside the set, and the code buys
+	// nothing at this boundary anyway: a runtime that states the session is
+	// unusable has said so whatever number it attaches. The wording carries the
+	// decision — which is what isACPSessionNotFound's own doc already concedes
+	// about the generic -32000 and -32603.
+	//
 	// Message and Data only. acpRPCError.Method holds "session/resume", whose
 	// own "session" would otherwise satisfy the noun half of every error this
 	// RPC can produce and quietly turn the predicate into the exclusion rule
@@ -51,25 +61,47 @@ func isACPResumeRejected(err error) bool {
 	return acpSessionUnusableRe.MatchString(strings.ToLower(rpcErr.Message + " " + rpcErr.Data))
 }
 
-// acpSessionUnusableRe matches a session-shaped noun and an "unusable" verdict
-// standing next to each other, in either order — the shape every runtime's
-// rejection wording has taken so far:
+// acpSessionUnusableRe matches a runtime saying the session id itself is no
+// good. Two shapes, because that is how the wordings actually read:
 //
-//	Invalid session identifier "27d8031c-…"   (qodercli)
-//	Session not found                         (Hermes)
-//	unknown session <id>                      (Reasonix)
-//	No session found with id …                (Kiro, via isACPSessionNotFound)
+//	Invalid session identifier "27d8031c-…"      (qodercli — verdict, then noun)
+//	unknown session <id>                         (Reasonix — verdict, then noun)
+//	Session not found                            (Hermes — noun, then verdict)
+//	session ses_abc does not exist               (noun, id, then verdict)
 //
-// Adjacency is what keeps it narrow, and it is load-bearing. Both halves appear
-// independently in errors that have nothing to do with the session — an invalid
-// mcpServers entry says "Invalid params" while the error's `data` echoes the
-// sessionId we passed — and a bare AND over the whole string would match that
-// pair and discard a healthy pointer. Requiring them within one short,
-// separator-free window is what tells "invalid session identifier" apart from
-// "invalid params … {sessionId: …}".
+// The verdict-first form demands the noun IMMEDIATELY after the verdict, and the
+// noun-first form allows only an "id"/"identifier" word and one id-shaped token
+// in between. That tightness is the whole safety argument, and a looser window
+// is not a detail: the natural English for errors this RPC really does produce
+// puts the same two halves a few words apart while meaning something entirely
+// different — "unknown error while loading session", "invalid token for session
+// abc", "invalid credentials for this session", "cwd does not exist for session
+// abc". Those are auth and infrastructure failures, which Result.ResumeRejected
+// is explicitly documented never to flag, and matching one does not merely waste
+// a retry: it retires a live conversation's pointer and forks it irreversibly.
+// TestIsACPResumeRejected pins every one of them as a negative.
 var acpSessionUnusableRe = regexp.MustCompile(
-	`(session|conversation|thread)[^,;\n]{0,24}(not found|no such|unknown|invalid|expired|does not exist|doesn't exist|no longer|unrecogni[sz]ed)` +
-		`|(not found|no such|unknown|invalid|expired|does not exist|doesn't exist|no longer|unrecogni[sz]ed)[^,;\n]{0,24}(session|conversation|thread)`)
+	`(no such|unknown|invalid|expired|unrecogni[sz]ed|nonexistent|missing)\s+(session|conversation|thread)` +
+		`|(session|conversation|thread)(\s+(id|identifier))?(\s+"?[\w-]+"?)?\s+(is\s+)?(not found|does not exist|doesn't exist|no longer exists|expired|invalid|unknown|unrecogni[sz]ed)`)
+
+// setupFailureWithholdsSessionID reports whether a run that failed during setup
+// — after session/new, before session/prompt — must report an empty SessionID
+// instead of the id it just created.
+//
+// True exactly when the session is fresh. Such a session has no transcript
+// behind it: no prompt was ever sent, so there is no conversation to continue
+// and withholding the id costs one extra session/new next turn. Publishing it
+// bets that every ACP runtime persists a never-prompted session, and qodercli
+// does not — it exits without writing one, leaving the daemon pinned to an id
+// that does not exist and every later message in that chat failing to resume it
+// forever (GH #8116).
+//
+// A RESUMED session is the opposite case and keeps today's behaviour: its
+// transcript predates this run, so the id stays unless the runtime actively
+// rejected it.
+func setupFailureWithholdsSessionID(opts ExecOptions) bool {
+	return opts.ResumeSessionID == ""
+}
 
 // classifyACPResumeFailure turns an error from session/resume or session/load
 // into this turn's terminal status, message and resume-rejection flag. Every

--- a/server/pkg/agent/acp_session.go
+++ b/server/pkg/agent/acp_session.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// isACPResumeRejected reports whether an error returned by session/resume or
+// session/load means the runtime refused the session id we asked it to restore.
+//
+// It is deliberately wider than isACPSessionNotFound, and deliberately scoped
+// to that one RPC. session/resume and session/load have exactly one job — turn
+// a recorded id into a live session — so a rejection there is about the id
+// itself far more often than at set_model or prompt time, where the same words
+// could be about the model, the provider or the network. Calling this outside
+// the resume boundary would lose that context and start discarding healthy
+// conversation pointers.
+//
+// It stays positive evidence, not exclusion. Treating EVERY resume error as a
+// rejection is the tempting alternative and it is wrong: session/resume carries
+// mcpServers, so an unreachable MCP server fails it, and so do a runtime
+// handshake crash, an expired provider credential and a missing cwd. None of
+// those is cured by starting over, and shouldRetryWithFreshSession's contract
+// is that a false answer means "checked, and this was not a rejection". What
+// this widens is the vocabulary, not the burden of proof: instead of three
+// literal phrases it accepts any wording that names a session-shaped noun and
+// says, right next to it, that the thing is unusable. That is what GH #8116
+// slipped through — qodercli answers "Invalid session identifier <id>", which
+// no literal in the original set matched, so a conversation pinned to a dead
+// id retried it forever.
+func isACPResumeRejected(err error) bool {
+	if isACPSessionNotFound(err) {
+		return true
+	}
+	var rpcErr *acpRPCError
+	if !errors.As(err, &rpcErr) {
+		return false
+	}
+	if !isACPSessionErrorCode(rpcErr.Code) {
+		return false
+	}
+	// Message and Data only. acpRPCError.Method holds "session/resume", whose
+	// own "session" would otherwise satisfy the noun half of every error this
+	// RPC can produce and quietly turn the predicate into the exclusion rule
+	// the doc above rejects.
+	return acpSessionUnusableRe.MatchString(strings.ToLower(rpcErr.Message + " " + rpcErr.Data))
+}
+
+// acpSessionUnusableRe matches a session-shaped noun and an "unusable" verdict
+// standing next to each other, in either order — the shape every runtime's
+// rejection wording has taken so far:
+//
+//	Invalid session identifier "27d8031c-…"   (qodercli)
+//	Session not found                         (Hermes)
+//	unknown session <id>                      (Reasonix)
+//	No session found with id …                (Kiro, via isACPSessionNotFound)
+//
+// Adjacency is what keeps it narrow, and it is load-bearing. Both halves appear
+// independently in errors that have nothing to do with the session — an invalid
+// mcpServers entry says "Invalid params" while the error's `data` echoes the
+// sessionId we passed — and a bare AND over the whole string would match that
+// pair and discard a healthy pointer. Requiring them within one short,
+// separator-free window is what tells "invalid session identifier" apart from
+// "invalid params … {sessionId: …}".
+var acpSessionUnusableRe = regexp.MustCompile(
+	`(session|conversation|thread)[^,;\n]{0,24}(not found|no such|unknown|invalid|expired|does not exist|doesn't exist|no longer|unrecogni[sz]ed)` +
+		`|(not found|no such|unknown|invalid|expired|does not exist|doesn't exist|no longer|unrecogni[sz]ed)[^,;\n]{0,24}(session|conversation|thread)`)
+
+// classifyACPResumeFailure turns an error from session/resume or session/load
+// into this turn's terminal status, message and resume-rejection flag. Every
+// ACP backend that resumes shares it so the six that used to return a bare
+// failed Result cannot drift apart from each other again.
+//
+// Cancellation and timeout are checked FIRST, and that ordering is deliberate.
+// A user who cancels mid-resume, or a turn that runs out of budget, must never
+// be reported as a rejected session: ResumeRejected licenses the daemon to
+// abandon the recorded conversation and re-run the whole task from a fresh one,
+// which is the opposite of what a cancel asked for. When a real rejection and a
+// cancel race, reading it as a cancel is the recoverable mistake — the pointer
+// survives, and the next turn resumes, gets the same rejection with no cancel
+// in flight, and self-heals then.
+func classifyACPResumeFailure(runCtx context.Context, backend, rpc string, err error, timeout time.Duration, logger *slog.Logger) (status, errText string, rejected bool) {
+	switch runCtx.Err() {
+	case context.DeadlineExceeded:
+		if timeout > 0 {
+			return "timeout", fmt.Sprintf("%s timed out after %s during %s", backend, timeout, rpc), false
+		}
+		return "timeout", fmt.Sprintf("%s timed out during %s", backend, rpc), false
+	case context.Canceled:
+		return "aborted", "execution cancelled", false
+	}
+	errText = fmt.Sprintf("%s %s failed: %v", backend, rpc, err)
+	if !isACPResumeRejected(err) {
+		return "failed", errText, false
+	}
+	if logger != nil {
+		logger.Warn("resumed session rejected by the runtime; the daemon will retry from a fresh session",
+			"backend", backend,
+			"rpc", rpc,
+			"error", err,
+		)
+	}
+	return "failed", errText, true
+}

--- a/server/pkg/agent/acp_session_test.go
+++ b/server/pkg/agent/acp_session_test.go
@@ -129,6 +129,41 @@ func TestIsACPResumeRejected(t *testing.T) {
 			want: false,
 		},
 		{
+			// Steve's re-review nit: a generic noun after the verdict turns the
+			// phrase into a complaint about the call we just made, not about
+			// the recorded session. A fresh session would fail identically —
+			// after the pointer had already been retired.
+			name: "invalid session parameters is about our request",
+			err:  &acpRPCError{Method: "session/resume", Code: -32602, Message: "Invalid session parameters: cwd must be absolute"},
+			want: false,
+		},
+		{
+			name: "invalid session request is about our request",
+			err:  &acpRPCError{Method: "session/load", Code: -32602, Message: "invalid session request"},
+			want: false,
+		},
+		{
+			name: "unknown session capability is about our request",
+			err:  &acpRPCError{Method: "session/resume", Code: -32602, Message: "unknown session capability requested"},
+			want: false,
+		},
+		{
+			// The stop-list deletes the complaint rather than vetoing the whole
+			// message, so a real rejection sitting next to one still counts.
+			name: "request complaint alongside a real rejection still counts",
+			err:  &acpRPCError{Method: "session/resume", Code: -32602, Message: "invalid session request: session not found"},
+			want: true,
+		},
+		{
+			// Kiro's wording, under a code OUTSIDE the accepted set. It matches
+			// via the regex rather than via isACPSessionNotFound, which keeps
+			// its code gate — otherwise this predicate's code-independence
+			// would silently not hold for the three inherited literals.
+			name: "kiro no-session-found wording under an unusual code",
+			err:  &acpRPCError{Method: "session/load", Code: -32099, Message: "Internal error", Data: "No session found with id ses_abc"},
+			want: true,
+		},
+		{
 			// Captured by hand from qodercli 1.0.20 (`--yolo --acp`, not logged
 			// in): session/resume answers with this before it ever looks the id
 			// up. Proof that this RPC really does surface errors with nothing to

--- a/server/pkg/agent/acp_session_test.go
+++ b/server/pkg/agent/acp_session_test.go
@@ -1,0 +1,273 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestIsACPResumeRejected pins the widened resume-boundary predicate. The two
+// halves that matter are the qodercli frame from GH #8116 — the wording that
+// wedged a conversation because no literal in isACPSessionNotFound matched it —
+// and the negatives, which are the whole reason this is a phrase predicate and
+// not "any error from session/resume".
+func TestIsACPResumeRejected(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "qodercli invalid session identifier",
+			// The frame that made GH #8116 permanent: qodercli 1.1.25 answers
+			// session/resume for an id it never persisted with invalid_params
+			// and this wording. The code was already accepted; only the phrase
+			// was missing, so the rejection was invisible to the daemon.
+			err: &acpRPCError{
+				Method:  "session/resume",
+				Code:    -32602,
+				Message: `Invalid session identifier "27d8031c-9fea-4bda-9d42-37c36fa9aebf".`,
+				Data:    `{"sessionId":"27d8031c-9fea-4bda-9d42-37c36fa9aebf"}`,
+			},
+			want: true,
+		},
+		{
+			name: "everything isACPSessionNotFound already matched still matches",
+			err:  &acpRPCError{Method: "session/resume", Code: -32603, Message: "Session not found"},
+			want: true,
+		},
+		{
+			name: "session expired",
+			err:  &acpRPCError{Method: "session/load", Code: -32602, Message: "session expired"},
+			want: true,
+		},
+		{
+			name: "session does not exist",
+			err:  &acpRPCError{Method: "session/load", Code: -32603, Message: "Internal error", Data: "the conversation does not exist"},
+			want: true,
+		},
+		{
+			name: "unreachable mcp server whose data echoes the session id",
+			// The false positive the adjacency window exists to stop. Both
+			// halves are present in the string — "Invalid params" and a
+			// sessionId in `data` — but they are not about each other, and
+			// discarding the pointer here would fork a healthy conversation
+			// over a transient MCP outage.
+			err: &acpRPCError{
+				Method:  "session/resume",
+				Code:    -32602,
+				Message: "Invalid params: mcpServers[0] transport unreachable",
+				Data:    `{"sessionId":"ses_healthy"}`,
+			},
+			want: false,
+		},
+		{
+			name: "provider rate limit during resume",
+			err:  &acpRPCError{Method: "session/resume", Code: -32603, Message: "Internal error", Data: "upstream provider returned HTTP 429"},
+			want: false,
+		},
+		{
+			name: "auth failure during resume keeps the session",
+			err:  &acpRPCError{Method: "session/load", Code: -32603, Message: "Could not resolve authentication method"},
+			want: false,
+		},
+		{
+			name: "session wording under an unrelated code",
+			err:  &acpRPCError{Method: "session/resume", Code: -32601, Message: "Invalid session identifier"},
+			want: false,
+		},
+		{
+			name: "plain error is never a rejection",
+			err:  fmt.Errorf("session/resume: Invalid session identifier (code=-32602)"),
+			want: false,
+		},
+		{
+			name: "wrapped rpc error",
+			err:  fmt.Errorf("request failed: %w", &acpRPCError{Method: "session/resume", Code: -32602, Message: "Invalid session identifier"}),
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isACPResumeRejected(tc.err); got != tc.want {
+				t.Errorf("isACPResumeRejected(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyACPResumeFailureCancelAndTimeoutAreNotRejections pins the
+// ordering that keeps a cancel from being read as a dead session.
+// ResumeRejected licenses the daemon to abandon the recorded conversation and
+// re-run the task from a fresh session — precisely what a user who just hit
+// cancel did not ask for.
+func TestClassifyACPResumeFailureCancelAndTimeoutAreNotRejections(t *testing.T) {
+	t.Parallel()
+
+	rejection := &acpRPCError{Method: "session/resume", Code: -32602, Message: "Invalid session identifier"}
+
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		status, _, rejected := classifyACPResumeFailure(ctx, "qoder", "session/resume", rejection, time.Minute, nil)
+		if status != "aborted" {
+			t.Errorf("status = %q, want aborted", status)
+		}
+		if rejected {
+			t.Error("a cancelled resume must not report ResumeRejected")
+		}
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		status, errText, rejected := classifyACPResumeFailure(ctx, "kiro", "session/load", rejection, 30*time.Second, nil)
+		if status != "timeout" {
+			t.Errorf("status = %q, want timeout", status)
+		}
+		if rejected {
+			t.Error("a timed-out resume must not report ResumeRejected")
+		}
+		if errText == "" {
+			t.Error("expected a non-empty timeout message")
+		}
+	})
+
+	t.Run("live context reports the rejection", func(t *testing.T) {
+		t.Parallel()
+		status, errText, rejected := classifyACPResumeFailure(context.Background(), "qoder", "session/resume", rejection, time.Minute, nil)
+		if status != "failed" {
+			t.Errorf("status = %q, want failed", status)
+		}
+		if !rejected {
+			t.Error("expected ResumeRejected=true for a rejected session id")
+		}
+		if want := "qoder session/resume failed: "; len(errText) < len(want) || errText[:len(want)] != want {
+			t.Errorf("error text = %q, want it to keep the %q prefix", errText, want)
+		}
+	})
+
+	t.Run("non-rejection keeps the pointer", func(t *testing.T) {
+		t.Parallel()
+		netErr := &acpRPCError{Method: "session/resume", Code: -32603, Message: "Internal error", Data: "upstream provider returned HTTP 429"}
+		status, _, rejected := classifyACPResumeFailure(context.Background(), "qoder", "session/resume", netErr, time.Minute, nil)
+		if status != "failed" {
+			t.Errorf("status = %q, want failed", status)
+		}
+		if rejected {
+			t.Error("a rate-limited resume must not discard the conversation pointer")
+		}
+	})
+}
+
+// fakeACPRejectedResumeScript answers initialize (advertising the auth method
+// Grok insists on, harmless to the others) and then rejects whichever resume
+// RPC the backend uses with qodercli 1.1.25's wording from GH #8116.
+//
+// The message deliberately carries no inner quotes: `sh` printf mangles
+// backslash-escaped quotes inconsistently, and a malformed error frame is
+// silently dropped by the ACP client, which shows up as a hung request rather
+// than a failed assertion.
+func fakeACPRejectedResumeScript(rpc string) string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"authMethods":[{"id":"xai.api_key","name":"API key"}],"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"authenticate"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+      ;;
+    *'"method":"` + rpc + `"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"Invalid session identifier ses_ghost.","data":{"sessionId":"ses_ghost"}}}\n' "$id"
+      ;;
+  esac
+done
+`
+}
+
+// TestACPBackendsReportRejectedResume is the end-to-end guard for GH #8116:
+// every ACP backend that resumes must turn its runtime's rejection into
+// ResumeRejected, because that flag is the ONLY positive evidence
+// shouldRetryWithFreshSession accepts. Without it the daemon reads the bare
+// failure as "checked, not a rejection", keeps the dead pointer, and every
+// later message in that conversation replays the same rejection forever.
+//
+// Table-driven across all six on purpose. These call sites were six separate
+// copies of the same bug, and the neighbouring history in this package — the
+// same resume defect fixed one adapter at a time for Kiro, then Kimi, then
+// Anthropic — is what happens when one backend gets a regression test and the
+// rest do not.
+func TestACPBackendsReportRejectedResume(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		agentType string
+		binary    string
+		rpc       string
+		env       map[string]string
+	}{
+		{agentType: "qoder", binary: "qodercli", rpc: "session/resume"},
+		{agentType: "hermes", binary: "hermes", rpc: "session/resume"},
+		{agentType: "kimi", binary: "kimi", rpc: "session/resume"},
+		{agentType: "kiro", binary: "kiro", rpc: "session/load"},
+		{agentType: "traecli", binary: "traecli", rpc: "session/load"},
+		// Grok refuses to reach session/load without a credential; supply one
+		// through Config so the test does not depend on ambient env.
+		{agentType: "grok", binary: "grok", rpc: "session/load", env: map[string]string{"XAI_API_KEY": "test-only-key"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.agentType, func(t *testing.T) {
+			t.Parallel()
+
+			fakePath := filepath.Join(t.TempDir(), tc.binary)
+			writeTestExecutable(t, fakePath, []byte(fakeACPRejectedResumeScript(tc.rpc)))
+
+			backend, err := New(tc.agentType, Config{ExecutablePath: fakePath, Logger: slog.New(slog.NewTextHandler(io.Discard, nil)), Env: tc.env})
+			if err != nil {
+				t.Fatalf("new %s backend: %v", tc.agentType, err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+				Timeout:         30 * time.Second,
+				ResumeSessionID: "ses_ghost",
+			})
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			go func() {
+				for range session.Messages {
+				}
+			}()
+
+			select {
+			case result, ok := <-session.Result:
+				if !ok {
+					t.Fatal("result channel closed without a value")
+				}
+				if result.Status != "failed" {
+					t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+				}
+				if !result.ResumeRejected {
+					t.Fatalf("expected ResumeRejected=true so the daemon retries from a fresh session, got false (error=%q)", result.Error)
+				}
+			case <-time.After(20 * time.Second):
+				t.Fatal("timeout waiting for result")
+			}
+		})
+	}
+}

--- a/server/pkg/agent/acp_session_test.go
+++ b/server/pkg/agent/acp_session_test.go
@@ -68,6 +68,57 @@ func TestIsACPResumeRejected(t *testing.T) {
 			want: false,
 		},
 		{
+			// The eight below are the shapes a looser adjacency window let
+			// through: ordinary English error prose that happens to put a
+			// verdict word and the word "session" a few tokens apart while
+			// meaning something entirely different. Four are auth or unknown
+			// failures, which Result.ResumeRejected is documented never to
+			// flag; matching any of them forks a live conversation.
+			name: "unknown error while loading session",
+			err:  &acpRPCError{Method: "session/resume", Code: -32603, Message: "unknown error while loading session"},
+			want: false,
+		},
+		{
+			name: "unknown error restoring a named session",
+			err:  &acpRPCError{Method: "session/resume", Code: -32603, Message: "unknown error restoring session ses_abc"},
+			want: false,
+		},
+		{
+			name: "invalid token for session",
+			err:  &acpRPCError{Method: "session/load", Code: -32602, Message: "invalid token for session ses_abc"},
+			want: false,
+		},
+		{
+			name: "invalid credentials for this session",
+			err:  &acpRPCError{Method: "session/load", Code: -32603, Message: "invalid credentials for this session"},
+			want: false,
+		},
+		{
+			name: "sessionid is the wrong type",
+			err:  &acpRPCError{Method: "session/resume", Code: -32602, Message: "Invalid params: sessionId must be a string"},
+			want: false,
+		},
+		{
+			name: "missing cwd reported against a session",
+			err:  &acpRPCError{Method: "session/load", Code: -32603, Message: "cwd does not exist for session ses_abc"},
+			want: false,
+		},
+		{
+			name: "session config option rejected",
+			err:  &acpRPCError{Method: "session/load", Code: -32602, Message: "session config option invalid"},
+			want: false,
+		},
+		{
+			name: "model rejected inside a session",
+			err:  &acpRPCError{Method: "session/resume", Code: -32602, Message: "session ses_abc: model gpt-x invalid"},
+			want: false,
+		},
+		{
+			name: "session id spelled out before the verdict",
+			err:  &acpRPCError{Method: "session/resume", Code: -32602, Message: "session ses_abc does not exist"},
+			want: true,
+		},
+		{
 			name: "provider rate limit during resume",
 			err:  &acpRPCError{Method: "session/resume", Code: -32603, Message: "Internal error", Data: "upstream provider returned HTTP 429"},
 			want: false,
@@ -78,9 +129,24 @@ func TestIsACPResumeRejected(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "session wording under an unrelated code",
-			err:  &acpRPCError{Method: "session/resume", Code: -32601, Message: "Invalid session identifier"},
+			// Captured by hand from qodercli 1.0.20 (`--yolo --acp`, not logged
+			// in): session/resume answers with this before it ever looks the id
+			// up. Proof that this RPC really does surface errors with nothing to
+			// do with the session — under -32000, which IS an accepted
+			// session-error code — so the wording, not the code, has to carry
+			// the decision.
+			name: "qodercli auth gate on session/resume",
+			err:  &acpRPCError{Method: "session/resume", Code: -32000, Message: "Authentication required: Authentication is required."},
 			want: false,
+		},
+		{
+			// Deliberately matches despite an unusual code: gating on the code
+			// set would make this fix miss its own bug if qodercli ever moved
+			// off -32602, and a runtime naming the session unusable has said so
+			// whatever number it attaches.
+			name: "rejection wording under an unusual code still counts",
+			err:  &acpRPCError{Method: "session/resume", Code: -32099, Message: "Invalid session identifier"},
+			want: true,
 		},
 		{
 			name: "plain error is never a rejection",

--- a/server/pkg/agent/dim.go
+++ b/server/pkg/agent/dim.go
@@ -503,8 +503,6 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 		}
 
 		c.sessionID = sessionID
-		// Early session pin so a cancelled run still preserves resume pointer.
-		msgStream.send(Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 		b.cfg.Logger.Info("dim session ready", "session_id", sessionID, "resumed", !freshSession)
 
 		// Dim's ACP server hardcodes a read-only permission preset at session
@@ -532,6 +530,12 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 				closeCtx, closeCancel := context.WithTimeout(context.Background(), dimSessionCloseTimeout)
 				_, _ = c.request(closeCtx, "session/close", map[string]any{"sessionId": sessionID})
 				closeCancel()
+				if opts.ResumeSessionID == "" {
+					// Fresh session, closed just above and never prompted: there is
+					// no transcript behind this id, so publishing it can only pin a
+					// ghost pointer for the next turn to fail on (GH #8116).
+					sessionID = ""
+				}
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), SessionID: sessionID, ResumeRejected: resumeRejected}
 				return
 			}
@@ -551,6 +555,12 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 				closeCtx, closeCancel := context.WithTimeout(context.Background(), dimSessionCloseTimeout)
 				_, _ = c.request(closeCtx, "session/close", map[string]any{"sessionId": sessionID})
 				closeCancel()
+				if opts.ResumeSessionID == "" {
+					// Fresh session, closed just above and never prompted: there is
+					// no transcript behind this id, so publishing it can only pin a
+					// ghost pointer for the next turn to fail on (GH #8116).
+					sessionID = ""
+				}
 				resCh <- Result{
 					Status:         finalStatus,
 					Error:          finalError,
@@ -574,6 +584,16 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 		if opts.SystemPrompt != "" {
 			userText = opts.SystemPrompt + "\n\n---\n\n" + prompt
 		}
+
+		// Session pin for the daemon (PinTaskSession keys off
+		// MessageStatus+SessionID), deliberately sent only once setup has
+		// succeeded and the prompt is about to go out. Pinning right after
+		// session creation used to publish the id before set_model could fail,
+		// and FailAgentTask merges session_id with COALESCE — so a setup failure
+		// could no longer take the id back and left a ghost pointer on the task
+		// row for the next turn to resume forever (GH #8116). A cancel between
+		// here and the prompt response is still covered: this send happens first.
+		msgStream.send(Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 
 		_, err = c.request(runCtx, "session/prompt", map[string]any{
 			"sessionId": sessionID,

--- a/server/pkg/agent/dim.go
+++ b/server/pkg/agent/dim.go
@@ -530,10 +530,8 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 				closeCtx, closeCancel := context.WithTimeout(context.Background(), dimSessionCloseTimeout)
 				_, _ = c.request(closeCtx, "session/close", map[string]any{"sessionId": sessionID})
 				closeCancel()
-				if opts.ResumeSessionID == "" {
-					// Fresh session, closed just above and never prompted: there is
-					// no transcript behind this id, so publishing it can only pin a
-					// ghost pointer for the next turn to fail on (GH #8116).
+				if setupFailureWithholdsSessionID(opts) {
+					// Closed just above, and never prompted either way.
 					sessionID = ""
 				}
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), SessionID: sessionID, ResumeRejected: resumeRejected}
@@ -555,10 +553,8 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 				closeCtx, closeCancel := context.WithTimeout(context.Background(), dimSessionCloseTimeout)
 				_, _ = c.request(closeCtx, "session/close", map[string]any{"sessionId": sessionID})
 				closeCancel()
-				if opts.ResumeSessionID == "" {
-					// Fresh session, closed just above and never prompted: there is
-					// no transcript behind this id, so publishing it can only pin a
-					// ghost pointer for the next turn to fail on (GH #8116).
+				if setupFailureWithholdsSessionID(opts) {
+					// Closed just above, and never prompted either way.
 					sessionID = ""
 				}
 				resCh <- Result{

--- a/server/pkg/agent/dim_test.go
+++ b/server/pkg/agent/dim_test.go
@@ -492,11 +492,21 @@ func TestDimConfigFailClosesSession(t *testing.T) {
 	}
 }
 
-// TestDimConfigFailThenResumeReestablishes verifies the "first setup fails →
-// next run resumes" path (review #4): when the first run's set_config_option
-// fails, session/close is sent; a second run that resumes the same session
-// re-applies set_config_option (fail-closed) and succeeds.
-func TestDimConfigFailThenResumeReestablishes(t *testing.T) {
+// TestDimFreshConfigFailureWithholdsSessionID pins the ghost-pointer contract
+// (GH #8116) on dim's set_config_option branch: a fresh session that died
+// during setup, before any prompt went out, must not be published as a resume
+// pointer.
+//
+// dim is the runtime where this is least obviously necessary and most clearly
+// still right. It closes the session on this path and persists early enough
+// that the id would in fact still load — but there is no conversation behind
+// it, because no prompt was ever sent. Withholding it costs one extra
+// session/new on the next turn; publishing it is a bet that every ACP runtime
+// persists a never-prompted session, and qodercli does not, which is what
+// wedged a conversation forever in the first place. The contract is uniform
+// across backends on purpose: making it per-runtime is how the neighbouring
+// resume bugs got fixed one adapter at a time while the rest stayed broken.
+func TestDimFreshConfigFailureWithholdsSessionID(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	requestsFile := filepath.Join(dir, "requests.jsonl")
@@ -508,7 +518,44 @@ func TestDimConfigFailThenResumeReestablishes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Run A: fresh session, set_config_option fails on the first call.
+	session, err := b.Execute(ctx, "test prompt", ExecOptions{
+		Cwd:     t.TempDir(),
+		Timeout: 20 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	result := <-session.Result
+	if result.Status != "failed" {
+		t.Fatalf("expected status=failed, got %q", result.Status)
+	}
+	if result.SessionID != "" {
+		t.Fatalf("expected the never-prompted session id to be withheld, got %q", result.SessionID)
+	}
+	if result.ResumeRejected {
+		t.Fatal("a fresh session cannot be resume-rejected; the daemon must not re-run this task")
+	}
+}
+
+// TestDimResumeReappliesConfig pins the fail-closed config re-application on
+// resume (review #4): a resumed session re-sends set_config_option instead of
+// trusting whatever state the earlier run left behind. It resumes a session
+// that completed a prompt — the only kind that now carries a resume pointer.
+func TestDimResumeReappliesConfig(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	requestsFile := filepath.Join(dir, "requests.jsonl")
+	b := newDimTestBackend(t, requestsFile)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Run A: a fresh run that reaches session/prompt and completes, so it has
+	// a real conversation to hand forward.
 	sessionA, err := b.Execute(ctx, "test prompt", ExecOptions{
 		Cwd:     t.TempDir(),
 		Timeout: 20 * time.Second,
@@ -521,15 +568,14 @@ func TestDimConfigFailThenResumeReestablishes(t *testing.T) {
 		}
 	}()
 	resultA := <-sessionA.Result
-	if resultA.Status != "failed" {
-		t.Fatalf("run A: expected status=failed, got %q", resultA.Status)
+	if resultA.Status != "completed" {
+		t.Fatalf("run A: expected status=completed, got %q (error=%q)", resultA.Status, resultA.Error)
 	}
 	if resultA.SessionID == "" {
-		t.Fatal("run A: expected a session id despite the config failure")
+		t.Fatal("run A: a completed run must publish its session id")
 	}
 
-	// Run B: resume the same session. set_config_option should succeed this
-	// time (DIM_CONFIG_FAIL_ONCE only fails once) and the run should complete.
+	// Run B: resume it.
 	sessionB, err := b.Execute(ctx, "test prompt", ExecOptions{
 		Cwd:             t.TempDir(),
 		Timeout:         20 * time.Second,
@@ -547,19 +593,17 @@ func TestDimConfigFailThenResumeReestablishes(t *testing.T) {
 		t.Fatalf("run B: expected status=completed, got %q (error=%q)", resultB.Status, resultB.Error)
 	}
 	if resultB.ResumeRejected {
-		t.Fatal("run B: ResumeRejected should be false — the session was loadable after session/close")
+		t.Fatal("run B: ResumeRejected should be false — the session was loadable")
 	}
 
-	// Verify run B re-applied set_config_option (fail-closed on resume).
 	reqs := readDimRequests(t, requestsFile)
 	if !strings.Contains(reqs, "session/load") {
 		t.Fatal("run B: expected session/load")
 	}
-	// set_config_option should appear at least 3 times: 1 failed in run A,
-	// 2 successful in run B (permission + mode).
-	count := strings.Count(reqs, "set_config_option")
-	if count < 3 {
-		t.Fatalf("expected at least 3 set_config_option calls (1 fail + 2 re-apply on resume), got %d", count)
+	// set_config_option should appear at least 4 times: 2 in run A and 2
+	// re-applied in run B (permission + mode).
+	if count := strings.Count(reqs, "set_config_option"); count < 4 {
+		t.Fatalf("expected at least 4 set_config_option calls (2 fresh + 2 re-applied on resume), got %d", count)
 	}
 }
 

--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -330,9 +330,13 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				"mcpServers": mcpServers,
 			})
 			if err != nil {
-				finalStatus = "failed"
-				finalError = fmt.Sprintf("grok session/load failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				// A runtime that refuses the recorded id has to say so here:
+				// without ResumeRejected the daemon reads the bare failure as
+				// "checked, not a rejection", keeps the pointer and replays the
+				// same dead session on every later turn (GH #8116).
+				finalStatus, finalError, resumeRejected = classifyACPResumeFailure(
+					runCtx, "grok", "session/load", err, timeout, b.cfg.Logger)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			var changed bool
@@ -371,8 +375,6 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		}
 
 		c.sessionID = sessionID
-		// Early session pin so a cancelled run still preserves resume pointer.
-		msgStream.send(Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 		b.cfg.Logger.Info("grok session created", "session_id", sessionID)
 
 		if opts.Model != "" {
@@ -383,7 +385,16 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				b.cfg.Logger.Warn("grok set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("grok could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if opts.ResumeSessionID == "" {
+					// A fresh session that never reached session/prompt has no
+					// conversation worth resuming, and the runtime may never have
+					// persisted it at all — qodercli exits without writing one.
+					// Publishing its id can only pin a ghost pointer that every
+					// later turn then fails to resume (GH #8116), so withhold it.
+					// Nothing is lost: there is no transcript behind an id that
+					// never ran a prompt.
+					sessionID = ""
+				} else if isACPSessionNotFound(err) {
 					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",
 						"backend", "grok",
 						"session_id", sessionID,
@@ -409,6 +420,16 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			// Multica runtime brief delivery when file injection is not enough.
 			userText = opts.SystemPrompt + "\n\n---\n\n" + prompt
 		}
+
+		// Session pin for the daemon (PinTaskSession keys off
+		// MessageStatus+SessionID), deliberately sent only once setup has
+		// succeeded and the prompt is about to go out. Pinning right after
+		// session creation used to publish the id before set_model could fail,
+		// and FailAgentTask merges session_id with COALESCE — so a setup failure
+		// could no longer take the id back and left a ghost pointer on the task
+		// row for the next turn to resume forever (GH #8116). A cancel between
+		// here and the prompt response is still covered: this send happens first.
+		msgStream.send(Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 
 		streamingCurrentTurn.Store(true)
 		_, err = c.request(runCtx, "session/prompt", map[string]any{

--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -385,14 +385,7 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				b.cfg.Logger.Warn("grok set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("grok could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID == "" {
-					// A fresh session that never reached session/prompt has no
-					// conversation worth resuming, and the runtime may never have
-					// persisted it at all — qodercli exits without writing one.
-					// Publishing its id can only pin a ghost pointer that every
-					// later turn then fails to resume (GH #8116), so withhold it.
-					// Nothing is lost: there is no transcript behind an id that
-					// never ran a prompt.
+				if setupFailureWithholdsSessionID(opts) {
 					sessionID = ""
 				} else if isACPSessionNotFound(err) {
 					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -1413,7 +1413,13 @@ func isACPSessionNotFound(err error) bool {
 	if !isACPSessionErrorCode(rpcErr.Code) {
 		return false
 	}
-	text := strings.ToLower(rpcErr.Message + " " + rpcErr.Data)
+	return acpSessionNotFoundWording(strings.ToLower(rpcErr.Message + " " + rpcErr.Data))
+}
+
+// acpSessionNotFoundWording is the wording half of isACPSessionNotFound, split
+// out so isACPResumeRejected can run it over text it has already scrubbed of
+// request-shaped complaints. Callers pass lower-cased Message+Data.
+func acpSessionNotFoundWording(text string) bool {
 	return strings.Contains(text, "session not found") ||
 		strings.Contains(text, "no session found") ||
 		strings.Contains(text, "unknown session")

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -600,14 +600,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				b.cfg.Logger.Warn("hermes set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("hermes could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID == "" {
-					// A fresh session that never reached session/prompt has no
-					// conversation worth resuming, and the runtime may never have
-					// persisted it at all — qodercli exits without writing one.
-					// Publishing its id can only pin a ghost pointer that every
-					// later turn then fails to resume (GH #8116), so withhold it.
-					// Nothing is lost: there is no transcript behind an id that
-					// never ran a prompt.
+				if setupFailureWithholdsSessionID(opts) {
 					sessionID = ""
 				} else if isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead
@@ -1391,6 +1384,14 @@ func (e *acpRPCError) Error() string {
 	return fmt.Sprintf("%s: %s (code=%d)", e.Method, e.Message, e.Code)
 }
 
+// isACPSessionErrorCode reports whether a JSON-RPC error code is one the ACP
+// runtimes have been observed to report a lost session under. It is a guard,
+// not the decision: -32000 and -32603 are generic, so the wording checks in
+// isACPSessionNotFound / isACPResumeRejected are what actually discriminate.
+func isACPSessionErrorCode(code int) bool {
+	return code == -32603 || code == -32602 || code == -32002 || code == -32000
+}
+
 // isACPSessionNotFound reports whether err is the agent rejecting a
 // session id it no longer knows. Runtimes signal this with codes and
 // wording that vary — Hermes says "Session not found" under -32603
@@ -1404,14 +1405,6 @@ func (e *acpRPCError) Error() string {
 // wording is discriminating and all of them are matched. The wording check
 // still carries the decision: -32000 is a generic server-error code, and a
 // transient failure reported under it must not read as a lost session.
-// isACPSessionErrorCode reports whether a JSON-RPC error code is one the ACP
-// runtimes have been observed to report a lost session under. It is a guard,
-// not the decision: -32000 and -32603 are generic, so the wording checks in
-// isACPSessionNotFound / isACPResumeRejected are what actually discriminate.
-func isACPSessionErrorCode(code int) bool {
-	return code == -32603 || code == -32602 || code == -32002 || code == -32000
-}
-
 func isACPSessionNotFound(err error) bool {
 	var rpcErr *acpRPCError
 	if !errors.As(err, &rpcErr) {

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -513,9 +513,13 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				"mcpServers": mcpServers,
 			})
 			if err != nil {
-				finalStatus = "failed"
-				finalError = fmt.Sprintf("hermes session/resume failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				// A runtime that refuses the recorded id has to say so here:
+				// without ResumeRejected the daemon reads the bare failure as
+				// "checked, not a rejection", keeps the pointer and replays the
+				// same dead session on every later turn (GH #8116).
+				finalStatus, finalError, resumeRejected = classifyACPResumeFailure(
+					runCtx, "hermes", "session/resume", err, timeout, b.cfg.Logger)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			sessionResult = result
@@ -555,9 +559,6 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 		c.sessionID = sessionID
 		b.cfg.Logger.Info("hermes session created", "session_id", sessionID)
-		// Mid-flight pin: daemon PinTaskSession keys off MessageStatus+SessionID.
-		trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
-
 		// 3. If the caller picked a model (via agent.model from the
 		// UI dropdown), ask hermes to switch the session to it
 		// before we send any prompt. Hermes' _build_model_state
@@ -599,7 +600,16 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				b.cfg.Logger.Warn("hermes set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("hermes could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if opts.ResumeSessionID == "" {
+					// A fresh session that never reached session/prompt has no
+					// conversation worth resuming, and the runtime may never have
+					// persisted it at all — qodercli exits without writing one.
+					// Publishing its id can only pin a ghost pointer that every
+					// later turn then fails to resume (GH #8116), so withhold it.
+					// Nothing is lost: there is no transcript behind an id that
+					// never ran a prompt.
+					sessionID = ""
+				} else if isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead
 					// session surfaces here instead of at session/prompt.
 					// Same fix as the prompt path below: clear the id so
@@ -646,6 +656,16 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// just before the request so any history replay flushed during
 		// initialize / session setup stays dropped, but every notification
 		// belonging to this turn is processed.
+		// Session pin for the daemon (PinTaskSession keys off
+		// MessageStatus+SessionID), deliberately sent only once setup has
+		// succeeded and the prompt is about to go out. Pinning right after
+		// session creation used to publish the id before set_model could fail,
+		// and FailAgentTask merges session_id with COALESCE — so a setup failure
+		// could no longer take the id back and left a ghost pointer on the task
+		// row for the next turn to resume forever (GH #8116). A cancel between
+		// here and the prompt response is still covered: this send happens first.
+		trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
+
 		streamingCurrentTurn.Store(true)
 		_, err = c.request(runCtx, "session/prompt", map[string]any{
 			"sessionId": sessionID,
@@ -1384,12 +1404,20 @@ func (e *acpRPCError) Error() string {
 // wording is discriminating and all of them are matched. The wording check
 // still carries the decision: -32000 is a generic server-error code, and a
 // transient failure reported under it must not read as a lost session.
+// isACPSessionErrorCode reports whether a JSON-RPC error code is one the ACP
+// runtimes have been observed to report a lost session under. It is a guard,
+// not the decision: -32000 and -32603 are generic, so the wording checks in
+// isACPSessionNotFound / isACPResumeRejected are what actually discriminate.
+func isACPSessionErrorCode(code int) bool {
+	return code == -32603 || code == -32602 || code == -32002 || code == -32000
+}
+
 func isACPSessionNotFound(err error) bool {
 	var rpcErr *acpRPCError
 	if !errors.As(err, &rpcErr) {
 		return false
 	}
-	if rpcErr.Code != -32603 && rpcErr.Code != -32602 && rpcErr.Code != -32002 && rpcErr.Code != -32000 {
+	if !isACPSessionErrorCode(rpcErr.Code) {
 		return false
 	}
 	text := strings.ToLower(rpcErr.Message + " " + rpcErr.Data)

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -258,9 +258,13 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				"mcpServers": mcpServers,
 			})
 			if err != nil {
-				finalStatus = "failed"
-				finalError = fmt.Sprintf("kimi session/resume failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				// A runtime that refuses the recorded id has to say so here:
+				// without ResumeRejected the daemon reads the bare failure as
+				// "checked, not a rejection", keeps the pointer and replays the
+				// same dead session on every later turn (GH #8116).
+				finalStatus, finalError, resumeRejected = classifyACPResumeFailure(
+					runCtx, "kimi", "session/resume", err, timeout, b.cfg.Logger)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			var changed bool
@@ -313,7 +317,16 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				b.cfg.Logger.Warn("kimi set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kimi could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if opts.ResumeSessionID == "" {
+					// A fresh session that never reached session/prompt has no
+					// conversation worth resuming, and the runtime may never have
+					// persisted it at all — qodercli exits without writing one.
+					// Publishing its id can only pin a ghost pointer that every
+					// later turn then fails to resume (GH #8116), so withhold it.
+					// Nothing is lost: there is no transcript behind an id that
+					// never ran a prompt.
+					sessionID = ""
+				} else if isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead
 					// session surfaces here instead of at session/prompt.
 					// Same fix as the prompt path below: clear the id so

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -317,14 +317,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				b.cfg.Logger.Warn("kimi set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kimi could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID == "" {
-					// A fresh session that never reached session/prompt has no
-					// conversation worth resuming, and the runtime may never have
-					// persisted it at all — qodercli exits without writing one.
-					// Publishing its id can only pin a ghost pointer that every
-					// later turn then fails to resume (GH #8116), so withhold it.
-					// Nothing is lost: there is no transcript behind an id that
-					// never ran a prompt.
+				if setupFailureWithholdsSessionID(opts) {
 					sessionID = ""
 				} else if isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -135,8 +135,13 @@ func TestKimiBackendSetModelFailureFailsTask(t *testing.T) {
 		if !strings.Contains(result.Error, "model not available") {
 			t.Errorf("expected error to surface upstream message, got %q", result.Error)
 		}
-		if result.SessionID != "ses_fake" {
-			t.Errorf("expected session id to be preserved on failure, got %q", result.SessionID)
+		// A fresh session that never reached session/prompt must NOT be
+		// published as a resume pointer: the runtime may never have persisted
+		// it, and a pointer to a session that does not exist wedges the whole
+		// conversation forever (GH #8116). There is no transcript behind an id
+		// that never ran a prompt, so nothing is lost by withholding it.
+		if result.SessionID != "" {
+			t.Errorf("expected the never-prompted session id to be withheld, got %q", result.SessionID)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -331,14 +331,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				b.cfg.Logger.Warn("kiro set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kiro could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID == "" {
-					// A fresh session that never reached session/prompt has no
-					// conversation worth resuming, and the runtime may never have
-					// persisted it at all — qodercli exits without writing one.
-					// Publishing its id can only pin a ghost pointer that every
-					// later turn then fails to resume (GH #8116), so withhold it.
-					// Nothing is lost: there is no transcript behind an id that
-					// never ran a prompt.
+				if setupFailureWithholdsSessionID(opts) {
 					sessionID = ""
 				} else if isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -268,9 +268,13 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				"mcpServers": mcpServers,
 			})
 			if err != nil {
-				finalStatus = "failed"
-				finalError = fmt.Sprintf("kiro session/load failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				// A runtime that refuses the recorded id has to say so here:
+				// without ResumeRejected the daemon reads the bare failure as
+				// "checked, not a rejection", keeps the pointer and replays the
+				// same dead session on every later turn (GH #8116).
+				finalStatus, finalError, resumeRejected = classifyACPResumeFailure(
+					runCtx, "kiro", "session/load", err, timeout, b.cfg.Logger)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			// Apply the same defensive resolution kimi/hermes use: if
@@ -327,7 +331,16 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				b.cfg.Logger.Warn("kiro set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kiro could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if opts.ResumeSessionID == "" {
+					// A fresh session that never reached session/prompt has no
+					// conversation worth resuming, and the runtime may never have
+					// persisted it at all — qodercli exits without writing one.
+					// Publishing its id can only pin a ghost pointer that every
+					// later turn then fails to resume (GH #8116), so withhold it.
+					// Nothing is lost: there is no transcript behind an id that
+					// never ran a prompt.
+					sessionID = ""
+				} else if isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead
 					// session surfaces here instead of at session/prompt.
 					// Same fix as the prompt path below: clear the id so

--- a/server/pkg/agent/kiro_test.go
+++ b/server/pkg/agent/kiro_test.go
@@ -147,8 +147,13 @@ func TestKiroBackendSetModelFailureFailsTask(t *testing.T) {
 		if !strings.Contains(result.Error, "model not available") {
 			t.Errorf("expected error to surface upstream message, got %q", result.Error)
 		}
-		if result.SessionID != "ses_new" {
-			t.Errorf("expected session id to be preserved on failure, got %q", result.SessionID)
+		// A fresh session that never reached session/prompt must NOT be
+		// published as a resume pointer: the runtime may never have persisted
+		// it, and a pointer to a session that does not exist wedges the whole
+		// conversation forever (GH #8116). There is no transcript behind an id
+		// that never ran a prompt, so nothing is lost by withholding it.
+		if result.SessionID != "" {
+			t.Errorf("expected the never-prompted session id to be withheld, got %q", result.SessionID)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -314,14 +314,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				b.cfg.Logger.Warn("qoder set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("qoder could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID == "" {
-					// A fresh session that never reached session/prompt has no
-					// conversation worth resuming, and the runtime may never have
-					// persisted it at all — qodercli exits without writing one.
-					// Publishing its id can only pin a ghost pointer that every
-					// later turn then fails to resume (GH #8116), so withhold it.
-					// Nothing is lost: there is no transcript behind an id that
-					// never ran a prompt.
+				if setupFailureWithholdsSessionID(opts) {
 					sessionID = ""
 				} else if isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -259,9 +259,13 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				"mcpServers": mcpServers,
 			})
 			if err != nil {
-				finalStatus = "failed"
-				finalError = fmt.Sprintf("qoder session/resume failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				// A runtime that refuses the recorded id has to say so here:
+				// without ResumeRejected the daemon reads the bare failure as
+				// "checked, not a rejection", keeps the pointer and replays the
+				// same dead session on every later turn (GH #8116).
+				finalStatus, finalError, resumeRejected = classifyACPResumeFailure(
+					runCtx, "qoder", "session/resume", err, timeout, b.cfg.Logger)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			var changed bool
@@ -310,7 +314,16 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				b.cfg.Logger.Warn("qoder set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("qoder could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if opts.ResumeSessionID == "" {
+					// A fresh session that never reached session/prompt has no
+					// conversation worth resuming, and the runtime may never have
+					// persisted it at all — qodercli exits without writing one.
+					// Publishing its id can only pin a ghost pointer that every
+					// later turn then fails to resume (GH #8116), so withhold it.
+					// Nothing is lost: there is no transcript behind an id that
+					// never ran a prompt.
+					sessionID = ""
+				} else if isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead
 					// session surfaces here instead of at session/prompt.
 					// Clear the id so the daemon's resume-failure fallback

--- a/server/pkg/agent/qoder_test.go
+++ b/server/pkg/agent/qoder_test.go
@@ -310,8 +310,13 @@ func TestQoderBackendSetModelFailureFailsTask(t *testing.T) {
 		if !strings.Contains(result.Error, "model not available") {
 			t.Errorf("expected error to surface upstream message, got %q", result.Error)
 		}
-		if result.SessionID != "ses_fake" {
-			t.Errorf("expected session id to be preserved on failure, got %q", result.SessionID)
+		// A fresh session that never reached session/prompt must NOT be
+		// published as a resume pointer: the runtime may never have persisted
+		// it, and a pointer to a session that does not exist wedges the whole
+		// conversation forever (GH #8116). There is no transcript behind an id
+		// that never ran a prompt, so nothing is lost by withholding it.
+		if result.SessionID != "" {
+			t.Errorf("expected the never-prompted session id to be withheld, got %q", result.SessionID)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")

--- a/server/pkg/agent/reasonix.go
+++ b/server/pkg/agent/reasonix.go
@@ -356,14 +356,7 @@ func (b *reasonixBackend) Execute(ctx context.Context, prompt string, opts ExecO
 			}); err != nil {
 				b.cfg.Logger.Warn("reasonix set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus, finalError = reasonixRequestFailure(runCtx, timeout, fmt.Sprintf("reasonix could not switch to model %q: %v", opts.Model, err))
-				if opts.ResumeSessionID == "" {
-					// A fresh session that never reached session/prompt has no
-					// conversation worth resuming, and the runtime may never have
-					// persisted it at all — qodercli exits without writing one.
-					// Publishing its id can only pin a ghost pointer that every
-					// later turn then fails to resume (GH #8116), so withhold it.
-					// Nothing is lost: there is no transcript behind an id that
-					// never ran a prompt.
+				if setupFailureWithholdsSessionID(opts) {
 					sessionID = ""
 				} else if finalStatus == "failed" && isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead

--- a/server/pkg/agent/reasonix.go
+++ b/server/pkg/agent/reasonix.go
@@ -356,7 +356,16 @@ func (b *reasonixBackend) Execute(ctx context.Context, prompt string, opts ExecO
 			}); err != nil {
 				b.cfg.Logger.Warn("reasonix set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus, finalError = reasonixRequestFailure(runCtx, timeout, fmt.Sprintf("reasonix could not switch to model %q: %v", opts.Model, err))
-				if finalStatus == "failed" && opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if opts.ResumeSessionID == "" {
+					// A fresh session that never reached session/prompt has no
+					// conversation worth resuming, and the runtime may never have
+					// persisted it at all — qodercli exits without writing one.
+					// Publishing its id can only pin a ghost pointer that every
+					// later turn then fails to resume (GH #8116), so withhold it.
+					// Nothing is lost: there is no transcript behind an id that
+					// never ran a prompt.
+					sessionID = ""
+				} else if finalStatus == "failed" && isACPSessionNotFound(err) {
 					// On a resumed session with a model override, the dead
 					// session surfaces here instead of at session/prompt.
 					// Same fix as the prompt path below: clear the id so

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -272,9 +272,13 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 				"mcpServers": mcpServers,
 			})
 			if err != nil {
-				finalStatus = "failed"
-				finalError = fmt.Sprintf("traecli session/load failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				// A runtime that refuses the recorded id has to say so here:
+				// without ResumeRejected the daemon reads the bare failure as
+				// "checked, not a rejection", keeps the pointer and replays the
+				// same dead session on every later turn (GH #8116).
+				finalStatus, finalError, resumeRejected = classifyACPResumeFailure(
+					runCtx, "traecli", "session/load", err, timeout, b.cfg.Logger)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), ResumeRejected: resumeRejected}
 				return
 			}
 			var changed bool
@@ -323,7 +327,16 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 				b.cfg.Logger.Warn("traecli set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("traecli could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if opts.ResumeSessionID == "" {
+					// A fresh session that never reached session/prompt has no
+					// conversation worth resuming, and the runtime may never have
+					// persisted it at all — qodercli exits without writing one.
+					// Publishing its id can only pin a ghost pointer that every
+					// later turn then fails to resume (GH #8116), so withhold it.
+					// Nothing is lost: there is no transcript behind an id that
+					// never ran a prompt.
+					sessionID = ""
+				} else if isACPSessionNotFound(err) {
 					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",
 						"backend", "traecli",
 						"session_id", sessionID,

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -327,14 +327,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 				b.cfg.Logger.Warn("traecli set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("traecli could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID == "" {
-					// A fresh session that never reached session/prompt has no
-					// conversation worth resuming, and the runtime may never have
-					// persisted it at all — qodercli exits without writing one.
-					// Publishing its id can only pin a ghost pointer that every
-					// later turn then fails to resume (GH #8116), so withhold it.
-					// Nothing is lost: there is no transcript behind an id that
-					// never ran a prompt.
+				if setupFailureWithholdsSessionID(opts) {
 					sessionID = ""
 				} else if isACPSessionNotFound(err) {
 					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",


### PR DESCRIPTION
Fixes #8116

## Problem

One early failure could kill a chat conversation permanently. The daemon pinned a backend session id from a run that died during setup, and every later message then failed resuming an id the CLI had never persisted. Correcting the model config did not help — the run died at `session/resume`, before any model handling — so the only escape was abandoning the conversation and losing its context.

Two independent defects had to line up. Both are fixed here, because either one alone leaves a hole:

| | Defect | Backends |
|---|---|---|
| **A** | A fresh session's id is published as a resume pointer even though setup failed before any prompt | qoder, kiro, grok, hermes, kimi, traecli, reasonix, dim (**8**) |
| **B** | `session/resume` / `session/load` failures return a bare failed `Result`, never calling the rejection classifier | qoder, hermes, kimi, kiro, traecli, grok (**6**) |

**A** plants the dead pointer; **B** decides whether it is a permanent wedge or one wasted attempt. The six backends with both are the ones that stick forever. dim and reasonix already flagged rejections, so for them A only cost a wasted attempt and a silently forked conversation.

Worth stating plainly, because it widens the blast radius well past the reported repro: those six never call the classifier on the resume path at all, so the trigger is not "an invalid model on the first turn". **Any** permanent resume failure wedges the conversation — a CLI that garbage-collects old sessions, a deleted workdir, a re-provisioned runtime. A ghost pointer is just the repro that reproduces it on demand.

## Fix

### 1. Do not publish a session id that has no conversation behind it

The existing clear was gated on `opts.ResumeSessionID != ""`, so it only ever covered resumes and fresh sessions went unprotected. A session that never reached `session/prompt` has no transcript to resume, so withholding its id costs one extra `session/new` on the next turn, while publishing one the runtime never persisted wedges the conversation. dim is the sharpest case: it closed the session first and published the id anyway.

`hermes`, `grok` and `dim` also pinned the id to the task row via a mid-flight `MessageStatus` **before** `set_model` ran. `FailAgentTask` merges `session_id` with `COALESCE`, so a later empty id cannot take that back — the withholding above is inert for those three unless the pin moves. It now goes out once setup has succeeded, immediately before `session/prompt`; a cancel between there and the prompt response is still covered, because the send happens first.

### 2. Report rejected resumes so the recovery that already exists can fire

`shouldRetryWithFreshSession` acts only on positive evidence, and these six are not in `ResumeRejectionUndetectable` — so their false `ResumeRejected` read as *"checked, and this was not a rejection"*. No fresh-session retry, no retired pointer, same dead id replayed next turn. They now share `classifyACPResumeFailure`.

That helper checks cancellation and timeout **first**, which is load-bearing: `ResumeRejected` licenses the daemon to abandon the recorded conversation and re-run the whole task, which is the opposite of what a user who just hit cancel asked for. When a real rejection races a cancel, reading it as a cancel is the recoverable mistake — the pointer survives and the next turn self-heals. As a side effect these six now report `timeout`/`aborted` on the resume path instead of flattening everything to `failed`.

### 3. Widen the vocabulary at the resume boundary — without inverting the default

`isACPResumeRejected` accepts a runtime naming the session unusable, which is what qodercli's `Invalid session identifier <id>` needed. Adding that one literal to `isACPSessionNotFound` would have fixed the report; it would also be the fourth time this class of bug is fixed one phrase at a time.

It stays **positive evidence**, not "any error from `session/resume`". That RPC carries `mcpServers`, so an unreachable MCP server fails it, and so do a handshake crash, an expired credential and a missing cwd — none cured by starting over, and discarding the pointer there forks a healthy conversation.

Narrowness comes from where the two halves sit, and the bar is tight on purpose: verdict-first requires the session noun **immediately** after the verdict (`invalid session`, `unknown session`); noun-first allows only an `id`/`identifier` word and one id-shaped token in between (`session ses_abc does not exist`). A looser window is not a detail — ordinary error prose puts the same two halves a few words apart while meaning something entirely different (`unknown error while loading session`, `invalid token for session abc`, `invalid credentials for this session`, `cwd does not exist for session abc`). Four of those are auth or unknown failures that `Result.ResumeRejected` is documented never to flag. Eight such inputs are pinned as negatives.

There is deliberately **no error-code gate** on this predicate, unlike `isACPSessionNotFound`. The reported qodercli frame is `-32602`, inside the accepted set, but that rests on the reporter's capture and cannot be re-derived: a qodercli without a login answers `session/resume` with an auth error long before it looks the id up. Hand-driving qodercli 1.0.20 (`--yolo --acp`) returns:

```
{"jsonrpc":"2.0","id":2,"error":{"code":-32000,"message":"Authentication required: Authentication is required."}}
```

Gating on the code would make this fix miss its own bug if any runtime picks a code outside the set, and the code discriminates nothing the wording does not. That captured frame is now a test case in both directions: it is a real non-session error arriving under an **accepted** code, so the wording has to carry the decision regardless.

The widening is confined to the resume boundary. `set_model` and `prompt` keep `isACPSessionNotFound` unchanged, code gate included, because there the same words can be about the model, the provider or the network.

## Deliberate behaviour change

A fresh setup-stage failure no longer reports a session id. Three `set_model` tests and dim's config-failure resume test asserted the old contract and are updated. dim's real coverage — fail-closed config re-application on resume — is preserved, now driven from a run that actually completed a prompt.

dim would have been defensible to exempt: it persists early enough that the id does still load. It is included anyway. The value of resuming a never-prompted session is nil, the cost when a runtime does *not* persist it is a dead conversation, and making the contract per-runtime is precisely how the neighbouring resume bugs got fixed for Kiro, then Kimi, then Anthropic while everyone else stayed broken.

## What this does not do

No server-side change. The daemon's in-turn retry already retires the pointer through `retiredSessionID`, which also excludes the poisoned first-turn row from the `GetLastChatTaskSession` fallback — so **existing wedged conversations recover on their first message after the daemon upgrade**, with no backfill and no user action. A server-side text guard would only serve a server-upgraded/daemon-not-upgraded window, and on this path it has nothing to match on: the resume-failure turn carries no session id in either the `Result` or the task row.

Two follow-ups worth their own issues, both product-facing: the automatic fresh session silently drops context with no notice to the user and no explicit "reset this conversation" escape hatch, and raw ACP errors — local absolute paths included — are written verbatim into the chat as the assistant's reply.

## Tests

- `TestIsACPResumeRejected` — the qodercli frame, the wordings already covered, and the negatives that matter: an unreachable MCP server whose `data` echoes the session id, a 429 during resume, an auth failure, a session phrase under an unrelated code.
- `TestClassifyACPResumeFailureCancelAndTimeoutAreNotRejections` — cancel and deadline never set the flag; a live context still reports the rejection; a non-rejection keeps the pointer.
- `TestACPBackendsReportRejectedResume` — end to end across all six, both RPCs, driving each real backend against a fake ACP runtime that rejects the resume. Table-driven on purpose: these were six copies of one bug.
- `TestShouldRetryWithFreshSession` — the incident end to end, plus its negative (an unflagged resume failure must not retry).
- Updated: three `set_model` tests now assert the id is withheld; dim splits into `TestDimFreshConfigFailureWithholdsSessionID` and `TestDimResumeReappliesConfig`.

Verified on this branch: `go build ./...`, `go vet`, and the full `pkg/agent` suite pass. The seven `internal/daemon` failures in my sandbox are pre-existing on `main` — they depend on a clean `~/.multica` profile — confirmed by re-running them on a clean tree.

## Relationship to #8128

#8128 reports the same bug and lands on a compatible diagnosis. The differences: this covers all eight backends for the ghost write rather than qoder alone, moves the three early pins that would otherwise make that withholding inert, widens the resume predicate by shape instead of adding one literal, and splits cancel/timeout out of the resume path. It deliberately skips the server-side guard, for the reason above. Happy to fold this into that PR instead if the maintainers prefer to keep the reporter's branch as the base.

