### PR TITLE
fix(issues): refresh idle timeline timestamps independently

### DIFF
--- a/packages/core/hooks/use-relative-time-tick.test.tsx
+++ b/packages/core/hooks/use-relative-time-tick.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { StrictMode, createElement } from "react";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useRelativeTimeTick } from "./use-relative-time-tick";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+});
+
+afterEach(() => {
+  cleanup();
+  expect(vi.getTimerCount()).toBe(0);
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("useRelativeTimeTick", () => {
+  it("shares one clock and stops it after the last subscriber leaves", () => {
+    const first = renderHook(useRelativeTimeTick);
+    const second = renderHook(useRelativeTimeTick);
+    const initial = first.result.current;
+    expect(vi.getTimerCount()).toBe(1);
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(first.result.current).not.toBe(initial);
+    expect(second.result.current).toBe(first.result.current);
+    first.unmount();
+    expect(vi.getTimerCount()).toBe(1);
+    second.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("pauses while hidden and immediately catches up when visible or focused", () => {
+    const visibility = vi.spyOn(document, "visibilityState", "get");
+    const hook = renderHook(useRelativeTimeTick);
+    visibility.mockReturnValue("hidden");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    const hidden = hook.result.current;
+    expect(vi.getTimerCount()).toBe(0);
+    act(() => vi.advanceTimersByTime(600_000));
+    expect(hook.result.current).toBe(hidden);
+    visibility.mockReturnValue("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(hook.result.current).not.toBe(hidden);
+    expect(vi.getTimerCount()).toBe(1);
+    const visible = hook.result.current;
+    act(() => window.dispatchEvent(new Event("focus")));
+    expect(hook.result.current).not.toBe(visible);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it("does not start a timer when first mounted in a hidden document", () => {
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    renderHook(useRelativeTimeTick);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("survives StrictMode remounts and removes visibility/focus listeners", () => {
+    const removeDocument = vi.spyOn(document, "removeEventListener");
+    const removeWindow = vi.spyOn(window, "removeEventListener");
+    const hook = renderHook(useRelativeTimeTick, {
+      wrapper: ({ children }) => createElement(StrictMode, null, children),
+    });
+    expect(vi.getTimerCount()).toBe(1);
+    hook.unmount();
+    expect(removeDocument).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+    expect(removeWindow).toHaveBeenCalledWith("focus", expect.any(Function));
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    act(() => window.dispatchEvent(new Event("focus")));
+    expect(vi.getTimerCount()).toBe(0);
+    const remounted = renderHook(useRelativeTimeTick);
+    const initial = remounted.result.current;
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(remounted.result.current).not.toBe(initial);
+  });
+});

--- a/packages/core/hooks/use-relative-time-tick.ts
+++ b/packages/core/hooks/use-relative-time-tick.ts
@@ -1,0 +1,55 @@
+import { useSyncExternalStore } from "react";
+
+const listeners = new Set<() => void>();
+let tick = 0;
+let timer: ReturnType<typeof setInterval> | undefined;
+
+function notify() {
+  tick += 1;
+  listeners.forEach((listener) => listener());
+}
+
+function stopTimer() {
+  clearInterval(timer);
+  timer = undefined;
+}
+
+function resume() {
+  if (document.visibilityState === "hidden") {
+    stopTimer();
+    return;
+  }
+  notify();
+  timer ??= setInterval(notify, 30_000);
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  if (listeners.size === 1) {
+    document.addEventListener("visibilitychange", resume);
+    window.addEventListener("focus", resume);
+    resume();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      stopTimer();
+      document.removeEventListener("visibilitychange", resume);
+      window.removeEventListener("focus", resume);
+    }
+  };
+}
+
+// One clock per renderer, subscribed only by relative-time text leaves. Hidden
+// documents and unmounted timelines do not keep an interval running.
+export function useRelativeTimeTick(): number {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+function getSnapshot() {
+  return tick;
+}
+
+function getServerSnapshot() {
+  return 0;
+}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -29,7 +29,8 @@ import { QuickEmojiPicker } from "@multica/ui/components/common/quick-emoji-pick
 import { cn } from "@multica/ui/lib/utils";
 import { copyText } from "@multica/ui/lib/clipboard";
 import { useActorName } from "@multica/core/workspace/hooks";
-import { useLocale, useTimeAgo } from "../../i18n";
+import { useLocale } from "../../i18n";
+import { RelativeTime } from "./relative-time";
 import { ContentEditor, type ContentEditorRef, ReadonlyContent, useFileDropZone, FileDropOverlay, Attachment as AttachmentRenderer, AttachmentDownloadProvider, useUploadGate, useComposerSubmit } from "../../editor";
 import { useCommentUploads } from "./use-comment-uploads";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
@@ -628,7 +629,6 @@ function CommentRow({
 }) {
   const { t } = useT("issues");
   const locale = useLocale();
-  const timeAgo = useTimeAgo();
   const { getActorName } = useActorName();
 
   const edit = useEditAttachmentState(issueId, entry, onEdit);
@@ -668,7 +668,7 @@ function CommentRow({
           <TooltipTrigger
             render={
               <span className="text-caption text-muted-foreground cursor-default">
-                {timeAgo(entry.created_at)}
+                <RelativeTime dateTime={entry.created_at} />
               </span>
             }
           />
@@ -936,7 +936,6 @@ function CommentCardImpl({
 }: CommentCardProps) {
   const { t } = useT("issues");
   const locale = useLocale();
-  const timeAgo = useTimeAgo();
   const { getActorName } = useActorName();
   const isCollapsed = useCommentCollapseStore((s) => s.isCollapsed(issueId, entry.id));
   const toggleCollapse = useCommentCollapseStore((s) => s.toggle);
@@ -1052,7 +1051,7 @@ function CommentCardImpl({
                 <TooltipTrigger
                   render={
                     <span className="shrink-0 text-caption text-muted-foreground cursor-default">
-                      {timeAgo(entry.created_at)}
+                      <RelativeTime dateTime={entry.created_at} />
                     </span>
                   }
                 />

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -718,6 +718,29 @@ describe("IssueDetail (shared)", () => {
     mockApiObj.getProject.mockReset();
   });
 
+  it("refreshes idle activity, comment, and reply timestamps without refetching (#7899)", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setInterval", "clearInterval"] });
+    vi.setSystemTime(new Date("2026-01-18T00:04:45Z"));
+    const created_at = "2026-01-18T00:00:00Z";
+    mockApiObj.listTimeline.mockResolvedValue([
+      { ...mockTimeline[0], id: "idle-root", created_at },
+      { ...mockTimeline[1], id: "idle-reply", parent_id: "idle-root", created_at },
+      { type: "activity", id: "idle-activity", actor_type: "member", actor_id: "user-1",
+        action: "priority_changed", details: { from: "low", to: "high" }, created_at },
+    ]);
+    const view = renderIssueDetail();
+    try {
+      await waitFor(() => expect(screen.getAllByText("4m ago")).toHaveLength(3));
+      const fetches = mockApiObj.listTimeline.mock.calls.length;
+      act(() => vi.advanceTimersByTime(30_000));
+      expect(screen.getAllByText("5m ago")).toHaveLength(3);
+      expect(mockApiObj.listTimeline).toHaveBeenCalledTimes(fetches);
+    } finally {
+      view.unmount();
+      vi.useRealTimers();
+    }
+  });
+
   it("opens source-context creation from both a root comment and a reply", async () => {
     mockApiObj.listTimeline.mockResolvedValue([
       { ...mockTimeline[0], id: "source-root", parent_id: null },

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -124,7 +124,8 @@ import { useIssueTimeline } from "../hooks/use-issue-timeline";
 import { useIssueReactions } from "../hooks/use-issue-reactions";
 import { useIssueSubscribers } from "../hooks/use-issue-subscribers";
 import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
-import { useLocale, useTimeAgo } from "../../i18n";
+import { useLocale } from "../../i18n";
+import { RelativeTime } from "./relative-time";
 import {
   useRestoredScrollOffset,
   useRestoredScrollRef,
@@ -535,7 +536,6 @@ function ActivityBlock({
   resolveStatusCategory,
   resolveStatusColor,
   t,
-  timeAgo,
   locale,
 }: {
   entries: TimelineEntry[];
@@ -553,7 +553,6 @@ function ActivityBlock({
   /** A custom status's own `#rrggbb`; null for built-ins and unknown keys. */
   resolveStatusColor: (statusKey: string) => string | null;
   t: ActivityT;
-  timeAgo: (dateStr: string) => string;
   locale: string;
 }) {
   if (!expanded) {
@@ -663,7 +662,7 @@ function ActivityBlock({
                 <TooltipTrigger
                   render={
                     <span className="ml-auto shrink-0 cursor-default">
-                      {timeAgo(entry.created_at)}
+                      <RelativeTime dateTime={entry.created_at} />
                     </span>
                   }
                 />
@@ -1137,7 +1136,6 @@ export function IssueDetailSkeleton({ leading }: { leading?: ReactNode } = {}) {
 export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId, highlightRequestToken, leadingAction }: IssueDetailProps) {
   const { t } = useT("issues");
   const locale = useLocale();
-  const timeAgo = useTimeAgo();
   const id = issueId;
   const user = useAuthStore((s) => s.user);
   const paths = useWorkspacePaths();
@@ -2693,7 +2691,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
         resolveStatusCategory={resolveStatusCategory}
         resolveStatusColor={resolveStatusColor}
         t={t}
-        timeAgo={timeAgo}
         locale={locale}
       />
     );

--- a/packages/views/issues/components/relative-time.test.tsx
+++ b/packages/views/issues/components/relative-time.test.tsx
@@ -1,0 +1,41 @@
+import { memo, StrictMode } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import { RelativeTime } from "./relative-time";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-18T00:04:45Z"));
+  vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+// Clock lifecycle coverage lives in core/hooks/use-relative-time-tick.test.tsx.
+it("updates only timestamp leaves beneath memoized rows, preserving localized text", () => {
+  const renderRow = vi.fn();
+  const Row = memo(function Row() {
+    renderRow();
+    return <RelativeTime dateTime="2026-01-18T00:00:00Z" />;
+  });
+  render(
+    <StrictMode>
+      <I18nProvider locale="en" resources={{ en: { common: enCommon } }}>
+        <Row />
+        <Row />
+      </I18nProvider>
+    </StrictMode>,
+  );
+  expect(screen.getAllByText("4m ago")).toHaveLength(2);
+  const renders = renderRow.mock.calls.length;
+  act(() => vi.advanceTimersByTime(30_000));
+  expect(screen.getAllByText("5m ago")).toHaveLength(2);
+  expect(renderRow).toHaveBeenCalledTimes(renders);
+  expect(screen.getAllByText("5m ago")[0]).toHaveAttribute("dateTime", "2026-01-18T00:00:00Z");
+});

--- a/packages/views/issues/components/relative-time.tsx
+++ b/packages/views/issues/components/relative-time.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useRelativeTimeTick } from "@multica/core/hooks/use-relative-time-tick";
+import { useTimeAgo } from "../../i18n";
+
+export function RelativeTime({ dateTime }: { dateTime: string }) {
+  useRelativeTimeTick();
+  const timeAgo = useTimeAgo();
+  return <time dateTime={dateTime}>{timeAgo(dateTime)}</time>;
+}


### PR DESCRIPTION
## What does this PR do?

Keeps relative timestamps on Task/Issue timelines current while the page is idle. Activity entries, root comments, and nested replies refresh within 30 seconds without a query refetch or a render of the entire detail page/comment body.

## Related Issue

Closes #7899.

Related prior attempt: #7912 (closed without merging). This implementation uses independently subscribed timestamp leaves rather than threading a page-level tick through comment props. It does not reuse commits from that PR.

## Type of Change

- [x] Bug fix
- [x] Tests

## Thinking Path

1. The existing `useTimeAgo` formatter reads `Date.now()` only when React renders; elapsed time alone cannot update its consumers.
2. A timer on `IssueDetail` would refresh unrelated page work, and memoized comment rows would need tick props.
3. A small `RelativeTime` leaf preserves the existing formatter and tooltip wrappers while subscribing independently of its parent.
4. One shared, subscription-owned clock in `@multica/core` avoids per-row intervals. It pauses in hidden documents, refreshes immediately on visibility/focus restoration, and removes the interval/listeners when its last subscriber unmounts.

## Changes Made

- Add `useRelativeTimeTick` in `packages/core/hooks` with lifecycle tests.
- Add `RelativeTime` in the shared issue components and use it for activity, comment, and reply timestamps.
- Keep locale formatting, absolute-date tooltips, query behavior, and timeline ordering unchanged.
- Add an actual `IssueDetail` regression plus a memoized-parent render-count test.

## How to Test

1. Open a Task/Issue timeline with a recent activity, root comment, and reply.
2. Leave the page idle across a minute boundary. All visible relative timestamps should update within 30 seconds without navigation or a server event.
3. Hide the tab, wait, then return; timestamps should immediately catch up. Existing absolute-date tooltips should still work.

Local verification:

- **RED:** the new `IssueDetail` test fails on the original implementation: three `4m ago` labels never become `5m ago` after 30 seconds.
- **PASS:** `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx issues/components/relative-time.test.tsx` (77 tests).
- **PASS:** `pnpm --filter @multica/core exec vitest run hooks/use-relative-time-tick.test.tsx` (4 tests).
- **PASS:** ESLint on all seven changed files; `git diff --check`.
- **PASS:** focused Playwright/Chromium fixture at 1280x720 and 390x844: all three production `RelativeTime` leaves advance from `4m ago` to `5m ago`, existing tooltip wrappers open, no horizontal overflow or browser exceptions. This is a component fixture, not a full-application screenshot.
- **PASS:** `pnpm typecheck` (all 9 workspace tasks, including web and desktop; the repository command excludes the independent mobile app).
- **PASS:** all applicable GitHub CI checks ([run 34325504538](https://github.com/multica-ai/multica/actions/runs/34325504538)), including frontend build and 7,583 frontend tests across views/web/core/desktop. The relevant IssueDetail, RelativeTime and clock tests are present in those logs.
- **PASS:** five additional local review probes: SSR without document/window/timers; recycled date props; hidden elapsed time/backward clock adjustment; locale and hour/day boundaries; 1,000 timestamp leaves sharing one timer without parent-row renders, followed by unmount/remount.
- **PASS:** isolated native Electron 39.8.7 fixture on macOS, using actual elapsed time and BrowserWindow visibility (no fake clock or Playwright renderer attachment): visible `4m -> 5m`; hidden for 50 seconds with labels unchanged; restored immediately to `6m`.

## Review Result

Maintainer-style review found no blocking issue; no additional product-code changes were needed. The 81 focused tests were re-run successfully. A conflict-free prospective merge with upstream `f11121c61` has identical frontend source/configuration to the tested head; the intervening base changes are CLI/daemon-only.

## Scope And Risks

- Limited to shared web/desktop Task/Issue timelines. Other relative-time consumers and the independent mobile app are unchanged.
- Updates are minute-level presentation, with up to 30 seconds of visible lag; this is not a second-accurate clock.
- No server, API, persistence, dependency, translation, or editor changes.
- Browser and Electron verification use a component fixture, not an authenticated full Multica workflow. Windows/Linux native window behavior and OS suspend/resume are not directly tested.

## Checklist

- [x] Thinking path included
- [x] Focused tests run and passing
- [x] Regression and lifecycle coverage added
- [ ] Full-application before/after screenshots included
- [x] Documentation/landing/i18n changes not applicable to this scoped bug fix
- [x] Risks and verification gaps documented
- [x] Will address reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex.

**Prompt / approach:** The user requested taking #7899 through implementation and validation to a draft PR, then explicitly authorized detailed testing/review and readiness when no blocker remains. Codex inspected the current timeline and prior closed PR, reproduced the bug with a failing integration test, implemented a shared clock with leaf-only subscriptions, and used the maintainer-pr-review workflow for lifecycle, performance, SSR, localization, merge-tree and native-window verification. No merge is requested.
