### PR TITLE
MUL-7173: fix(daemon): enforce machine ownership for single-runtime claims

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3435,6 +3435,16 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// Match batch claim's machine boundary for daemon tokens. PAT/JWT
+	// callers retain workspace-member access, and NULL daemon_id runtimes
+	// remain unpinned, as in batch claim and daemon WebSocket authorization.
+	if middleware.DaemonAuthPathFromContext(r.Context()) == middleware.DaemonAuthPathDaemonToken {
+		daemonID := middleware.DaemonIDFromContext(r.Context())
+		if daemonID == "" || (runtime.DaemonID.Valid && runtime.DaemonID.String != daemonID) {
+			writeError(w, http.StatusNotFound, "runtime not found")
+			return
+		}
+	}
 	runtimeWorkspaceID := uuidToString(runtime.WorkspaceID)
 	authMs = time.Since(start).Milliseconds()
 

--- a/server/internal/handler/daemon_claim_channel_type_test.go
+++ b/server/internal/handler/daemon_claim_channel_type_test.go
@@ -99,11 +99,11 @@ type claimedChatChannel struct {
 
 // claimChatChannelFields claims the queued task for runtimeID and returns the
 // channel-awareness fields the daemon reads off the claim response.
-func claimChatChannelFields(t *testing.T, runtimeID string) claimedChatChannel {
+func claimChatChannelFields(t *testing.T, runtimeID, daemonID string) claimedChatChannel {
 	t.Helper()
 	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
-		testWorkspaceID, "claim-channel-type")
+		testWorkspaceID, daemonID)
 	req = withURLParam(req, "runtimeId", runtimeID)
 
 	testHandler.ClaimTaskByRuntime(w, req)
@@ -127,7 +127,7 @@ func TestClaim_FeishuBoundSessionReportsChannelType(t *testing.T) {
 		t.Skip("database not available")
 	}
 	ctx := context.Background()
-	agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "feishu-backed chat")
+	agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "feishu-backed chat")
 	// last_thread_id != last_message_id: the shape that would set ChatInThread on
 	// Slack. Feishu must still report false — there is no reader to thread into.
 	seedChannelBinding(t, ctx, agentID, sessionID, "feishu", "msg-1", "thread-9")
@@ -135,7 +135,7 @@ func TestClaim_FeishuBoundSessionReportsChannelType(t *testing.T) {
 	seedChannelTaskDelivery(t, ctx, taskID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
 
-	claimed := claimChatChannelFields(t, runtimeID)
+	claimed := claimChatChannelFields(t, runtimeID, daemonID)
 	if claimed.ChannelType != "feishu" {
 		t.Errorf("chat_channel_type = %q, want %q — a Feishu session must not look like a web chat", claimed.ChannelType, "feishu")
 	}
@@ -149,13 +149,13 @@ func TestClaim_SlackBoundSessionStillReportsThreadState(t *testing.T) {
 		t.Skip("database not available")
 	}
 	ctx := context.Background()
-	agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "slack-backed chat")
+	agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "slack-backed chat")
 	seedChannelBinding(t, ctx, agentID, sessionID, "slack", "msg-1", "thread-9")
 	taskID := insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 	seedChannelTaskDelivery(t, ctx, taskID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
 
-	claimed := claimChatChannelFields(t, runtimeID)
+	claimed := claimChatChannelFields(t, runtimeID, daemonID)
 	if claimed.ChannelType != "slack" {
 		t.Errorf("chat_channel_type = %q, want %q", claimed.ChannelType, "slack")
 	}
@@ -178,13 +178,13 @@ func TestClaim_UnlistedChannelBoundSessionReportsChannelType(t *testing.T) {
 		t.Skip("database not available")
 	}
 	ctx := context.Background()
-	agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "wecom-backed chat")
+	agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "wecom-backed chat")
 	seedChannelBinding(t, ctx, agentID, sessionID, "wecom", "msg-1", "thread-9")
 	taskID := insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 	seedChannelTaskDelivery(t, ctx, taskID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
 
-	claimed := claimChatChannelFields(t, runtimeID)
+	claimed := claimChatChannelFields(t, runtimeID, daemonID)
 	if claimed.ChannelType != "wecom" {
 		t.Errorf("chat_channel_type = %q, want %q — a channel the handler does not name must not look like a web chat", claimed.ChannelType, "wecom")
 	}
@@ -198,11 +198,11 @@ func TestClaim_UnboundSessionReportsNoChannelType(t *testing.T) {
 		t.Skip("database not available")
 	}
 	ctx := context.Background()
-	agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "web chat")
+	agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "web chat")
 	insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
 
-	claimed := claimChatChannelFields(t, runtimeID)
+	claimed := claimChatChannelFields(t, runtimeID, daemonID)
 	if claimed.ChannelType != "" {
 		t.Errorf("chat_channel_type = %q, want empty for a web-only session", claimed.ChannelType)
 	}
@@ -216,13 +216,13 @@ func TestClaim_ChannelOriginChatWithoutTaskDeliveryIsPrivateMulticaTurn(t *testi
 		t.Skip("database not available")
 	}
 	ctx := context.Background()
-	agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "old channel chat continued in web")
+	agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "old channel chat continued in web")
 	seedChannelBinding(t, ctx, agentID, sessionID, "slack", "msg-1", "thread-9")
 	// Deliberately no channel_task_delivery: this is the shape produced by a
 	// Web/Desktop/Mobile send after /new moves the external route elsewhere.
 	insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
-	claimed := claimChatChannelFields(t, runtimeID)
+	claimed := claimChatChannelFields(t, runtimeID, daemonID)
 	if claimed.ChannelType != "" || claimed.InThread || claimed.DeliversFiles {
 		t.Fatalf("private continuation leaked channel audience: %+v", claimed)
 	}
@@ -253,13 +253,13 @@ func TestClaim_BoundSessionReportsRoomShape(t *testing.T) {
 	} {
 		name := tc.channelType + "/" + tc.chatType
 		t.Run(name, func(t *testing.T) {
-			agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, name+" chat")
+			agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, name+" chat")
 			seedChannelBindingOfChatType(t, ctx, agentID, sessionID, tc.channelType, tc.chatType, "msg-1", "msg-1")
 			taskID := insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 			seedChannelTaskDelivery(t, ctx, taskID, sessionID)
 			requeueTaskForClaim(t, ctx, sessionID)
 
-			claimed := claimChatChannelFields(t, runtimeID)
+			claimed := claimChatChannelFields(t, runtimeID, daemonID)
 			if claimed.ChannelType != tc.channelType {
 				t.Errorf("chat_channel_type = %q, want %q", claimed.ChannelType, tc.channelType)
 			}
@@ -279,11 +279,11 @@ func TestClaim_UnboundSessionReportsNoRoomShape(t *testing.T) {
 		t.Skip("database not available")
 	}
 	ctx := context.Background()
-	agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "web chat shape")
+	agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "web chat shape")
 	insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
 
-	if claimed := claimChatChannelFields(t, runtimeID); claimed.ChatType != "" {
+	if claimed := claimChatChannelFields(t, runtimeID, daemonID); claimed.ChatType != "" {
 		t.Errorf("chat_type = %q, want empty for a web-only session", claimed.ChatType)
 	}
 }
@@ -336,13 +336,13 @@ func TestClaim_FileDeliveryIsTheDeploymentsAnswerNotTheChannelTypes(t *testing.T
 
 	t.Run("declared: the deployment wired the hop", func(t *testing.T) {
 		declareFileDeliveryForTest(t, "wecom")
-		agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "wecom chat with storage")
+		agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "wecom chat with storage")
 		seedChannelBinding(t, ctx, agentID, sessionID, "wecom", "msg-1", "msg-1")
 		taskID := insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 		seedChannelTaskDelivery(t, ctx, taskID, sessionID)
 		requeueTaskForClaim(t, ctx, sessionID)
 
-		claimed := claimChatChannelFields(t, runtimeID)
+		claimed := claimChatChannelFields(t, runtimeID, daemonID)
 		if claimed.ChannelType != "wecom" {
 			t.Fatalf("chat_channel_type = %q, want wecom", claimed.ChannelType)
 		}
@@ -353,13 +353,13 @@ func TestClaim_FileDeliveryIsTheDeploymentsAnswerNotTheChannelTypes(t *testing.T
 
 	t.Run("not declared: the same channel with no object storage", func(t *testing.T) {
 		declareFileDeliveryForTest(t) // nothing declared, as a storage-less deployment
-		agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "wecom chat without storage")
+		agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "wecom chat without storage")
 		seedChannelBinding(t, ctx, agentID, sessionID, "wecom", "msg-1", "msg-1")
 		taskID := insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 		seedChannelTaskDelivery(t, ctx, taskID, sessionID)
 		requeueTaskForClaim(t, ctx, sessionID)
 
-		claimed := claimChatChannelFields(t, runtimeID)
+		claimed := claimChatChannelFields(t, runtimeID, daemonID)
 		if claimed.ChannelType != "wecom" {
 			t.Fatalf("chat_channel_type = %q, want wecom", claimed.ChannelType)
 		}
@@ -370,24 +370,24 @@ func TestClaim_FileDeliveryIsTheDeploymentsAnswerNotTheChannelTypes(t *testing.T
 
 	t.Run("declared for one channel does not answer for another", func(t *testing.T) {
 		declareFileDeliveryForTest(t, "wecom")
-		agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "slack chat alongside wecom")
+		agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "slack chat alongside wecom")
 		seedChannelBinding(t, ctx, agentID, sessionID, "slack", "msg-1", "msg-1")
 		taskID := insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 		seedChannelTaskDelivery(t, ctx, taskID, sessionID)
 		requeueTaskForClaim(t, ctx, sessionID)
 
-		if claimed := claimChatChannelFields(t, runtimeID); claimed.DeliversFiles {
+		if claimed := claimChatChannelFields(t, runtimeID, daemonID); claimed.DeliversFiles {
 			t.Error("a Slack session inherited WeCom's delivery capability; the flag is per channel, not per deployment")
 		}
 	})
 
 	t.Run("a web chat is answered by its own branch, not this flag", func(t *testing.T) {
 		declareFileDeliveryForTest(t, "wecom")
-		agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "web chat alongside wecom")
+		agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "web chat alongside wecom")
 		insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 		requeueTaskForClaim(t, ctx, sessionID)
 
-		claimed := claimChatChannelFields(t, runtimeID)
+		claimed := claimChatChannelFields(t, runtimeID, daemonID)
 		if claimed.ChannelType != "" {
 			t.Fatalf("chat_channel_type = %q, want empty for a web chat", claimed.ChannelType)
 		}

--- a/server/internal/handler/daemon_single_claim_auth_test.go
+++ b/server/internal/handler/daemon_single_claim_auth_test.go
@@ -1,0 +1,148 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/multica-ai/multica/server/internal/auth"
+	"github.com/multica-ai/multica/server/internal/middleware"
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+// Exercise the real authentication middleware: machine identity must come
+// from the credential, not a caller-supplied daemon_id or identity header.
+func TestClaimTaskByRuntime_DaemonOwnership(t *testing.T) {
+	tests := []struct {
+		name           string
+		credential     string
+		daemonID       string
+		unboundRuntime bool
+		otherWorkspace bool
+		nonMember      bool
+		expired        bool
+		revoked        bool
+		missingRuntime bool
+		wantStatus     int
+	}{
+		{name: "own machine", credential: "daemon", daemonID: "machine-b", wantStatus: http.StatusOK},
+		{name: "peer machine cannot spoof ownership", credential: "daemon", daemonID: "machine-a", wantStatus: http.StatusNotFound},
+		{name: "missing machine identity", credential: "daemon", wantStatus: http.StatusNotFound},
+		{name: "unbound cloud runtime", credential: "daemon", daemonID: "machine-a", unboundRuntime: true, wantStatus: http.StatusOK},
+		{name: "cross workspace", credential: "daemon", daemonID: "machine-b", otherWorkspace: true, wantStatus: http.StatusNotFound},
+		{name: "expired daemon token", credential: "daemon", daemonID: "machine-b", expired: true, wantStatus: http.StatusUnauthorized},
+		{name: "revoked daemon token", credential: "daemon", daemonID: "machine-b", revoked: true, wantStatus: http.StatusUnauthorized},
+		{name: "missing runtime", credential: "daemon", daemonID: "machine-b", missingRuntime: true, wantStatus: http.StatusNotFound},
+		{name: "PAT member compatibility", credential: "pat", wantStatus: http.StatusOK},
+		{name: "PAT nonmember denied", credential: "pat", nonMember: true, wantStatus: http.StatusNotFound},
+		{name: "JWT member compatibility", credential: "jwt", wantStatus: http.StatusOK},
+		{name: "JWT nonmember denied", credential: "jwt", nonMember: true, wantStatus: http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtimeCols := testutil.Cols{"daemon_id": "machine-b"}
+			if tt.unboundRuntime {
+				runtimeCols["daemon_id"] = nil
+			}
+			runtimeID := dbfx.Runtime(t, "single claim ownership", runtimeCols)
+			agentID := dbfx.Agent(t, "single claim ownership", runtimeID)
+			issueID := dbfx.Issue(t, "single claim ownership")
+			taskID := dbfx.Task(t, agentID, testutil.Cols{
+				"runtime_id": runtimeID,
+				"issue_id":   issueID,
+			})
+			// Claiming can create a task token. It has no FK-based cleanup.
+			dbfx.Cleanup(t, `DELETE FROM task_token WHERE task_id = $1`, taskID)
+
+			credentialWorkspaceID := testWorkspaceID
+			if tt.otherWorkspace {
+				credentialWorkspaceID = dbfx.Workspace(t, "other claim workspace", "claim-"+uuid.NewString())
+			}
+			credentialUserID := testUserID
+			if tt.nonMember {
+				credentialUserID = dbfx.User(t, "nonmember", uuid.NewString()+"@example.com")
+			}
+			expiresAt := time.Now().Add(time.Hour)
+			if tt.expired {
+				expiresAt = time.Now().Add(-time.Hour)
+			}
+			var token string
+			switch tt.credential {
+			case "daemon":
+				token = "mdt_" + uuid.NewString()
+				dbfx.Insert(t, "daemon_token", testutil.Cols{
+					"token_hash":   auth.HashToken(token),
+					"workspace_id": credentialWorkspaceID,
+					"daemon_id":    tt.daemonID,
+					"expires_at":   expiresAt,
+				})
+				if tt.revoked {
+					dbfx.Exec(t, `DELETE FROM daemon_token WHERE token_hash = $1`, auth.HashToken(token))
+				}
+			case "pat":
+				token = "mul_" + uuid.NewString()
+				dbfx.Insert(t, "personal_access_token", testutil.Cols{
+					"user_id":      credentialUserID,
+					"name":         "single claim ownership",
+					"token_hash":   auth.HashToken(token),
+					"token_prefix": token[:12],
+					"expires_at":   expiresAt,
+				})
+			case "jwt":
+				var err error
+				token, err = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+					"sub": credentialUserID,
+					"exp": expiresAt.Unix(),
+				}).SignedString(auth.JWTSecret())
+				if err != nil {
+					t.Fatalf("sign JWT: %v", err)
+				}
+			}
+
+			router := chi.NewRouter()
+			router.Use(middleware.DaemonAuth(testHandler.Queries, nil, nil, nil))
+			router.Post("/api/daemon/runtimes/{runtimeId}/tasks/claim", testHandler.ClaimTaskByRuntime)
+			requestedRuntimeID := runtimeID
+			if tt.missingRuntime {
+				requestedRuntimeID = uuid.NewString()
+			}
+			req := testutil.JSONRequest(http.MethodPost, "/api/daemon/runtimes/"+requestedRuntimeID+"/tasks/claim?daemon_id=machine-b", map[string]string{
+				"daemon_id": "machine-b",
+			})
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("X-Daemon-ID", "machine-b")
+			req.Header.Set("X-Workspace-ID", testWorkspaceID)
+			response := testutil.Call(t, router.ServeHTTP, req)
+
+			var status string
+			var dispatched, prepareLease bool
+			dbfx.QueryRow(t, `SELECT status, dispatched_at IS NOT NULL, prepare_lease_expires_at IS NOT NULL FROM agent_task_queue WHERE id = $1`, taskID).
+				Scan(&status, &dispatched, &prepareLease)
+			tokenCount := dbfx.Count(t, `SELECT count(*) FROM task_token WHERE task_id = $1`, taskID)
+			if tt.wantStatus != http.StatusOK {
+				if status != "queued" || dispatched || prepareLease || tokenCount != 0 {
+					t.Fatalf("denied claim mutated task: status=%s dispatched=%v prepare_lease=%v tokens=%d (HTTP %d)", status, dispatched, prepareLease, tokenCount, response.Code)
+				}
+				response.Want(tt.wantStatus)
+				return
+			}
+
+			var body struct {
+				Task *struct {
+					ID        string `json:"id"`
+					AuthToken string `json:"auth_token"`
+				} `json:"task"`
+			}
+			response.Want(http.StatusOK).JSON(&body)
+			if body.Task == nil || body.Task.ID != taskID || body.Task.AuthToken == "" {
+				t.Fatalf("authorized claim did not return the queued task and token: %s", response.Text())
+			}
+			if status != "dispatched" || !dispatched || tokenCount != 1 {
+				t.Fatalf("authorized claim not finalized: status=%s dispatched=%v tokens=%d", status, dispatched, tokenCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Apply the existing daemon machine-ownership boundary to the legacy single-runtime claim endpoint.

Runtime IDs are workspace-scoped, but daemon credentials also identify a particular machine. Batch claim and daemon WebSocket authorization already check that identity against a bound runtime. The single-runtime claim path only checked workspace access. This change adds the machine check before entering the task service, without changing shared authorization helpers or scheduling behavior.

## Related Issue

CODI-16 (internal tracking), limited to the single-runtime claim fix. This PR does **not** close the broader callback-authorization audit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/daemon.go`: add a 10-line ownership guard in `ClaimTaskByRuntime`. For daemon-token authentication, require a non-empty authenticated daemon ID and reject a different bound owner with `404 runtime not found`, before any claim side effects.
- Preserve PAT/JWT workspace-member access and the existing unpinned (`daemon_id IS NULL`) runtime behavior used by batch claim and WebSocket authorization.
- `server/internal/handler/daemon_single_claim_auth_test.go`: add 12 cases through the real `DaemonAuth` middleware and database fixtures. Cover the owning machine, a peer machine with caller-supplied identity fields, missing identity, unbound runtime, cross-workspace access, expired/deleted daemon credentials, missing runtime, and PAT/JWT member/nonmember access. Rejected requests must leave the task queued without dispatch/prepare-lease timestamps or task tokens.
- `server/internal/handler/daemon_claim_channel_type_test.go`: pass each fixture's registered daemon ID into its claim request instead of an unrelated hardcoded ID. Existing channel-response assertions are unchanged.

### Scope and risks

No schema, query, batch-claim, WebSocket, or callback changes. Clients using the correct machine credential retain their existing behavior; claims made with another machine's credential are intentionally rejected. Generalizing the shared runtime/task authorization helpers is deferred to the remaining CODI-16 work.

## How to Test

Use an isolated PostgreSQL database, apply the repository migrations, and set `DATABASE_URL` explicitly. The local runs used `pgvector/pgvector:pg17`; that temporary database was removed afterward. No shared development data or real-agent execution was used.

From `server/`:

1. Regression coverage (passed, all 12 cases, three repetitions, race detection enabled):
   ```bash
   ../scripts/go-test-with-agent-cli-guard.sh -- go test -race ./internal/handler -run '^TestClaimTaskByRuntime_DaemonOwnership$' -count=3 -v
   ```
   Before the guard was added, the peer-machine and missing-identity cases failed on the unmodified `2ed2432a2` baseline because the request reached claim finalization. After the guard, they are rejected before task mutation.

2. Build and static checks (passed):
   ```bash
   go build ./cmd/server
   go vet ./internal/handler ./internal/middleware
   ```
   `gofmt` and `git diff --check` are clean.

3. Broader regression (not fully green):
   ```bash
   ../scripts/go-test-with-agent-cli-guard.sh -- go test -race ./internal/handler ./internal/middleware -count=1 -timeout=5m
   ```
   Middleware passed. Handler reported only `TestClaimTasksByRuntime_ClaimPollHintSchedulesNextDeferredTask`: `5032ms, want 1..5000ms`. The same test also failed in three runs on the untouched `2ed2432a2` baseline (`5125/5132/5131ms`). It was left unchanged; no race was reported.

4. `make check-worktree` was attempted from the repository root but stopped because this isolated checkout has no `.env.worktree`. The full TypeScript/E2E pipeline was therefore not run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

The all-tests-pass checkbox is deliberately unchecked because of the baseline timing failure and unavailable full-stack checks documented above. UI, product-copy, landing-copy, and documentation checkboxes are not applicable to this backend-only guard.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Verify CODI-16 against upstream main and implement a small, independently reviewable fix. Traced authenticated identity through daemon middleware, compared single-runtime claim with batch claim and WebSocket authorization, reproduced the missing guard using real-auth database tests, added the endpoint-local check, and ran targeted race tests plus broader regression/build/vet checks. Kept callback auditing and shared-helper changes out of scope.

## Screenshots (optional)

Not applicable; no UI changes.
