### PR TITLE
MUL-7164 fix(tasks): retry transient provider rejections

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -5116,25 +5116,28 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 // etc.) are intentionally excluded — those are real problems that the user
 // should see, not infrastructure flakiness.
 //
-// The one agent_error.* exception is provider_network: a mid-stream provider
-// disconnect (e.g. Claude Code's "API Error: Connection closed mid-response")
-// is transient infrastructure flakiness, not an agent decision. Unattended
-// issue runs otherwise terminate on it, while interactive chat only survives
-// because the CLI's own in-process retry happens to recover first — so we make
-// the platform retry it directly (MUL-4910). It is resume-safe (not in
+// Two agent_error.* exceptions are transient provider failures:
+// provider_network covers a mid-stream disconnect (e.g. Claude Code's "API
+// Error: Connection closed mid-response"), while
+// provider_capacity_or_rate_limit covers a provider that temporarily refuses a
+// request. Unattended runs otherwise terminate on either one, while manually
+// sending the same prompt again often succeeds. Both are resume-safe (not in
 // resumeUnsafeFailureReason), so the retry child inherits the session and
-// continues the truncated conversation rather than restarting from scratch.
+// continues the conversation rather than restarting from scratch. Capacity
+// keeps the task's existing attempt ceiling: by default that is one automatic
+// resend, the same operation that currently succeeds when the user retries.
 // skill_bundle_unavailable is retryable for the same reason: the agent process
 // never started, so there is nothing to be idempotent about, and every bundle
 // that did download is already cached on disk — a retry resumes from there
 // instead of re-fetching the whole set (MUL-5370).
 var retryableReasons = map[string]bool{
-	string(taskfailure.ReasonRuntimeOffline):         true,
-	string(taskfailure.ReasonRuntimeRecovery):        true,
-	string(taskfailure.ReasonTimeout):                true,
-	"codex_semantic_inactivity":                      true,
-	string(taskfailure.ReasonAgentProviderNetwork):   true,
-	string(taskfailure.ReasonSkillBundleUnavailable): true,
+	string(taskfailure.ReasonRuntimeOffline):                   true,
+	string(taskfailure.ReasonRuntimeRecovery):                  true,
+	string(taskfailure.ReasonTimeout):                          true,
+	"codex_semantic_inactivity":                                true,
+	string(taskfailure.ReasonAgentProviderNetwork):             true,
+	string(taskfailure.ReasonAgentProviderCapacityOrRateLimit): true,
+	string(taskfailure.ReasonSkillBundleUnavailable):           true,
 }
 
 // runtime_offline retries start deferred, not queued: their positive fire_at

--- a/server/internal/service/task_complete_race_test.go
+++ b/server/internal/service/task_complete_race_test.go
@@ -257,6 +257,9 @@ func TestTaskFailureClassifiers(t *testing.T) {
 		// Transient mid-stream provider disconnect (MUL-4910): retryable, and
 		// resume-safe so the retry continues the truncated conversation.
 		{reason: "agent_error.provider_network", wantType: "agent_error", wantResumeOK: true, wantRetry: true},
+		// A provider can report a transient concurrency rejection as HTTP 403.
+		// Retrying the same session is safe and matches a manual resend.
+		{reason: "agent_error.provider_capacity_or_rate_limit", wantType: "agent_error", wantResumeOK: true, wantRetry: true},
 		{reason: "runtime_recovery", wantType: "runtime", wantResumeOK: true, wantRetry: true},
 		{reason: "iteration_limit", wantType: "agent_output", wantResumeOK: false, wantRetry: false},
 		{reason: "api_invalid_request", wantType: "agent_error", wantResumeOK: false, wantRetry: false},
@@ -323,6 +326,48 @@ func TestEnvironmentPrepareFailureIsNotAutoRetried(t *testing.T) {
 	}
 	if resumeUnsafeFailureReason(reason) {
 		t.Errorf("resumeUnsafeFailureReason(%q) = true, want false: the agent never started", reason)
+	}
+}
+
+func TestConcurrentRequestLimitRetries(t *testing.T) {
+	const raw = "Failed to authenticate. API Error: 403 You've reached your concurrent request limit. Please wait for your ongoing requests to finish and try again."
+
+	resolveReason := func(reported string) string {
+		if reported == "" {
+			reported = taskfailure.Classify(raw).String()
+		}
+		return taskfailure.NormalizeDaemonReason(reported, raw).String()
+	}
+
+	for _, tc := range []struct {
+		name     string
+		reported string
+	}{
+		{name: "current daemon", reported: ""},
+		{name: "older daemon classified 403 as auth", reported: string(taskfailure.ReasonAgentProviderAuthOrAccess)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reason := resolveReason(tc.reported)
+			if reason != string(taskfailure.ReasonAgentProviderCapacityOrRateLimit) {
+				t.Fatalf("resolved reason = %q, want %q", reason, taskfailure.ReasonAgentProviderCapacityOrRateLimit)
+			}
+			if resumeUnsafeFailureReason(reason) {
+				t.Fatalf("concurrent request rejection must keep the resumable session")
+			}
+
+			task := db.AgentTaskQueue{
+				Attempt:       1,
+				MaxAttempts:   2,
+				ChatSessionID: pgtype.UUID{Bytes: [16]byte{1}, Valid: true},
+			}
+			if !retryEligible(reason, task) {
+				t.Fatalf("first transient rejection must schedule the one remaining attempt")
+			}
+			task.Attempt = 2
+			if retryEligible(reason, task) {
+				t.Fatalf("retry must stop at the task's existing attempt ceiling")
+			}
+		})
 	}
 }
 

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -35,6 +35,14 @@ var (
 	httpCapacityCodeRe = regexp.MustCompile(`(^|[^0-9])(429|529)([^0-9]|$)`)
 )
 
+// concurrentRequestLimitWitness is emitted by Anthropic-compatible providers
+// that use HTTP 403 for a transient request rejection. Claude Code prefixes the
+// response with "Failed to authenticate", but neither label establishes that
+// credentials expired: a later request with the same credentials and session
+// can succeed. This wire shape must therefore beat the generic 403 auth rule and
+// take the bounded retry path.
+const concurrentRequestLimitWitness = "concurrent request limit"
+
 // Classify maps a free-form error string from the agent runtime / CLI
 // to one of the 14 agent_error.* sub-reasons. Always returns a valid
 // Reason; falls back to ReasonAgentUnknown when no rule matches and for
@@ -100,6 +108,13 @@ func Classify(rawError string) Reason {
 		strings.Contains(lower, providerUnconfiguredPhrase),
 		strings.Contains(lower, "no provider configured"):
 		return ReasonAgentMissingConfig
+
+	// A specific transient provider rejection can arrive as HTTP 403 and with a
+	// misleading auth prefix from the CLI. Match its semantic witness before the
+	// generic 403 fallback so the platform can retry instead of telling the user
+	// to sign in again.
+	case strings.Contains(lower, concurrentRequestLimitWitness):
+		return ReasonAgentProviderCapacityOrRateLimit
 
 	// 3. Auth / access. 401 / 403 / "Not logged in" / invalid token
 	//    / lacks access to the model. Status codes use a digit boundary
@@ -416,6 +431,16 @@ var legacyEnvironmentPrepareWitnesses = []string{
 	"reuse execution environment:",
 }
 
+// legacyConcurrentRequestLimitReasons are the stale buckets emitted by daemons
+// whose classifier lets a generic HTTP 403 win over this transient wire shape.
+// The refined auth bucket is the observed Claude Code result; unknown and
+// agent_error cover older classifier generations.
+var legacyConcurrentRequestLimitReasons = map[string]bool{
+	string(ReasonAgentProviderAuthOrAccess): true,
+	string(ReasonAgentUnknown):              true,
+	"agent_error":                           true,
+}
+
 func isPiProviderNetworkError(lower string) bool {
 	for _, message := range []string{"connection error.", "request timed out."} {
 		if lower == message ||
@@ -469,6 +494,10 @@ var legacyOpencodeStreamEndedReasons = map[string]bool{
 // can be deleted once no daemon old enough to produce its wire shape is still
 // reporting.
 func NormalizeDaemonReason(reason, rawError string) Reason {
+	if legacyConcurrentRequestLimitReasons[reason] &&
+		strings.Contains(strings.ToLower(rawError), concurrentRequestLimitWitness) {
+		return ReasonAgentProviderCapacityOrRateLimit
+	}
 	if legacySkillBundleReasons[reason] &&
 		strings.HasPrefix(strings.TrimSpace(rawError), legacySkillBundlePrefix) {
 		return ReasonSkillBundleUnavailable

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -222,6 +222,11 @@ func TestClassifyOrderingPriorities(t *testing.T) {
 		// auth rejection.
 		{"missing api key beats 401", "missing api_key for openai (401 returned downstream)", ReasonAgentMissingConfig},
 
+		// Some Anthropic-compatible providers return 403 for a transient
+		// concurrency rejection. The semantic message must beat the generic
+		// status-code fallback; credentials are still valid and retrying works.
+		{"403 concurrent request limit beats auth", "Failed to authenticate. API Error: 403 You've reached your concurrent request limit. Please wait for your ongoing requests to finish and try again.", ReasonAgentProviderCapacityOrRateLimit},
+
 		// Both "429" and "rate limit" present — should still land in
 		// the capacity bucket, not the quota bucket.
 		{"429 rate limit", "API Error: 429 rate limit reached", ReasonAgentProviderCapacityOrRateLimit},
@@ -238,6 +243,26 @@ func TestClassifyOrderingPriorities(t *testing.T) {
 				t.Errorf("Classify(%q) = %q, want %q", c.in, got, c.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeDaemonReasonUpgradesConcurrentRequestLimit(t *testing.T) {
+	t.Parallel()
+
+	const raw = "Failed to authenticate. API Error: 403 You've reached your concurrent request limit. Please wait for your ongoing requests to finish and try again."
+
+	for _, reason := range []string{
+		string(ReasonAgentProviderAuthOrAccess),
+		string(ReasonAgentUnknown),
+		"agent_error",
+	} {
+		if got := NormalizeDaemonReason(reason, raw); got != ReasonAgentProviderCapacityOrRateLimit {
+			t.Errorf("NormalizeDaemonReason(%q, concurrent request rejection) = %q, want %q", reason, got, ReasonAgentProviderCapacityOrRateLimit)
+		}
+	}
+
+	if got := NormalizeDaemonReason(string(ReasonAgentProviderAuthOrAccess), "API Error: 403 Forbidden"); got != ReasonAgentProviderAuthOrAccess {
+		t.Errorf("plain 403 auth rejection changed to %q", got)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Claude Code can surface an Anthropic-compatible provider response as authentication_failed / HTTP 403 while the response text says concurrent request limit. Retrying the same prompt with the same credentials and session can succeed, but Multica currently lets the generic 403 classifier win, persists provider_auth_or_access, tells the user to sign in again, and terminates the task.

This PR recognizes that exact transient wire shape before the generic auth fallback, upgrades stale auth reasons reported by older installed daemons, and lets provider capacity/rate-limit failures use the existing bounded retry path. The retry keeps the same session and existing max_attempts ceiling, so the default behavior is one automatic resend rather than an unbounded loop.

## Related Issue

Local incident evidence is included as a verbatim regression fixture; no public issue exists yet.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Make the exact concurrent request limit witness outrank the generic HTTP 403 auth rule.
- Normalize provider_auth_or_access from older daemons to provider_capacity_or_rate_limit for the same exact wire shape.
- Add provider_capacity_or_rate_limit to the bounded, resume-safe task retry allowlist.
- Cover current-daemon classification, mixed-version normalization, same-session retry, and the existing attempt ceiling.

## How to Test

1. Run: cd server && go test ./pkg/taskfailure ./internal/service ./internal/daemon -count=1
2. Run: cd server && go vet ./pkg/taskfailure ./internal/service ./internal/daemon
3. Run: cd server && go test ./... -count=1

All commands pass locally.

## Risks

The capacity/rate-limit bucket now gets one retry under the existing default max_attempts=2. Tasks that explicitly set max_attempts=1 remain non-retryable, autopilot tasks remain excluded, and the retry ceiling prevents loops. The session is preserved because this failure does not poison conversation history.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs
- [ ] If this PR touches Chinese product copy, I checked it against the product conventions
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

UI, documentation, runtime inventory, and Chinese copy are unchanged, so those unchecked items are not applicable.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Started from the local daemon timeline and Claude Code rollout record, converted the exact observed error into a failing classifier test, traced it through daemon/server mixed-version normalization and retry eligibility, then implemented the smallest bounded fix and ran the complete Go test suite.