### PR TITLE
MUL-7169: fix(agent): preserve JSON null in Qwen tool results

### DIFF
--- a/server/pkg/agent/qwen.go
+++ b/server/pkg/agent/qwen.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -389,9 +390,14 @@ func qwenResultUsage(usage *qwenUsage, model string) map[string]TokenUsage {
 }
 
 func qwenToolResultOutput(raw json.RawMessage) string {
-	var text string
-	if json.Unmarshal(raw, &text) == nil {
-		return text
+	// Unmarshal accepts null into a string without error, leaving it empty.
+	// Only unwrap JSON strings; preserve every other result verbatim.
+	trimmed := bytes.TrimLeft(raw, " \t\r\n")
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var text string
+		if json.Unmarshal(raw, &text) == nil {
+			return text
+		}
 	}
 	return string(raw)
 }

--- a/server/pkg/agent/qwen_test.go
+++ b/server/pkg/agent/qwen_test.go
@@ -76,6 +76,68 @@ func TestBuildQwenArgsYoloAlwaysPresent(t *testing.T) {
 	}
 }
 
+func TestQwenToolResultOutput(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"missing", "", ""},
+		{"string", `"hello"`, "hello"},
+		{"empty string", `""`, ""},
+		{"quoted null", `"null"`, "null"},
+		{"null", "null", "null"},
+		{"null with whitespace", " \t\r\nnull \t\r\n", " \t\r\nnull \t\r\n"},
+		{"string with whitespace", " \t\r\n\"hello\" \t\r\n", "hello"},
+		{"escaped string", `"line\n\u4e2d\""`, "line\n中\""},
+		{"decode once", `"\"hello\""`, `"hello"`},
+		{"object", `{"ok":true}`, `{"ok":true}`},
+		{"array", `["hello",null]`, `["hello",null]`},
+		{"number", "42", "42"},
+		{"boolean", "false", "false"},
+		{"object with whitespace", " \t{\"ok\":true}\n", " \t{\"ok\":true}\n"},
+		{"malformed string", `"unfinished`, `"unfinished`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := qwenToolResultOutput(json.RawMessage(tc.raw)); got != tc.want {
+				t.Fatalf("qwenToolResultOutput(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHandleQwenEventPreservesNullToolResult(t *testing.T) {
+	t.Parallel()
+	var event qwenStreamEvent
+	if err := json.Unmarshal([]byte(`{"type":"user","message":{"role":"user","content":[
+		{"type":"tool_result","tool_use_id":"null-result","content":null},
+		{"type":"tool_result","tool_use_id":"empty-result","content":""},
+		{"type":"tool_result","tool_use_id":"missing-result"}
+	]}}`), &event); err != nil {
+		t.Fatal(err)
+	}
+	messages := make(chan Message, 3)
+	handleQwenEvent(event, messages, &qwenStreamState{})
+	if len(messages) != 3 {
+		t.Fatalf("got %d messages, want 3 tool results", len(messages))
+	}
+	for _, want := range []struct {
+		callID string
+		output string
+	}{
+		{"null-result", "null"},
+		{"empty-result", ""},
+		{"missing-result", ""},
+	} {
+		got := <-messages
+		if got.Type != MessageToolResult || got.CallID != want.callID || got.Output != want.output {
+			t.Fatalf("got type=%q callID=%q output=%q, want type=%q callID=%q output=%q",
+				got.Type, got.CallID, got.Output, MessageToolResult, want.callID, want.output)
+		}
+	}
+}
+
 func fakeQwenScript() string {
 	return `#!/bin/sh
 if [ -n "$QWEN_ARGS_FILE" ]; then printf '%s\n' "$@" > "$QWEN_ARGS_FILE"; fi


### PR DESCRIPTION
## What does this PR do?

Preserve JSON `null` in Qwen tool-result output instead of silently turning it into an empty string.

Qwen's user-event adapter calls `qwenToolResultOutput` for each tool result. The helper previously treated successful `json.Unmarshal` into a string as proof that the input was a JSON string. Go also accepts `null` into a string without error, leaving its zero value unchanged, so an explicit null result became indistinguishable from empty output.

Check the first non-JSON-whitespace byte before decoding. Decode exactly one layer only for JSON strings; pass other values through verbatim. This fixes the live Qwen call path without importing the broader provider/image helper from the original proposal.

## Related Issue

Addresses the Qwen null-parsing finding in the [review of #8046](https://github.com/multica-ai/multica/pull/8046#issuecomment-5567223297).

Independent of PR A (#8181) and the PR B/C design discussions (#8182, #8183, #8184). This PR is based directly on upstream main and does not close the broader CODI-10 work.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/qwen.go`: only attempt string unwrapping when the first non-whitespace byte is a double quote; preserve null and other non-string JSON bytes.
- `server/pkg/agent/qwen_test.go`: add a 15-case parser matrix for strings, empty input, null, whitespace, escapes, one-layer decoding, objects, arrays, numbers, booleans, and malformed input.
- Add a regression through `handleQwenEvent -> handleQwenUser` that verifies output and call IDs for explicit null, empty string, and missing content.

Scope/risk: explicit null now appears as the text `null`. Empty strings and missing content remain empty, valid JSON strings still decode once, and other payloads retain their bytes. No protocol, schema, UI, redaction, or other-provider changes; no recovery of previously lost null output.

## How to Test

Run from `server/`:

1. Focused regression:
   `../scripts/go-test-with-agent-cli-guard.sh -- go test ./pkg/agent -run '^(TestQwenToolResultOutput|TestHandleQwenEventPreservesNullToolResult)$' -count=1`
2. All Qwen tests with race detection:
   `../scripts/go-test-with-agent-cli-guard.sh -- go test -race ./pkg/agent -run 'Qwen' -count=1`
3. Build and static analysis:
   `go build ./...` and `go vet ./pkg/agent`.

Regression proof: with the new tests and the original implementation, the null and whitespace-wrapped null cases fail, and the real event-handler regression reports empty output instead of `null`. All focused tests pass after the fix.

Validation passed: focused regression tests, all Qwen tests with `-race` (7.904s), `go build ./...`, `go vet ./pkg/agent`, gofmt, and diff whitespace checks.

Broader-check limitation: `go test -race ./pkg/agent -count=1` is not green on this machine. A separate baseline run, with `pkg/agent` unchanged from upstream main (`2ed2432a2`), also failed in four existing Codex lifecycle tests: `TestCodexCancellationBeforeTurnStartedStopsProcessImmediately`, `TestCodexNonResponsiveInterruptStopsProcessAtConfiguredDeadline`, `TestCodexExecuteTimesOutWhenTurnStopsAfterToolResult`, and `TestCodexExecuteFirstTurnRetryErrorDoesNotSatisfyProgress` (cleanup-duration/result-timeout assertions). Those failures are not being addressed in this Qwen-only PR; no full-suite pass is claimed. A focused rerun of those four tests on this branch reproduced the two cancellation/interrupt cleanup-duration failures; the two result-timeout tests passed when run in that smaller selection.

`make check-worktree` was attempted but stopped before checks because this isolated checkout has no `.env.worktree`. No database/frontend/E2E or real-agent-account smoke test was run; the agent CLI guard prevents default tests from accidentally invoking installed agent CLIs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

UI screenshots, user-facing documentation, new-runtime copy, and Chinese product-copy items are not applicable to this adapter-only correction.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Asked to fix the reviewer's Qwen null-parsing finding in a standalone PR. Inspected the live adapter and the original PR's string-type guard, wrote failing parser/event-handler regressions first, applied the guard directly to Qwen's existing helper, and ran guarded Go tests plus build/vet. Kept this separate from truncation metadata, UI decisions, image handling, and redaction design.

## Screenshots (optional)

Not applicable: no UI changes.
