### PR TITLE
MUL-7165: fix(daemon): keep tool output previews UTF-8 safe

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -9102,10 +9102,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 						}
 					}
 					s := msgSeq.Add(1)
-					output := msg.Output
-					if len(output) > 8192 {
-						output = output[:8192]
-					}
+					output := toolOutputPreview(msg.Output)
 					toolName := msg.Tool
 					if toolName == "" && msg.CallID != "" {
 						mu.Lock()

--- a/server/internal/daemon/tool_output_preview.go
+++ b/server/internal/daemon/tool_output_preview.go
@@ -1,0 +1,28 @@
+package daemon
+
+import (
+	"unicode/utf8"
+
+	"github.com/multica-ai/multica/server/internal/util"
+)
+
+// toolOutputPreviewBudget keeps the existing byte budget for tool_result
+// previews. It does not limit the full output consumed by the agent.
+const toolOutputPreviewBudget = 8192
+
+// toolOutputPreview returns the longest complete-rune prefix within the budget.
+// Normalize malformed UTF-8 and NULs with the existing persistence sanitizer
+// first, so normalization cannot expand a byte-bounded preview past the budget.
+func toolOutputPreview(raw string) string {
+	output := util.SanitizeTextForPostgres(raw)
+	if len(output) <= toolOutputPreviewBudget {
+		return output
+	}
+
+	end := toolOutputPreviewBudget
+	// output is valid UTF-8, so at most three continuation bytes are skipped.
+	for !utf8.RuneStart(output[end]) {
+		end--
+	}
+	return output[:end]
+}

--- a/server/internal/daemon/tool_output_preview_test.go
+++ b/server/internal/daemon/tool_output_preview_test.go
@@ -1,0 +1,104 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+func TestToolOutputPreview(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, input, want string
+	}{
+		{"empty", "", ""},
+		{"short unicode", "执行完成 😀\n", "执行完成 😀\n"},
+		{"under budget", strings.Repeat("a", 8191), strings.Repeat("a", 8191)},
+		{"exact budget", strings.Repeat("a", 8192), strings.Repeat("a", 8192)},
+		{"over budget", strings.Repeat("a", 8193), strings.Repeat("a", 8192)},
+		{"chinese", strings.Repeat("中", 5000), strings.Repeat("中", 2730)},
+		{"emoji", strings.Repeat("😀", 3000), strings.Repeat("😀", 2048)},
+		// Server-side redaction may expand this input. That is not source truncation.
+		{"redaction growth", strings.Repeat("TOKEN=x ", 1024), strings.Repeat("TOKEN=x ", 1024)},
+		{"nul", "before\x00after", "beforeafter"},
+		{"invalid utf8", "a\xffb", "a\uFFFDb"},
+		{"normalization growth", strings.Repeat("a", 8191) + "\xff", strings.Repeat("a", 8191)},
+		{"normalization shrink", strings.Repeat("a", 8191) + "\x00b", strings.Repeat("a", 8191) + "b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toolOutputPreview(tt.input); got != tt.want {
+				t.Fatalf("preview differs from expected text: got %d bytes, want %d", len(got), len(tt.want))
+			}
+		})
+	}
+}
+
+func TestToolOutputPreviewRuneBoundaries(t *testing.T) {
+	t.Parallel()
+	// Include every cut inside 2-, 3-, and 4-byte runes, plus both exact
+	// boundaries. A literal replacement character is valid text to preserve.
+	for _, char := range []string{"é", "中", "😀", "\uFFFD"} {
+		for kept := 0; kept <= len(char); kept++ {
+			t.Run(fmt.Sprintf("%s/%d", char, kept), func(t *testing.T) {
+				prefix := strings.Repeat("a", 8192-kept)
+				want := prefix
+				if kept == len(char) {
+					want += char
+				}
+				if got := toolOutputPreview(prefix + char + "tail"); got != want {
+					t.Fatalf("cut must retain exactly the complete runes: got %d bytes, want %d", len(got), len(want))
+				}
+			})
+		}
+	}
+}
+
+// Exercise the reporting path: JSON encoding must not repair a split rune by
+// inserting replacement characters into an otherwise valid tool result.
+func TestExecuteAndDrain_ToolOutputUTF8Boundary(t *testing.T) {
+	t.Parallel()
+	d, rec := newTranscriptRecorder(t)
+	messages := make(chan agent.Message, 1)
+	messages <- agent.Message{
+		Type: agent.MessageToolResult, Tool: "bash", Output: strings.Repeat("中", 2731),
+	}
+	close(messages)
+	results := make(chan agent.Result, 1)
+	results <- agent.Result{Status: "completed"}
+	close(results)
+	backend := sessionBackend{session: &agent.Session{Messages: messages, Result: results}}
+
+	if _, _, err := d.executeAndDrain(context.Background(), backend, "p", agent.ExecOptions{},
+		slog.Default(), "task-utf8-preview", "", new(atomic.Int32)); err != nil {
+		t.Fatalf("executeAndDrain: %v", err)
+	}
+	reported := rec.snapshot()
+	if len(reported) != 1 || reported[0].Type != "tool_result" || reported[0].Tool != "bash" {
+		t.Fatalf("expected one bash tool_result, got %+v", reported)
+	}
+	want := strings.Repeat("中", 2730)
+	if got := reported[0].Output; got != want {
+		t.Fatalf("reported output differs from the complete-rune prefix: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+func BenchmarkToolOutputPreview(b *testing.B) {
+	for _, tt := range []struct{ name, input string }{
+		{"8KiB", strings.Repeat("ordinary log line\n", 512)[:8192]},
+		{"300KiBChinese", strings.Repeat("中", 100*1024)},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			b.SetBytes(int64(len(tt.input)))
+			b.ReportAllocs()
+			for b.Loop() {
+				toolOutputPreview(tt.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Keep daemon tool-result previews on complete UTF-8 code points within the existing 8192-byte budget.

For example, 2731 Chinese characters occupy 8193 bytes. The current raw byte cut splits the final character, and JSON encoding turns that fragment into replacement characters (8196 bytes after decoding in the regression test). The preview now retains exactly 2730 complete characters / 8190 bytes.

The helper normalizes malformed UTF-8 and NULs using the existing persistence sanitizer before applying the budget. Clean output that fits is unchanged.

## Related Issue

PR A requested in the [review of #8046](https://github.com/multica-ai/multica/pull/8046#issuecomment-5567223297), covering the UTF-8 correctness portion of CODI-10 / MUL-7065.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/tool_output_preview.go`: extract the text-only preview helper from #8046, retaining normalization and a complete-rune byte cut. The boundary adjustment inspects at most three continuation bytes.
- `server/internal/daemon/daemon.go`: use the helper in the tool-result reporting path.
- `server/internal/daemon/tool_output_preview_test.go`: cover exact prefixes, all cut positions in 2/3/4-byte code points, normalization, an input that grows under later redaction, and the actual reporting path; add a small benchmark.

Scope and limitations: truncation metadata/UI and the in-band/unknown-notice product decisions remain PR B; redaction ordering remains a separate security-design discussion for PR C. Provider unwrapping and structured-image handling also remain follow-ups. This change adds no protocol fields, schema/UI changes, notices, or redaction rules, and does not claim to make truncation visible. There is no daemon-side redaction-length check; subsequent server redaction may exceed the soft preview budget.

## How to Test

1. From `server/`, run:
   ```sh
   ../scripts/go-test-with-agent-cli-guard.sh -- go test -race ./internal/daemon ./internal/util -count=1
   go build ./...
   go vet ./internal/daemon ./internal/util
   ```
   All passed locally. `gofmt` and `git diff --check` are clean.
2. `TestExecuteAndDrain_ToolOutputUTF8Boundary` failed against unmodified main before the fix (8196 bytes reported, expected 8190), then passed with the helper wired in. It exercises message reporting and JSON encoding/decoding with a fake backend.
3. Benchmark:
   ```sh
   ../scripts/go-test-with-agent-cli-guard.sh -- go test ./internal/daemon -run '^$' -bench '^BenchmarkToolOutputPreview$' -benchmem
   ```
   Local Apple M5 Pro results: 8 KiB ordinary text ~192 ns/op; 300 KiB Chinese text ~107 µs/op; both 0 allocations/op. These measure the helper, not end-to-end throughput.

`make check-worktree` was attempted but stopped before checks because the new isolated worktree has no `.env.worktree`. The full frontend/database/E2E pipeline was not run; this PR changes only daemon text-preview code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

UI, product-copy, runtime, and documentation checklist items are not applicable to this code-only fix.

## AI Disclosure

**AI tool used:** OpenAI Codex; adapted from the Claude Code-assisted implementation in #8046.

**Prompt / approach:** Read the complete reviewer response and the original `codi-10-truncation` branch, extract only PR A onto a fresh branch from upstream main, reproduce the split-rune bug through the reporting path, and verify the reduced helper with boundary tests, race tests, build/vet, and benchmarks.

## Screenshots (optional)

Not applicable; no UI changes.
