### PR TITLE
fix(daemon): retry terminal task reports

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -930,6 +931,17 @@ func (d *Daemon) handleLocalSkillImport(ctx context.Context, rt Runtime, pending
 // Overridable for tests to avoid real sleeps.
 var runtimeReportBackoffs = []time.Duration{0, 500 * time.Millisecond, 2 * time.Second, 4 * time.Second}
 
+// taskTerminalReportBackoffs keeps a finished agent attached to its server-side
+// task while a short coordinator or reverse-proxy outage clears. Terminal
+// reports are idempotent on the server, so retrying the same complete/fail
+// payload is safe even when the server committed the first request but the
+// response was lost.
+//
+// The wider window than runtimeReportBackoffs is intentional: a terminal task
+// result has no later heartbeat cycle that can repair a missed callback.
+// Overridable for tests to avoid real sleeps.
+var taskTerminalReportBackoffs = []time.Duration{0, time.Second, 4 * time.Second, 10 * time.Second, 30 * time.Second}
+
 // reportLocalSkillListResult delivers a list-report to the server with retry
 // on transient failures. See reportRuntimeResultWithRetry for semantics.
 func (d *Daemon) reportLocalSkillListResult(ctx context.Context, rt Runtime, requestID string, payload map[string]any) {
@@ -1007,6 +1019,63 @@ func (d *Daemon) reportRuntimeResultWithRetry(ctx context.Context, kind, runtime
 	}
 	d.logger.Error("runtime async report exhausted retries",
 		"kind", kind, "runtime_id", runtimeID, "request_id", requestID, "error", lastErr)
+}
+
+// shouldRetryTaskTerminalReport distinguishes a real missing task from a
+// transient proxy/router 404. The daemon API returns a structured "task not
+// found" body when the task was deleted; generic "404 page not found" bodies
+// can be emitted temporarily by the same-origin proxy while the backend is
+// unavailable and are safe to retry.
+func shouldRetryTaskTerminalReport(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var reqErr *requestError
+	if !errors.As(err, &reqErr) {
+		return true
+	}
+	if reqErr.StatusCode >= 500 {
+		return true
+	}
+	if reqErr.StatusCode == http.StatusRequestTimeout || reqErr.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	return reqErr.StatusCode == http.StatusNotFound && !isTaskNotFoundError(err)
+}
+
+// reportTaskTerminalWithRetry delivers the final complete/fail payload with a
+// bounded retry window. Returning the last error lets handleTask leave a clear
+// local diagnostic without misclassifying successful agent work as a failure.
+func (d *Daemon) reportTaskTerminalWithRetry(ctx context.Context, taskID, outcome string, fn func(context.Context) error) error {
+	var lastErr error
+	for attempt, wait := range taskTerminalReportBackoffs {
+		if wait > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(wait):
+			}
+		}
+
+		err := fn(ctx)
+		if err == nil {
+			if attempt > 0 {
+				d.logger.Info("task terminal report succeeded after retry",
+					"task_id", taskID, "outcome", outcome, "attempt", attempt+1)
+			}
+			return nil
+		}
+		lastErr = err
+		if !shouldRetryTaskTerminalReport(err) {
+			return err
+		}
+		if attempt+1 < len(taskTerminalReportBackoffs) {
+			d.logger.Warn("task terminal report failed — will retry",
+				"task_id", taskID, "outcome", outcome, "attempt", attempt+1, "error", err)
+		}
+	}
+	return lastErr
 }
 
 // handleUpdate performs the CLI update when triggered by the server via heartbeat.
@@ -1455,7 +1524,9 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		taskLog.Error("task failed", "error", err)
 		// runTask returned without a TaskResult, so we don't have a SessionID
 		// to forward — best we can do is record the failure.
-		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", "agent_error"); failErr != nil {
+		if failErr := d.reportTaskTerminalWithRetry(ctx, task.ID, "failed", func(ctx context.Context) error {
+			return d.client.FailTask(ctx, task.ID, err.Error(), "", "", "agent_error")
+		}); failErr != nil {
 			taskLog.Error("fail task callback failed", "error", failErr)
 		}
 		return
@@ -1489,16 +1560,17 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		if failureReason == "" {
 			failureReason = "agent_error"
 		}
-		if err := d.client.FailTask(ctx, task.ID, result.Comment, result.SessionID, result.WorkDir, failureReason); err != nil {
+		if err := d.reportTaskTerminalWithRetry(ctx, task.ID, "blocked", func(ctx context.Context) error {
+			return d.client.FailTask(ctx, task.ID, result.Comment, result.SessionID, result.WorkDir, failureReason)
+		}); err != nil {
 			taskLog.Error("report blocked task failed", "error", err)
 		}
 	default:
 		taskLog.Info("task completed", "status", result.Status)
-		if err := d.client.CompleteTask(ctx, task.ID, result.Comment, result.BranchName, result.SessionID, result.WorkDir); err != nil {
-			taskLog.Error("complete task failed, falling back to fail", "error", err)
-			if failErr := d.client.FailTask(ctx, task.ID, fmt.Sprintf("complete task failed: %s", err.Error()), result.SessionID, result.WorkDir, "agent_error"); failErr != nil {
-				taskLog.Error("fail task fallback also failed", "error", failErr)
-			}
+		if err := d.reportTaskTerminalWithRetry(ctx, task.ID, "completed", func(ctx context.Context) error {
+			return d.client.CompleteTask(ctx, task.ID, result.Comment, result.BranchName, result.SessionID, result.WorkDir)
+		}); err != nil {
+			taskLog.Error("complete task delivery failed", "error", err)
 		}
 	}
 

--- a/server/internal/daemon/task_terminal_report_test.go
+++ b/server/internal/daemon/task_terminal_report_test.go
@@ -1,0 +1,108 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestShouldRetryTaskTerminalReport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "success", err: nil, want: false},
+		{name: "network error", err: errors.New("connection reset"), want: true},
+		{name: "bad gateway", err: &requestError{StatusCode: http.StatusBadGateway, Body: "Bad Gateway"}, want: true},
+		{name: "request timeout", err: &requestError{StatusCode: http.StatusRequestTimeout, Body: "request timeout"}, want: true},
+		{name: "rate limited", err: &requestError{StatusCode: http.StatusTooManyRequests, Body: "too many requests"}, want: true},
+		{name: "generic proxy not found", err: &requestError{StatusCode: http.StatusNotFound, Body: "404 page not found"}, want: true},
+		{name: "task deleted", err: &requestError{StatusCode: http.StatusNotFound, Body: `{"error":"task not found"}`}, want: false},
+		{name: "bad request", err: &requestError{StatusCode: http.StatusBadRequest, Body: `{"error":"invalid request"}`}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldRetryTaskTerminalReport(tt.err); got != tt.want {
+				t.Fatalf("shouldRetryTaskTerminalReport(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReportTaskTerminalWithRetry(t *testing.T) {
+	original := taskTerminalReportBackoffs
+	taskTerminalReportBackoffs = []time.Duration{0, 0, 0}
+	t.Cleanup(func() { taskTerminalReportBackoffs = original })
+
+	d := &Daemon{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	wantErrors := []error{
+		&requestError{StatusCode: http.StatusBadGateway, Body: "Bad Gateway"},
+		&requestError{StatusCode: http.StatusNotFound, Body: "404 page not found"},
+		nil,
+	}
+	var gotErrors []error
+	err := d.reportTaskTerminalWithRetry(context.Background(), "task-1", "completed", func(context.Context) error {
+		next := wantErrors[len(gotErrors)]
+		gotErrors = append(gotErrors, next)
+		return next
+	})
+	if err != nil {
+		t.Fatalf("reportTaskTerminalWithRetry returned %v", err)
+	}
+	if !reflect.DeepEqual(gotErrors, wantErrors) {
+		t.Fatalf("attempts = %#v, want %#v", gotErrors, wantErrors)
+	}
+}
+
+func TestReportTaskTerminalWithRetryStopsOnPermanentError(t *testing.T) {
+	original := taskTerminalReportBackoffs
+	taskTerminalReportBackoffs = []time.Duration{0, 0, 0}
+	t.Cleanup(func() { taskTerminalReportBackoffs = original })
+
+	d := &Daemon{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	want := &requestError{StatusCode: http.StatusNotFound, Body: `{"error":"task not found"}`}
+	attempts := 0
+	err := d.reportTaskTerminalWithRetry(context.Background(), "task-1", "completed", func(context.Context) error {
+		attempts++
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestReportTaskTerminalWithRetryReturnsLastTransientError(t *testing.T) {
+	original := taskTerminalReportBackoffs
+	taskTerminalReportBackoffs = []time.Duration{0, 0}
+	t.Cleanup(func() { taskTerminalReportBackoffs = original })
+
+	d := &Daemon{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	first := errors.New("connection reset")
+	last := &requestError{StatusCode: http.StatusBadGateway, Body: "Bad Gateway"}
+	errorsByAttempt := []error{first, last}
+	attempts := 0
+	err := d.reportTaskTerminalWithRetry(context.Background(), "task-1", "completed", func(context.Context) error {
+		next := errorsByAttempt[attempts]
+		attempts++
+		return next
+	})
+	if !errors.Is(err, last) {
+		t.Fatalf("error = %v, want final transient error %v", err, last)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}


### PR DESCRIPTION
## Summary

- retry terminal complete/fail callbacks across bounded network, 5xx, timeout, rate-limit, and generic proxy-404 failures
- stop immediately when the daemon API explicitly reports that the task no longer exists
- preserve a successful agent outcome instead of converting delivery failure into a failed task
- add focused retry, exhaustion, and permanent-error tests

## Why

A short backend or same-origin proxy interruption can currently strand an already-finished task in `running`: streamed messages may fail, the one-shot completion callback may receive a transient response, and the fallback fail callback can fail as well. Completion is server-side idempotent, so a bounded retry window safely closes that gap, including the case where the first request committed but its response was lost.

## Validation

- `git diff --check`
- focused Go tests are included; repository CI is the executable validation because Go 1.26.1 is not installed on the authoring host