### PR TITLE
MUL-7151 fix(issues): stop the full-log trigger from keeping focus after a pointer open

### DIFF
--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -117,6 +117,14 @@ interface AgentTranscriptDialogProps {
   items: TimelineItem[];
   agentName: string;
   isLive?: boolean;
+  /**
+   * Whether focus returns to the trigger when the dialog closes. Pass `true`
+   * only for a keyboard open, where the reader has no other way back. After a
+   * pointer open, returning focus is what leaves the trigger wearing a focus
+   * ring and its tooltip once Esc closes the log — and, on the hover-revealed
+   * comment action row, holds the whole row visible with the pointer long gone.
+   */
+  finalFocus?: boolean;
   /** Loading/error content while the caller retrieves the transcript. */
   contentState?: React.ReactNode;
   /**
@@ -307,6 +315,7 @@ export function AgentTranscriptDialog({
   items,
   agentName,
   isLive = false,
+  finalFocus = false,
   headerSlot,
   contentState,
 }: AgentTranscriptDialogProps) {
@@ -854,6 +863,7 @@ export function AgentTranscriptDialog({
       <DialogContent
         className="!max-w-5xl !w-[calc(100vw-4rem)] !max-h-[calc(100vh-4rem)] !h-[calc(100vh-4rem)] flex flex-col !p-0 !gap-0 overflow-hidden"
         showCloseButton={false}
+        finalFocus={finalFocus}
       >
         <DialogTitle className="sr-only">{t(($) => $.transcript.dialog_title)}</DialogTitle>
 

--- a/packages/views/common/task-transcript/transcript-button.tsx
+++ b/packages/views/common/task-transcript/transcript-button.tsx
@@ -72,6 +72,10 @@ export function TranscriptButton({
   headerSlot,
 }: TranscriptButtonProps) {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  // A click carrying no detail count came from Enter/Space. Only that reader
+  // gets focus handed back when the dialog closes: after a pointer open it
+  // would return a focus ring and this button's tooltip on Esc.
+  const [fromKeyboard, setFromKeyboard] = useState(false);
   const [loading, setLoading] = useState(false);
   const [loadedItems, setLoadedItems] = useState<TimelineItem[] | null>(null);
   const open = controlledOpen ?? uncontrolledOpen;
@@ -105,6 +109,7 @@ export function TranscriptButton({
     (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
+      setFromKeyboard(e.detail === 0);
       if (liveCacheMode) {
         setLiveSession(true);
         setOpen(true);
@@ -175,6 +180,7 @@ export function TranscriptButton({
             agentName={agentName}
             isLive={isLive}
             onOpenChange={setOpen}
+            finalFocus={fromKeyboard}
             headerSlot={headerSlot}
           />
         ) : (
@@ -185,6 +191,7 @@ export function TranscriptButton({
             items={items}
             agentName={agentName}
             isLive={isLive}
+            finalFocus={fromKeyboard}
             headerSlot={headerSlot}
           />
         ))}
@@ -197,6 +204,7 @@ interface LiveTranscriptDialogProps {
   agentName: string;
   isLive: boolean;
   onOpenChange: (open: boolean) => void;
+  finalFocus?: boolean;
   headerSlot?: React.ReactNode;
 }
 
@@ -216,6 +224,7 @@ function LiveTranscriptDialog({
   agentName,
   isLive,
   onOpenChange,
+  finalFocus,
   headerSlot,
 }: LiveTranscriptDialogProps) {
   const queryClient = useQueryClient();
@@ -260,6 +269,7 @@ function LiveTranscriptDialog({
       items={items}
       agentName={agentName}
       isLive={isLive}
+      finalFocus={finalFocus}
       headerSlot={headerSlot}
     />
   );

--- a/packages/views/common/task-transcript/transcript-button.tsx
+++ b/packages/views/common/task-transcript/transcript-button.tsx
@@ -37,7 +37,17 @@ interface TranscriptButtonProps {
   title?: string;
   renderButton?: boolean;
   open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  /**
+   * `fromKeyboard` reports how the open was requested, so a parent that hosts
+   * the dialog on another instance can hand it back as `finalFocus`.
+   */
+  onOpenChange?: (open: boolean, fromKeyboard?: boolean) => void;
+  /**
+   * Whether focus returns to the trigger on close. Only a dialog-owning
+   * instance needs this: one that renders the dialog for a trigger living
+   * somewhere else never sees the click that would tell it.
+   */
+  finalFocus?: boolean;
   /**
    * Optional content rendered above the transcript event list. Used to
    * surface autopilot webhook payloads inline with the run history.
@@ -69,6 +79,7 @@ export function TranscriptButton({
   renderButton = true,
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
+  finalFocus,
   headerSlot,
 }: TranscriptButtonProps) {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
@@ -76,6 +87,9 @@ export function TranscriptButton({
   // gets focus handed back when the dialog closes: after a pointer open it
   // would return a focus ring and this button's tooltip on Esc.
   const [fromKeyboard, setFromKeyboard] = useState(false);
+  // A dialog-owning parent knows better than this instance's own clicks —
+  // when the trigger lives elsewhere, those never happen.
+  const returnFocus = finalFocus ?? fromKeyboard;
   const [loading, setLoading] = useState(false);
   const [loadedItems, setLoadedItems] = useState<TimelineItem[] | null>(null);
   const open = controlledOpen ?? uncontrolledOpen;
@@ -109,14 +123,15 @@ export function TranscriptButton({
     (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      setFromKeyboard(e.detail === 0);
+      const keyboard = e.detail === 0;
+      setFromKeyboard(keyboard);
       if (liveCacheMode) {
         setLiveSession(true);
-        setOpen(true);
+        setOpen(true, keyboard);
         return;
       }
       if (providedItems !== undefined || loadedItems !== null) {
-        setOpen(true);
+        setOpen(true, keyboard);
         return;
       }
       setLoading(true);
@@ -124,12 +139,12 @@ export function TranscriptButton({
         .listTaskMessages(task.id)
         .then((msgs) => {
           setLoadedItems(buildTimeline(msgs));
-          setOpen(true);
+          setOpen(true, keyboard);
         })
         .catch((err) => {
           console.error(err);
           setLoadedItems([]);
-          setOpen(true);
+          setOpen(true, keyboard);
         })
         .finally(() => setLoading(false));
     },
@@ -180,7 +195,7 @@ export function TranscriptButton({
             agentName={agentName}
             isLive={isLive}
             onOpenChange={setOpen}
-            finalFocus={fromKeyboard}
+            finalFocus={returnFocus}
             headerSlot={headerSlot}
           />
         ) : (
@@ -191,7 +206,7 @@ export function TranscriptButton({
             items={items}
             agentName={agentName}
             isLive={isLive}
-            finalFocus={fromKeyboard}
+            finalFocus={returnFocus}
             headerSlot={headerSlot}
           />
         ))}
@@ -204,7 +219,7 @@ interface LiveTranscriptDialogProps {
   agentName: string;
   isLive: boolean;
   onOpenChange: (open: boolean) => void;
-  finalFocus?: boolean;
+  finalFocus: boolean;
   headerSlot?: React.ReactNode;
 }
 

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -307,7 +307,7 @@ export function ActiveTaskRow({
 }: {
   task: AgentTask;
   issueId: string;
-  onTranscriptOpenChange?: (open: boolean) => void;
+  onTranscriptOpenChange?: (open: boolean, fromKeyboard?: boolean) => void;
 }) {
   const { t } = useT("issues");
   const [cancelling, setCancelling] = useState(false);

--- a/packages/views/issues/components/inline-comment-run.focus.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.focus.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+// Where focus lands when the full log closes. Kept apart from
+// inline-comment-run.test.tsx because these cases need the real Base UI dialog
+// — the focus return is the behaviour under test, so a stubbed dialog would
+// assert nothing.
+
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { api } from "@multica/core/api";
+import type { AgentTask } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { InlineCommentRun } from "./inline-comment-run";
+
+vi.mock("@multica/core/api", () => ({ api: {
+  getIssue: vi.fn(), listTaskMessages: vi.fn(), cancelTask: vi.fn(), rerunIssue: vi.fn(),
+}, dispatchReasonCode: () => undefined }));
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "workspace" }));
+vi.mock("@multica/core/workspace/hooks", () => ({ useActorName: () => ({ getActorName: () => "Reviewer" }) }));
+vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
+vi.mock("../../editor", () => ({ ReadonlyContent: () => <div /> }));
+
+// Stand in for the transcript body only. The dialog shell stays real so
+// `finalFocus` reaches Base UI's focus manager exactly as it does in the app.
+vi.mock("../../common/task-transcript/agent-transcript-dialog", async () => {
+  const { Dialog, DialogContent, DialogTitle } = await import("@multica/ui/components/ui/dialog");
+  return {
+    AgentTranscriptDialog: ({ open, onOpenChange, finalFocus }: {
+      open: boolean; onOpenChange: (open: boolean) => void; finalFocus?: boolean;
+    }) => (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent finalFocus={finalFocus}>
+          <DialogTitle>Full transcript</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    ),
+    StepBody: () => null,
+  };
+});
+
+const id = "4a2e8d1c-7f9b-4e2a-9c1d-123456789abc";
+const completed: AgentTask = {
+  id, agent_id: "agent", runtime_id: "runtime", issue_id: "issue", status: "completed", priority: 0,
+  created_at: "2026-09-07T00:00:00Z", started_at: "2026-09-07T00:00:00Z", dispatched_at: null,
+  completed_at: "2026-09-07T00:01:23Z", result: null, error: null,
+};
+
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+function renderHeaderRun() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrap = (children: ReactNode) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  renderWithI18n(wrap(
+    <InlineCommentRun run={{ task: completed, commentId: "comment", hasReply: true }} presentation="header" />,
+  ));
+  return screen.getByRole("button", { name: "Open full log" });
+}
+
+describe("InlineCommentRun full log focus", () => {
+  it("leaves the trigger alone after a pointer open, so Esc reveals no ring or tooltip", async () => {
+    vi.mocked(api.listTaskMessages).mockResolvedValue([]);
+    const user = userEvent.setup();
+    const trigger = renderHeaderRun();
+
+    await user.click(trigger);
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    // No focus on the trigger is what keeps its ring, its tooltip and the
+    // hover-revealed action row it sits in from coming back with the dialog.
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(trigger).not.toHaveFocus();
+  });
+
+  it("hands focus back to the trigger after a keyboard open", async () => {
+    vi.mocked(api.listTaskMessages).mockResolvedValue([]);
+    const user = userEvent.setup();
+    const trigger = renderHeaderRun();
+
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -32,8 +32,16 @@ import { useRunDisclosureMotion } from "./use-run-comment-motion";
 export function useInlineCommentRunState() {
   const [expanded, setExpanded] = useState(false);
   const [fullLogOpen, setFullLogOpen] = useState(false);
+  // A click carrying no detail count came from Enter/Space. Only that reader
+  // needs focus handed back when the log closes; giving it back after a
+  // pointer open is what leaves this trigger ringed and tooltipped on Esc.
+  const [logFromKeyboard, setLogFromKeyboard] = useState(false);
   const disclosure = useRunDisclosureMotion(expanded);
-  return { expanded, setExpanded, fullLogOpen, setFullLogOpen, disclosure };
+  const openFullLog = (event: React.MouseEvent<HTMLElement>) => {
+    setLogFromKeyboard(event.detail === 0);
+    setFullLogOpen(true);
+  };
+  return { expanded, setExpanded, fullLogOpen, setFullLogOpen, openFullLog, logFromKeyboard, disclosure };
 }
 
 export type InlineCommentRunState = ReturnType<typeof useInlineCommentRunState>;
@@ -54,7 +62,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   const active = isActiveCommentRun(task);
   const localViewState = useInlineCommentRunState();
   const state = viewState ?? localViewState;
-  const { expanded, setExpanded, fullLogOpen, setFullLogOpen } = state;
+  const { expanded, setExpanded, fullLogOpen, setFullLogOpen, openFullLog, logFromKeyboard } = state;
   const [confirmStop, setConfirmStop] = useState(false);
   const [now, setNow] = useState(Date.now);
   const [visibleCount, setVisibleCount] = useState(12);
@@ -101,7 +109,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   const stepLabel = steps.length > 0 ? t(($) => $.inline_run.steps, { count: steps.length }) : "";
   const stopLabel = cancel.isPending || cancel.isSuccess ? t(($) => $.inline_run.stopping) : t(($) => $.inline_run.stop);
   const transcript = fullLogOpen && <AgentTranscriptDialog open onOpenChange={setFullLogOpen}
-    task={task} items={items} agentName={name} isLive={active}
+    task={task} items={items} agentName={name} isLive={active} finalFocus={logFromKeyboard}
     contentState={isPending ? <p role="status" className="text-body text-muted-foreground">{t(($) => $.inline_run.loading)}</p>
       : isError ? <div role="alert" className="text-body text-destructive">{t(($) => $.inline_run.load_failed)}
         <button className="ml-2 underline" type="button" onClick={() => void refetch()}>{t(($) => $.inline_run.try_again)}</button>
@@ -120,7 +128,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
         <TooltipTrigger render={<Button type="button" size="icon-sm" variant="ghost"
           className="text-muted-foreground aria-expanded:bg-transparent aria-expanded:hover:bg-muted dark:aria-expanded:hover:bg-muted/50"
           aria-label={t(($) => $.inline_run.full_log)} aria-haspopup="dialog" aria-expanded={fullLogOpen}
-          onClick={() => setFullLogOpen(true)}>
+          onClick={openFullLog}>
           <ScrollText aria-hidden className="size-3.5" />
         </Button>} />
         <TooltipContent>{t(($) => $.inline_run.full_log)}</TooltipContent>
@@ -178,7 +186,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
             onClick={() => setVisibleCount((count) => count + 12)}>{t(($) => $.inline_run.show_earlier, { count: rows.length - visibleCount })}</button>}
           {rows.slice(-visibleCount).map((row) => <InlineStep key={row.seq} row={row} live={active} formatText={formatText} />)}
           <button type="button" className="flex items-center gap-1.5 rounded py-2 text-caption text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={() => setFullLogOpen(true)}>{t(($) => $.inline_run.full_log)}<ExternalLink className="size-3" /></button>
+            onClick={openFullLog}>{t(($) => $.inline_run.full_log)}<ExternalLink className="size-3" /></button>
         </div>}
       </div>
       {transcript}

--- a/packages/views/issues/components/issue-agent-header-chip.focus.test.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.focus.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+// Where focus lands when the full log closes on the header-chip path. The
+// trigger lives in the active-work popover while the chip itself renders the
+// dialog, so the open modality has to survive that hop — the sibling suite
+// stubs both the row and the dialog and cannot see it. Real popover, real
+// dialog: focus return is the behaviour under test.
+
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "@multica/core/api";
+import type { AgentTask } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { IssueAgentHeaderChip } from "./issue-agent-header-chip";
+
+vi.mock("@multica/core/api", () => ({ api: {
+  listTasksByIssue: vi.fn(), listTaskMessages: vi.fn(), cancelTask: vi.fn(),
+}, dispatchReasonCode: () => undefined }));
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "workspace" }));
+vi.mock("@multica/core/workspace/hooks", () => ({ useActorName: () => ({
+  getActorName: () => "Reviewer", getActorInitials: () => "RE", getActorAvatarUrl: () => null,
+}) }));
+vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
+vi.mock("../../agents/components/agent-avatar-stack", () => ({ AgentAvatarStack: () => <span /> }));
+
+// Stand in for the transcript body only; the dialog shell stays real so
+// `finalFocus` reaches Base UI's focus manager as it does in the app.
+vi.mock("../../common/task-transcript/agent-transcript-dialog", async () => {
+  const { Dialog, DialogContent, DialogTitle } = await import("@multica/ui/components/ui/dialog");
+  return {
+    AgentTranscriptDialog: ({ open, onOpenChange, finalFocus }: {
+      open: boolean; onOpenChange: (open: boolean) => void; finalFocus?: boolean;
+    }) => (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent finalFocus={finalFocus}>
+          <DialogTitle>Full transcript</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    ),
+  };
+});
+
+const running: AgentTask = {
+  id: "4a2e8d1c-7f9b-4e2a-9c1d-123456789abc", agent_id: "agent", runtime_id: "runtime",
+  issue_id: "issue-1", status: "running", priority: 0, created_at: "2026-09-07T00:00:00Z",
+  started_at: "2026-09-07T00:00:00Z", dispatched_at: null, completed_at: null, result: null, error: null,
+};
+
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+async function openActiveWorkPopover() {
+  vi.mocked(api.listTasksByIssue).mockResolvedValue([running]);
+  vi.mocked(api.listTaskMessages).mockResolvedValue([]);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const user = userEvent.setup();
+  renderWithI18n(
+    <QueryClientProvider client={client}><IssueAgentHeaderChip issueId="issue-1" /></QueryClientProvider>,
+  );
+  const chip = await screen.findByRole("button", { name: /working/i });
+  chip.focus();
+  await user.keyboard("{Enter}");
+  return { user, trigger: await screen.findByRole("button", { name: "View transcript" }) };
+}
+
+// The log opens over the still-open popover, so the first Esc dismisses the
+// popover and the second closes the log.
+async function closeLog(user: ReturnType<typeof userEvent.setup>) {
+  await user.keyboard("{Escape}");
+  await user.keyboard("{Escape}");
+  await waitFor(() => expect(screen.queryByText("Full transcript")).not.toBeInTheDocument());
+}
+
+describe("IssueAgentHeaderChip full log focus", () => {
+  it("hands focus back to the row trigger after a keyboard open", async () => {
+    const { user, trigger } = await openActiveWorkPopover();
+
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    await screen.findByText("Full transcript");
+    await closeLog(user);
+
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it("leaves the row trigger alone after a pointer open", async () => {
+    const { user, trigger } = await openActiveWorkPopover();
+
+    await user.click(trigger);
+    await screen.findByText("Full transcript");
+    await closeLog(user);
+
+    expect(trigger).not.toHaveFocus();
+  });
+});

--- a/packages/views/issues/components/issue-agent-header-chip.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.tsx
@@ -77,11 +77,15 @@ export const IssueAgentHeaderChip = memo(function IssueAgentHeaderChip({
     return { running, queued };
   }, [tasks]);
 
-  const [openedTranscriptTaskSnapshot, setOpenedTranscriptTaskSnapshot] =
-    useState<AgentTask | null>(null);
-  const openedTranscriptTask = openedTranscriptTaskSnapshot
-    ? tasks.find((task) => task.id === openedTranscriptTaskSnapshot.id) ??
-      openedTranscriptTaskSnapshot
+  // The row owns the trigger, this level owns the dialog — so the row's open
+  // signal has to carry how it was requested, or the dialog would never learn
+  // it and would always drop a keyboard reader's focus on close.
+  const [openedTranscript, setOpenedTranscript] = useState<
+    { task: AgentTask; fromKeyboard: boolean } | null
+  >(null);
+  const openedTranscriptTask = openedTranscript
+    ? tasks.find((task) => task.id === openedTranscript.task.id) ??
+      openedTranscript.task
     : null;
 
   // No active work → render nothing.
@@ -94,8 +98,8 @@ export const IssueAgentHeaderChip = memo(function IssueAgentHeaderChip({
           issueId={issueId}
           running={running}
           queued={queued}
-          onTranscriptOpenChange={(task, open) => {
-            setOpenedTranscriptTaskSnapshot(open ? task : null);
+          onTranscriptOpenChange={(task, open, fromKeyboard) => {
+            setOpenedTranscript(open ? { task, fromKeyboard } : null);
           }}
         />
       ) : null}
@@ -107,8 +111,9 @@ export const IssueAgentHeaderChip = memo(function IssueAgentHeaderChip({
           title={t(($) => $.execution_log.transcript_tooltip)}
           renderButton={false}
           open
+          finalFocus={openedTranscript?.fromKeyboard === true}
           onOpenChange={(open) => {
-            if (!open) setOpenedTranscriptTaskSnapshot(null);
+            if (!open) setOpenedTranscript(null);
           }}
         />
       ) : null}
@@ -120,7 +125,11 @@ interface ActiveChipProps {
   issueId: string;
   running: AgentTask[];
   queued: AgentTask[];
-  onTranscriptOpenChange: (task: AgentTask, open: boolean) => void;
+  onTranscriptOpenChange: (
+    task: AgentTask,
+    open: boolean,
+    fromKeyboard: boolean,
+  ) => void;
 }
 
 function ActiveChip({
@@ -216,8 +225,8 @@ function ActiveChip({
                 key={task.id}
                 task={task}
                 issueId={issueId}
-                onTranscriptOpenChange={(open) => {
-                  onTranscriptOpenChange(task, open);
+                onTranscriptOpenChange={(open, fromKeyboard) => {
+                  onTranscriptOpenChange(task, open, fromKeyboard === true);
                 }}
               />
             ))}


### PR DESCRIPTION
## Problem

Opening a comment's run log and closing it with <kbd>Esc</kbd> left the trigger button focused: it came back with a focus ring, its "Open full log" tooltip opened, and — because comment actions are hover-revealed via `:focus-within` — the whole action row stayed visible with the pointer long gone.

The dialog was doing the textbook thing: return focus to the trigger. The trouble is that <kbd>Esc</kbd> is keyboard input, so the browser marks the restored focus `:focus-visible` even for a reader who opened the log with a mouse click.

## Change

Return focus only when the log was opened from the keyboard — a click carrying no `detail` count, the same signal `useRunDisclosureMotion` already uses for the run disclosure. That reader has no other way back to the trigger. A pointer reader does, and now leaves focus where the dialog took it.

`AgentTranscriptDialog` gained a `finalFocus` prop (forwarded to Base UI's `DialogContent`) that defaults to not restoring, and both of its triggers — the inline comment run and the older `TranscriptButton`, which has the same tooltip-on-an-icon-button shape — pass the open modality through.

## Verification

- New `inline-comment-run.focus.test.tsx` drives the real Base UI dialog rather than the stub the sibling suite uses, since focus return is the behaviour under test: a pointer open then <kbd>Esc</kbd> leaves the trigger unfocused, a keyboard open then <kbd>Esc</kbd> hands it back. Confirmed the first case fails against the previous behaviour.
- `pnpm --filter @multica/views test` — 417 files, 4964 tests pass.
- `tsc --noEmit` and `eslint` clean on the touched files.
