### PR TITLE
feat(views): show parents waiting on sub-issues

### DIFF
--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -28,6 +28,7 @@ import { IssueActionsContextMenu } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 import { CustomStatusChip, useIsCustomStatus } from "./custom-status-chip";
+import { issueStatusCategory } from "@multica/core/issues";
 import { useIssueSurfaceActionsOptional } from "../surface/actions-context";
 function formatDate(date: string, locale: string): string {
   return formatDateOnly(date, { month: "short", day: "numeric" }, locale);
@@ -181,7 +182,11 @@ export const BoardCardContent = memo(function BoardCardContent({
           {priorityIconNode}
           <p className="text-caption text-muted-foreground truncate">{issue.identifier}</p>
         </div>
-        <IssueAgentActivityIndicator issueId={issue.id} />
+        <IssueAgentActivityIndicator
+          issueId={issue.id}
+          childProgress={childProgress}
+          statusCategory={issueStatusCategory(issue)}
+        />
       </div>
 
       {/* Row 2: Title */}

--- a/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
@@ -27,7 +27,22 @@ vi.mock("../../agents/components/agent-activity-hover-content", () => ({
 }));
 
 vi.mock("../../i18n", () => ({
-  useT: () => ({ t: () => "Working" }),
+  useT: () => ({
+    t: (
+      selector: (value: Record<string, unknown>) => unknown,
+      variables?: Record<string, number>,
+    ) => {
+      const translations = {
+        agent_activity: {
+          status_running: "Working",
+          status_queued: "Queued",
+          status_waiting: "Waiting on sub-issues",
+          waiting_detail: `${variables?.done ?? 0}/${variables?.total ?? 1} complete`,
+        },
+      };
+      return selector(translations) as string;
+    },
+  }),
 }));
 
 // The hover card only portals its content once open, so absence of the body
@@ -140,5 +155,22 @@ describe("IssueAgentActivityIndicator", () => {
     );
 
     expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an accessible waiting badge and progress detail", () => {
+    mockState.snapshot = [];
+    render(
+      <IssueAgentActivityIndicator
+        issueId="issue-1"
+        statusCategory="in_progress"
+        childProgress={{ done: 0, total: 1 }}
+      />,
+    );
+
+    expect(screen.getByTestId("hover-card")).not.toBeNull();
+    expect(
+      screen.getByLabelText("Waiting on sub-issues, 0/1 complete"),
+    ).not.toBeNull();
+    expect(screen.getByText("0/1 complete")).not.toBeNull();
   });
 });

--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -9,12 +9,16 @@ import {
 } from "@multica/ui/components/ui/hover-card";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
-import type { AgentTask } from "@multica/core/types";
+import type { AgentTask, IssueStatusCategory } from "@multica/core/types";
 import { cn } from "@multica/ui/lib/utils";
 import type { AvatarSize } from "@multica/ui/lib/avatar-size";
 import { AgentAvatarStack } from "../../agents/components/agent-avatar-stack";
 import { AgentActivityHoverContent } from "../../agents/components/agent-activity-hover-content";
-import { selectIssueTasks, type IssueTaskGroups } from "../surface/activity";
+import {
+  deriveIssueExecutionState,
+  selectIssueTasks,
+  type IssueTaskGroups,
+} from "../surface/activity";
 import { useT } from "../../i18n";
 
 const EMPTY_GROUPS: IssueTaskGroups = { running: [], queued: [] };
@@ -47,6 +51,8 @@ interface IssueAgentActivityIndicatorProps {
   // Whether hovering opens the activity card. Opt OUT where the card's only
   // incremental information is not worth a popup (Inbox — see below).
   hoverCard?: boolean;
+  childProgress?: { done: number; total: number } | null;
+  statusCategory?: IssueStatusCategory | null;
 }
 
 /**
@@ -56,7 +62,9 @@ interface IssueAgentActivityIndicatorProps {
  *
  *   - has ≥1 running task  → tiny avatar stack + shimmering "Working"
  *   - 0 running, ≥1 queued → half-opacity stack + muted "Queued"
- *   - nothing               → return null (no chrome, no placeholder)
+ *   - no active task + unfinished children on an in-progress issue
+ *                           → muted "Waiting on sub-issues"
+ *   - otherwise             → return null (no chrome, no placeholder)
  *
  * The shimmer reuses chat's `animate-chat-text-shimmer` utility (defined
  * in packages/ui/styles/base.css). Earlier iterations layered a brand
@@ -90,6 +98,8 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
   issueId,
   size = "xs",
   hoverCard = true,
+  childProgress,
+  statusCategory,
 }: IssueAgentActivityIndicatorProps) {
   const { t } = useT("issues");
   const wsId = useWorkspaceId();
@@ -114,10 +124,34 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
     };
   }, [groups]);
 
-  if (agentIds.length === 0) return null;
-  const isRunning = opacity === "full";
+  const executionState = deriveIssueExecutionState(
+    groups,
+    statusCategory,
+    childProgress,
+  );
+  if (!executionState) return null;
 
-  const badge = (
+  const isWaiting = executionState === "waiting";
+  const isRunning = executionState === "working";
+  const waitingLabel = isWaiting
+    ? t(($) => $.agent_activity.status_waiting)
+    : "";
+  const waitingDetail = isWaiting && childProgress
+    ? t(($) => $.agent_activity.waiting_detail, {
+        done: childProgress.done,
+        total: childProgress.total,
+      })
+    : "";
+
+  const badge = isWaiting ? (
+    <span
+      className="text-micro text-muted-foreground"
+      title={waitingDetail}
+      aria-label={`${waitingLabel}, ${waitingDetail}`}
+    >
+      {waitingLabel}
+    </span>
+  ) : (
     <>
       <AgentAvatarStack
         agentIds={agentIds}
@@ -146,6 +180,30 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
   if (!hoverCard) {
     return (
       <span className="inline-flex shrink-0 items-center gap-1">{badge}</span>
+    );
+  }
+
+  if (isWaiting) {
+    return (
+      <HoverCard>
+        <HoverCardTrigger
+          delay={OPEN_DELAY_MS}
+          closeDelay={CLOSE_DELAY_MS}
+          render={
+            <span className="inline-flex shrink-0 items-center gap-1" />
+          }
+        >
+          {badge}
+        </HoverCardTrigger>
+        <HoverCardContent align="end" className="w-64">
+          <div className="space-y-1">
+            <div className="text-body font-medium">{waitingLabel}</div>
+            <div className="text-caption text-muted-foreground">
+              {waitingDetail}
+            </div>
+          </div>
+        </HoverCardContent>
+      </HoverCard>
     );
   }
 

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -25,6 +25,7 @@ import { LabelChip } from "../../labels/label-chip";
 import { CustomStatusChip } from "./custom-status-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 import { useIssueSurfaceSelection } from "../surface/selection-context";
+import { issueStatusCategory } from "@multica/core/issues";
 import { useLocale } from "../../i18n";
 
 export interface ChildProgress {
@@ -113,7 +114,11 @@ function ListRowContent({
           <span className="min-w-16 shrink-0 text-caption text-muted-foreground">
             {issue.identifier}
           </span>
-          <IssueAgentActivityIndicator issueId={issue.id} />
+          <IssueAgentActivityIndicator
+            issueId={issue.id}
+            childProgress={childProgress}
+            statusCategory={issueStatusCategory(issue)}
+          />
 
           <span className="flex min-w-0 flex-1 items-center gap-1.5">
             <span className="truncate">{issue.title}</span>

--- a/packages/views/issues/components/table-inline-title.test.tsx
+++ b/packages/views/issues/components/table-inline-title.test.tsx
@@ -15,8 +15,23 @@ import type { Issue } from "@multica/core/types";
 // wired into the cell with the row's issue — otherwise the badge insertion in
 // table-view.tsx could be deleted and every test here would still pass.
 vi.mock("./issue-agent-activity-indicator", () => ({
-  IssueAgentActivityIndicator: ({ issueId }: { issueId: string }) => (
-    <span data-testid="issue-agent-activity" data-issue-id={issueId} />
+  IssueAgentActivityIndicator: ({
+    issueId,
+    childProgress,
+    statusCategory,
+  }: {
+    issueId: string;
+    childProgress?: { done: number; total: number } | null;
+    statusCategory?: string | null;
+  }) => (
+    <span
+      data-testid="issue-agent-activity"
+      data-issue-id={issueId}
+      data-child-progress={
+        childProgress ? `${childProgress.done}/${childProgress.total}` : ""
+      }
+      data-status-category={statusCategory ?? ""}
+    />
   ),
 }));
 
@@ -227,5 +242,23 @@ describe("InlineTitle", () => {
       badge.compareDocumentPosition(titleButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("forwards child progress and the resolved status category", () => {
+    const row = makeRow("Original");
+    row.issue.status = "in_progress";
+    render(
+      <InlineTitle
+        {...baseProps}
+        row={row}
+        editing={false}
+        onEditingChange={vi.fn()}
+        childProgress={{ done: 1, total: 3 }}
+      />,
+    );
+
+    const badge = screen.getByTestId("issue-agent-activity");
+    expect(badge.getAttribute("data-child-progress")).toBe("1/3");
+    expect(badge.getAttribute("data-status-category")).toBe("in_progress");
   });
 });

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -149,6 +149,7 @@ import {
 import type { ChildProgress } from "./list-row";
 import { ListLoadMoreFooter } from "./list-load-more-footer";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+import { issueStatusCategory } from "@multica/core/issues";
 
 // Enough placeholder rows to cover a typical viewport; the virtualizer only
 // mounts what fits, so overshooting costs nothing.
@@ -633,6 +634,7 @@ export function InlineTitle({
   toggleLabel,
   renameLabel,
   createSubIssueLabel,
+  childProgress,
 }: {
   row: Extract<IssueTableDisplayRow, { kind: "issue" }>;
   /** Rename state is owned by the table (one editor at a time) so it also
@@ -647,6 +649,7 @@ export function InlineTitle({
   toggleLabel: string;
   renameLabel: string;
   createSubIssueLabel: string;
+  childProgress?: ChildProgress | null;
 }) {
   const [draft, setDraft] = useState(row.issue.title);
   const editingRef = useRef(editing);
@@ -718,7 +721,11 @@ export function InlineTitle({
       <span className="min-w-16 shrink-0 text-caption text-muted-foreground">
         {row.issue.identifier}
       </span>
-      <IssueAgentActivityIndicator issueId={row.issue.id} />
+      <IssueAgentActivityIndicator
+        issueId={row.issue.id}
+        childProgress={childProgress}
+        statusCategory={issueStatusCategory(row.issue)}
+      />
       {editing ? (
         <Input
           autoFocus
@@ -1146,6 +1153,7 @@ function IssueTableBodyCell({
           toggleLabel={t(($) => $.table.toggle_sub_issues)}
           renameLabel={t(($) => $.table.rename_title)}
           createSubIssueLabel={t(($) => $.actions.create_sub_issue)}
+          childProgress={meta.childProgressMap.get(issue.id)}
         />
       );
     case "identifier":

--- a/packages/views/issues/surface/activity.test.ts
+++ b/packages/views/issues/surface/activity.test.ts
@@ -1,6 +1,13 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
-import type { AgentTask } from "@multica/core/types";
-import { deriveIssueSurfaceActivity, selectIssueTasks } from "./activity";
+import type { AgentTask, IssueStatusCategory } from "@multica/core/types";
+import {
+  deriveIssueExecutionState,
+  deriveIssueSurfaceActivity,
+  selectIssueTasks,
+  type IssueTaskGroups,
+} from "./activity";
 
 function task(overrides: Partial<AgentTask>): AgentTask {
   return {
@@ -80,5 +87,67 @@ describe("selectIssueTasks", () => {
     expect(groups.queued.map((t) => t.id)).not.toContain("done-1");
     const noMatch = selectIssueTasks(snapshot, "does-not-exist");
     expect(noMatch).toEqual({ running: [], queued: [] });
+  });
+});
+
+describe("deriveIssueExecutionState", () => {
+  const noTasks: IssueTaskGroups = { running: [], queued: [] };
+
+  it.each([
+    {
+      name: "running takes precedence over queued tasks and unfinished children",
+      groups: {
+        running: [task({ status: "running" })],
+        queued: [task({ id: "queued", status: "queued" })],
+      },
+      statusCategory: "in_progress",
+      childProgress: { done: 0, total: 2 },
+      expected: "working",
+    },
+    {
+      name: "queued takes precedence over unfinished children",
+      groups: { running: [], queued: [task({ status: "queued" })] },
+      statusCategory: "in_progress",
+      childProgress: { done: 0, total: 2 },
+      expected: "queued",
+    },
+    {
+      name: "an idle in-progress parent with unfinished children is waiting",
+      groups: noTasks,
+      statusCategory: "in_progress",
+      childProgress: { done: 1, total: 2 },
+      expected: "waiting",
+    },
+    {
+      name: "a parent whose children are all terminal is idle",
+      groups: noTasks,
+      statusCategory: "in_progress",
+      childProgress: { done: 2, total: 2 },
+      expected: null,
+    },
+    {
+      name: "an in-progress issue without children is idle",
+      groups: noTasks,
+      statusCategory: "in_progress",
+      childProgress: undefined,
+      expected: null,
+    },
+    {
+      name: "a non-in-progress parent is idle",
+      groups: noTasks,
+      statusCategory: "todo",
+      childProgress: { done: 0, total: 2 },
+      expected: null,
+    },
+  ] satisfies Array<{
+    name: string;
+    groups: IssueTaskGroups;
+    statusCategory: IssueStatusCategory;
+    childProgress?: { done: number; total: number };
+    expected: "working" | "queued" | "waiting" | null;
+  }>)("$name", ({ groups, statusCategory, childProgress, expected }) => {
+    expect(
+      deriveIssueExecutionState(groups, statusCategory, childProgress),
+    ).toBe(expected);
   });
 });

--- a/packages/views/issues/surface/activity.ts
+++ b/packages/views/issues/surface/activity.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
 import { useWorkspaceId } from "@multica/core/hooks";
-import type { AgentTask } from "@multica/core/types";
+import type { AgentTask, IssueStatusCategory } from "@multica/core/types";
 
 export interface IssueActivityState {
   isWorking: boolean;
@@ -29,6 +29,26 @@ function isQueuedTaskStatus(status: AgentTask["status"]) {
 export interface IssueTaskGroups {
   running: AgentTask[];
   queued: AgentTask[];
+}
+
+export type IssueExecutionState = "working" | "queued" | "waiting";
+
+export function deriveIssueExecutionState(
+  groups: IssueTaskGroups,
+  statusCategory?: IssueStatusCategory | null,
+  childProgress?: { done: number; total: number } | null,
+): IssueExecutionState | null {
+  if (groups.running.length > 0) return "working";
+  if (groups.queued.length > 0) return "queued";
+  if (
+    statusCategory === "in_progress" &&
+    childProgress &&
+    childProgress.total > 0 &&
+    childProgress.done < childProgress.total
+  ) {
+    return "waiting";
+  }
+  return null;
 }
 
 /**

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -578,7 +578,9 @@
     "chip_agents_working_other": "{{count}} agents working",
     "issues_count_one": "{{count}} issue",
     "issues_count_other": "{{count}} issues",
-    "chip_agents_working_unknown": "Agents working: —"
+    "chip_agents_working_unknown": "Agents working: —",
+    "status_waiting": "Waiting on sub-issues",
+    "waiting_detail": "{{done}}/{{total}} complete"
   },
   "filtered_empty": {
     "title": "No issues match these filters",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -557,7 +557,9 @@
     "tasks_count_other": "実行 {{count}} 件",
     "chip_agents_working_other": "作業中のエージェント {{count}} 件",
     "issues_count_other": "タスク {{count}} 件",
-    "chip_agents_working_unknown": "作業中のエージェント: —"
+    "chip_agents_working_unknown": "作業中のエージェント: —",
+    "status_waiting": "サブタスク待ち",
+    "waiting_detail": "{{done}}/{{total}} 完了"
   },
   "filtered_empty": {
     "title": "フィルター条件に一致するタスクがありません",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -557,7 +557,9 @@
     "tasks_count_other": "실행 {{count}}개",
     "chip_agents_working_other": "작업 중인 에이전트 {{count}}개",
     "issues_count_other": "태스크 {{count}}개",
-    "chip_agents_working_unknown": "작업 중인 에이전트: —"
+    "chip_agents_working_unknown": "작업 중인 에이전트: —",
+    "status_waiting": "하위 태스크 대기 중",
+    "waiting_detail": "{{done}}/{{total}} 완료"
   },
   "filtered_empty": {
     "title": "필터 조건에 맞는 태스크가 없습니다",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -557,7 +557,9 @@
     "tasks_count_other": "{{count}} 次运行",
     "chip_agents_working_other": "{{count}} 个智能体工作中",
     "issues_count_other": "{{count}} 个任务",
-    "chip_agents_working_unknown": "工作中的智能体：—"
+    "chip_agents_working_unknown": "工作中的智能体：—",
+    "status_waiting": "等待子任务",
+    "waiting_detail": "已完成 {{done}}/{{total}}"
   },
   "filtered_empty": {
     "title": "没有符合筛选条件的任务",


### PR DESCRIPTION
## What does this PR do?

Adds a derived `Waiting on sub-issues` presentation state for an in-progress parent that has unfinished children but no active agent run. Running and queued work retain precedence, so the shared display order is:

1. Running task → `Working`
2. Queued, dispatched, or local-directory-waiting task → `Queued`
3. No active task + in-progress status + unfinished children → `Waiting on sub-issues`
4. Otherwise, no execution-state indicator

The lifecycle model remains unchanged. Board, list, and table surfaces reuse the child-progress map and workspace task snapshot they already receive, so this adds no persisted status, API, query, or polling behavior. Existing realtime issue and task events continue to refresh those two inputs.

## Related Issue

Closes #7925

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added one pure execution-state derivation shared by all issue surfaces, with coverage for precedence, no-child, unfinished-child, all-terminal-child, and non-in-progress cases.
- Extended the existing activity indicator with localized waiting text, child completion detail, and an accessible combined label.
- Wired the already-loaded child progress and resolved status category through board cards, list rows, and table title cells.
- Added English, Simplified Chinese, Japanese, and Korean strings.

## How to Test

1. `pnpm --filter @multica/views exec vitest run issues/surface/activity.test.ts issues/components/issue-agent-activity-indicator.test.tsx issues/components/table-inline-title.test.tsx`
2. `pnpm --filter @multica/views typecheck`
3. `pnpm --filter @multica/views test`

All checks pass: 22 focused tests and the full 4,977-test views suite.

Manual behavior to verify: an in-progress parent with incomplete children and no active run shows `Waiting on sub-issues`; queue or start a run and it changes to `Queued` or `Working`; complete all children and the waiting indicator disappears.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots *(not included: this is a passive state variant covered by component rendering and accessibility assertions)*
- [x] I have updated relevant documentation to reflect my changes *(not applicable: no API, lifecycle, or documented workflow changes)*
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) *(not applicable)*
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
Reviewed the issue contract, current main implementation, realtime invalidation paths, child-progress semantics, and the closed prior attempt. Implemented the smallest frontend-only derivation, separated its boundary matrix into a node-environment unit test, and retained component tests for rendering, accessibility, and table wiring.

## Screenshots (optional)

No screenshots included. The waiting variant is text-only and is covered by the component render assertion for `Waiting on sub-issues, 0/1 complete`.
