### PR TITLE
MUL-7152: refine agent run motion

### DIFF
--- a/packages/ui/lib/motion.ts
+++ b/packages/ui/lib/motion.ts
@@ -1,4 +1,6 @@
 export const UI_EASE_OUT = [0.23, 1, 0.32, 1] as const;
+export const UI_EASE_IN = [0.4, 0, 1, 1] as const;
+export const UI_EASE_OUT_CSS = "cubic-bezier(0.23, 1, 0.32, 1)";
 
 export const UI_MOTION_DURATION = {
   micro: 0.1,

--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -125,6 +125,13 @@ describe("InlineCommentRun", () => {
     const current = task();
     const { client, rerender } = setup(current);
     await screen.findByText("pnpm test");
+    const progress = screen.getByText("pnpm test");
+    expect(progress).not.toHaveClass("animate-chat-text-shimmer");
+    expect(progress.closest("[data-run-summary]")).toHaveClass("h-[1lh]", "overflow-hidden");
+    expect(document.querySelector("[data-run-loading-indicator]")).toHaveClass(
+      "motion-safe:animate-spin",
+      "motion-safe:[animation-duration:900ms]",
+    );
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     const toggle = screen.getByRole("button", { name: /View activity/ });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
@@ -132,7 +139,7 @@ describe("InlineCommentRun", () => {
     expect(toggle).toHaveAttribute("aria-expanded", "true");
     const tail: TaskMessagePayload = { task_id: id, issue_id: "issue", seq: 3, type: "tool_result", tool: "exec_command", output: "12 passed" };
     act(() => client.setQueryData(chatKeys.taskMessages(id), [...messages, tail]));
-    expect(screen.queryByText("Waiting for the agent to respond.")).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText("Waiting for the agent to respond.")).not.toBeInTheDocument());
     vi.mocked(api.listTaskMessages).mockResolvedValue([...messages, tail]);
     rerender({ ...current, status: "completed", completed_at: "2026-09-07T00:01:23Z" }, true);
     await screen.findByText("Completed");
@@ -161,12 +168,14 @@ describe("InlineCommentRun", () => {
     await screen.findByText("pnpm test");
     await receive({ type: "tool_result", tool: "exec_command", output: "12 passed" });
     expect(screen.getByText("pnpm test")).toBeInTheDocument();
-    expect(screen.queryByText("Waiting for the agent to respond.")).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText("Waiting for the agent to respond.")).not.toBeInTheDocument());
     await receive({ type: "text", content: "  " });
     expect(screen.getByText("pnpm test")).toBeInTheDocument();
     await receive({ type: "text", content: "Tests passed. Reviewing the changes." });
     await screen.findByText("Tests passed. Reviewing the changes.");
-    expect(screen.queryByText("pnpm test")).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText("pnpm test")).not.toBeInTheDocument(),
+    );
   });
 
   it("keeps completed replies readable without fetching or duplicating their deliverable", () => {

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useId, useMemo, useState } from "react";
-import { AlertCircle, Brain, ChevronRight, ExternalLink, Loader2, MessageSquare, RotateCcw, ScrollText, Square, Terminal } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { AlertCircle, Brain, ChevronRight, CirclePause, Clock3, ExternalLink, Loader2, MessageSquare, RotateCcw, ScrollText, Square, Terminal } from "lucide-react";
 import { toast } from "sonner";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useTraceIssueLabels } from "../../common/task-transcript/use-trace-issue-labels";
@@ -9,10 +10,12 @@ import { useActorName } from "@multica/core/workspace/hooks";
 import { useTaskMessages } from "@multica/core/chat/queries";
 import { useCancelIssueRun, useRetryIssueRun } from "@multica/core/issues/mutations";
 import { dispatchReasonCode } from "@multica/core/api";
+import type { AgentTask } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { Button } from "@multica/ui/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { cn } from "@multica/ui/lib/utils";
+import { UI_EASE_IN, UI_EASE_OUT, UI_MOTION_DURATION } from "@multica/ui/lib/motion";
 import { AgentTranscriptDialog, StepBody } from "../../common/task-transcript/agent-transcript-dialog";
 import { buildTimeline } from "../../common/task-transcript/build-timeline";
 import { buildSteps, groupSteps, isCallStep, isGroupRow, type TraceRow } from "../../common/task-transcript/build-steps";
@@ -27,7 +30,7 @@ import { TaskStatusIcon } from "./task-status-icon";
 import { useStatusLabel } from "./task-run-labels";
 import { commentRunOutput, isActiveCommentRun, showCommentRunInHeader, type CommentRun } from "./comment-runs";
 
-import { useRunDisclosureMotion } from "./use-run-comment-motion";
+import { useRunAnimationVisibility, useRunDisclosureMotion } from "./use-run-comment-motion";
 
 export function useInlineCommentRunState() {
   const [expanded, setExpanded] = useState(false);
@@ -58,6 +61,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   const [confirmStop, setConfirmStop] = useState(false);
   const [now, setNow] = useState(Date.now);
   const [visibleCount, setVisibleCount] = useState(12);
+  const animationVisibility = useRunAnimationVisibility<HTMLDivElement>();
   const cancel = useCancelIssueRun(task.issue_id);
   const retry = useRetryIssueRun(task.issue_id);
   const regionId = useId();
@@ -96,6 +100,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
     : task.status === "dispatched" ? t(($) => $.inline_run.starting)
     : task.status === "waiting_local_directory" ? t(($) => $.inline_run.waiting_directory)
     : activitySummary;
+  const summaryMotionKey = `${task.status}:${current?.seq ?? "empty"}`;
   const showProgress = active && !hasReply;
   const activityLabel = t(($) => $.inline_run.view_activity);
   const stepLabel = steps.length > 0 ? t(($) => $.inline_run.steps, { count: steps.length }) : "";
@@ -131,7 +136,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   return (
     <section aria-label={t(($) => $.inline_run.label, { name })}
       className={cn("@container/run min-w-0 py-2", className)} data-run-id={task.id}>
-      <div className="flex min-h-7 min-w-0 items-center gap-2" data-run-summary-row>
+      <div ref={animationVisibility.ref} className="flex min-h-7 min-w-0 items-center gap-2" data-run-summary-row>
         {showIdentity && <>
           <ActorAvatar actorType="agent" actorId={task.agent_id} size="md" enableHoverCard />
           <span className="max-w-[30%] shrink-0 truncate text-body font-medium" title={name}>{name}</span>
@@ -148,10 +153,8 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
           aria-expanded={expanded} aria-controls={expanded ? regionId : undefined}
           onClick={(event) => { state.disclosure.onTrigger(event); setExpanded(!expanded); }}>
           {showProgress
-            ? <span data-run-summary className="min-w-0 flex-1 truncate" title={summary}>
-                <span className={cn("inline-block max-w-full truncate align-bottom",
-                  (task.status === "running" || task.status === "dispatched") && "animate-chat-text-shimmer")}>{summary}</span>
-              </span>
+            ? <><RunActivityIndicator status={task.status} animate={animationVisibility.visible} />
+                <RunActivitySummary summary={summary} motionKey={summaryMotionKey} /></>
             : <span className={cn(showIdentity && "@max-[32rem]/run:sr-only")}>{activityLabel}</span>}
           {!showProgress && stepLabel && <span className="text-faint-foreground @max-[32rem]/run:hidden">· {stepLabel}</span>}
           <ChevronRight ref={state.disclosure.chevronRef} aria-hidden className={cn("size-3.5 shrink-0", expanded && "rotate-90")} />
@@ -169,7 +172,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
       <div className={cn(showIdentity && "pl-8")}>
         {output && <div className="mt-2 text-body"><ReadonlyContent content={redactSecrets(output)} /></div>}
         {failure && <p className="mt-1 text-caption text-destructive">{failure}</p>}
-        {expanded && <div ref={state.disclosure.contentRef} id={regionId} className="mt-2 min-w-0 space-y-1">
+        {expanded && <div id={regionId} className="mt-2 min-w-0 space-y-1">
           {isPending && <p className="text-caption text-muted-foreground">{t(($) => $.inline_run.loading)}</p>}
           {isError && <div role="alert" className="text-caption text-destructive">{t(($) => $.inline_run.load_failed)}
             <button className="ml-2 underline" type="button" onClick={() => void refetch()}>{t(($) => $.inline_run.try_again)}</button></div>}
@@ -214,7 +217,7 @@ function InlineStep({ row, live, formatText }: { row: TraceRow; live: boolean; f
       </span>}
       <ChevronRight ref={disclosure.chevronRef} aria-hidden className={cn("size-3 shrink-0 text-muted-foreground", open && "rotate-90")} />
     </summary>
-    {open && <div ref={disclosure.contentRef} className="min-w-0 space-y-2 overflow-hidden pl-5.5">
+    {open && <div className="min-w-0 space-y-2 overflow-hidden pl-5.5">
       {grouped ? <>
         {row.steps.length > limit && <button type="button" className="py-1 text-muted-foreground" onClick={() => setLimit((value) => value + 12)}>
           {t(($) => $.inline_run.show_earlier, { count: row.steps.length - limit })}</button>}
@@ -226,4 +229,36 @@ function InlineStep({ row, live, formatText }: { row: TraceRow; live: boolean; f
       </> : <StepBody item={row.item} />}
     </div>}
   </details>;
+}
+
+function RunActivityIndicator({ status, animate }: { status: AgentTask["status"]; animate: boolean }) {
+  if (status === "running" || status === "dispatched") {
+    return <Loader2 aria-hidden data-run-loading-indicator className={cn(
+      "size-3.5 shrink-0 stroke-[2.25] text-info",
+      animate && "motion-safe:animate-spin motion-safe:[animation-duration:900ms]",
+    )} />;
+  }
+  if (status === "waiting_local_directory") {
+    return <CirclePause aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />;
+  }
+  return <Clock3 aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />;
+}
+
+function RunActivitySummary({ summary, motionKey }: { summary: string; motionKey: string }) {
+  const shouldReduceMotion = useReducedMotion() ?? false;
+  return <span data-run-summary className="grid h-[1lh] min-w-0 flex-1 overflow-hidden" title={summary}>
+    <AnimatePresence initial={false}>
+      <motion.span key={motionKey}
+        className="col-start-1 row-start-1 block min-w-0 max-w-full truncate"
+        initial={shouldReduceMotion ? false : { opacity: 0, transform: "translateY(6px)" }}
+        animate={shouldReduceMotion ? undefined : { opacity: 1, transform: "translateY(0)", transition: {
+          duration: UI_MOTION_DURATION.fast, ease: UI_EASE_OUT,
+        } }}
+        exit={shouldReduceMotion ? undefined : { opacity: 0, transform: "translateY(-6px)", transition: {
+          duration: UI_MOTION_DURATION.micro, ease: UI_EASE_IN,
+        } }}>
+        {summary}
+      </motion.span>
+    </AnimatePresence>
+  </span>;
 }

--- a/packages/views/issues/components/use-run-comment-motion.test.tsx
+++ b/packages/views/issues/components/use-run-comment-motion.test.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { cleanup, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentTask } from "@multica/core/types";
-import { useNewRunIds, useRunCommentMotion, useRunDisclosureMotion } from "./use-run-comment-motion";
+import { useNewRunIds, useRunAnimationVisibility, useRunCommentMotion, useRunDisclosureMotion } from "./use-run-comment-motion";
 
 const animate = vi.fn((_frames: Keyframe[], _options: KeyframeAnimationOptions) => ({ cancel: vi.fn() }));
 const originalAnimate = Object.getOwnPropertyDescriptor(Element.prototype, "animate");
@@ -37,8 +37,12 @@ function Disclosure() {
     <button key={String(open)} onClick={(event) => { motion.onTrigger(event); setOpen(!open); }}>
       <svg ref={motion.chevronRef} style={{ rotate: open ? "90deg" : "0deg" }} />Toggle
     </button>
-    {open && <div ref={motion.contentRef}>Activity</div>}
+    {open && <div>Activity</div>}
   </>;
+}
+function Visibility() {
+  const { ref, visible } = useRunAnimationVisibility<HTMLDivElement>();
+  return <div ref={ref} data-testid="visibility" data-visible={visible} />;
 }
 
 describe("run comment motion", () => {
@@ -58,13 +62,13 @@ describe("run comment motion", () => {
     expect(result.current.size).toBe(0);
   });
 
-  it("animates live arrival once and never replays on a virtualized remount", () => {
+  it("animates live arrival once with shared timing and never replays on a virtualized remount", () => {
     const view = render(<Slot />);
     expect(animate).not.toHaveBeenCalled();
     view.rerender(<Slot entering />);
     expect(animate).toHaveBeenCalledWith(
       [{ opacity: 0, transform: "translateY(4px)" }, { opacity: 1, transform: "translateY(0)" }],
-      expect.objectContaining({ duration: 160 }),
+      expect.objectContaining({ duration: 150, easing: "cubic-bezier(0.23, 1, 0.32, 1)" }),
     );
     view.rerender(<Slot entering />);
     expect(animate).toHaveBeenCalledTimes(1);
@@ -76,50 +80,74 @@ describe("run comment motion", () => {
     expect(animate).not.toHaveBeenCalled();
   });
 
-  it("fades only the arriving reply and changed status, not routine rerenders", () => {
+  it("prioritizes an arriving reply over a simultaneous status change", () => {
     const view = render(<Slot status="running" />);
     view.rerender(<Slot status="completed" replyId="reply" />);
-    expect(animate.mock.instances).toEqual([screen.getByText("Reply"), screen.getByText("completed")]);
-    expect(animate.mock.calls.map((call) => call[1].duration)).toEqual([160, 100]);
+    expect(animate.mock.instances).toEqual([screen.getByText("Reply")]);
+    expect(animate.mock.calls.map((call) => call[1].duration)).toEqual([150]);
     view.rerender(<Slot status="completed" replyId="reply" />);
-    expect(animate).toHaveBeenCalledTimes(2);
+    expect(animate).toHaveBeenCalledTimes(1);
     view.unmount();
     animate.mockClear();
     render(<Slot status="completed" replyId="reply" />);
     expect(animate).not.toHaveBeenCalled();
   });
 
-  it("keeps reduced motion to a short fade without displacement", () => {
+  it("uses the micro timing for a status-only change", () => {
+    const view = render(<Slot status="running" />);
+    view.rerender(<Slot status="completed" />);
+    expect(animate.mock.instances).toEqual([screen.getByText("completed")]);
+    expect(animate.mock.calls.map((call) => call[1].duration)).toEqual([100]);
+  });
+
+  it("disables run arrival motion when reduced motion is requested", () => {
     reduced = true;
     const view = render(<Slot />);
     view.rerender(<Slot entering />);
-    expect(animate).toHaveBeenCalledWith([{ opacity: 0 }, { opacity: 1 }], expect.objectContaining({ duration: 60 }));
+    expect(animate).not.toHaveBeenCalled();
   });
 
-  it("fades pointer disclosure once and keeps keyboard disclosure immediate", () => {
+  it("pauses ambient run motion outside the viewport", async () => {
+    let notify!: IntersectionObserverCallback;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    vi.stubGlobal("IntersectionObserver", class {
+      constructor(callback: IntersectionObserverCallback) {
+        notify = callback;
+      }
+      observe = observe;
+      disconnect = disconnect;
+    });
+    const view = render(<Visibility />);
+    await waitFor(() => expect(observe).toHaveBeenCalledWith(screen.getByTestId("visibility")));
+    act(() => notify([{ isIntersecting: false } as IntersectionObserverEntry], {} as IntersectionObserver));
+    expect(screen.getByTestId("visibility")).toHaveAttribute("data-visible", "false");
+    act(() => notify([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver));
+    expect(screen.getByTestId("visibility")).toHaveAttribute("data-visible", "true");
+    view.unmount();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("rotates pointer disclosure with shared timing and keeps keyboard disclosure immediate", () => {
     render(<Disclosure />);
     const toggle = () => screen.getByRole("button", { name: "Toggle" });
     fireEvent.click(toggle(), { detail: 1 });
     expect(screen.getByText("Activity")).toBeInTheDocument();
-    expect(animate).toHaveBeenCalledWith(
-      [{ opacity: 0, transform: "translateY(-4px)" }, { opacity: 1, transform: "translateY(0)" }],
-      expect.objectContaining({ duration: 180 }),
-    );
-    expect(animate).toHaveBeenCalledWith([{ rotate: "0deg" }, { rotate: "90deg" }], expect.objectContaining({ duration: 180 }));
+    expect(animate).toHaveBeenCalledTimes(1);
+    expect(animate).toHaveBeenCalledWith([{ rotate: "0deg" }, { rotate: "90deg" }], expect.objectContaining({ duration: 150 }));
     fireEvent.click(toggle(), { detail: 1 });
-    expect(animate).toHaveBeenCalledWith([{ rotate: "90deg" }, { rotate: "0deg" }], expect.objectContaining({ duration: 120 }));
+    expect(animate).toHaveBeenCalledWith([{ rotate: "90deg" }, { rotate: "0deg" }], expect.objectContaining({ duration: 100 }));
     animate.mockClear();
     fireEvent.click(toggle(), { detail: 0 });
     expect(screen.getByText("Activity")).toBeInTheDocument();
     expect(animate).not.toHaveBeenCalled();
   });
 
-  it("uses only a short content fade for reduced-motion disclosure", () => {
+  it("disables pointer disclosure motion when reduced motion is requested", () => {
     reduced = true;
     render(<Disclosure />);
     fireEvent.click(screen.getByRole("button", { name: "Toggle" }), { detail: 1 });
-    expect(animate).toHaveBeenCalledTimes(1);
-    expect(animate).toHaveBeenCalledWith([{ opacity: 0 }, { opacity: 1 }], expect.objectContaining({ duration: 60 }));
+    expect(animate).not.toHaveBeenCalled();
   });
 
   it("reverses a rapid toggle from the visible arrow angle and cancels stale motion", () => {
@@ -131,7 +159,7 @@ describe("run comment motion", () => {
     computed.rotate = "42deg";
     const style = vi.spyOn(window, "getComputedStyle").mockReturnValue(computed);
     fireEvent.click(toggle, { detail: 1 });
-    expect(animate).toHaveBeenLastCalledWith([{ rotate: "42deg" }, { rotate: "0deg" }], expect.objectContaining({ duration: 120 }));
+    expect(animate).toHaveBeenLastCalledWith([{ rotate: "42deg" }, { rotate: "0deg" }], expect.objectContaining({ duration: 100 }));
     for (const animation of firstAnimations) expect(animation.cancel).toHaveBeenCalled();
     style.mockRestore();
   });

--- a/packages/views/issues/components/use-run-comment-motion.ts
+++ b/packages/views/issues/components/use-run-comment-motion.ts
@@ -1,17 +1,18 @@
-import { useEffect, useLayoutEffect, useRef, useState, type MouseEvent } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type MouseEvent } from "react";
 import type { AgentTask } from "@multica/core/types";
+import { UI_EASE_OUT_CSS, UI_MOTION_DURATION } from "@multica/ui/lib/motion";
 
 const EMPTY_IDS: ReadonlySet<string> = new Set();
-const EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
 
 function reveal(element: HTMLElement | null, duration: number, translate = 0) {
   if (!element?.animate) return;
   const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+  if (reduced) return;
   return element.animate(
-    translate && !reduced
+    translate
       ? [{ opacity: 0, transform: `translateY(${translate}px)` }, { opacity: 1, transform: "translateY(0)" }]
       : [{ opacity: 0 }, { opacity: 1 }],
-    { duration: reduced ? 60 : duration, easing: EASING },
+    { duration, easing: UI_EASE_OUT_CSS },
   );
 }
 
@@ -37,6 +38,20 @@ export function useNewRunIds(issueId: string, tasks: readonly AgentTask[] | unde
   return arrivals.issueId === issueId ? arrivals.ids : EMPTY_IDS;
 }
 
+/** Pause ambient run motion outside the viewport, including Virtuoso overscan. */
+export function useRunAnimationVisibility<T extends Element>() {
+  const [element, setElement] = useState<T | null>(null);
+  const [visible, setVisible] = useState(true);
+  const ref = useCallback((node: T | null) => setElement(node), []);
+  useEffect(() => {
+    if (!element || typeof IntersectionObserver !== "function") return;
+    const observer = new IntersectionObserver(([entry]) => setVisible(entry?.isIntersecting ?? true));
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [element]);
+  return { ref, visible };
+}
+
 /** Animate observed changes only. A virtualized row's first mount is always still. */
 export function useRunCommentMotion(entering: boolean, replyId: string | undefined, status: string) {
   const ref = useRef<HTMLDivElement>(null);
@@ -45,13 +60,15 @@ export function useRunCommentMotion(entering: boolean, replyId: string | undefin
     const before = previous.current;
     previous.current = { entering, replyId, status };
     const animations: (Animation | undefined)[] = [];
-    if (entering && !before.entering) animations.push(reveal(ref.current, 160, 4));
-    if (replyId && replyId !== before.replyId) {
+    if (entering && !before.entering) {
+      animations.push(reveal(ref.current, UI_MOTION_DURATION.fast * 1000, 4));
+    } else if (replyId && replyId !== before.replyId) {
       const body = Array.from(ref.current?.querySelectorAll<HTMLElement>("[data-comment-content]") ?? [])
         .find((element) => element.dataset.commentContent === replyId);
-      animations.push(reveal(body ?? null, 160));
+      animations.push(reveal(body ?? null, UI_MOTION_DURATION.fast * 1000));
+    } else if (status !== before.status) {
+      animations.push(reveal(ref.current?.querySelector("[data-run-status]") ?? null, UI_MOTION_DURATION.micro * 1000));
     }
-    if (status !== before.status) animations.push(reveal(ref.current?.querySelector("[data-run-status]") ?? null, 100));
     return () => { for (const animation of animations) animation?.cancel(); };
   }, [entering, replyId, status]);
   return ref;
@@ -59,7 +76,6 @@ export function useRunCommentMotion(entering: boolean, replyId: string | undefin
 
 /** Animate the toggle itself, including when historical runs mount a new trigger. */
 export function useRunDisclosureMotion(open: boolean) {
-  const contentRef = useRef<HTMLDivElement>(null);
   const chevronRef = useRef<SVGSVGElement>(null);
   const pending = useRef(false);
   const focusedTrigger = useRef<HTMLElement | null>(null);
@@ -74,16 +90,15 @@ export function useRunDisclosureMotion(open: boolean) {
     }
     if (!requested) return;
     const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    const duration = open ? 180 : 120;
-    const arrow = !reduced ? chevronRef.current?.animate?.(
+    if (reduced) return;
+    const duration = (open ? UI_MOTION_DURATION.fast : UI_MOTION_DURATION.micro) * 1000;
+    const arrow = chevronRef.current?.animate?.(
       [{ rotate: fromRotation.current }, { rotate: open ? "90deg" : "0deg" }],
-      { duration, easing: EASING },
-    ) : undefined;
-    const content = open ? reveal(contentRef.current, duration, -4) : undefined;
-    return () => { arrow?.cancel(); content?.cancel(); };
+      { duration, easing: UI_EASE_OUT_CSS },
+    );
+    return () => { arrow?.cancel(); };
   }, [open]);
   return {
-    contentRef,
     chevronRef,
     onTrigger(event: MouseEvent<HTMLElement>) {
       pending.current = event.detail > 0;


### PR DESCRIPTION
## Summary

- turn the live one-line agent activity into a fixed-height upward ticker instead of shimmering text
- make active loading legible with a faster, higher-contrast spinner and state-specific queued/waiting icons
- choreograph run arrival, reply, status, and disclosure motion around shared timing tokens
- disable motion for reduced-motion users and pause ambient spinning outside the viewport

## Validation

- `pnpm --filter @multica/views exec vitest run issues/components/use-run-comment-motion.test.tsx issues/components/inline-comment-run.test.tsx issues/components/issue-detail.test.tsx` (97 passed)
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/ui typecheck`
- targeted ESLint for all changed files
- full `@multica/views` suite: 4,963 passed; unrelated existing `layout/sidebar-resize.test.tsx` localStorage assertion failed and reproduces in isolation

Closes MUL-7152
