### PR TITLE
MUL-7146: lowercase comment content once per search row

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -702,22 +702,23 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 	// final page is known. Per-term BOOL_OR flags keep the legacy eligibility rule
 	// where terms may be spread across comments, while comment_all_terms keeps
 	// ranking/snippet tied to one comment.
+	const loweredCommentContent = "lowered_comment.content"
 	commentFlagColumns := []string{
 		"c.issue_id",
-		fmt.Sprintf("BOOL_OR(LOWER(c.content) LIKE %s) AS comment_phrase", phraseContainsParam),
+		fmt.Sprintf("BOOL_OR(%s LIKE %s) AS comment_phrase", loweredCommentContent, phraseContainsParam),
 	}
 	commentCandidateFlags := []string{"aggregated_comments.comment_phrase"}
 	commentTerms := make([]string, 0, len(termContainsParams))
 	for index, termParam := range termContainsParams {
 		alias := fmt.Sprintf("comment_term_%d", index)
 		commentFlagColumns = append(commentFlagColumns,
-			fmt.Sprintf("BOOL_OR(LOWER(c.content) LIKE %s) AS %s", termParam, alias),
+			fmt.Sprintf("BOOL_OR(%s LIKE %s) AS %s", loweredCommentContent, termParam, alias),
 		)
 		commentCandidateFlags = append(commentCandidateFlags, "aggregated_comments."+alias)
-		commentTerms = append(commentTerms, fmt.Sprintf("LOWER(c.content) LIKE %s", termParam))
+		commentTerms = append(commentTerms, fmt.Sprintf("%s LIKE %s", loweredCommentContent, termParam))
 	}
 
-	commentSnippetPredicate := fmt.Sprintf("LOWER(c.content) LIKE %s", phraseContainsParam)
+	commentSnippetPredicate := fmt.Sprintf("%s LIKE %s", loweredCommentContent, phraseContainsParam)
 	if len(commentTerms) > 1 {
 		commentAllTerms := "(" + strings.Join(commentTerms, " AND ") + ")"
 		commentFlagColumns = append(commentFlagColumns,
@@ -735,11 +736,20 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 		commentSnippetPredicate,
 	))
 
+	// PostgreSQL otherwise inlines this scalar LATERAL subquery and recomputes
+	// LOWER(c.content) for every flag. OFFSET 0 is the intentional planner fence
+	// that keeps the long comment body lowercased once per row. Future indexable
+	// text predicates must stay outside this projection-only fence so an index on
+	// LOWER(c.content) can still match them.
 	commentMatchesCTE := fmt.Sprintf(`comment_matches AS MATERIALIZED (
 		SELECT *
 		FROM (
 			SELECT %s
 			FROM comment c
+			CROSS JOIN LATERAL (
+				SELECT LOWER(c.content) AS content
+				OFFSET 0
+			) lowered_comment
 			WHERE c.workspace_id = %s
 			GROUP BY c.issue_id
 		) aggregated_comments

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -702,7 +702,7 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 	// final page is known. Per-term BOOL_OR flags keep the legacy eligibility rule
 	// where terms may be spread across comments, while comment_all_terms keeps
 	// ranking/snippet tied to one comment.
-	const loweredCommentContent = "lowered_comment.content"
+	const loweredCommentContent = "lowered_comment.lowered"
 	commentFlagColumns := []string{
 		"c.issue_id",
 		fmt.Sprintf("BOOL_OR(%s LIKE %s) AS comment_phrase", loweredCommentContent, phraseContainsParam),
@@ -747,7 +747,7 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 			SELECT %s
 			FROM comment c
 			CROSS JOIN LATERAL (
-				SELECT LOWER(c.content) AS content
+				SELECT LOWER(c.content) AS lowered
 				OFFSET 0
 			) lowered_comment
 			WHERE c.workspace_id = %s

--- a/server/internal/handler/search_test.go
+++ b/server/internal/handler/search_test.go
@@ -23,8 +23,8 @@ func TestBuildSearchQuery_SingleTerm(t *testing.T) {
 	if !strings.Contains(query, "LOWER(COALESCE(i.description, '')) LIKE") {
 		t.Error("query should contain LOWER(COALESCE(i.description, '')) LIKE")
 	}
-	if !strings.Contains(query, "LOWER(c.content) LIKE") {
-		t.Error("query should contain LOWER(c.content) LIKE")
+	if !strings.Contains(query, "lowered_comment.content LIKE") {
+		t.Error("query should match against the pre-lowered comment content")
 	}
 
 	// Exact title rank should not double-LOWER the pattern.
@@ -103,6 +103,22 @@ func TestBuildSearchQuery_MultiTerm(t *testing.T) {
 	// Multi-word query should have AND conditions.
 	if !strings.Contains(query, " AND ") {
 		t.Error("multi-word query should contain AND conditions for per-term matching")
+	}
+}
+
+func TestBuildSearchQuery_LowersCommentContentOnce(t *testing.T) {
+	query, _ := buildSearchQuery("Foo Bar Baz", []string{"Foo", "Bar", "Baz"}, 0, false, false, []string{"done", "cancelled"})
+
+	if count := strings.Count(query, "LOWER(c.content)"); count != 1 {
+		t.Fatalf("query lowers comment content %d times, want exactly once:\n%s", count, query)
+	}
+	if !strings.Contains(query, "CROSS JOIN LATERAL (") ||
+		!strings.Contains(query, "SELECT LOWER(c.content) AS content") ||
+		!strings.Contains(query, "OFFSET 0\n\t\t\t) lowered_comment") {
+		t.Fatalf("query does not retain the OFFSET 0 planner fence around comment lowercasing:\n%s", query)
+	}
+	if strings.Contains(query, "LOWER(c.content) LIKE") {
+		t.Fatalf("comment predicates bypass the pre-lowered value:\n%s", query)
 	}
 }
 
@@ -334,7 +350,7 @@ func TestBuildSearchQuery_CommentSubqueryWorkspaceScope(t *testing.T) {
 	if fromCountMulti != 1 {
 		t.Errorf("multi-term query has %d comment scans, want exactly one:\n%s", fromCountMulti, multiQuery)
 	}
-	if !strings.Contains(multiQuery, "BOOL_OR((LOWER(c.content) LIKE") || !strings.Contains(multiQuery, "AS comment_all_terms") {
+	if !strings.Contains(multiQuery, "BOOL_OR((lowered_comment.content LIKE") || !strings.Contains(multiQuery, "AS comment_all_terms") {
 		t.Errorf("multi-term query does not retain the same-comment all-terms flag:\n%s", multiQuery)
 	}
 	if !strings.Contains(multiQuery, "ARRAY_AGG(c.id ORDER BY c.created_at DESC, c.id DESC)") {
@@ -357,7 +373,7 @@ func TestBuildSearchQuery_HydratesOnlyTheSelectedPage(t *testing.T) {
 	if limitAt == -1 || issueHydrationAt < limitAt || commentHydrationAt < limitAt {
 		t.Fatalf("full issue/comment hydration must happen after LIMIT/OFFSET:\n%s", query)
 	}
-	if lastTextMatch := strings.LastIndex(query, "LOWER(c.content) LIKE"); lastTextMatch > limitAt {
+	if lastTextMatch := strings.LastIndex(query, "lowered_comment.content LIKE"); lastTextMatch > limitAt {
 		t.Errorf("comment hydration repeats a text search after LIMIT/OFFSET:\n%s", query)
 	}
 }

--- a/server/internal/handler/search_test.go
+++ b/server/internal/handler/search_test.go
@@ -23,7 +23,7 @@ func TestBuildSearchQuery_SingleTerm(t *testing.T) {
 	if !strings.Contains(query, "LOWER(COALESCE(i.description, '')) LIKE") {
 		t.Error("query should contain LOWER(COALESCE(i.description, '')) LIKE")
 	}
-	if !strings.Contains(query, "lowered_comment.content LIKE") {
+	if !strings.Contains(query, "lowered_comment.lowered LIKE") {
 		t.Error("query should match against the pre-lowered comment content")
 	}
 
@@ -112,10 +112,17 @@ func TestBuildSearchQuery_LowersCommentContentOnce(t *testing.T) {
 	if count := strings.Count(query, "LOWER(c.content)"); count != 1 {
 		t.Fatalf("query lowers comment content %d times, want exactly once:\n%s", count, query)
 	}
-	if !strings.Contains(query, "CROSS JOIN LATERAL (") ||
-		!strings.Contains(query, "SELECT LOWER(c.content) AS content") ||
-		!strings.Contains(query, "OFFSET 0\n\t\t\t) lowered_comment") {
+	if !strings.Contains(query, "CROSS JOIN LATERAL (") {
+		t.Fatalf("query does not use a lateral join for comment lowercasing:\n%s", query)
+	}
+	if !strings.Contains(query, "SELECT LOWER(c.content) AS lowered") {
+		t.Fatalf("query does not project pre-lowered comment content:\n%s", query)
+	}
+	if !strings.Contains(query, "OFFSET 0") {
 		t.Fatalf("query does not retain the OFFSET 0 planner fence around comment lowercasing:\n%s", query)
+	}
+	if !strings.Contains(query, ") lowered_comment") {
+		t.Fatalf("query does not retain the lateral alias after comment lowercasing:\n%s", query)
 	}
 	if strings.Contains(query, "LOWER(c.content) LIKE") {
 		t.Fatalf("comment predicates bypass the pre-lowered value:\n%s", query)
@@ -350,7 +357,7 @@ func TestBuildSearchQuery_CommentSubqueryWorkspaceScope(t *testing.T) {
 	if fromCountMulti != 1 {
 		t.Errorf("multi-term query has %d comment scans, want exactly one:\n%s", fromCountMulti, multiQuery)
 	}
-	if !strings.Contains(multiQuery, "BOOL_OR((lowered_comment.content LIKE") || !strings.Contains(multiQuery, "AS comment_all_terms") {
+	if !strings.Contains(multiQuery, "BOOL_OR((lowered_comment.lowered LIKE") || !strings.Contains(multiQuery, "AS comment_all_terms") {
 		t.Errorf("multi-term query does not retain the same-comment all-terms flag:\n%s", multiQuery)
 	}
 	if !strings.Contains(multiQuery, "ARRAY_AGG(c.id ORDER BY c.created_at DESC, c.id DESC)") {
@@ -373,7 +380,7 @@ func TestBuildSearchQuery_HydratesOnlyTheSelectedPage(t *testing.T) {
 	if limitAt == -1 || issueHydrationAt < limitAt || commentHydrationAt < limitAt {
 		t.Fatalf("full issue/comment hydration must happen after LIMIT/OFFSET:\n%s", query)
 	}
-	if lastTextMatch := strings.LastIndex(query, "lowered_comment.content LIKE"); lastTextMatch > limitAt {
+	if lastTextMatch := strings.LastIndex(query, "lowered_comment.lowered LIKE"); lastTextMatch > limitAt {
 		t.Errorf("comment hydration repeats a text search after LIMIT/OFFSET:\n%s", query)
 	}
 }


### PR DESCRIPTION
Related to MUL-7146

## Summary

- lower each comment body once per scanned row through a fenced `CROSS JOIN LATERAL`
- reuse the lowered value for phrase, per-term, same-comment, and snippet predicates without changing search eligibility, ranking, or snippet selection
- pin the intentional `OFFSET 0` planner fence and single-`LOWER` shape with a regression test

This PR does not add a migration, change an API, alter query parameters, or introduce the separately discussed minimum query length.

## Evidence

On the isolated local PostgreSQL 17 database, `EXPLAIN VERBOSE` shows the fenced query as `Nested Loop -> Result`, with `lower(c.content)` produced once and carried into both aggregate predicates. Removing `OFFSET 0` removes the `Result` node and inlines a separate `lower(c.content)` expression into each aggregate.

The prior reproducible PostgreSQL 16 benchmark in the MUL-7146 discussion measured the four-term zero-hit case at 938 ms before and 328 ms after this exact rewrite (about 65% lower), with the per-term slope falling from 188 ms to 34 ms. Those scratch-database ratios are evidence for the direction, not a production latency guarantee.

## Validation

- `go test ./internal/handler -run Search -count=1`
- `go test ./internal/handler -count=1` (full package, passed in 46.161 s)
- `go vet ./internal/handler`
- `go build ./...`
- existing database-backed candidate parity matrix passed all 15 cases, including cross-field/comment matches, ranking, snippets, special characters, pagination, and empty results
- `git diff --check`

## Risk and rollback

The intentional planner fence changes the execution-plan shape. The benchmark showed the strongest improvement for multi-term queries, while a high-hit single-term query was roughly flat to slightly slower; production rollout should compare `EXPLAIN (ANALYZE, BUFFERS)` and monitor search latency and timeout rates. Future indexable `LOWER(c.content)` filters must remain outside this projection-only fence.

Rollback is a single commit revert. There is no schema, data, or mixed-version compatibility constraint.
