### PR TITLE
MUL-7176 perf(issues): reuse status catalogs across child completion checks

### DIFF
--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -82,8 +82,18 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	// inherit, so a move into a custom done/cancelled status fires the barrier
 	// exactly like a move into Done or Cancelled. (MUL-6243)
 	effective := h.childStatusResolver(ctx)
-	prevTerminal := isTerminalChildStatus(effective(prev))
-	nowTerminal := isTerminalChildStatus(effective(issue))
+	prevStatus, err := effective(prev)
+	if err != nil {
+		slog.Warn("child done: failed to resolve previous child status", "error", err, "child_id", uuidToString(issue.ID))
+		return
+	}
+	nowStatus, err := effective(issue)
+	if err != nil {
+		slog.Warn("child done: failed to resolve child status", "error", err, "child_id", uuidToString(issue.ID))
+		return
+	}
+	prevTerminal := isTerminalChildStatus(prevStatus)
+	nowTerminal := isTerminalChildStatus(nowStatus)
 	if prevTerminal || !nowTerminal {
 		return
 	}
@@ -98,7 +108,11 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	// Custom statuses inherit the canonical status they name, so a custom
 	// terminal status closes this out and a custom backlog status parks it,
 	// exactly like Done/Cancelled and Backlog do. (MUL-6243)
-	parentStatus := effective(parent)
+	parentStatus, err := effective(parent)
+	if err != nil {
+		slog.Warn("child done: failed to resolve parent status", "error", err, "parent_id", uuidToString(parent.ID))
+		return
+	}
 	if parentStatus == "done" || parentStatus == "cancelled" {
 		return
 	}
@@ -133,7 +147,11 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 			"parent_id", uuidToString(parent.ID))
 		return
 	}
-	isTerminal := func(c db.Issue) bool { return isTerminalChildStatus(effective(c)) }
+	isTerminal, err := resolveTerminalChildren(children, effective)
+	if err != nil {
+		slog.Warn("child done: failed to resolve sibling statuses", "error", err, "parent_id", uuidToString(parent.ID))
+		return
+	}
 	if !stageBarrierClosed(children, issue, isTerminal) {
 		return
 	}
@@ -191,7 +209,6 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 	}
 
 	effective := h.childStatusResolver(ctx)
-	isTerminal := func(c db.Issue) bool { return isTerminalChildStatus(effective(c)) }
 	for _, g := range groups {
 		parent, err := h.Queries.GetIssue(ctx, g.parentID)
 		if err != nil {
@@ -200,7 +217,11 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 			continue
 		}
 		// Same parent guards as the single path (see notifyParentOfChildDone).
-		parentStatus := effective(parent)
+		parentStatus, err := effective(parent)
+		if err != nil {
+			slog.Warn("batch child done: failed to resolve parent status", "error", err, "parent_id", uuidToString(parent.ID))
+			continue
+		}
 		if parentStatus == "done" || parentStatus == "cancelled" {
 			continue
 		}
@@ -218,6 +239,11 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 			continue
 		}
 
+		isTerminal, err := resolveTerminalChildren(children, effective)
+		if err != nil {
+			slog.Warn("batch child done: failed to resolve sibling statuses", "error", err, "parent_id", uuidToString(parent.ID))
+			continue
+		}
 		batch := len(g.children) > 1
 		if !siblingsAreStaged(children) {
 			// Unstaged: one implicit stage. Fire once iff every child is terminal
@@ -370,19 +396,40 @@ func isTerminalChildStatus(status string) bool {
 //
 // Resolve without rewriting the issue rows, which also supply the original
 // user-selected status to downstream rendering. Built-in keys need no I/O.
-func (h *Handler) childStatusResolver(ctx context.Context) func(db.Issue) string {
+func (h *Handler) childStatusResolver(ctx context.Context) func(db.Issue) (string, error) {
 	resolvers := make(map[pgtype.UUID]*issuestatus.Resolver)
-	return func(c db.Issue) string {
+	return func(c db.Issue) (string, error) {
 		if issuestatus.IsBuiltIn(c.Status) {
-			return c.Status
+			return c.Status, nil
 		}
 		resolver := resolvers[c.WorkspaceID]
 		if resolver == nil {
 			resolver = issuestatus.NewResolver(c.WorkspaceID)
 			resolvers[c.WorkspaceID] = resolver
 		}
-		return resolver.Effective(ctx, h.issueStatusCatalog(), c.Status)
+		status := resolver.Effective(ctx, h.issueStatusCatalog(), c.Status)
+		return status, resolver.Err()
 	}
+}
+
+// resolveTerminalChildren checks every status needed by the stage barrier and
+// progress summary before either can produce a notification. The returned
+// predicate only reads this snapshot, so a late catalog failure cannot be
+// hidden by the bool-only stage helpers. Stored status keys stay untouched.
+func resolveTerminalChildren(children []db.Issue, effective func(db.Issue) (string, error)) (func(db.Issue) bool, error) {
+	terminal := make(map[pgtype.UUID]bool, len(children))
+	staged := siblingsAreStaged(children)
+	for _, child := range children {
+		if staged && !child.Stage.Valid {
+			continue // Neither stage helper considers unstaged siblings.
+		}
+		status, err := effective(child)
+		if err != nil {
+			return nil, fmt.Errorf("resolve child %s status %q: %w", uuidToString(child.ID), child.Status, err)
+		}
+		terminal[child.ID] = isTerminalChildStatus(status)
+	}
+	return func(child db.Issue) bool { return terminal[child.ID] }, nil
 }
 
 // siblingsAreStaged reports whether any child in the set carries an explicit

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -396,6 +396,9 @@ func isTerminalChildStatus(status string) bool {
 //
 // Resolve without rewriting the issue rows, which also supply the original
 // user-selected status to downstream rendering. Built-in keys need no I/O.
+// Unlike display-oriented Resolver callers, this side-effecting path must
+// reject unresolved custom keys: parent or sibling rows can be newer than the
+// catalog snapshot. A miss must not bypass a parked/terminal parent's guard.
 func (h *Handler) childStatusResolver(ctx context.Context) func(db.Issue) (string, error) {
 	resolvers := make(map[pgtype.UUID]*issuestatus.Resolver)
 	return func(c db.Issue) (string, error) {
@@ -408,7 +411,13 @@ func (h *Handler) childStatusResolver(ctx context.Context) func(db.Issue) (strin
 			resolvers[c.WorkspaceID] = resolver
 		}
 		status := resolver.Effective(ctx, h.issueStatusCatalog(), c.Status)
-		return status, resolver.Err()
+		if err := resolver.Err(); err != nil {
+			return "", err
+		}
+		if !issuestatus.IsCategory(status) {
+			return "", fmt.Errorf("unresolved status %q in workspace %s", c.Status, uuidToString(c.WorkspaceID))
+		}
+		return status, nil
 	}
 }
 

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -81,8 +81,9 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	// Both sides of the transition are resolved to the canonical status they
 	// inherit, so a move into a custom done/cancelled status fires the barrier
 	// exactly like a move into Done or Cancelled. (MUL-6243)
-	prevTerminal := isTerminalChildStatus(issuestatus.Effective(ctx, h.Queries, prev.WorkspaceID, prev.Status))
-	nowTerminal := isTerminalChildStatus(issuestatus.Effective(ctx, h.Queries, issue.WorkspaceID, issue.Status))
+	effective := h.childStatusResolver(ctx)
+	prevTerminal := isTerminalChildStatus(effective(prev))
+	nowTerminal := isTerminalChildStatus(effective(issue))
 	if prevTerminal || !nowTerminal {
 		return
 	}
@@ -97,7 +98,7 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	// Custom statuses inherit the canonical status they name, so a custom
 	// terminal status closes this out and a custom backlog status parks it,
 	// exactly like Done/Cancelled and Backlog do. (MUL-6243)
-	parentStatus := issuestatus.Effective(ctx, h.Queries, parent.WorkspaceID, parent.Status)
+	parentStatus := effective(parent)
 	if parentStatus == "done" || parentStatus == "cancelled" {
 		return
 	}
@@ -132,7 +133,8 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 			"parent_id", uuidToString(parent.ID))
 		return
 	}
-	if !stageBarrierClosed(children, issue, h.terminalChildPredicate(ctx)) {
+	isTerminal := func(c db.Issue) bool { return isTerminalChildStatus(effective(c)) }
+	if !stageBarrierClosed(children, issue, isTerminal) {
 		return
 	}
 	staged := siblingsAreStaged(children)
@@ -143,7 +145,7 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	if staged {
 		closedStage = issue.Stage.Int32
 	}
-	h.postChildDoneComment(ctx, parent, issue, children, staged, closedStage, false)
+	h.postChildDoneComment(ctx, parent, issue, children, staged, closedStage, false, isTerminal)
 }
 
 // notifyParentsOfBatchChildDone emits child-done parent notifications for a
@@ -188,6 +190,8 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 		g.children = append(g.children, c)
 	}
 
+	effective := h.childStatusResolver(ctx)
+	isTerminal := func(c db.Issue) bool { return isTerminalChildStatus(effective(c)) }
 	for _, g := range groups {
 		parent, err := h.Queries.GetIssue(ctx, g.parentID)
 		if err != nil {
@@ -196,7 +200,7 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 			continue
 		}
 		// Same parent guards as the single path (see notifyParentOfChildDone).
-		parentStatus := issuestatus.Effective(ctx, h.Queries, parent.WorkspaceID, parent.Status)
+		parentStatus := effective(parent)
 		if parentStatus == "done" || parentStatus == "cancelled" {
 			continue
 		}
@@ -214,7 +218,6 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 			continue
 		}
 
-		isTerminal := h.terminalChildPredicate(ctx)
 		batch := len(g.children) > 1
 		if !siblingsAreStaged(children) {
 			// Unstaged: one implicit stage. Fire once iff every child is terminal
@@ -223,7 +226,7 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 			if !stageBarrierClosed(children, g.children[0], isTerminal) {
 				continue
 			}
-			h.postChildDoneComment(ctx, parent, g.children[0], children, false, 0, batch)
+			h.postChildDoneComment(ctx, parent, g.children[0], children, false, 0, batch, isTerminal)
 			continue
 		}
 
@@ -254,7 +257,7 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 		if !found {
 			continue
 		}
-		h.postChildDoneComment(ctx, parent, rep, children, true, bestStage, batch)
+		h.postChildDoneComment(ctx, parent, rep, children, true, bestStage, batch, isTerminal)
 	}
 }
 
@@ -269,7 +272,7 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 // an unstaged set). `batch` selects batch-aware wording: a single update keeps
 // its historical byte-identical copy, while a batch that finished several
 // children at once must not claim "the last sub-issue just finished".
-func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db.Issue, children []db.Issue, staged bool, closedStage int32, batch bool) {
+func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db.Issue, children []db.Issue, staged bool, closedStage int32, batch bool, isTerminal func(db.Issue) bool) {
 	prefix := h.getIssuePrefix(ctx, completed.WorkspaceID)
 	identifier := prefix + "-" + strconv.Itoa(int(completed.Number))
 	childID := uuidToString(completed.ID)
@@ -283,7 +286,7 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 
 	var content string
 	if staged {
-		summary, nextStage := stageProgressSummary(children, closedStage, h.terminalChildPredicate(ctx))
+		summary, nextStage := stageProgressSummary(children, closedStage, isTerminal)
 		advance := stageAdvanceInstruction(nextStage, parentID)
 		if batch {
 			content = fmt.Sprintf(
@@ -355,23 +358,30 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 // cancelled sibling will never complete, so it must not hold a stage open.
 //
 // Takes a CANONICAL status. Callers that hold a raw `issue.status` must pass it
-// through terminalChildPredicate first, so a custom status in the done or
+// through childStatusResolver first, so a custom status in the done or
 // cancelled category closes a stage exactly like Done and Cancelled do.
 func isTerminalChildStatus(status string) bool {
 	return status == "done" || status == "cancelled"
 }
 
-// terminalChildPredicate returns the terminal test for a sibling set, resolving
-// each child's status to the canonical status it inherits. Built-in keys
-// resolve to themselves without a query, so this is free for every workspace
-// that has not defined a custom status. (MUL-6243)
+// childStatusResolver shares each workspace's catalog across the guards,
+// sibling scans and progress summary of one completion notification pass.
+// It must not outlive that pass: later notifications need a fresh catalog.
 //
-// A predicate rather than a rewritten []db.Issue on purpose: the same slice is
-// also rendered into the stage-progress comment, and mutating Status there
-// would show the category instead of the status the user actually picked.
-func (h *Handler) terminalChildPredicate(ctx context.Context) func(db.Issue) bool {
-	return func(c db.Issue) bool {
-		return isTerminalChildStatus(issuestatus.Effective(ctx, h.Queries, c.WorkspaceID, c.Status))
+// Resolve without rewriting the issue rows, which also supply the original
+// user-selected status to downstream rendering. Built-in keys need no I/O.
+func (h *Handler) childStatusResolver(ctx context.Context) func(db.Issue) string {
+	resolvers := make(map[pgtype.UUID]*issuestatus.Resolver)
+	return func(c db.Issue) string {
+		if issuestatus.IsBuiltIn(c.Status) {
+			return c.Status
+		}
+		resolver := resolvers[c.WorkspaceID]
+		if resolver == nil {
+			resolver = issuestatus.NewResolver(c.WorkspaceID)
+			resolvers[c.WorkspaceID] = resolver
+		}
+		return resolver.Effective(ctx, h.issueStatusCatalog(), c.Status)
 	}
 }
 

--- a/server/internal/handler/issue_child_done_resolver_test.go
+++ b/server/internal/handler/issue_child_done_resolver_test.go
@@ -1,0 +1,169 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/issuestatus"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+type childDoneCatalog struct {
+	issuestatus.Querier
+	reads      map[pgtype.UUID]int
+	pointReads int
+	fail       bool
+}
+
+func (c *childDoneCatalog) ListIssueStatusEntries(ctx context.Context, arg db.ListIssueStatusEntriesParams) ([]db.IssueStatus, error) {
+	c.reads[arg.WorkspaceID]++
+	if c.fail {
+		return nil, errors.New("test catalog unavailable")
+	}
+	return c.Querier.ListIssueStatusEntries(ctx, arg)
+}
+
+func (c *childDoneCatalog) GetIssueStatusEntryByKey(ctx context.Context, arg db.GetIssueStatusEntryByKeyParams) (db.IssueStatus, error) {
+	c.pointReads++
+	if c.fail {
+		return db.IssueStatus{}, errors.New("test catalog unavailable")
+	}
+	return c.Querier.GetIssueStatusEntryByKey(ctx, arg)
+}
+
+func TestChildDoneStatusResolver(t *testing.T) {
+	ctx := context.Background()
+	for _, batch := range []bool{false, true} {
+		for _, staged := range []bool{false, true} {
+			for _, mode := range []string{"custom", "builtins", "unknown", "unavailable"} {
+				t.Run(fmt.Sprintf("batch=%t/staged=%t/%s", batch, staged, mode), func(t *testing.T) {
+					catalog := &childDoneCatalog{Querier: testHandler.Queries, reads: map[pgtype.UUID]int{}, fail: mode == "unavailable"}
+					h := *testHandler
+					h.IssueStatusCatalog = catalog
+					var completed []db.Issue
+					type expectedParent struct {
+						id       string
+						comments int
+					}
+					var parents []expectedParent
+					var workspaces []pgtype.UUID
+					for workspace := 0; workspace < 2; workspace++ {
+						ws := dbfx.Workspace(t, "Child resolver", fmt.Sprintf("child-resolver-%t-%t-%s-%d", batch, staged, mode, workspace), testutil.Cols{"issue_prefix": "CHD"})
+						workspaces = append(workspaces, parseUUID(ws))
+						fixture := testutil.New(testPool, ws, testUserID)
+						for key, category := range map[string]string{"approved": "done", "dropped": "cancelled", "review": "in_review"} {
+							if workspace == 1 && key == "approved" {
+								category = "in_progress"
+							}
+							cols := testutil.Cols{"workspace_id": ws, "key": key, "name": key, "category": category, "color": "#123456"}
+							if key == "dropped" {
+								cols["archived_at"] = testutil.Raw("now()")
+							}
+							fixture.Insert(t, "issue_status", cols)
+						}
+						parentCount := 1
+						if batch {
+							parentCount = 2
+						}
+						for range parentCount {
+							parentStatus := "review"
+							statuses := []string{"approved", "dropped", "approved"}
+							wantComments := 0
+							if mode == "builtins" {
+								parentStatus = "in_progress"
+								statuses = []string{"done", "cancelled", "done"}
+								wantComments = 1
+							} else if mode == "custom" && workspace == 0 {
+								wantComments = 1
+							} else if mode == "unknown" {
+								statuses[0] = "missing"
+							}
+							parentID := fixture.Issue(t, "Resolver parent", testutil.Cols{"status": parentStatus})
+							parents = append(parents, expectedParent{parentID, wantComments})
+							for _, status := range statuses {
+								cols := testutil.Cols{"parent_issue_id": parentID, "status": status}
+								if staged {
+									cols["stage"] = 1
+								}
+								id := fixture.Issue(t, "Resolver child", cols)
+								row, err := h.Queries.GetIssue(ctx, parseUUID(id))
+								if err != nil {
+									t.Fatal(err)
+								}
+								completed = append(completed, row)
+							}
+							if staged {
+								fixture.Issue(t, "Parked next stage", testutil.Cols{"parent_issue_id": parentID, "status": "backlog", "stage": 2})
+							}
+							fixture.Cleanup(t, "DELETE FROM comment WHERE issue_id = $1", parentID)
+						}
+						if !batch {
+							last := completed[len(completed)-1]
+							prev := last
+							prev.Status = "in_progress"
+							h.notifyParentOfChildDone(ctx, prev, last)
+						}
+					}
+					if batch {
+						h.notifyParentsOfBatchChildDone(ctx, completed)
+					}
+					wantReads := 1
+					if mode == "builtins" {
+						wantReads = 0
+					}
+					for _, ws := range workspaces {
+						if got := catalog.reads[ws]; got != wantReads {
+							t.Errorf("workspace %s catalog reads = %d, want %d", uuidToString(ws), got, wantReads)
+						}
+					}
+					if catalog.pointReads != 0 {
+						t.Errorf("per-key reads = %d, want 0", catalog.pointReads)
+					}
+					for _, parent := range parents {
+						if got := countSystemCommentsOn(t, parent.id); got != parent.comments {
+							t.Errorf("parent %s comments = %d, want %d", parent.id, got, parent.comments)
+						}
+						if staged && parent.comments == 1 {
+							var content string
+							dbfx.QueryRow(t, "SELECT content FROM comment WHERE issue_id = $1 AND author_type = 'system'", parent.id).Scan(&content)
+							if !strings.Contains(content, "Stage 1") || !strings.Contains(content, "Stage 2") {
+								t.Errorf("lost stage progress: %s", content)
+							}
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestChildStatusResolverRefreshesForNextPass(t *testing.T) {
+	ctx := context.Background()
+	ws := dbfx.Workspace(t, "Resolver refresh", "child-resolver-refresh")
+	catalog := &childDoneCatalog{Querier: testHandler.Queries, reads: map[pgtype.UUID]int{}}
+	h := *testHandler
+	h.IssueStatusCatalog = catalog
+	issue := db.Issue{WorkspaceID: parseUUID(ws), Status: "approved"}
+	first := h.childStatusResolver(ctx)
+	if got := first(issue); got != "approved" {
+		t.Fatalf("unknown key resolved to %q", got)
+	}
+	dbfx.Insert(t, "issue_status", testutil.Cols{"workspace_id": ws, "key": "approved", "name": "Approved", "category": "done", "color": "#123456"})
+	if got := first(issue); got != "approved" {
+		t.Fatalf("one pass changed its snapshot to %q", got)
+	}
+	if got := h.childStatusResolver(ctx)(issue); got != "done" {
+		t.Fatalf("next pass did not refresh: %q", got)
+	}
+	if issue.Status != "approved" {
+		t.Fatal("resolver mutated the raw status")
+	}
+	if catalog.reads[issue.WorkspaceID] != 2 || catalog.pointReads != 0 {
+		t.Fatalf("catalog counts: %+v, point=%d", catalog.reads, catalog.pointReads)
+	}
+}

--- a/server/internal/handler/issue_child_done_resolver_test.go
+++ b/server/internal/handler/issue_child_done_resolver_test.go
@@ -18,10 +18,15 @@ type childDoneCatalog struct {
 	reads      map[pgtype.UUID]int
 	pointReads int
 	fail       bool
+	failNext   map[pgtype.UUID]bool
 }
 
 func (c *childDoneCatalog) ListIssueStatusEntries(ctx context.Context, arg db.ListIssueStatusEntriesParams) ([]db.IssueStatus, error) {
 	c.reads[arg.WorkspaceID]++
+	if c.failNext[arg.WorkspaceID] {
+		delete(c.failNext, arg.WorkspaceID)
+		return nil, errors.New("test transient catalog failure")
+	}
 	if c.fail {
 		return nil, errors.New("test catalog unavailable")
 	}
@@ -150,20 +155,158 @@ func TestChildStatusResolverRefreshesForNextPass(t *testing.T) {
 	h.IssueStatusCatalog = catalog
 	issue := db.Issue{WorkspaceID: parseUUID(ws), Status: "approved"}
 	first := h.childStatusResolver(ctx)
-	if got := first(issue); got != "approved" {
-		t.Fatalf("unknown key resolved to %q", got)
+	if got, err := first(issue); got != "approved" || err != nil {
+		t.Fatalf("unknown key resolved to %q, err=%v", got, err)
 	}
 	dbfx.Insert(t, "issue_status", testutil.Cols{"workspace_id": ws, "key": "approved", "name": "Approved", "category": "done", "color": "#123456"})
-	if got := first(issue); got != "approved" {
-		t.Fatalf("one pass changed its snapshot to %q", got)
+	if got, err := first(issue); got != "approved" || err != nil {
+		t.Fatalf("one pass changed its snapshot to %q, err=%v", got, err)
 	}
-	if got := h.childStatusResolver(ctx)(issue); got != "done" {
-		t.Fatalf("next pass did not refresh: %q", got)
+	if got, err := h.childStatusResolver(ctx)(issue); got != "done" || err != nil {
+		t.Fatalf("next pass did not refresh: %q, err=%v", got, err)
 	}
 	if issue.Status != "approved" {
 		t.Fatal("resolver mutated the raw status")
 	}
 	if catalog.reads[issue.WorkspaceID] != 2 || catalog.pointReads != 0 {
 		t.Fatalf("catalog counts: %+v, point=%d", catalog.reads, catalog.pointReads)
+	}
+}
+
+func TestChildDoneCatalogFailureSkipsNotification(t *testing.T) {
+	ctx := context.Background()
+	for _, batch := range []bool{false, true} {
+		for _, tc := range []struct {
+			name, previous, current, parent string
+			siblingStage                    int
+		}{
+			{name: "child_transition", previous: "working", current: "done", parent: "parked"},
+			{name: "child_cancellation", previous: "working", current: "cancelled", parent: "parked"},
+			{name: "parent_backlog", previous: "in_progress", current: "done", parent: "parked"},
+			{name: "parent_terminal", previous: "in_progress", current: "done", parent: "approved"},
+			{name: "stage_barrier", previous: "in_progress", current: "done", parent: "in_progress", siblingStage: 1},
+			{name: "progress_summary", previous: "in_progress", current: "done", parent: "in_progress", siblingStage: 2},
+		} {
+			if batch && tc.previous == "working" {
+				continue // The batch notifier receives already-collected transitions.
+			}
+			t.Run(fmt.Sprintf("batch=%t/%s", batch, tc.name), func(t *testing.T) {
+				ws := dbfx.Workspace(t, "Transient status read", "child-status-failure")
+				fx := testutil.New(testPool, ws, testUserID)
+				for key, category := range map[string]string{"working": "in_progress", "parked": "backlog", "approved": "done"} {
+					fx.Insert(t, "issue_status", testutil.Cols{"workspace_id": ws, "key": key, "name": key, "category": category, "color": "#123456"})
+				}
+				agentID := fx.Agent(t, "Parent assignee", fx.Runtime(t, "Parent runtime"))
+				parentID := fx.Issue(t, "Parent", testutil.Cols{"status": tc.parent, "assignee_type": "agent", "assignee_id": agentID})
+				fx.Cleanup(t, "DELETE FROM comment WHERE issue_id = $1", parentID)
+				fx.Cleanup(t, "DELETE FROM agent_task_queue WHERE issue_id = $1", parentID)
+				childCols := testutil.Cols{"parent_issue_id": parentID, "status": tc.current}
+				if tc.siblingStage != 0 {
+					childCols["stage"] = 1
+					fx.Issue(t, "Custom-status sibling", testutil.Cols{"parent_issue_id": parentID, "status": "approved", "stage": tc.siblingStage})
+				}
+				childID := fx.Issue(t, "Completed child", childCols)
+				child, err := testHandler.Queries.GetIssue(ctx, parseUUID(childID))
+				if err != nil {
+					t.Fatal(err)
+				}
+				previous := child
+				previous.Status = tc.previous
+				catalog := &childDoneCatalog{
+					Querier: testHandler.Queries, reads: map[pgtype.UUID]int{},
+					failNext: map[pgtype.UUID]bool{parseUUID(ws): true},
+				}
+				h := *testHandler
+				h.IssueStatusCatalog = catalog
+				notify := func() {
+					if batch {
+						h.notifyParentsOfBatchChildDone(ctx, []db.Issue{child})
+					} else {
+						h.notifyParentOfChildDone(ctx, previous, child)
+					}
+				}
+				notify()
+				if got := countSystemCommentsOn(t, parentID); got != 0 {
+					t.Errorf("failed catalog read posted %d comments, want none", got)
+				}
+				if got := countPendingTasksForAgent(t, parentID, agentID); got != 0 {
+					t.Errorf("failed catalog read queued %d parent runs, want none", got)
+				}
+				if got := catalog.reads[parseUUID(ws)]; got != 1 {
+					t.Errorf("failed pass made %d catalog reads, want 1", got)
+				}
+				// A subsequent notification pass gets a fresh catalog. This is not an
+				// automatic retry of the already-committed child status update.
+				notify()
+				want := 0
+				if tc.parent == "in_progress" {
+					want = 1
+				}
+				if got := countSystemCommentsOn(t, parentID); got != want {
+					t.Errorf("after recovery: %d comments, want %d", got, want)
+				}
+				if got := countPendingTasksForAgent(t, parentID, agentID); got != want {
+					t.Errorf("after recovery: %d parent runs, want %d", got, want)
+				}
+				if catalog.reads[parseUUID(ws)] != 2 || catalog.pointReads != 0 {
+					t.Errorf("catalog counts: %+v, point=%d", catalog.reads, catalog.pointReads)
+				}
+			})
+		}
+	}
+}
+
+func TestBatchChildDoneCatalogFailureIsolation(t *testing.T) {
+	ctx := context.Background()
+	failedWS := dbfx.Workspace(t, "Failed catalog", "child-failed-catalog")
+	healthyWS := dbfx.Workspace(t, "Healthy catalog", "child-healthy-catalog")
+	for _, ws := range []string{failedWS, healthyWS} {
+		fx := testutil.New(testPool, ws, testUserID)
+		for key, category := range map[string]string{"working": "in_progress", "parked": "backlog"} {
+			fx.Insert(t, "issue_status", testutil.Cols{"workspace_id": ws, "key": key, "name": key, "category": category, "color": "#123456"})
+		}
+	}
+	cases := []struct {
+		workspace, status string
+		want              int
+	}{
+		{failedWS, "working", 0}, // First read fails; skip this parent.
+		{failedWS, "parked", 0},  // Cached failure must not bypass this guard.
+		{healthyWS, "working", 1},
+		{failedWS, "in_progress", 1}, // Built-in-only groups need no catalog.
+	}
+	var completed []db.Issue
+	var parents []string
+	for _, tc := range cases {
+		fx := testutil.New(testPool, tc.workspace, testUserID)
+		parentID := fx.Issue(t, "Batch parent", testutil.Cols{"status": tc.status})
+		parents = append(parents, parentID)
+		fx.Cleanup(t, "DELETE FROM comment WHERE issue_id = $1", parentID)
+		childID := fx.Issue(t, "Batch child", testutil.Cols{"parent_issue_id": parentID, "status": "done"})
+		child, err := testHandler.Queries.GetIssue(ctx, parseUUID(childID))
+		if err != nil {
+			t.Fatal(err)
+		}
+		completed = append(completed, child)
+	}
+	catalog := &childDoneCatalog{
+		Querier: testHandler.Queries, reads: map[pgtype.UUID]int{},
+		failNext: map[pgtype.UUID]bool{parseUUID(failedWS): true},
+	}
+	h := *testHandler
+	h.IssueStatusCatalog = catalog
+	h.notifyParentsOfBatchChildDone(ctx, completed)
+	for i, tc := range cases {
+		if got := countSystemCommentsOn(t, parents[i]); got != tc.want {
+			t.Errorf("group %d (%s): %d comments, want %d", i, tc.status, got, tc.want)
+		}
+	}
+	for _, ws := range []string{failedWS, healthyWS} {
+		if got := catalog.reads[parseUUID(ws)]; got != 1 {
+			t.Errorf("workspace %s made %d catalog reads, want 1", ws, got)
+		}
+	}
+	if catalog.pointReads != 0 {
+		t.Errorf("per-key reads = %d, want 0", catalog.pointReads)
 	}
 }

--- a/server/internal/handler/issue_child_done_resolver_test.go
+++ b/server/internal/handler/issue_child_done_resolver_test.go
@@ -19,6 +19,7 @@ type childDoneCatalog struct {
 	pointReads int
 	fail       bool
 	failNext   map[pgtype.UUID]bool
+	afterRead  func()
 }
 
 func (c *childDoneCatalog) ListIssueStatusEntries(ctx context.Context, arg db.ListIssueStatusEntriesParams) ([]db.IssueStatus, error) {
@@ -30,7 +31,13 @@ func (c *childDoneCatalog) ListIssueStatusEntries(ctx context.Context, arg db.Li
 	if c.fail {
 		return nil, errors.New("test catalog unavailable")
 	}
-	return c.Querier.ListIssueStatusEntries(ctx, arg)
+	entries, err := c.Querier.ListIssueStatusEntries(ctx, arg)
+	if err == nil && c.afterRead != nil {
+		afterRead := c.afterRead
+		c.afterRead = nil
+		afterRead()
+	}
+	return entries, err
 }
 
 func (c *childDoneCatalog) GetIssueStatusEntryByKey(ctx context.Context, arg db.GetIssueStatusEntryByKeyParams) (db.IssueStatus, error) {
@@ -155,12 +162,12 @@ func TestChildStatusResolverRefreshesForNextPass(t *testing.T) {
 	h.IssueStatusCatalog = catalog
 	issue := db.Issue{WorkspaceID: parseUUID(ws), Status: "approved"}
 	first := h.childStatusResolver(ctx)
-	if got, err := first(issue); got != "approved" || err != nil {
-		t.Fatalf("unknown key resolved to %q, err=%v", got, err)
+	if _, err := first(issue); err == nil {
+		t.Fatal("unknown key must prevent side effects")
 	}
 	dbfx.Insert(t, "issue_status", testutil.Cols{"workspace_id": ws, "key": "approved", "name": "Approved", "category": "done", "color": "#123456"})
-	if got, err := first(issue); got != "approved" || err != nil {
-		t.Fatalf("one pass changed its snapshot to %q, err=%v", got, err)
+	if _, err := first(issue); err == nil {
+		t.Fatal("one pass must not refresh a missing key")
 	}
 	if got, err := h.childStatusResolver(ctx)(issue); got != "done" || err != nil {
 		t.Fatalf("next pass did not refresh: %q, err=%v", got, err)
@@ -170,6 +177,204 @@ func TestChildStatusResolverRefreshesForNextPass(t *testing.T) {
 	}
 	if catalog.reads[issue.WorkspaceID] != 2 || catalog.pointReads != 0 {
 		t.Fatalf("catalog counts: %+v, point=%d", catalog.reads, catalog.pointReads)
+	}
+}
+
+func TestChildDoneCatalogSnapshotPredatesParent(t *testing.T) {
+	ctx := context.Background()
+	for _, batch := range []bool{false, true} {
+		for _, category := range []string{"backlog", "done", "cancelled"} {
+			t.Run(fmt.Sprintf("batch=%t/%s", batch, category), func(t *testing.T) {
+				ws := dbfx.Workspace(t, "New parent status", "child-status-snapshot")
+				fx := testutil.New(testPool, ws, testUserID)
+				for key, category := range map[string]string{"working": "in_progress", "parked": "backlog"} {
+					fx.Insert(t, "issue_status", testutil.Cols{"workspace_id": ws, "key": key, "name": key, "category": category, "color": "#123456"})
+				}
+				agentID := fx.Agent(t, "Parent assignee", fx.Runtime(t, "Parent runtime"))
+				parentID := fx.Issue(t, "Parent", testutil.Cols{"status": "in_progress", "assignee_type": "agent", "assignee_id": agentID})
+				fx.Cleanup(t, "DELETE FROM comment WHERE issue_id = $1", parentID)
+				fx.Cleanup(t, "DELETE FROM agent_task_queue WHERE issue_id = $1", parentID)
+				childID := fx.Issue(t, "Completed child", testutil.Cols{"parent_issue_id": parentID, "status": "done", "stage": 1})
+				fx.Issue(t, "Later stage", testutil.Cols{"parent_issue_id": parentID, "status": "backlog", "stage": 2})
+				child, err := testHandler.Queries.GetIssue(ctx, parseUUID(childID))
+				if err != nil {
+					t.Fatal(err)
+				}
+				previous := child
+				previous.Status = "working"
+				var completed []db.Issue
+				if batch {
+					// An earlier parent group loads the shared catalog before the
+					// affected parent row is read. This parked group stays silent.
+					firstParent := fx.Issue(t, "Earlier parked parent", testutil.Cols{"status": "parked"})
+					fx.Cleanup(t, "DELETE FROM comment WHERE issue_id = $1", firstParent)
+					firstID := fx.Issue(t, "Earlier completed child", testutil.Cols{"parent_issue_id": firstParent, "status": "done"})
+					first, err := testHandler.Queries.GetIssue(ctx, parseUUID(firstID))
+					if err != nil {
+						t.Fatal(err)
+					}
+					completed = append(completed, first)
+				}
+				completed = append(completed, child)
+				newKey := "new_" + category
+				catalog := &childDoneCatalog{
+					Querier: testHandler.Queries, reads: map[pgtype.UUID]int{},
+					afterRead: func() {
+						// Commit both changes after materializing the catalog rows,
+						// but before GetIssue reads the affected parent. No sleeps or
+						// read errors: only the snapshot is older than the parent row.
+						fx.Insert(t, "issue_status", testutil.Cols{"workspace_id": ws, "key": newKey, "name": newKey, "category": category, "color": "#123456"})
+						fx.Exec(t, "UPDATE issue SET status = $1 WHERE id = $2", newKey, parentID)
+					},
+				}
+				h := *testHandler
+				h.IssueStatusCatalog = catalog
+				if batch {
+					h.notifyParentsOfBatchChildDone(ctx, completed)
+				} else {
+					h.notifyParentOfChildDone(ctx, previous, child)
+				}
+				if catalog.afterRead != nil {
+					t.Fatal("test did not mutate the parent after the catalog read")
+				}
+				if got := countSystemCommentsOn(t, parentID); got != 0 {
+					t.Errorf("parent in newly created %s status received %d comments, want none", category, got)
+				}
+				if got := countPendingTasksForAgent(t, parentID, agentID); got != 0 {
+					t.Errorf("parent in newly created %s status received %d queued runs, want none", category, got)
+				}
+				if catalog.reads[parseUUID(ws)] != 1 || catalog.pointReads != 0 {
+					t.Errorf("snapshot miss must not re-read: catalog=%+v, point=%d", catalog.reads, catalog.pointReads)
+				}
+				parent, err := h.Queries.GetIssue(ctx, parseUUID(parentID))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if parent.Status != newKey {
+					t.Errorf("stored parent status = %q, want %q", parent.Status, newKey)
+				}
+			})
+		}
+	}
+}
+
+func TestChildDoneUnknownStatusSkipsNotification(t *testing.T) {
+	ctx := context.Background()
+	for _, batch := range []bool{false, true} {
+		for _, tc := range []struct {
+			name, previous, current, parent string
+			siblingStage                    int
+		}{
+			{name: "previous_child", previous: "missing", current: "done", parent: "in_progress"},
+			{name: "current_child", previous: "in_progress", current: "missing", parent: "in_progress"},
+			{name: "parent", previous: "in_progress", current: "done", parent: "missing"},
+			{name: "deleted_parent_status", previous: "in_progress", current: "done", parent: "missing"},
+			{name: "stage_barrier", previous: "in_progress", current: "done", parent: "in_progress", siblingStage: 1},
+			{name: "progress_summary", previous: "in_progress", current: "done", parent: "in_progress", siblingStage: 2},
+		} {
+			if batch && (tc.previous == "missing" || tc.current == "missing") {
+				continue // Transition filtering belongs to BatchUpdateIssues, not its notifier.
+			}
+			t.Run(fmt.Sprintf("batch=%t/%s", batch, tc.name), func(t *testing.T) {
+				ws := dbfx.Workspace(t, "Unknown notification status", "child-status-unknown")
+				fx := testutil.New(testPool, ws, testUserID)
+				if tc.name == "deleted_parent_status" {
+					id := fx.Insert(t, "issue_status", testutil.Cols{"workspace_id": ws, "key": "missing", "name": "Deleted", "category": "backlog", "color": "#123456"})
+					fx.Exec(t, "DELETE FROM issue_status WHERE id = $1", id)
+				}
+				agentID := fx.Agent(t, "Parent assignee", fx.Runtime(t, "Parent runtime"))
+				parentID := fx.Issue(t, "Parent", testutil.Cols{"status": tc.parent, "assignee_type": "agent", "assignee_id": agentID})
+				fx.Cleanup(t, "DELETE FROM comment WHERE issue_id = $1", parentID)
+				fx.Cleanup(t, "DELETE FROM agent_task_queue WHERE issue_id = $1", parentID)
+				cols := testutil.Cols{"parent_issue_id": parentID, "status": tc.current}
+				if tc.siblingStage != 0 {
+					cols["stage"] = 1
+					fx.Issue(t, "Unknown-status sibling", testutil.Cols{"parent_issue_id": parentID, "status": "missing", "stage": tc.siblingStage})
+				}
+				childID := fx.Issue(t, "Completed child", cols)
+				child, err := testHandler.Queries.GetIssue(ctx, parseUUID(childID))
+				if err != nil {
+					t.Fatal(err)
+				}
+				previous := child
+				previous.Status = tc.previous
+				catalog := &childDoneCatalog{Querier: testHandler.Queries, reads: map[pgtype.UUID]int{}}
+				h := *testHandler
+				h.IssueStatusCatalog = catalog
+				if batch {
+					h.notifyParentsOfBatchChildDone(ctx, []db.Issue{child})
+				} else {
+					h.notifyParentOfChildDone(ctx, previous, child)
+				}
+				if got := countSystemCommentsOn(t, parentID); got != 0 {
+					t.Errorf("unknown status produced %d comments, want none", got)
+				}
+				if got := countPendingTasksForAgent(t, parentID, agentID); got != 0 {
+					t.Errorf("unknown status queued %d parent runs, want none", got)
+				}
+				if catalog.reads[parseUUID(ws)] != 1 || catalog.pointReads != 0 {
+					t.Errorf("unknown status triggered extra reads: catalog=%+v, point=%d", catalog.reads, catalog.pointReads)
+				}
+				stored, err := h.Queries.GetIssue(ctx, child.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if stored.Status != tc.current {
+					t.Errorf("notification changed committed child status to %q, want %q", stored.Status, tc.current)
+				}
+			})
+		}
+	}
+}
+
+func TestBatchChildDoneUnknownStatusIsolation(t *testing.T) {
+	ctx := context.Background()
+	ws := dbfx.Workspace(t, "Missing key", "child-missing-key")
+	otherWS := dbfx.Workspace(t, "Known key", "child-known-key")
+	for _, workspace := range []string{ws, otherWS} {
+		dbfx.Insert(t, "issue_status", testutil.Cols{"workspace_id": workspace, "key": "working", "name": "Working", "category": "in_progress", "color": "#123456"})
+	}
+	dbfx.Insert(t, "issue_status", testutil.Cols{"workspace_id": otherWS, "key": "missing", "name": "Known elsewhere", "category": "in_progress", "color": "#123456"})
+	cases := []struct {
+		workspace, status string
+		want              int
+	}{
+		{ws, "missing", 0},
+		{ws, "working", 1}, // A missing key must not poison this workspace's valid catalog.
+		{ws, "in_progress", 1},
+		{otherWS, "missing", 1}, // The same key resolves independently in another workspace.
+	}
+	var completed []db.Issue
+	var parents, agents []string
+	for i, tc := range cases {
+		fx := testutil.New(testPool, tc.workspace, testUserID)
+		agentID := fx.Agent(t, fmt.Sprintf("Parent assignee %d", i), fx.Runtime(t, fmt.Sprintf("Parent runtime %d", i)))
+		parentID := fx.Issue(t, "Batch parent", testutil.Cols{"status": tc.status, "assignee_type": "agent", "assignee_id": agentID})
+		parents = append(parents, parentID)
+		agents = append(agents, agentID)
+		fx.Cleanup(t, "DELETE FROM comment WHERE issue_id = $1", parentID)
+		fx.Cleanup(t, "DELETE FROM agent_task_queue WHERE issue_id = $1", parentID)
+		childID := fx.Issue(t, "Batch child", testutil.Cols{"parent_issue_id": parentID, "status": "done"})
+		child, err := testHandler.Queries.GetIssue(ctx, parseUUID(childID))
+		if err != nil {
+			t.Fatal(err)
+		}
+		completed = append(completed, child)
+	}
+	catalog := &childDoneCatalog{Querier: testHandler.Queries, reads: map[pgtype.UUID]int{}}
+	h := *testHandler
+	h.IssueStatusCatalog = catalog
+	h.notifyParentsOfBatchChildDone(ctx, completed)
+	for i, tc := range cases {
+		if got := countSystemCommentsOn(t, parents[i]); got != tc.want {
+			t.Errorf("group %d (%s): %d comments, want %d", i, tc.status, got, tc.want)
+		}
+		if got := countPendingTasksForAgent(t, parents[i], agents[i]); got != tc.want {
+			t.Errorf("group %d (%s): %d queued runs, want %d", i, tc.status, got, tc.want)
+		}
+	}
+	if catalog.reads[parseUUID(ws)] != 1 || catalog.reads[parseUUID(otherWS)] != 1 || catalog.pointReads != 0 {
+		t.Errorf("catalog counts: %+v, point=%d", catalog.reads, catalog.pointReads)
 	}
 }
 

--- a/server/internal/issuestatus/issuestatus.go
+++ b/server/internal/issuestatus/issuestatus.go
@@ -451,6 +451,7 @@ type Resolver struct {
 	categories  map[string]string
 	names       map[string]string
 	loaded      bool
+	loadErr     error
 }
 
 // NewResolver returns a Resolver for one workspace. It performs no I/O.
@@ -460,7 +461,8 @@ func NewResolver(workspaceID pgtype.UUID) *Resolver {
 
 // load fetches the catalog once, on the first call that needs it. A failed read
 // leaves the maps nil, which makes every lookup below fall back to its
-// key-unchanged branch — the same fail-safe the single-shot resolver applies.
+// key-unchanged branch. Callers making side-effect decisions must check Err
+// rather than treating a failed read as an unknown status.
 func (r *Resolver) load(ctx context.Context, q Querier) {
 	if r.loaded {
 		return
@@ -471,6 +473,7 @@ func (r *Resolver) load(ctx context.Context, q Querier) {
 		IncludeArchived: true,
 	})
 	if err != nil {
+		r.loadErr = err
 		return
 	}
 	r.categories = make(map[string]string, len(entries))
@@ -479,6 +482,13 @@ func (r *Resolver) load(ctx context.Context, q Querier) {
 		r.categories[e.Key] = e.Category
 		r.names[e.Key] = e.Name
 	}
+}
+
+// Err returns the cached catalog-read error, or nil before the first catalog
+// read and after a successful read. It performs no I/O. A fresh Resolver
+// is required to try again after a failed read.
+func (r *Resolver) Err() error {
+	return r.loadErr
 }
 
 // Effective mirrors the package-level Effective, but amortizes the catalog read

--- a/server/internal/issuestatus/issuestatus.go
+++ b/server/internal/issuestatus/issuestatus.go
@@ -462,7 +462,8 @@ func NewResolver(workspaceID pgtype.UUID) *Resolver {
 // load fetches the catalog once, on the first call that needs it. A failed read
 // leaves the maps nil, which makes every lookup below fall back to its
 // key-unchanged branch. Callers making side-effect decisions must check Err
-// rather than treating a failed read as an unknown status.
+// and require a valid resolved category: a successful read can still miss a
+// custom key that was created after the snapshot.
 func (r *Resolver) load(ctx context.Context, q Querier) {
 	if r.loaded {
 		return

--- a/server/internal/issuestatus/issuestatus_test.go
+++ b/server/internal/issuestatus/issuestatus_test.go
@@ -507,6 +507,34 @@ func TestResolverFailsSafeWhenTheCatalogReadFails(t *testing.T) {
 	}
 }
 
+func TestResolverReportsCachedLoadFailure(t *testing.T) {
+	ctx := context.Background()
+	q := newFakeQuerier(custom("parked", Backlog))
+	readErr := errors.New("transient catalog failure")
+	q.err = readErr
+	r := NewResolver(testWorkspace)
+	if got := r.Err(); got != nil || q.lists != 0 {
+		t.Fatalf("unused resolver: err=%v, reads=%d", got, q.lists)
+	}
+	if got := r.Effective(ctx, q, Done); got != Done || r.Err() != nil || q.lists != 0 {
+		t.Fatalf("built-in status touched the catalog: status=%q, err=%v, reads=%d", got, r.Err(), q.lists)
+	}
+	if got := r.Effective(ctx, q, "parked"); got != "parked" || !errors.Is(r.Err(), readErr) {
+		t.Fatalf("failed read: status=%q, err=%v", got, r.Err())
+	}
+	q.err = nil
+	if got := r.Effective(ctx, q, "parked"); got != "parked" || !errors.Is(r.Err(), readErr) || q.lists != 1 {
+		t.Fatalf("failure was not cached: status=%q, err=%v, reads=%d", got, r.Err(), q.lists)
+	}
+	fresh := NewResolver(testWorkspace)
+	if got := fresh.Effective(ctx, q, "parked"); got != Backlog || fresh.Err() != nil || q.lists != 2 {
+		t.Fatalf("fresh resolver did not recover: status=%q, err=%v, reads=%d", got, fresh.Err(), q.lists)
+	}
+	if got := fresh.Effective(ctx, q, "unknown"); got != "unknown" || fresh.Err() != nil || q.lists != 2 {
+		t.Fatalf("unknown key confused with read failure: status=%q, err=%v, reads=%d", got, fresh.Err(), q.lists)
+	}
+}
+
 // ExpandCategories is what keeps the (workspace_id, status) index usable for a
 // category filter; wrapping the column in issue_effective_status() instead made
 // it a full workspace scan.

--- a/server/internal/service/builtin_skills/multica-platform/references/issues.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/issues.md
@@ -323,6 +323,12 @@ status (`done`/`cancelled`). A completion that does not close a stage is silent
 so the parent is woken once when the *last* sub-issue finishes — not on every
 child.
 
+Completion notifications are best-effort. If the status catalog cannot be read,
+or a custom status needed for the checks cannot be resolved (including a status
+created after the notification pass's catalog snapshot), the server skips that
+parent's notification and wake. The child's committed status change remains
+saved; there is no automatic replay of the skipped notification.
+
 Advancement is agent-driven: the server only detects the closed barrier and
 wakes the parent assignee, who then decides whether to promote the next stage's
 `backlog` sub-issues to `todo`.


### PR DESCRIPTION
## What does this PR do?

Child-completion notifications repeatedly resolve custom statuses while checking the changed child, parent, siblings, stage gates, and progress summary. Reuse one lazy `issuestatus.Resolver` per workspace for one notification pass, including all parent groups in a batch. Built-in-only passes still make zero catalog reads; custom-status passes make at most one catalog read per workspace.

The review fixes make this side-effecting path fail closed: a catalog-read error or an unresolved custom key skips the affected parent's notification and wake. The latter also covers a parent row whose newly created status is newer than the cached catalog. The stage algorithm and successfully resolved status behavior remain unchanged; this is deliberately stricter for unknown/deleted keys, not a zero-behavior-change claim.

## Related Issue

Tracks CODI-19 in the contributor's coding workspace. Based directly on `main`, independently of CODI-18 and CODI-20.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/issue_child_done.go`: share workspace-keyed, pass-local resolvers; require successful category resolution before notification side effects. Resolve participating sibling statuses before stage/progress helpers run. Single notifications return on an error; batch notifications skip the affected parent group. Unknown-key errors do not poison valid keys in the same catalog.
- `server/internal/issuestatus/issuestatus.go`: expose the cached read error through `Resolver.Err()`. The existing display-oriented `Effective`/`Name` fallback behavior is unchanged; category validation belongs to the private notification resolver.
- `server/internal/handler/issue_child_done_resolver_test.go` and `server/internal/issuestatus/issuestatus_test.go`: database-backed notification/query-count regressions and resolver error coverage. Include deterministic catalog-then-parent mutation cases for new backlog/done/cancelled statuses in single and batch paths; unknown/deleted keys; sibling/progress checks; parent-group/workspace isolation; and fresh-pass resolution.
- `server/internal/service/builtin_skills/multica-platform/references/issues.md`: document best-effort notification semantics.

Risks and scope:

- Stored status keys and committed status updates are never rewritten or rolled back. Notifications skipped for resolution uncertainty are not automatically replayed; a subsequent pass gets a fresh catalog but does not reconstruct a lost completion event.
- No additional point lookup or catalog refresh on a miss. No global cache, new API, migration, or frontend change. Archived custom statuses remain resolvable.
- The O(n²) batch sibling traversal and the separate transition lookups in `issue.go` remain outside this PR, tracked separately as CODI-23 and CODI-22.

## How to Test

Use `DATABASE_URL` pointing to an isolated, migrated PostgreSQL 17 database. From the repository root:

1. Focused regressions, including both review fixes:

   ```bash
   scripts/go-test-with-agent-cli-guard.sh -- go -C server test -race ./internal/handler ./internal/issuestatus -run 'Test(Child|Stage|Batch.*(Child|Terminal)|Resolver|Effective)' -count=3 -timeout=5m
   ```

2. Full relevant packages:

   ```bash
   scripts/go-test-with-agent-cli-guard.sh -- go -C server test -race ./internal/handler ./internal/issuestatus -count=1 -timeout=5m
   ```

3. Build/vet:

   ```bash
   cd server && go build ./cmd/server/ && go vet ./internal/handler ./internal/issuestatus
   ```

Latest local results (2026-09-09):

- Red/green verification: before the new guard, all six catalog-snapshot regressions produced one wrong notification and one queued parent run; after it, all six produce neither. The focused suite passed three consecutive race-enabled runs, including existing zero/one-read assertions. Build/vet, `gofmt`, and `git diff --check` passed.
- The unfiltered full handler run failed only `TestClaimTasksByRuntime_ClaimPollHintSchedulesNextDeferredTask`: 5074ms versus a 5000ms upper bound. An untouched `b5a7ee1e0` checkout reproduced that assertion in 3/3 focused runs (5076–5084ms). The full relevant packages passed with only that test excluded via `-skip '^TestClaimTasksByRuntime_ClaimPollHintSchedulesNextDeferredTask$'` (handler: 65.861s). No unrelated test or production logic was modified.
- `make check-worktree` stopped because this backend-only checkout has no `.env.worktree`; the full-stack frontend/E2E checks were not run locally. The isolated database lacks optional `pg_bigm`, so its guarded migrations were skipped. No end-to-end latency claim is made.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (focused and filtered full Go suites; unfiltered failure and baseline reproduction documented above)
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Traced the existing child-completion path and reused its request-local status resolver. Followed both reviewer reproductions with database-backed red/green tests, deterministic mutations after catalog materialization, and explicit checks for both notifications and queued parent runs. Kept strict category validation local to the side-effecting path, preserved display fallback behavior, and checked race-enabled regressions in an isolated database. Compared the unrelated timing assertion against an untouched baseline and documented the verification limits.

## Screenshots (optional)

Not applicable; backend-only change.
