### PR TITLE
fix(sidebar): unify navigation font size

### DIFF
--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -274,6 +274,20 @@ describe("PinRow", () => {
   });
 });
 
+describe("navigation typography", () => {
+  it("uses the body type step for every navigation row", () => {
+    const { container } = renderWithI18n(<AppSidebar />);
+    const navButtons = container.querySelectorAll<HTMLButtonElement>(
+      'button[data-href="/acme/inbox"], button[data-href="/acme/chat"], button[data-href="/acme/my-issues"], button[data-href="/acme/issues"], button[data-href="/acme/projects"], button[data-href="/acme/autopilots"], button[data-href="/acme/agents"], button[data-href="/acme/squads"], button[data-href="/acme/usage"], button[data-href="/acme/runtimes"], button[data-href="/acme/skills"], button[data-href="/acme/settings"]',
+    );
+
+    expect(navButtons).toHaveLength(12);
+    for (const button of navButtons) {
+      expect(button).toHaveClass("text-body");
+    }
+  });
+});
+
 // On a phone the sidebar is a Sheet laid over the page, so a nav tap that
 // leaves it open renders the destination underneath and reads as a dead tap.
 describe("mobile sheet dismissal", () => {

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -169,7 +169,7 @@ const utilityNav: { key: NavKey; labelKey: NavLabelKey }[] = [
 ];
 
 const NAV_ITEM_CLASS_NAME =
-  "text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground";
+  "text-body text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground";
 
 function DraftDot() {
   const hasDraft = useIssueDraftStore((s) => s.hasDraft());


### PR DESCRIPTION
## Summary

Fixes HOM-37 by explicitly applying the shared body typography token to every sidebar navigation group and adding a regression test that covers all 12 navigation destinations. The branch is based on the latest `main`, so it preserves the current sidebar grouping and navigation order unchanged.

## Before

Analytics and Settings rendered smaller than the other sidebar navigation entries.

![Before: Analytics and Settings use a smaller font size](https://raw.githubusercontent.com/HomyeeKing/multica/pr-assets/hom-37/hom37-before.png)

## After

All sidebar navigation labels now use the same 14px body typography token. The verified order remains: Inbox, My Issues, Chat; Work; AI Team; then Analytics and Settings in the footer.

![After: current sidebar order preserved and all navigation labels use a consistent font size](https://raw.githubusercontent.com/HomyeeKing/multica/pr-assets/hom-37/hom37-order-verified.png)

## Verification

- 46 focused Vitest tests pass
- `@multica/views` typecheck passes
- `@multica/views` lint passes with existing warnings only
- Browser check at 1280×900 confirms the latest-main grouping/order is unchanged and all 12 navigation labels render at 14px
- `code-review-expert`: APPROVE, no P0–P3 findings
