### PR TITLE
MUL-7146: extend search statement timeout to 8 seconds

### DIFF
--- a/server/internal/handler/search.go
+++ b/server/internal/handler/search.go
@@ -25,16 +25,16 @@ import (
 // therefore still make either path slow enough that the frontend appears to
 // hang ("搜索卡死没有任何反应", MUL-4059).
 //
-// The 5 s cap leaves headroom above the production-observed candidate-first
-// maximum (1.79 s in the MUL-7055 matrix) while keeping a bounded database
-// safety fuse. Interactive web callers cancel superseded searches, and the
-// mobile API client has a 30 s request timeout, so this remains within the
-// first-party clients' request budgets. On timeout the caller sees a 503 with
-// a descriptive error rather than a stalled connection — SearchIssues /
-// SearchProjects map SQLSTATE 57014 to http.StatusServiceUnavailable so the
-// frontend can distinguish this from a generic 500.
+// The 8 s cap adds three seconds of headroom above the MUL-7146 requests that
+// reached the previous 5 s database fuse, while remaining bounded well below
+// the mobile API client's 30 s request timeout. Interactive web callers cancel
+// superseded searches, limiting how long abandoned work can occupy a pooled
+// connection. On timeout the caller sees a 503 with a descriptive error rather
+// than a stalled connection — SearchIssues / SearchProjects map SQLSTATE 57014
+// to http.StatusServiceUnavailable so the frontend can distinguish this from a
+// generic 500.
 const (
-	searchStatementTimeout = 5 * time.Second
+	searchStatementTimeout = 8 * time.Second
 
 	searchWorkMemEnv       = "DATABASE_SEARCH_WORK_MEM_MB"
 	defaultSearchWorkMemMB = 64


### PR DESCRIPTION
Closes MUL-7146

## Summary

- raise the transaction-local PostgreSQL timeout shared by issue and project search from 5 seconds to 8 seconds
- update the timeout rationale to reflect the MUL-7146 production observations and first-party request budgets
- keep the existing `SET LOCAL`, read-only transaction, cancellation, and HTTP 503 behavior unchanged

No environment variable, migration, API contract, or deployment configuration is added.

## Evidence

Current-workspace read-only probes found successful end-to-end issue searches at 5.64–5.68 seconds and four-term searches returning HTTP 503 at 5.84–5.87 seconds after reaching the 5-second PostgreSQL fuse. End-to-end measurements include CLI and network overhead, so they do not establish the exact SQL completion time. An 8-second cap adds three seconds of bounded headroom without extending toward the mobile client's 30-second request ceiling.

## Validation

- `cd server && go test ./internal/handler -run 'Test(IsSearchStatementTimeout|RunSearchQuery_StatementTimeoutFires)$' -count=1 -v`
- `cd server && go vet ./internal/handler`
- `cd server && go build ./...`
- `git diff --check`

All checks pass. The live-PostgreSQL timeout test confirms that the transaction-local safety fuse still surfaces SQLSTATE 57014.

## Risk and rollback

An overloaded search may occupy a connection from the shared primary pool for up to three seconds longer and retain its demand-driven per-node working memory for that period. The transaction remains read-only and bounded, and interactive web callers continue to cancel superseded requests. Rollback is a single commit revert with no schema or data changes.

The post-change production completion distribution is intentionally not claimed here; rollout should monitor search 503s, latency percentiles, database CPU, pool acquire wait, and non-search tail latency.
