### PR TITLE
MUL-7164 fix(tasks): classify concurrent request rejections

### DIFF
--- a/server/internal/service/task_complete_race_test.go
+++ b/server/internal/service/task_complete_race_test.go
@@ -257,6 +257,9 @@ func TestTaskFailureClassifiers(t *testing.T) {
 		// Transient mid-stream provider disconnect (MUL-4910): retryable, and
 		// resume-safe so the retry continues the truncated conversation.
 		{reason: "agent_error.provider_network", wantType: "agent_error", wantResumeOK: true, wantRetry: true},
+		// Capacity/rate-limit failures keep their existing user-retry posture.
+		// Correcting a misleading auth label must not enable an automatic resend.
+		{reason: "agent_error.provider_capacity_or_rate_limit", wantType: "agent_error", wantResumeOK: true, wantRetry: false},
 		{reason: "runtime_recovery", wantType: "runtime", wantResumeOK: true, wantRetry: true},
 		{reason: "iteration_limit", wantType: "agent_output", wantResumeOK: false, wantRetry: false},
 		{reason: "api_invalid_request", wantType: "agent_error", wantResumeOK: false, wantRetry: false},

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -35,6 +35,14 @@ var (
 	httpCapacityCodeRe = regexp.MustCompile(`(^|[^0-9])(429|529)([^0-9]|$)`)
 )
 
+// concurrentRequestLimitWitness is emitted by Anthropic-compatible providers
+// that use HTTP 403 for a transient concurrency rejection. Claude Code may
+// prefix it with an authentication or access-token failure, but credentials
+// remain valid and a later request can succeed. Match the semantic witness
+// before both token-window and generic auth rules so the persisted reason and
+// member-facing recovery guidance describe the actual failure.
+const concurrentRequestLimitWitness = "concurrent request limit"
+
 // Classify maps a free-form error string from the agent runtime / CLI
 // to one of the 14 agent_error.* sub-reasons. Always returns a valid
 // Reason; falls back to ReasonAgentUnknown when no rule matches and for
@@ -71,6 +79,12 @@ func Classify(rawError string) Reason {
 	lower := strings.ToLower(trimmed)
 
 	switch {
+	// A concurrent-request rejection can contain both "access token" and HTTP
+	// 403. Its specific semantic witness must beat the broader context and auth
+	// rules below; this classification does not itself make the reason retryable.
+	case strings.Contains(lower, concurrentRequestLimitWitness):
+		return ReasonAgentProviderCapacityOrRateLimit
+
 	// 1. Context / token window overflow. Checked early so "token
 	//    limit" doesn't get swallowed by the broader "limit" / "quota"
 	//    rule below.
@@ -453,6 +467,17 @@ var legacyOpencodeStreamEndedReasons = map[string]bool{
 	"agent_error":                     true,
 }
 
+// legacyConcurrentRequestLimitReasons are the stale buckets emitted by daemons
+// whose classifiers let a generic token/context or HTTP 403 rule win over this
+// more specific wire shape. The raw witness keeps the upgrade narrow; unrelated
+// context overflows and authentication failures retain their original reason.
+var legacyConcurrentRequestLimitReasons = map[string]bool{
+	string(ReasonAgentContextOverflow):      true,
+	string(ReasonAgentProviderAuthOrAccess): true,
+	string(ReasonAgentUnknown):              true,
+	"agent_error":                           true,
+}
+
 // NormalizeDaemonReason upgrades a failure_reason reported by an older daemon
 // onto the taxonomy this server understands, using the raw error text as the
 // witness. It returns the reason unchanged when nothing applies.
@@ -469,6 +494,10 @@ var legacyOpencodeStreamEndedReasons = map[string]bool{
 // can be deleted once no daemon old enough to produce its wire shape is still
 // reporting.
 func NormalizeDaemonReason(reason, rawError string) Reason {
+	if legacyConcurrentRequestLimitReasons[reason] &&
+		strings.Contains(strings.ToLower(rawError), concurrentRequestLimitWitness) {
+		return ReasonAgentProviderCapacityOrRateLimit
+	}
 	if legacySkillBundleReasons[reason] &&
 		strings.HasPrefix(strings.TrimSpace(rawError), legacySkillBundlePrefix) {
 		return ReasonSkillBundleUnavailable

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -222,6 +222,12 @@ func TestClassifyOrderingPriorities(t *testing.T) {
 		// auth rejection.
 		{"missing api key beats 401", "missing api_key for openai (401 returned downstream)", ReasonAgentMissingConfig},
 
+		// Some Anthropic-compatible providers return 403 for a transient
+		// concurrency rejection. The semantic witness must beat generic auth and
+		// token/context matching even when the CLI prefixes both misleadingly.
+		{"403 concurrent request limit beats auth", "Failed to authenticate. API Error: 403 You've reached your concurrent request limit. Please wait for your ongoing requests to finish and try again.", ReasonAgentProviderCapacityOrRateLimit},
+		{"access token concurrent request limit beats context", "Failed to refresh access token. API Error: 403 You've reached your concurrent request limit.", ReasonAgentProviderCapacityOrRateLimit},
+
 		// Both "429" and "rate limit" present — should still land in
 		// the capacity bucket, not the quota bucket.
 		{"429 rate limit", "API Error: 429 rate limit reached", ReasonAgentProviderCapacityOrRateLimit},
@@ -238,6 +244,30 @@ func TestClassifyOrderingPriorities(t *testing.T) {
 				t.Errorf("Classify(%q) = %q, want %q", c.in, got, c.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeDaemonReasonUpgradesConcurrentRequestLimit(t *testing.T) {
+	t.Parallel()
+
+	const raw = "Failed to refresh access token. API Error: 403 You've reached your concurrent request limit."
+
+	for _, reason := range []string{
+		string(ReasonAgentContextOverflow),
+		string(ReasonAgentProviderAuthOrAccess),
+		string(ReasonAgentUnknown),
+		"agent_error",
+	} {
+		if got := NormalizeDaemonReason(reason, raw); got != ReasonAgentProviderCapacityOrRateLimit {
+			t.Errorf("NormalizeDaemonReason(%q, concurrent request rejection) = %q, want %q", reason, got, ReasonAgentProviderCapacityOrRateLimit)
+		}
+	}
+
+	if got := NormalizeDaemonReason(string(ReasonAgentProviderAuthOrAccess), "API Error: 403 Forbidden"); got != ReasonAgentProviderAuthOrAccess {
+		t.Errorf("plain 403 auth rejection changed to %q", got)
+	}
+	if got := NormalizeDaemonReason(string(ReasonAgentContextOverflow), "you exceeded the token limit"); got != ReasonAgentContextOverflow {
+		t.Errorf("ordinary token overflow changed to %q", got)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Claude Code can surface an Anthropic-compatible provider rejection as an authentication or access-token failure with HTTP 403 even though the specific response says the account has reached its concurrent request limit. Multica currently persists that as either `provider_auth_or_access` or, when the prefix contains both `token` and `limit`, `context_overflow`. The member is then told to sign in again or reduce context even though neither action addresses the failure.

This PR classifies the specific `concurrent request limit` witness as `provider_capacity_or_rate_limit` before the broader context and auth rules. It also upgrades the stale labels reported by older installed daemons at the server boundary.

Per @Bohan-J's review on #8180:

> We want the classification half of this PR. We'd like the auto-retry half taken out for now.

This split contains classification only. It does **not** add the capacity/rate-limit reason to `retryableReasons`, add a retry delay, or change task retry behavior. A service-layer regression explicitly pins `provider_capacity_or_rate_limit` as non-auto-retryable.

## Related context

- Split from #8180 after review.
- The original incident is represented verbatim in the regression fixtures.
- No public issue exists for the Multica-side misclassification.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change)
- [ ] Refactor / code improvement
- [ ] Documentation update
- [x] Tests
- [ ] CI / infrastructure

## Changes Made

- Match `concurrent request limit` before both the broad `token` + `limit` context rule and generic 403/auth rule.
- Normalize legacy `context_overflow`, `provider_auth_or_access`, `unknown`, and coarse `agent_error` labels only when the same narrow raw-error witness is present.
- Cover both observed phrasings:
  - `Failed to authenticate. API Error: 403 ... concurrent request limit`
  - `Failed to refresh access token. API Error: 403 ... concurrent request limit`
- Prove ordinary 403 auth failures and ordinary token-limit overflows are unchanged.
- Prove the corrected capacity reason remains resume-safe and non-auto-retryable.

## Offline backfill note

The MUL-1949 offline backfill SQL referenced by the classifier comments is not checked into this repository, so there is no migration file to update in this PR. If historical rows are reclassified, its CASE expression should add `%concurrent request limit%` before the token/context and 403/auth branches. `NormalizeDaemonReason` covers new submissions from mixed-version installed daemons; it does not rewrite already-persisted historical rows.

## Validation

- `go test ./pkg/taskfailure -count=1`
- focused classifier and mixed-version normalization tests under `-race`, 50 repetitions
- `go test ./internal/service -run '^TestTaskFailureClassifiers$' -count=1`
- `go vet ./pkg/taskfailure ./internal/service`
- `git diff --check`

## Risks

The witness is intentionally narrow and only changes taxonomy and member-facing recovery guidance. It cannot make unrelated capacity errors retry, and negative regressions preserve the existing auth and context classifications.

## Checklist

- [x] I have run targeted tests locally and they pass
- [x] I have added regression coverage
- [x] I have considered mixed-version daemon behavior
- [x] I have documented the external backfill boundary
- [ ] UI screenshots are not applicable
- [ ] Documentation changes are not applicable because retry behavior is unchanged

## AI Disclosure

**AI tool used:** OpenAI Codex

**Approach:** Split the accepted classification portion from #8180, added the exact ordering counterexample from review, kept retry behavior unchanged, and verified both current- and older-daemon reason paths.
