### PR TITLE
fix(daemon): retry proxy 404 terminal callbacks

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -542,7 +542,7 @@ func (c *Client) CompleteTask(ctx context.Context, taskID, output, branchName, s
 	if retiredSessionID != "" {
 		body["retired_session_id"] = retiredSessionID
 	}
-	return c.postJSONWithRetry(ctx, fmt.Sprintf("/api/daemon/tasks/%s/complete", taskID), body, nil, defaultTerminalRetrySchedule)
+	return c.postTerminalJSONWithRetry(ctx, fmt.Sprintf("/api/daemon/tasks/%s/complete", taskID), body, nil, defaultTerminalRetrySchedule)
 }
 
 func (c *Client) ReportTaskUsage(ctx context.Context, taskID string, usage []TaskUsageEntry) error {
@@ -580,7 +580,7 @@ func (c *Client) FailTask(ctx context.Context, taskID, errMsg, sessionID, workDi
 	if retiredSessionID != "" {
 		body["retired_session_id"] = retiredSessionID
 	}
-	return c.postJSONWithRetry(ctx, fmt.Sprintf("/api/daemon/tasks/%s/fail", taskID), body, nil, defaultTerminalRetrySchedule)
+	return c.postTerminalJSONWithRetry(ctx, fmt.Sprintf("/api/daemon/tasks/%s/fail", taskID), body, nil, defaultTerminalRetrySchedule)
 }
 
 // PinTaskSession persists the agent's session_id and work_dir on the task
@@ -1075,6 +1075,23 @@ func isTransientError(err error) bool {
 	return true
 }
 
+// isTerminalCallbackTransientError extends the ordinary transport predicate
+// for the complete/fail callback only. During an upstream restart the edge can
+// briefly answer a registered daemon route with chi's plain-text unmatched
+// route response. That response is operationally transient, while the JSON
+// 404 returned by the task handler is a permanent "task not found" signal.
+// Keep this distinction local to terminal callbacks: other compatibility
+// probes intentionally use the same plain-text 404 to detect an older server.
+func isTerminalCallbackTransientError(err error) bool {
+	if isTransientError(err) {
+		return true
+	}
+	var reqErr *requestError
+	return errors.As(err, &reqErr) &&
+		reqErr.StatusCode == http.StatusNotFound &&
+		strings.TrimSpace(reqErr.Body) == "404 page not found"
+}
+
 // postJSONWithRetry posts a JSON body with bounded exponential backoff,
 // intended for "must reach the server" terminal callbacks (CompleteTask /
 // FailTask). It retries transient errors per isTransientError and stops
@@ -1091,13 +1108,21 @@ func isTransientError(err error) bool {
 // idempotent success (see service/task.go), so a duplicate replay from a
 // retry is safe even if the server's prior response was lost in transit.
 func (c *Client) postJSONWithRetry(ctx context.Context, path string, reqBody any, respBody any, schedule []time.Duration) error {
-	return c.postJSONViaWithRetry(ctx, c.client, path, reqBody, respBody, schedule, nil)
+	return c.postJSONViaWithRetryWhen(ctx, c.client, path, reqBody, respBody, schedule, nil, isTransientError)
+}
+
+func (c *Client) postTerminalJSONWithRetry(ctx context.Context, path string, reqBody any, respBody any, schedule []time.Duration) error {
+	return c.postJSONViaWithRetryWhen(ctx, c.client, path, reqBody, respBody, schedule, nil, isTerminalCallbackTransientError)
 }
 
 // postJSONViaWithRetry is postJSONWithRetry over an explicit http.Client, so
 // large-body endpoints can run on bundleClient (deadline from ctx) while the
 // control-plane keeps its fixed 30s client.
 func (c *Client) postJSONViaWithRetry(ctx context.Context, httpClient *http.Client, path string, reqBody any, respBody any, schedule []time.Duration, stats *TransferStats) error {
+	return c.postJSONViaWithRetryWhen(ctx, httpClient, path, reqBody, respBody, schedule, stats, isTransientError)
+}
+
+func (c *Client) postJSONViaWithRetryWhen(ctx context.Context, httpClient *http.Client, path string, reqBody any, respBody any, schedule []time.Duration, stats *TransferStats, shouldRetry func(error) bool) error {
 	var lastErr error
 	for attempt := 0; ; attempt++ {
 		if err := ctx.Err(); err != nil {
@@ -1111,7 +1136,7 @@ func (c *Client) postJSONViaWithRetry(ctx context.Context, httpClient *http.Clie
 			return nil
 		}
 		lastErr = err
-		if !isTransientError(err) {
+		if !shouldRetry(err) {
 			return err
 		}
 		if attempt >= len(schedule) {

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -288,6 +288,27 @@ func TestIsTransientError(t *testing.T) {
 	}
 }
 
+func TestIsTerminalCallbackTransientError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"plain-text edge 404 is transient", &requestError{StatusCode: http.StatusNotFound, Body: "404 page not found"}, true},
+		{"plain-text edge 404 tolerates whitespace", &requestError{StatusCode: http.StatusNotFound, Body: " 404 page not found\n"}, true},
+		{"JSON task-not-found 404 is permanent", &requestError{StatusCode: http.StatusNotFound, Body: `{"error":"task not found"}`}, false},
+		{"other 404 is permanent", &requestError{StatusCode: http.StatusNotFound, Body: "not found"}, false},
+		{"5xx remains transient", &requestError{StatusCode: http.StatusBadGateway}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTerminalCallbackTransientError(tc.err); got != tc.want {
+				t.Fatalf("isTerminalCallbackTransientError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsIssueGCBatchUnsupported(t *testing.T) {
 	tests := []struct {
 		name string
@@ -369,6 +390,50 @@ func TestFailTask_RetriesOnTransient5xxThenSucceeds(t *testing.T) {
 	}
 	if got := calls.Load(); got != 3 {
 		t.Fatalf("expected 3 attempts (2 transient 5xx + 1 success), got %d", got)
+	}
+}
+
+func TestCompleteTask_RetriesPlainTextEdge404ThenSucceeds(t *testing.T) {
+	defer noSleepRetry(t)()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) < 3 {
+			http.Error(w, "404 page not found", http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.CompleteTask(context.Background(), "task-1", "done", "", "", "", false, "", ""); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("expected 3 attempts (2 edge 404s + 1 success), got %d", got)
+	}
+}
+
+func TestCompleteTask_JSONTaskNotFoundBailsImmediately(t *testing.T) {
+	defer noSleepRetry(t)()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"task not found"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	err := c.CompleteTask(context.Background(), "task-1", "done", "", "", "", false, "", "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 attempt for a real task-not-found response, got %d", got)
 	}
 }
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5920,7 +5920,7 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 		// warrant the legacy fallback, because at that point the server
 		// has already refused this task and the only useful UI signal
 		// left is a concrete failure.
-		if isTransientError(err) {
+		if isTerminalCallbackTransientError(err) {
 			taskLog.Error("complete task failed after retries; leaving task in running rather than falling back to fail", "error", err)
 			return
 		}

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -4697,6 +4697,46 @@ func TestReportTaskResult_TransientCompleteExhaustedDoesNotFallback(t *testing.T
 	}
 }
 
+// A reverse proxy can briefly return chi's plain-text unmatched-route body
+// while the backend is restarting. That response is not the task handler's
+// durable JSON 404, so exhausting retries must preserve the successful result
+// in running state instead of downgrading it through /fail.
+func TestReportTaskResult_Edge404CompleteExhaustedDoesNotFallback(t *testing.T) {
+	defer noSleepRetry(t)()
+
+	prevSchedule := defaultTerminalRetrySchedule
+	defaultTerminalRetrySchedule = []time.Duration{time.Nanosecond, time.Nanosecond}
+	t.Cleanup(func() { defaultTerminalRetrySchedule = prevSchedule })
+
+	var completeCalls, failCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case strings.HasSuffix(req.URL.Path, "/complete"):
+			completeCalls.Add(1)
+			http.Error(w, "404 page not found", http.StatusNotFound)
+		case strings.HasSuffix(req.URL.Path, "/fail"):
+			failCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+	d.reportTaskResult(context.Background(), "task-edge-404", TaskResult{
+		Status:  "completed",
+		Comment: "ok",
+	}, slog.Default())
+
+	if got := completeCalls.Load(); got != int32(len(defaultTerminalRetrySchedule)+1) {
+		t.Fatalf("expected %d complete attempts, got %d", len(defaultTerminalRetrySchedule)+1, got)
+	}
+	if got := failCalls.Load(); got != 0 {
+		t.Fatalf("exhausted edge 404 retries must NOT fall back to /fail; got %d", got)
+	}
+}
+
 // On permanent 4xx from /complete (e.g. 400 bad body, 404 task not found)
 // the helper bails immediately and the daemon falls back to /fail so the
 // UI shows a concrete failure rather than a perpetually-running task.


### PR DESCRIPTION
## Summary

- retry the reverse-proxy-shaped plain-text `404 page not found` response for complete/fail callbacks
- preserve JSON task-not-found 404 responses as permanent
- keep the exception scoped to terminal callbacks so compatibility probes retain their existing behavior
- avoid downgrading a successful result through `/fail` when edge-404 retries are exhausted

## Why

A backend interruption can present as a short 5xx burst followed by the proxy/router plain-text unmatched-route 404. The daemon currently treats that final 404 as permanent, so it stops the retry schedule and falls back from `/complete` to `/fail`. If the same edge state rejects `/fail`, the authoritative task remains running with no durable result.

The backend task handler returns JSON for a real missing task, so the response body distinguishes the transient edge response from the permanent application response.

## Tests

- callback predicate classification
- plain-text edge 404 retries and succeeds
- JSON task-not-found bails after one attempt
- exhausted edge 404 does not fall back to `/fail`

Local Go tooling is unavailable in this environment; repository CI is the executable verification.