### PR TITLE
fix(issues): preserve early detail-page scrolling

### DIFF
--- a/packages/views/issues/hooks/use-issue-detail-scroll-restore.test.tsx
+++ b/packages/views/issues/hooks/use-issue-detail-scroll-restore.test.tsx
@@ -139,6 +139,24 @@ describe("useIssueDetailScrollRestore", () => {
     expect(scroller.scrollTop).toBe(640);
   });
 
+  it("does not pull an unseen issue back to top after the user scrolls while it loads", () => {
+    const issue = nextKey("issue");
+
+    const { getByTestId, rerender } = render(
+      <Harness restoreKey={issue} ready={false} />,
+    );
+    const scroller = getByTestId("scroller") as HTMLElement;
+
+    expect(scroller.scrollTop).toBe(0);
+    fireEvent.wheel(scroller);
+    setScroll(scroller, 360);
+
+    rerender(<Harness restoreKey={issue} ready />);
+    flushNextAnimationFrame();
+
+    expect(scroller.scrollTop).toBe(360);
+  });
+
   it("does not save a new issue scroll position before that issue is ready", () => {
     const issueA = nextKey("issue-a");
     const issueB = nextKey("issue-b");

--- a/packages/views/issues/hooks/use-issue-detail-scroll-restore.ts
+++ b/packages/views/issues/hooks/use-issue-detail-scroll-restore.ts
@@ -29,10 +29,46 @@ export function useIssueDetailScrollRestore({
   overrideTop,
 }: UseIssueDetailScrollRestoreArgs) {
   const restoredKeyRef = useRef<string | null>(null);
+  const userScrolledBeforeReadyKeyRef = useRef<string | null>(null);
 
   useLayoutEffect(() => {
     restoredKeyRef.current = null;
+    userScrolledBeforeReadyKeyRef.current = null;
   }, [restoreKey]);
+
+  useLayoutEffect(() => {
+    if (!scrollContainerEl || disabled) return;
+    if (restoredKeyRef.current === restoreKey) return;
+
+    const target = overrideTop ?? scrollPositions.get(restoreKey) ?? 0;
+    if (target > 1) return;
+
+    // Establish a top-of-page target as soon as a new container/key is
+    // available. Waiting for the async timeline to become ready leaves a
+    // window where the user can start scrolling, only to be pulled back to
+    // zero when `ready` flips to true.
+    scrollContainerEl.scrollTop = target;
+  }, [scrollContainerEl, restoreKey, disabled, overrideTop]);
+
+  useLayoutEffect(() => {
+    if (!scrollContainerEl || disabled || ready) return;
+
+    const markUserScroll = () => {
+      userScrolledBeforeReadyKeyRef.current = restoreKey;
+    };
+
+    scrollContainerEl.addEventListener("wheel", markUserScroll, {
+      passive: true,
+    });
+    scrollContainerEl.addEventListener("touchmove", markUserScroll, {
+      passive: true,
+    });
+
+    return () => {
+      scrollContainerEl.removeEventListener("wheel", markUserScroll);
+      scrollContainerEl.removeEventListener("touchmove", markUserScroll);
+    };
+  }, [scrollContainerEl, restoreKey, ready, disabled]);
 
   useLayoutEffect(() => {
     if (!scrollContainerEl || disabled || !ready) return;
@@ -61,7 +97,9 @@ export function useIssueDetailScrollRestore({
 
     const target = overrideTop ?? scrollPositions.get(restoreKey) ?? 0;
     if (target <= 1) {
-      scrollContainerEl.scrollTop = target;
+      if (userScrolledBeforeReadyKeyRef.current !== restoreKey) {
+        scrollContainerEl.scrollTop = target;
+      }
       return;
     }
 


### PR DESCRIPTION
## What does this PR do?

Prevents an issue detail page from jumping back to the top when its async timeline becomes ready after the user has already started scrolling.

The scroll-restoration hook previously waited for the whole page to become ready before applying an unseen issue's zero offset. That late write raced with the user's first scroll. This change establishes zero-offset state as soon as the container is available, tracks wheel/touch intent during loading, and avoids overwriting that user-driven position when readiness changes. Programmatic layout shifts during loading are still reset, and positive saved positions still use the existing retry-based restoration path.

## Related Issue

Closes #8139

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Initialize top-of-page restoration when the issue scroll container becomes available.
- Preserve wheel/touch scrolling that happens before the async issue timeline is ready.
- Add a regression test for the late-ready jump while retaining the existing programmatic-shift and back-navigation cases.

## How to Test

1. Open an issue detail page whose timeline is still loading.
2. Start scrolling before loading completes.
3. Confirm the page no longer jumps back to the top when the timeline becomes ready.
4. Run `corepack pnpm --filter @multica/views test --run issues/hooks/use-issue-detail-scroll-restore.test.tsx`.
5. Run `corepack pnpm --filter @multica/views typecheck`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] New runtime / coding tool / UI tab synchronization is not applicable
- [x] Chinese product copy validation is not applicable
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Used Codex to inspect current open bug reports and existing scroll-restoration behavior, isolate the readiness race, add a focused regression test, and validate the fix against the hook's full test suite, TypeScript, and ESLint.

## Screenshots (optional)

Not included. The defect is a timing-dependent scroll jump; the regression test exercises the before-ready interaction directly.
