### PR TITLE
MUL-7175: perf(webhooks): reuse workspace status catalogs for PR close checks

### DIFF
--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -1668,9 +1668,12 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 		// silently auto-closing the issue — if nothing carrying closing
 		// intent was ever delivered, the user should decide manually.
 		if state == "merged" || state == "closed" {
+			// All linked issues belong to this workspace. Resolve custom statuses
+			// once per delivery; built-in statuses still need no catalog read.
+			resolver := issuestatus.NewResolver(wsID)
 			for _, issue := range reevalIssues {
 				// A custom terminal status counts as terminal here. (MUL-6243)
-				if s := issuestatus.Effective(ctx, h.Queries, issue.WorkspaceID, issue.Status); s == "done" || s == "cancelled" {
+				if s := resolver.Effective(ctx, h.issueStatusCatalog(), issue.Status); s == "done" || s == "cancelled" {
 					continue
 				}
 				// Combined across providers: an issue may also carry a still-open

--- a/server/internal/handler/vcs_webhook.go
+++ b/server/internal/handler/vcs_webhook.go
@@ -260,9 +260,11 @@ func (h *Handler) mirrorVCSPullRequest(ctx context.Context, conn db.VcsConnectio
 	}
 
 	if ev.State == "merged" || ev.State == "closed" {
+		// Keep the catalog local to this delivery and connection's workspace.
+		resolver := issuestatus.NewResolver(conn.WorkspaceID)
 		for _, issue := range reevalIssues {
 			// A custom terminal status counts as terminal here. (MUL-6243)
-			if s := issuestatus.Effective(ctx, h.Queries, issue.WorkspaceID, issue.Status); s == "done" || s == "cancelled" {
+			if s := resolver.Effective(ctx, h.issueStatusCatalog(), issue.Status); s == "done" || s == "cancelled" {
 				continue
 			}
 			counts, err := h.Queries.GetIssueCombinedPullRequestCloseAggregate(ctx, issue.ID)

--- a/server/internal/handler/webhook_status_resolver_test.go
+++ b/server/internal/handler/webhook_status_resolver_test.go
@@ -1,0 +1,147 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/integrations/vcs"
+	"github.com/multica-ai/multica/server/internal/issuestatus"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+type webhookStatusCatalog struct {
+	issuestatus.Querier
+	reads      map[pgtype.UUID]int
+	pointReads int
+	fail       bool
+}
+
+func (c *webhookStatusCatalog) ListIssueStatusEntries(ctx context.Context, arg db.ListIssueStatusEntriesParams) ([]db.IssueStatus, error) {
+	c.reads[arg.WorkspaceID]++
+	if c.fail {
+		return nil, errors.New("test catalog unavailable")
+	}
+	return c.Querier.ListIssueStatusEntries(ctx, arg)
+}
+
+func (c *webhookStatusCatalog) GetIssueStatusEntryByKey(ctx context.Context, arg db.GetIssueStatusEntryByKeyParams) (db.IssueStatus, error) {
+	c.pointReads++
+	if c.fail {
+		return db.IssueStatus{}, errors.New("test catalog unavailable")
+	}
+	return c.Querier.GetIssueStatusEntryByKey(ctx, arg)
+}
+
+// Exercise both real mirror paths, including their persisted PR close gate.
+// Signature parsing is covered by the existing provider webhook suites.
+func TestWebhookStatusResolver(t *testing.T) {
+	ctx := context.Background()
+	for _, provider := range []string{"github", "forgejo"} {
+		t.Run(provider, func(t *testing.T) {
+			for _, tc := range []struct {
+				name           string
+				statuses, want []string
+				fail           bool
+				wantReads      int
+			}{
+				{"custom", []string{"approved", "dropped", "review", "approved", "done"}, []string{"approved", "dropped", "done", "approved", "done"}, false, 1},
+				{"builtins", []string{"done", "cancelled", "in_review"}, []string{"done", "cancelled", "done"}, false, 0},
+				// An unresolved key keeps the old nonterminal-gate behavior. This
+				// optimization must not introduce a new close-policy decision.
+				{"unknown", []string{"missing", "missing"}, []string{"done", "done"}, false, 1},
+				{"unavailable", []string{"review", "review"}, []string{"done", "done"}, true, 1},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					catalog := &webhookStatusCatalog{Querier: testHandler.Queries, reads: map[pgtype.UUID]int{}, fail: tc.fail}
+					h := *testHandler
+					h.IssueStatusCatalog = catalog
+					// The same key is terminal in one workspace and nonterminal in
+					// the other; a process-wide resolver would close the wrong set.
+					for workspace := 0; workspace < 2; workspace++ {
+						ws := dbfx.Workspace(t, "Webhook status resolver", fmt.Sprintf("resolver-%s-%s-%d", provider, tc.name, workspace), testutil.Cols{"issue_prefix": "RSL"})
+						wsID := parseUUID(ws)
+						fixture := testutil.New(testPool, ws, testUserID)
+						for key, category := range map[string]string{"approved": "done", "dropped": "cancelled", "review": "in_review"} {
+							if workspace == 1 && key == "approved" {
+								category = "in_review"
+							}
+							cols := testutil.Cols{"workspace_id": ws, "key": key, "name": key, "category": category, "color": "#123456"}
+							if key == "approved" {
+								cols["archived_at"] = testutil.Raw("now()")
+							}
+							fixture.Insert(t, "issue_status", cols)
+						}
+						var ids, closing []string
+						for i, status := range tc.statuses {
+							ids = append(ids, fixture.Issue(t, "Resolver fixture", testutil.Cols{"status": status, "number": i + 1}))
+							closing = append(closing, fmt.Sprintf("Closes RSL-%d", i+1))
+						}
+						// Mirroring creates rows outside the fixture builders.
+						for _, table := range []string{"issue_pull_request", "issue_vcs_pull_request"} {
+							fixture.Cleanup(t, "DELETE FROM "+table+" WHERE issue_id IN (SELECT id FROM issue WHERE workspace_id = $1)", ws)
+						}
+						fixture.Cleanup(t, "DELETE FROM github_pull_request WHERE workspace_id = $1", ws)
+						fixture.Cleanup(t, "DELETE FROM vcs_pull_request WHERE workspace_id = $1", ws)
+						const timestamp = "2026-09-08T00:00:00Z"
+						var mirror func()
+						if provider == "github" {
+							p := &ghPullRequestPayload{}
+							p.Action = "closed"
+							p.Repository.Owner.Login, p.Repository.Name = "fixture", "resolver"
+							p.PullRequest.Number, p.PullRequest.Title = 1, "Resolve linked issues"
+							p.PullRequest.Body = strings.Join(closing, "\n")
+							p.PullRequest.State, p.PullRequest.Merged = "closed", true
+							p.PullRequest.HTMLURL = "https://github.test/fixture/resolver/pull/1"
+							p.PullRequest.CreatedAt, p.PullRequest.UpdatedAt = timestamp, timestamp
+							mirror = func() {
+								h.mirrorPullRequestForWorkspace(ctx, wsID, int64(91000+workspace), p, closeIntentPolicy{unrestricted: true})
+							}
+						} else {
+							connID := fixture.Insert(t, "vcs_connection", testutil.Cols{"workspace_id": ws, "provider": provider, "instance_url": "https://forgejo.test", "account_login": "fixture", "access_token_encrypted": "unused", "webhook_secret_encrypted": "unused"})
+							conn := db.VcsConnection{ID: parseUUID(connID), WorkspaceID: wsID, Provider: provider}
+							ev := vcs.PullRequestEvent{Action: "closed", State: "merged", RepoOwner: "fixture", RepoName: "resolver", Number: 1, Title: "Resolve linked issues", Body: strings.Join(closing, "\n"), HTMLURL: "https://forgejo.test/fixture/resolver/pulls/1", CreatedAt: timestamp, UpdatedAt: timestamp}
+							mirror = func() { h.mirrorVCSPullRequest(ctx, conn, ev) }
+						}
+						mirror()
+						if got := catalog.reads[wsID]; got != tc.wantReads {
+							t.Errorf("workspace %d catalog reads = %d, want %d", workspace, got, tc.wantReads)
+						}
+						for i, id := range ids {
+							want := tc.want[i]
+							if workspace == 1 && tc.statuses[i] == "approved" {
+								want = "done"
+							}
+							var status string
+							fixture.QueryRow(t, "SELECT status FROM issue WHERE id = $1", id).Scan(&status)
+							if status != want {
+								t.Errorf("workspace %d issue %d status = %q, want %q", workspace, i, status, want)
+							}
+						}
+						// A fresh delivery must not reuse even a successful prior
+						// resolver. Reset one row onto a custom terminal key and replay.
+						if tc.name == "custom" {
+							fixture.Exec(t, "UPDATE issue SET status = 'dropped' WHERE id = $1", ids[0])
+							mirror()
+							if catalog.reads[wsID] != 2 {
+								t.Errorf("replayed delivery reads = %d, want 2 total", catalog.reads[wsID])
+							}
+							var status string
+							fixture.QueryRow(t, "SELECT status FROM issue WHERE id = $1", ids[0]).Scan(&status)
+							if status != "dropped" {
+								t.Errorf("replay changed terminal status to %q", status)
+							}
+						}
+					}
+					if catalog.pointReads != 0 {
+						t.Errorf("per-key reads = %d, want 0", catalog.pointReads)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

PR merge/close webhooks can link several issues in one workspace. For custom issue statuses, both the GitHub and token-based VCS mirror paths currently do one status lookup per linked issue.

Use the existing request-scoped `issuestatus.Resolver` inside each workspace's terminal-PR loop. The loop reads the catalog at most once; built-in-only loops still do no catalog reads. This targets existing PR-to-issue automation without adding a cache service or changing the HTTP contract.

## Related Issue

Tracks CODI-18 in the contributor's coding workspace. Independent of the child-stage and comment-routing optimizations.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/github.go`: create a lazy resolver per workspace mirror pass.
- `server/internal/handler/vcs_webhook.go`: do the same for the connection's workspace.
- `server/internal/handler/webhook_status_resolver_test.go`: exercise both real mirror paths, query counts, built-ins, custom/archived terminal statuses, unknown keys, catalog errors, workspace isolation, and repeated delivery.

The close-intent policy and combined cross-provider PR aggregate are unchanged. Unknown keys and catalog failures retain the existing nonterminal-gate behavior; this PR does not redefine that policy. A resolver, including its failed-read fallback, lives only for the current mirror pass. No migration, frontend change, global cache, or new API.

## How to Test

With `DATABASE_URL` pointing to an isolated, migrated PostgreSQL 17 database, from the repository root:

1. Focused provider/catalog regression:
   `scripts/go-test-with-agent-cli-guard.sh -- go -C server test -race ./internal/handler ./internal/issuestatus -run 'Test(Webhook|VCSWebhook|CombinedClose|Resolver|Effective)' -count=1 -timeout=5m`
2. Full relevant packages:
   `scripts/go-test-with-agent-cli-guard.sh -- go -C server test -race ./internal/handler ./internal/issuestatus -count=1 -timeout=5m`
3. Build/vet:
   `cd server && go build ./cmd/server && go vet ./internal/handler ./internal/issuestatus`

All commands above passed locally on baseline `b5a7ee1e0` plus this patch (full handler suite: 80s), with no race report. The new query-count regression failed before the optimization. Tests use synthetic local fixtures and make no real VCS or agent calls.

`gofmt` and `git diff --check` are clean. `make check-worktree` was attempted but stopped before running checks because this backend-only checkout has no `.env.worktree`; the full-stack TypeScript/E2E pipeline was not run. The temporary database lacks optional `pg_bigm`, so its guarded migration was skipped by the repository runner.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (Go checks above; full-stack limitation noted)
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (local-scope code comments)
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Asked to deliver three independent, small optimizations from the latest main. Inspected the existing resolver and both webhook paths, added database-backed behavior/query-count regressions, implemented only request-local catalog reuse, and ran focused and full Go verification in an isolated local database. No performance latency claim is made without a benchmark.

## Screenshots (optional)

Not applicable; backend-only optimization.
