### PR TITLE
fix(issue metadata): preserve structured JSON values

### DIFF
--- a/server/cmd/multica/cmd_issue_metadata.go
+++ b/server/cmd/multica/cmd_issue_metadata.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -26,7 +27,7 @@ func buildMetadataFilterQueryParam(pairs []string) (string, error) {
 	if len(pairs) == 0 {
 		return "", nil
 	}
-	out := make(map[string]any, len(pairs))
+	out := make(map[string]json.RawMessage, len(pairs))
 	for _, pair := range pairs {
 		idx := strings.IndexByte(pair, '=')
 		if idx <= 0 {
@@ -41,11 +42,7 @@ func buildMetadataFilterQueryParam(pairs []string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("--metadata %s: %w", key, err)
 		}
-		var v any
-		if err := json.Unmarshal(encoded, &v); err != nil {
-			return "", fmt.Errorf("--metadata %s: encode value: %w", key, err)
-		}
-		out[key] = v
+		out[key] = encoded
 	}
 	buf, err := json.Marshal(out)
 	if err != nil {
@@ -56,7 +53,7 @@ func buildMetadataFilterQueryParam(pairs []string) (string, error) {
 
 // multica issue metadata {list|get|set|delete} — KV map attached to each issue
 // for agent pipeline state. See server/internal/handler/issue_metadata.go for
-// the constraints (key regex, 50-key cap, primitive-only values, 8KB blob).
+// the constraints (key regex, 50-key cap, non-null JSON values, 8KB blob).
 
 var issueMetadataCmd = &cobra.Command{
 	Use:   "metadata",
@@ -83,9 +80,12 @@ var issueMetadataSetCmd = &cobra.Command{
 	Long: `Set a single metadata key value. The value is JSON-parsed by default:
   --value true / --value false  → bool
   --value 3 / --value 3.14      → number
+  --value '["web","desktop"]' → array
+  --value '{"ready":true}'      → object
   --value waiting               → string
 Use --type to force a specific type. Quote like '"42"' (JSON-escaped) to force
-a string when the bare value would otherwise sniff as a number or bool.`,
+a string when the bare value would otherwise parse as JSON. Null is not allowed;
+use metadata delete to remove a key.`,
 	Args: exactArgs(1),
 	RunE: runIssueMetadataSet,
 }
@@ -117,10 +117,10 @@ func init() {
 }
 
 // parseMetadataValue converts a CLI --value flag (and optional --type) into
-// the JSON-encoded payload sent to the server. Default sniffing: if the
-// raw text parses as a JSON bool / number / string, that type is used; any
-// other JSON shape (null, array, object) is rejected even under default
-// because the server would reject it too.
+// the JSON-encoded payload sent to the server. If the raw text is valid
+// non-null JSON, its type and spelling are preserved; otherwise it is encoded
+// as a literal string. Null is reserved for absence, and callers must use
+// metadata delete to remove a key.
 //
 // forcedType non-empty overrides sniffing: "string" wraps verbatim as a
 // JSON string; "number" parses strictly as a number; "bool" requires the
@@ -149,13 +149,14 @@ func parseMetadataValue(raw, forcedType string) (json.RawMessage, error) {
 		return nil, fmt.Errorf("unknown --type %q (expected string, number, or bool)", forcedType)
 	}
 
-	// Auto-infer: try JSON parse, fall back to string.
-	var v any
-	if err := json.Unmarshal([]byte(raw), &v); err == nil {
-		switch v.(type) {
-		case string, bool, float64:
-			return json.RawMessage(raw), nil
+	// Preserve valid JSON verbatim instead of decoding numbers through
+	// float64, which could lose precision before PostgreSQL receives them.
+	encoded := []byte(raw)
+	if json.Valid(encoded) {
+		if string(bytes.TrimSpace(encoded)) == "null" {
+			return nil, errors.New("value cannot be null (use metadata delete to remove a key)")
 		}
+		return json.RawMessage(encoded), nil
 	}
 	buf, err := json.Marshal(raw)
 	if err != nil {
@@ -377,6 +378,10 @@ func metadataValueType(v any) string {
 		return "bool"
 	case float64:
 		return "number"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
 	default:
 		return "unknown"
 	}

--- a/server/cmd/multica/cmd_issue_metadata_test.go
+++ b/server/cmd/multica/cmd_issue_metadata_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -60,6 +61,167 @@ func newIssueMetadataDeleteTestCmd() *cobra.Command {
 	return c
 }
 
+func TestParseMetadataValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		forcedType string
+		want       string
+		wantErr    bool
+	}{
+		{name: "nested array", raw: `["frontend",{"release":{"ready":true}}]`, want: `["frontend",{"release":{"ready":true}}]`},
+		{name: "nested object", raw: `{"workstreams":[],"qa":{"passed":true}}`, want: `{"workstreams":[],"qa":{"passed":true}}`},
+		{name: "empty array", raw: `[]`, want: `[]`},
+		{name: "empty object", raw: `{}`, want: `{}`},
+		{name: "invalid JSON remains string", raw: `{"broken":`, want: `"{\"broken\":"`},
+		{name: "bare string remains string", raw: `waiting`, want: `"waiting"`},
+		{name: "bool", raw: `true`, want: `true`},
+		{name: "number preserves spelling", raw: `9007199254740993`, want: `9007199254740993`},
+		{name: "forced JSON-looking string", raw: `{"nested":true}`, forcedType: "string", want: `"{\"nested\":true}"`},
+		{name: "forced null-looking string", raw: `null`, forcedType: "string", want: `"null"`},
+		{name: "null rejected", raw: `null`, wantErr: true},
+		{name: "whitespace null rejected", raw: " \n null\t", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMetadataValue(tt.raw, tt.forcedType)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseMetadataValue(%q, %q) returned %s, want error", tt.raw, tt.forcedType, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMetadataValue(%q, %q): %v", tt.raw, tt.forcedType, err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("parseMetadataValue(%q, %q) = %s, want %s", tt.raw, tt.forcedType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildMetadataFilterQueryParamPreservesStructuredValuesAndNumbers(t *testing.T) {
+	got, err := buildMetadataFilterQueryParam([]string{
+		`workstreams=["frontend",{"release":{"ready":true}}]`,
+		`sequence=9007199254740993`,
+	})
+	if err != nil {
+		t.Fatalf("buildMetadataFilterQueryParam: %v", err)
+	}
+	want := `{"sequence":9007199254740993,"workstreams":["frontend",{"release":{"ready":true}}]}`
+	if got != want {
+		t.Fatalf("filter = %s, want %s", got, want)
+	}
+}
+
+func TestRunIssueMetadataRoundTripsStructuredAndForcedStringValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      string
+		forcedType string
+		wantRaw    string
+		wantValue  any
+	}{
+		{
+			name:      "structured",
+			value:     `{"checks":[],"summary":{"passed":true}}`,
+			wantRaw:   `{"checks":[],"summary":{"passed":true}}`,
+			wantValue: map[string]any{"checks": []any{}, "summary": map[string]any{"passed": true}},
+		},
+		{
+			name:       "forced string",
+			value:      `{"checks":[]}`,
+			forcedType: "string",
+			wantRaw:    `"{\"checks\":[]}"`,
+			wantValue:  `{"checks":[]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var received json.RawMessage
+			_, _ = metadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodPut:
+					var body struct {
+						Value json.RawMessage `json:"value"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Fatalf("decode metadata request: %v", err)
+					}
+					received = append(received[:0], body.Value...)
+				case http.MethodGet:
+					// Return the value captured from PUT so list and get exercise the
+					// same JSON decoding path used against a real API.
+				default:
+					t.Fatalf("metadata method = %s, want PUT or GET", r.Method)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"metadata": map[string]json.RawMessage{"payload": received},
+				})
+			})
+
+			cmd := newIssueMetadataSetTestCmd()
+			_ = cmd.Flags().Set("key", "payload")
+			_ = cmd.Flags().Set("value", tt.value)
+			_ = cmd.Flags().Set("output", "json")
+			if tt.forcedType != "" {
+				_ = cmd.Flags().Set("type", tt.forcedType)
+			}
+
+			out, err := captureStdout(t, func() error {
+				return runIssueMetadataSet(cmd, []string{testIssueUUID})
+			})
+			if err != nil {
+				t.Fatalf("runIssueMetadataSet: %v", err)
+			}
+			if string(received) != tt.wantRaw {
+				t.Fatalf("request value = %s, want %s", received, tt.wantRaw)
+			}
+			var response map[string]any
+			if err := json.Unmarshal([]byte(out), &response); err != nil {
+				t.Fatalf("decode command output: %v\n%s", err, out)
+			}
+			if !reflect.DeepEqual(response["payload"], tt.wantValue) {
+				t.Fatalf("output payload = %#v, want %#v", response["payload"], tt.wantValue)
+			}
+
+			listCmd := newIssueMetadataListTestCmd()
+			listOut, err := captureStdout(t, func() error {
+				return runIssueMetadataList(listCmd, []string{testIssueUUID})
+			})
+			if err != nil {
+				t.Fatalf("runIssueMetadataList: %v", err)
+			}
+			var listed map[string]any
+			if err := json.Unmarshal([]byte(listOut), &listed); err != nil {
+				t.Fatalf("decode list output: %v\n%s", err, listOut)
+			}
+			if !reflect.DeepEqual(listed["payload"], tt.wantValue) {
+				t.Fatalf("listed payload = %#v, want %#v", listed["payload"], tt.wantValue)
+			}
+
+			getCmd := newIssueMetadataGetTestCmd()
+			_ = getCmd.Flags().Set("key", "payload")
+			getOut, err := captureStdout(t, func() error {
+				return runIssueMetadataGet(getCmd, []string{testIssueUUID})
+			})
+			if err != nil {
+				t.Fatalf("runIssueMetadataGet: %v", err)
+			}
+			var gotValue any
+			if err := json.Unmarshal([]byte(getOut), &gotValue); err != nil {
+				t.Fatalf("decode get output: %v\n%s", err, getOut)
+			}
+			if !reflect.DeepEqual(gotValue, tt.wantValue) {
+				t.Fatalf("get payload = %#v, want %#v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+
 // captureStdout used in this file is the (string, error) helper defined
 // in cmd_skill_test.go.
 
@@ -88,7 +250,9 @@ func metadataTestServer(t *testing.T, metadataHandler http.HandlerFunc) (*httpte
 	t.Cleanup(srv.Close)
 	t.Setenv("MULTICA_SERVER_URL", srv.URL)
 	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
-	t.Setenv("MULTICA_TOKEN", "test-token")
+	// Use the task-token shape so these tests also run inside a daemon-managed
+	// agent worktree, where newAPIClient enforces the scoped-token contract.
+	t.Setenv("MULTICA_TOKEN", "mat_test-token")
 	return srv, &paths
 }
 

--- a/server/internal/handler/issue_metadata.go
+++ b/server/internal/handler/issue_metadata.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,12 +18,12 @@ import (
 )
 
 // Per-issue metadata is a small JSONB KV map agents use to record pipeline
-// state (PR number, pipeline_status, waiting_on, ...). Three rules govern
-// the V1 surface — they're enforced both in the handler and at the DB:
+// state (PR number, pipeline_status, waiting_on, ...). These rules govern
+// the surface — they're enforced both in the handler and at the DB:
 //
 //   - keys match `^[a-zA-Z_][a-zA-Z0-9_.-]{0,63}$` (handler)
 //   - at most 50 keys per issue (handler)
-//   - values are primitive: string / number / bool (handler)
+//   - values are any valid, non-null JSON value (handler)
 //   - JSONB column is an object and ≤ 8KB (DB CHECK; defense in depth)
 //
 // All mutations are single-key atomic. UpdateIssue does NOT touch metadata —
@@ -52,25 +53,21 @@ func validateIssueMetadataKey(key string) error {
 	return nil
 }
 
-// validateIssueMetadataValue rejects anything other than a primitive JSON
-// scalar. Null, arrays, and objects are not allowed — the V1 surface is
-// flat KV. Removing a key uses DELETE, not a null value.
+// validateIssueMetadataValue accepts any valid JSON value except null. It uses
+// json.Valid rather than decoding through float64 so numeric spelling and
+// precision survive unchanged on the way to PostgreSQL. Removing a key uses
+// DELETE, not a null value.
 func validateIssueMetadataValue(raw json.RawMessage) error {
 	if len(raw) == 0 {
 		return errors.New("value is required")
 	}
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return fmt.Errorf("value must be valid JSON: %w", err)
+	if !json.Valid(raw) {
+		return errors.New("value must be valid JSON")
 	}
-	switch v.(type) {
-	case string, bool, float64:
-		return nil
-	case nil:
+	if string(bytes.TrimSpace(raw)) == "null" {
 		return errors.New("value cannot be null (use DELETE to remove a key)")
-	default:
-		return errors.New("value must be a primitive: string, number, or bool")
 	}
+	return nil
 }
 
 // parseIssueMetadata decodes the JSONB bytes from db.Issue.Metadata into a
@@ -88,15 +85,18 @@ func parseIssueMetadata(raw []byte) map[string]any {
 // CountIssues / ListOpenIssues. Empty input means "no filter" and returns
 // a nil []byte, which the SQL layer interprets as "skip the @> check".
 //
-// Validates that the filter is itself a flat object of primitives, mirroring
-// the constraints we apply at write time — querying for `{key: {nested}}`
-// would never match since written values are primitive by construction.
+// Validates that the filter is itself an object whose keys and values mirror
+// the constraints applied at write time.
 func parseMetadataFilterParam(w http.ResponseWriter, raw string) ([]byte, bool) {
 	if raw == "" {
 		return nil, true
 	}
-	var parsed map[string]any
+	var parsed map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		writeError(w, http.StatusBadRequest, "metadata filter must be a JSON object")
+		return nil, false
+	}
+	if parsed == nil {
 		writeError(w, http.StatusBadRequest, "metadata filter must be a JSON object")
 		return nil, false
 	}
@@ -105,11 +105,8 @@ func parseMetadataFilterParam(w http.ResponseWriter, raw string) ([]byte, bool) 
 			writeError(w, http.StatusBadRequest, "metadata filter "+err.Error())
 			return nil, false
 		}
-		switch v.(type) {
-		case string, bool, float64:
-			// ok
-		default:
-			writeError(w, http.StatusBadRequest, "metadata filter values must be primitives (string, number, bool)")
+		if err := validateIssueMetadataValue(v); err != nil {
+			writeError(w, http.StatusBadRequest, "metadata filter "+err.Error())
 			return nil, false
 		}
 	}

--- a/server/internal/handler/issue_metadata_test.go
+++ b/server/internal/handler/issue_metadata_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 )
 
-// Round-trip: set primitives of each type, list, get them back, delete, confirm gone.
+// Round-trip: set scalars and structured values, list and issue-get them back,
+// delete one key, and confirm the unrelated values remain intact.
 func TestIssueMetadataSetGetDelete(t *testing.T) {
 	issueID := createMetadataTestIssue(t, "Metadata round-trip")
 
@@ -22,6 +23,10 @@ func TestIssueMetadataSetGetDelete(t *testing.T) {
 		{"pr_number", `482`},
 		{"is_blocked", `true`},
 		{"is_done", `false`},
+		{"workstreams", `["frontend",{"release":{"ready":true}}]`},
+		{"qa_evidence", `{"checks":[],"summary":{"passed":true}}`},
+		{"empty_array", `[]`},
+		{"empty_object", `{}`},
 	}
 
 	for _, c := range cases {
@@ -60,6 +65,51 @@ func TestIssueMetadataSetGetDelete(t *testing.T) {
 	if got := resp.Metadata["is_done"]; got != false {
 		t.Errorf("is_done: expected false, got %T %v", got, got)
 	}
+	workstreams, ok := resp.Metadata["workstreams"].([]any)
+	if !ok || len(workstreams) != 2 {
+		t.Fatalf("workstreams: expected native two-element array, got %T %v", resp.Metadata["workstreams"], resp.Metadata["workstreams"])
+	}
+	workstreamObject, ok := workstreams[1].(map[string]any)
+	if !ok {
+		t.Fatalf("workstreams nested value: expected object, got %T %v", workstreams[1], workstreams[1])
+	}
+	release, ok := workstreamObject["release"].(map[string]any)
+	if !ok || release["ready"] != true {
+		t.Errorf("workstreams nested object: got %T %v", workstreams[1], workstreams[1])
+	}
+	qa, ok := resp.Metadata["qa_evidence"].(map[string]any)
+	if !ok {
+		t.Fatalf("qa_evidence: expected native object with empty checks array, got %T %v", resp.Metadata["qa_evidence"], resp.Metadata["qa_evidence"])
+	}
+	if checks, ok := qa["checks"].([]any); !ok || len(checks) != 0 {
+		t.Errorf("qa_evidence checks: expected native empty array, got %T %v", qa["checks"], qa["checks"])
+	}
+	if got, ok := resp.Metadata["empty_array"].([]any); !ok || len(got) != 0 {
+		t.Errorf("empty_array: expected native empty array, got %T %v", resp.Metadata["empty_array"], resp.Metadata["empty_array"])
+	}
+	if got, ok := resp.Metadata["empty_object"].(map[string]any); !ok || len(got) != 0 {
+		t.Errorf("empty_object: expected native empty object, got %T %v", resp.Metadata["empty_object"], resp.Metadata["empty_object"])
+	}
+
+	// The ordinary issue response must expose the same native shapes as the
+	// dedicated metadata endpoint.
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues/"+issueID, nil)
+	req = withURLParam(req, "id", issueID)
+	testHandler.GetIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetIssue: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var issueResp IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&issueResp); err != nil {
+		t.Fatalf("decode issue response: %v", err)
+	}
+	if _, ok := issueResp.Metadata["workstreams"].([]any); !ok {
+		t.Errorf("issue metadata workstreams: expected native array, got %T %v", issueResp.Metadata["workstreams"], issueResp.Metadata["workstreams"])
+	}
+	if _, ok := issueResp.Metadata["qa_evidence"].(map[string]any); !ok {
+		t.Errorf("issue metadata qa_evidence: expected native object, got %T %v", issueResp.Metadata["qa_evidence"], issueResp.Metadata["qa_evidence"])
+	}
 
 	// Delete a key — refresh confirms it is gone, others remain.
 	w = httptest.NewRecorder()
@@ -87,8 +137,7 @@ func TestIssueMetadataSetGetDelete(t *testing.T) {
 	}
 }
 
-// Invalid keys / values / shapes are rejected with 400 — the regex, primitive,
-// and "no null" rules must all hold.
+// Invalid keys, null, and malformed request bodies are rejected with 400.
 func TestIssueMetadataValidation(t *testing.T) {
 	issueID := createMetadataTestIssue(t, "Metadata validation")
 
@@ -100,8 +149,7 @@ func TestIssueMetadataValidation(t *testing.T) {
 		{"key starts with digit", "1attempts", `{"value":"x"}`},
 		{"key has space", "foo bar", `{"value":"x"}`},
 		{"value is null", "k", `{"value":null}`},
-		{"value is array", "k", `{"value":[1,2]}`},
-		{"value is object", "k", `{"value":{"a":1}}`},
+		{"malformed JSON", "k", `{"value":[}`},
 		{"empty body", "k", ``},
 	}
 	for _, c := range bad {
@@ -127,13 +175,21 @@ func TestIssueMetadataSizeLimit(t *testing.T) {
 	issueID := createMetadataTestIssue(t, "Metadata size limit")
 
 	huge := strings.Repeat("a", 9000)
-	body, _ := json.Marshal(map[string]any{"value": huge})
-	w := httptest.NewRecorder()
-	req := newRequest("PUT", "/api/issues/"+issueID+"/metadata/blob", body)
-	req = withURLParams(req, "id", issueID, "key", "blob")
-	testHandler.SetIssueMetadataKey(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 from size CHECK, got %d: %s", w.Code, w.Body.String())
+	values := map[string]any{
+		"string":     huge,
+		"structured": map[string]any{"nested": []any{huge}},
+	}
+	for name, value := range values {
+		t.Run(name, func(t *testing.T) {
+			body, _ := json.Marshal(map[string]any{"value": value})
+			w := httptest.NewRecorder()
+			req := newRequest("PUT", "/api/issues/"+issueID+"/metadata/blob", body)
+			req = withURLParams(req, "id", issueID, "key", "blob")
+			testHandler.SetIssueMetadataKey(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 from size CHECK, got %d: %s", w.Code, w.Body.String())
+			}
+		})
 	}
 }
 
@@ -175,6 +231,7 @@ func TestIssueMetadataKeyCountCap(t *testing.T) {
 func TestListIssuesMetadataFilter(t *testing.T) {
 	waitingID := createMetadataTestIssue(t, "Waiting issue")
 	doneID := createMetadataTestIssue(t, "Done issue")
+	structuredID := createMetadataTestIssue(t, "Structured issue")
 
 	for issueID, status := range map[string]string{waitingID: "waiting_review", doneID: "deployed"} {
 		w := httptest.NewRecorder()
@@ -188,7 +245,16 @@ func TestListIssuesMetadataFilter(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	req := newRequest("GET", `/api/issues?metadata={"pipeline_status":"waiting_review"}`, nil)
+	req := newRequest("PUT", "/api/issues/"+structuredID+"/metadata/workstreams",
+		json.RawMessage(`{"value":["frontend",{"release":{"ready":true}}]}`))
+	req = withURLParams(req, "id", structuredID, "key", "workstreams")
+	testHandler.SetIssueMetadataKey(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("seed structured metadata: %d %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", `/api/issues?metadata={"pipeline_status":"waiting_review"}`, nil)
 	testHandler.ListIssues(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("List with filter: expected 200, got %d: %s", w.Code, w.Body.String())
@@ -214,12 +280,42 @@ func TestListIssuesMetadataFilter(t *testing.T) {
 		t.Errorf("waiting issue %s missing from filter result; got %d issues", waitingID, len(listResp.Issues))
 	}
 
+	// Structured metadata uses the same JSONB containment semantics as scalar
+	// values and must remain queryable after the write contract expands.
+	w = httptest.NewRecorder()
+	filter := `{"workstreams":["frontend",{"release":{"ready":true}}]}`
+	req = newRequest("GET", "/api/issues?metadata="+url.QueryEscape(filter), nil)
+	testHandler.ListIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("List with structured filter: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	listResp.Issues = nil
+	if err := json.NewDecoder(w.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode structured filter response: %v", err)
+	}
+	foundStructured := false
+	for _, iss := range listResp.Issues {
+		if iss.ID == structuredID {
+			foundStructured = true
+		}
+	}
+	if !foundStructured {
+		t.Errorf("structured issue %s missing from filter result; got %d issues", structuredID, len(listResp.Issues))
+	}
+
 	// Malformed filter → 400.
 	w = httptest.NewRecorder()
 	req = newRequest("GET", `/api/issues?metadata={not-json}`, nil)
 	testHandler.ListIssues(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("malformed metadata: expected 400, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", `/api/issues?metadata={"workstreams":null}`, nil)
+	testHandler.ListIssues(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("null metadata filter: expected 400, got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Issue metadata currently stores JSON arrays and objects as strings when written through the CLI, while the API rejects those shapes outright. That breaks typed workflow contracts which need to distinguish native structured values from JSON-looking strings.

This change lets any valid, non-null JSON value pass through the CLI and handler without decoding numbers through `float64`, so arrays, objects, and numeric spelling reach PostgreSQL JSONB intact. Invalid JSON and bare text keep the existing string fallback, while `--type string` still forces JSON-looking input to remain a string. `null` remains reserved for absence and must be handled with `metadata delete`.

The reasoning path was:

1. Reproduce the CLI failure with tests showing arrays/objects becoming quoted strings and `null` becoming the string `"null"`.
2. Confirm the existing SQL already performs atomic raw JSONB writes and enforces the 8KB object limit.
3. Expand only the CLI parsing and handler validation boundary, plus metadata filtering so readable/writable structured values remain queryable.
4. Verify native shapes through CLI set/list/get and API metadata/issue responses, retaining scalar and limit coverage.

## Related Issue

Closes #8141

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/cmd/multica/cmd_issue_metadata.go`: preserve any valid non-null JSON value, reject inferred null, report array/object table types, and preserve raw numeric spelling in metadata filters.
- `server/internal/handler/issue_metadata.go`: accept structured non-null JSON values and apply the same contract to JSONB containment filters.
- `server/cmd/multica/cmd_issue_metadata_test.go`: cover nested/empty arrays and objects, invalid JSON fallback, null rejection, forced strings, scalar compatibility, numeric spelling, and CLI set/list/get round trips.
- `server/internal/handler/issue_metadata_test.go`: cover JSONB round trips through metadata and issue responses, structured filtering, malformed/null input, and scalar/structured size-limit enforcement.

## How to Test

1. `cd server && go test ./cmd/multica -run '^(TestParseMetadataValue|TestBuildMetadataFilterQueryParamPreservesStructuredValuesAndNumbers|TestRunIssueMetadataRoundTripsStructuredAndForcedStringValues|TestRunIssueMetadata(List|Get|SetReturns|DeleteReturns))' -count=1`
2. With a temporary migrated PostgreSQL database, run `cd server && go test ./internal/handler -run '^Test(IssueMetadata(SetGetDelete|Validation|SizeLimit|KeyCountCap)|ListIssuesMetadataFilter|NewIssueDefaultsToEmptyMetadata)$' -count=1 -v`.
3. `cd server && go vet ./cmd/multica ./internal/handler`

All commands above pass locally. Before the implementation, the new CLI parsing test failed for nested/empty arrays and objects because they were quoted as strings, and failed null cases because null was quoted instead of rejected.

## Compatibility and risk

- Existing stored JSON-looking strings are not migrated or reinterpreted.
- Bare text and invalid JSON still become strings; booleans, numbers, and JSON strings keep their existing behavior.
- `--type string` remains an explicit escape hatch, including for object/array/null-looking text.
- The existing 50-key handler cap, atomic single-key SQL update, and 8KB database CHECK are unchanged and tested with structured input.
- No schema migration is required. The main risk is that previously rejected direct API array/object writes now succeed, which is the intended contract expansion.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable: no UI change)
- [x] I have updated relevant documentation to reflect my changes (CLI help and code contract comments)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (OpenAI Codex)

**Prompt / approach:** The agent was tasked with implementing upstream #8141. It inspected the current CLI, handler, JSONB query, existing tests, and repository contribution rules; added failing regression tests before the implementation; made the scoped parsing/validation change; and verified it with targeted CLI tests, a temporary real PostgreSQL database, and `go vet`.

## Screenshots (optional)

Not applicable; this change has no UI surface.
