### PR TITLE
MUL-7161: fix(dashboard): axis tick labels use foreground color in dark mode

### DIFF
--- a/packages/ui/components/ui/chart.tsx
+++ b/packages/ui/components/ui/chart.tsx
@@ -66,6 +66,7 @@ function ChartContainer({
         data-chart={chartId}
         className={cn(
           "flex aspect-video justify-center text-caption [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          "dark:[&_.recharts-cartesian-axis-tick_text]:fill-foreground",
           className
         )}
         {...props}


### PR DESCRIPTION
Chart x/y axis tick (and unit) labels render `fill-muted-foreground` — a mid-grey (`oklch(0.705 …)`) in dark mode, which reads as washed-out grey rather than white on dark surfaces.

This adds a dark-variant override on `ChartContainer` so `.recharts-cartesian-axis-tick text` uses `fill-foreground` (`oklch(0.985` ≈ white) in dark mode only. Light mode is untouched — ticks keep the muted tone.

- Works for all charts: `ChartContainer` is the single styling site for axis tick text (`packages/ui/components/ui/chart.tsx`), and unit strings (`$`, token counts) come from `tickFormatter` inside the same tick `<text>`, so one rule covers x and y.
- The `dark:` class variant is defined (`@custom-variant dark (&:is(.dark *))`) in all consuming apps (web, desktop, docs).
- Specificity: the variant rule carries the extra `:is(.dark *)` class, so it wins over the base rule without order dependence.