### PR TITLE
perf(comments): narrow conversation routing history queries

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -2779,22 +2779,22 @@ func (h *Handler) routeConversationOwnersForRoot(ctx context.Context, issue db.I
 		return []commentAgentTrigger{trigger}, true
 	}
 
-	rootID := uuidToString(root.ID)
-	excludedID := uuidToString(opts.ExcludeTriggerCommentID)
-
-	tasks, err := h.Queries.ListTasksByIssue(ctx, issue.ID)
+	// Excluding the root excludes every historical owner in this branch.
+	// Explicit mentions above retain their existing precedence.
+	if opts.ExcludeTriggerCommentID == root.ID {
+		return nil, false
+	}
+	tasks, err := h.Queries.ListTaskRoutingByIssueAndTriggerComment(ctx, db.ListTaskRoutingByIssueAndTriggerCommentParams{
+		WorkspaceID:      issue.WorkspaceID,
+		IssueID:          issue.ID,
+		TriggerCommentID: root.ID,
+	})
 	if err != nil {
 		return nil, false
 	}
 	routedAgents := make(map[string]conversationRoutedAgentInfo)
 	for _, task := range tasks {
-		if !task.TriggerCommentID.Valid || !task.AgentID.Valid {
-			continue
-		}
-		if excludedID != "" && uuidToString(task.TriggerCommentID) == excludedID {
-			continue
-		}
-		if uuidToString(task.TriggerCommentID) != rootID {
+		if !task.AgentID.Valid {
 			continue
 		}
 		agentID := uuidToString(task.AgentID)

--- a/server/internal/handler/comment_routing_query_test.go
+++ b/server/internal/handler/comment_routing_query_test.go
@@ -1,0 +1,165 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+type conversationRoutingQuerySpy struct {
+	db.DBTX
+	queries, rows, columns int
+	fail                   bool
+}
+
+func (s *conversationRoutingQuerySpy) Query(ctx context.Context, query string, args ...any) (pgx.Rows, error) {
+	if !strings.Contains(query, "-- name: ListTasksByIssue :many") && !strings.Contains(query, "-- name: ListTaskRoutingByIssueAndTriggerComment :many") {
+		return s.DBTX.Query(ctx, query, args...)
+	}
+	s.queries++
+	if s.fail {
+		return nil, errors.New("test routing query unavailable")
+	}
+	rows, err := s.DBTX.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	s.columns = len(rows.FieldDescriptions())
+	return &conversationRoutingRows{Rows: rows, spy: s}, nil
+}
+
+type conversationRoutingRows struct {
+	pgx.Rows
+	spy *conversationRoutingQuerySpy
+}
+
+func (r *conversationRoutingRows) Next() bool {
+	ok := r.Rows.Next()
+	if ok {
+		r.spy.rows++
+	}
+	return ok
+}
+
+func TestCommentConversationRoutingQuery(t *testing.T) {
+	ctx := context.Background()
+	issueID := dbfx.Issue(t, "Conversation routing")
+	rootID := dbfx.Comment(t, issueID, "Continue this conversation")
+	otherRootID := dbfx.Comment(t, issueID, "Another conversation")
+	emptyRootID := dbfx.Comment(t, issueID, "No prior run")
+	agentA := dbfx.Agent(t, "Routing agent A", testRuntimeID)
+	agentB := dbfx.Agent(t, "Routing agent B", testRuntimeID)
+	oldSquad := dbfx.Squad(t, "Old routing squad", agentA)
+	newSquad := dbfx.Squad(t, "New routing squad", agentA)
+	baseTime := time.Date(2026, 9, 8, 0, 0, 0, 0, time.UTC)
+	for _, row := range []struct {
+		agent string
+		squad any
+		ago   time.Duration
+	}{
+		{agentA, oldSquad, 3 * time.Hour},
+		{agentA, newSquad, 2 * time.Hour},
+		// The newest run has no squad: keep searching older runs for the
+		// newest non-NULL squad, rather than choosing the newest row alone.
+		{agentA, nil, time.Hour},
+		{agentB, nil, 90 * time.Minute},
+	} {
+		dbfx.Task(t, row.agent, testutil.Cols{"runtime_id": testRuntimeID, "issue_id": issueID, "trigger_comment_id": rootID, "status": "completed", "squad_id": row.squad, "created_at": baseTime.Add(-row.ago)})
+	}
+	for i := range 128 {
+		dbfx.Task(t, agentA, testutil.Cols{"runtime_id": testRuntimeID, "issue_id": issueID, "trigger_comment_id": otherRootID, "status": "completed", "trigger_summary": strings.Repeat("unrelated context ", 256), "created_at": baseTime.Add(time.Duration(i) * time.Second)})
+	}
+	dbfx.Task(t, agentA, testutil.Cols{"runtime_id": testRuntimeID, "issue_id": issueID, "status": "completed"})
+	otherIssue := dbfx.Issue(t, "Different issue")
+	// With no database FKs, independently enforce both IDs even for an
+	// inconsistent historical task whose trigger belongs to another issue.
+	dbfx.Task(t, agentA, testutil.Cols{"runtime_id": testRuntimeID, "issue_id": otherIssue, "trigger_comment_id": rootID, "status": "completed"})
+	foreignWS := dbfx.Workspace(t, "Foreign routing workspace", "foreign-routing-workspace")
+	issue, err := testHandler.Queries.GetIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := testHandler.Queries.GetCommentInWorkspace(ctx, db.GetCommentInWorkspaceParams{ID: parseUUID(rootID), WorkspaceID: issue.WorkspaceID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name          string
+		queries, rows int
+		found         bool
+	}{
+		{"matching history", 1, 4, true},
+		{"exclude other comment", 1, 4, true},
+		{"exclude root", 0, 0, false},
+		{"empty history", 1, 0, false},
+		{"wrong workspace", 1, 0, false},
+		{"query error", 1, 0, false},
+		{"explicit mention wins", 0, 0, true},
+		{"archived agent still rejected", 1, 4, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := &conversationRoutingQuerySpy{DBTX: testPool, fail: tc.name == "query error"}
+			h := *testHandler
+			h.Queries = db.New(spy)
+			inputIssue, inputRoot := issue, root
+			opts := commentTriggerComputeOptions{}
+			switch tc.name {
+			case "exclude other comment":
+				opts.ExcludeTriggerCommentID = parseUUID(otherRootID)
+			case "exclude root":
+				opts.ExcludeTriggerCommentID = root.ID
+			case "empty history":
+				inputRoot.ID = parseUUID(emptyRootID)
+			case "wrong workspace":
+				inputIssue.WorkspaceID = parseUUID(foreignWS)
+			case "explicit mention wins":
+				inputRoot.Content = fmt.Sprintf("Ask [B](mention://agent/%s)", agentB)
+			case "archived agent still rejected":
+				dbfx.Exec(t, "UPDATE agent SET archived_at = now() WHERE id = $1", agentA)
+				t.Cleanup(func() { dbfx.Exec(t, "UPDATE agent SET archived_at = NULL WHERE id = $1", agentA) })
+			}
+			triggers, found := h.routeConversationOwnersForRoot(ctx, inputIssue, inputRoot, testUserID, opts)
+			if found != tc.found {
+				t.Errorf("found = %t, want %t", found, tc.found)
+			}
+			if spy.queries != tc.queries || spy.rows != tc.rows {
+				t.Errorf("history queries/rows = %d/%d, want %d/%d", spy.queries, spy.rows, tc.queries, tc.rows)
+			}
+			if tc.queries > 0 && !spy.fail && spy.columns != 2 {
+				t.Errorf("history projection has %d columns, want agent_id and squad_id only", spy.columns)
+			}
+			want := map[string]string{}
+			if tc.found {
+				want[agentB] = ""
+				if tc.name != "explicit mention wins" && tc.name != "archived agent still rejected" {
+					want[agentA] = newSquad
+				}
+			}
+			if len(triggers) != len(want) {
+				t.Fatalf("triggers = %d, want %d", len(triggers), len(want))
+			}
+			for _, trigger := range triggers {
+				id := uuidToString(trigger.Agent.ID)
+				wantSquad, ok := want[id]
+				if !ok {
+					t.Fatalf("unexpected routed agent %s", id)
+				}
+				gotSquad := ""
+				if trigger.Squad != nil {
+					gotSquad = uuidToString(trigger.Squad.ID)
+				}
+				if gotSquad != wantSquad {
+					t.Errorf("agent %s squad = %s, want %s", id, gotSquad, wantSquad)
+				}
+			}
+		})
+	}
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -5981,6 +5981,51 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntimes(ctx context.Context, runti
 	return items, nil
 }
 
+const listTaskRoutingByIssueAndTriggerComment = `-- name: ListTaskRoutingByIssueAndTriggerComment :many
+SELECT t.agent_id, t.squad_id
+FROM agent_task_queue t
+JOIN issue i ON i.id = t.issue_id
+WHERE i.workspace_id = $1::uuid
+  AND t.issue_id = $2::uuid
+  AND t.trigger_comment_id = $3::uuid
+ORDER BY t.created_at DESC
+`
+
+type ListTaskRoutingByIssueAndTriggerCommentParams struct {
+	WorkspaceID      pgtype.UUID `json:"workspace_id"`
+	IssueID          pgtype.UUID `json:"issue_id"`
+	TriggerCommentID pgtype.UUID `json:"trigger_comment_id"`
+}
+
+type ListTaskRoutingByIssueAndTriggerCommentRow struct {
+	AgentID pgtype.UUID `json:"agent_id"`
+	SquadID pgtype.UUID `json:"squad_id"`
+}
+
+// Conversation continuation only needs the agents and historical squad roles
+// for this root comment, not every run's result/context on the issue. Keep the
+// same newest-first order as ListTasksByIssue: the caller selects the newest
+// non-NULL squad per agent, which need not belong to that agent's newest run.
+func (q *Queries) ListTaskRoutingByIssueAndTriggerComment(ctx context.Context, arg ListTaskRoutingByIssueAndTriggerCommentParams) ([]ListTaskRoutingByIssueAndTriggerCommentRow, error) {
+	rows, err := q.db.Query(ctx, listTaskRoutingByIssueAndTriggerComment, arg.WorkspaceID, arg.IssueID, arg.TriggerCommentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListTaskRoutingByIssueAndTriggerCommentRow{}
+	for rows.Next() {
+		var i ListTaskRoutingByIssueAndTriggerCommentRow
+		if err := rows.Scan(&i.AgentID, &i.SquadID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTasksByIssue = `-- name: ListTasksByIssue :many
 SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id FROM agent_task_queue
 WHERE issue_id = $1

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -2689,6 +2689,19 @@ SELECT * FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC;
 
+-- name: ListTaskRoutingByIssueAndTriggerComment :many
+-- Conversation continuation only needs the agents and historical squad roles
+-- for this root comment, not every run's result/context on the issue. Keep the
+-- same newest-first order as ListTasksByIssue: the caller selects the newest
+-- non-NULL squad per agent, which need not belong to that agent's newest run.
+SELECT t.agent_id, t.squad_id
+FROM agent_task_queue t
+JOIN issue i ON i.id = t.issue_id
+WHERE i.workspace_id = sqlc.arg('workspace_id')::uuid
+  AND t.issue_id = sqlc.arg('issue_id')::uuid
+  AND t.trigger_comment_id = sqlc.arg('trigger_comment_id')::uuid
+ORDER BY t.created_at DESC;
+
 -- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1


### PR DESCRIPTION
## What does this PR do?

Conversation continuation currently loads every run on an issue, including result/context fields, then filters in Go for the root comment. Replace that broad read with a workspace/issue/root-scoped query returning only `agent_id` and `squad_id`, which are the two fields this routing decision needs.

Keep newest-first history traversal and the existing newest non-NULL squad selection per agent. A newer direct-agent run must not erase an older squad role; this is intentionally not a LIMIT-1 or newest-row-per-agent optimization.

## Related Issue

Tracks CODI-20 in the contributor's coding workspace. This branch is based directly on main, independently of CODI-18 and CODI-19.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/db/queries/agent.sql`: add `ListTaskRoutingByIssueAndTriggerComment`, scoped through the issue's workspace, with the same `created_at DESC` order as the old history query. Select two columns, without a task-status filter or result limit. The trigger-comment index already exists; no migration is needed.
- `server/pkg/db/generated/agent.sql.go`: regenerate using the repository's pinned `make sqlc` command.
- `server/internal/handler/comment.go`: use that query after the existing explicit-mention path; skip historical lookup when the excluded trigger is the root itself. Agent invocation, pending-run, archived-agent, and squad checks remain downstream and unchanged.
- `server/internal/handler/comment_routing_query_test.go`: exercise real database queries and routing with noisy unrelated history, multiple agents/squads, newest NULL squad, root exclusion, no history, mismatched workspace/issue, query errors, explicit mentions, and archived agents.

No global cache, schema migration, public API, or frontend change. This only narrows historical reads; it does not change delivery policy or cap matching history. Equal timestamps retain the existing query's unspecified tie order.

## How to Test

With `DATABASE_URL` pointing to an isolated, migrated PostgreSQL 17 database, from the repository root:

1. Repeat the new regression:
   `scripts/go-test-with-agent-cli-guard.sh -- go -C server test -race ./internal/handler -run '^TestCommentConversationRoutingQuery$' -count=3 -timeout=5m`
2. Full handler suite:
   `scripts/go-test-with-agent-cli-guard.sh -- go -C server test -race ./internal/handler -count=1 -timeout=5m`
3. Build/vet:
   `cd server && go build ./cmd/server && go vet ./internal/handler ./pkg/db/generated`
4. Run `make sqlc` again and confirm it introduces no further generated changes. Also check `gofmt` and `git diff --check`.

The new regression passed three consecutive race-enabled runs. Its fixture read 133 rows and 55 columns on the old path, versus 4 matching rows and 2 columns after this change, while preserving the expected routed agents and latest non-NULL squad. These are fixture-level query observations, not a latency or production throughput benchmark.

Build, vet, formatting, diff checks, and SQL generation reproducibility passed on baseline `b5a7ee1e0` plus this patch. The full handler suite passed on rerun (82s, no race report). The first full run hit `TestClaimTasksByRuntime_ClaimPollHintSchedulesNextDeferredTask` with a 5105ms delay against its 5000ms bound; that existing timing assertion also reproduced on an untouched checkout of the same baseline during the companion optimization's verification. No unrelated test or production logic was changed to bypass it.

Tests use synthetic local fixtures and the agent CLI guard. `make check-worktree` was attempted but stopped because this backend-only checkout has no `.env.worktree`; the full-stack TypeScript/E2E pipeline was not run. The temporary database lacks optional `pg_bigm`, so its guarded migration was skipped by the repository runner.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (final Go verification; initial timing failure and full-stack limitation noted)
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (query/handler comments)
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Asked to implement three independent small optimizations from the latest main. Traced root-owner routing and its historical squad-selection semantics, added database-backed routing/query-shape regressions, introduced one purpose-specific sqlc query, and ran race-enabled verification in an isolated local database. Preserved explicit-mention precedence and all downstream agent/squad checks; documented the unrelated timing flake rather than modifying that code.

## Screenshots (optional)

Not applicable; backend-only optimization.
