### PR TITLE
MUL-7160: fix(agent): discover Codex models from the effective catalog

### DIFF
--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -245,11 +245,11 @@ func projectClaudeLevels(superset []string, allow map[string]bool) []ThinkingLev
 
 // ── Codex ────────────────────────────────────────────────────────────
 //
-// `codex debug models --bundled` is the structured discovery hook for the
-// visible model catalog, each model's reasoning catalog, and service tiers. OpenAI added
-// the command and `--bundled` flag together in Codex 0.122.0 (openai/codex
-// #18625). Older versions, failed invocations, and malformed/empty payloads
-// use codexStaticModels so the picker remains usable.
+// `codex debug models` is the structured discovery hook for the visible model
+// catalog, each model's reasoning catalog, and service tiers. OpenAI added the
+// command in Codex 0.122.0 (openai/codex #18625). Older versions, failed
+// invocations, and malformed/empty payloads use codexStaticModels so the
+// picker remains usable.
 //
 // We prefer this over the older config-error probe trick because:
 //   1. It gives us per-model subsets without hand-maintained tables.
@@ -258,14 +258,30 @@ func projectClaudeLevels(superset []string, allow map[string]bool) []ThinkingLev
 //
 // The subcommand emits JSON on stdout by default — there is no
 // `--output json` flag (a prior version of this code passed one and
-// silently failed on 0.131.0). We add `--bundled` to skip the network
-// refresh: discovery runs on every daemon poll and a network hop here
-// would block the picker behind whatever the user's connection allows.
-// The bundled catalog is what determines which `model_reasoning_effort`
-// tokens the local binary actually accepts, which is the only thing we
-// need for validation.
+// silently failed on 0.131.0).
 //
-// The static fallback deliberately mirrors a recently verified bundled
+// We deliberately do NOT pass `--bundled`. That flag reports the binary's
+// baked-in native catalog and intentionally ignores a configured
+// `model_catalog_json`, so a runtime whose catalog exposes a custom model
+// (e.g. `gateway/custom-codex` with its own reasoning levels and service
+// tiers) — set in config.toml or supplied through a runtime command prefix
+// like `-c model_catalog_json=/path` — would be discovered with the wrong IDs
+// and capabilities. Multica would then advertise Fast/effort options the
+// effective catalog does not have and drop valid persisted service_tier /
+// thinking_level overrides at launch, while a custom catalog that *restricts*
+// a native ID's capabilities would be over-advertised from the bundled set
+// (#8177). The runtime command's launch prefix (carried by Command.Prefix) is
+// applied ahead of the subcommand by runtimeCmd.exec, so the plain command
+// reports the exact catalog Codex will execute with, including a
+// `-c model_catalog_json=…` prefix.
+//
+// Dropping `--bundled` reintroduces the network refresh the flag used to skip,
+// so runCodexDebugModels caps the call with codexDebugModelsTimeout to keep
+// discovery bounded on the daemon poll path. A timeout, error, or empty/
+// malformed payload falls back to codexStaticModels rather than blocking or
+// emptying the picker.
+//
+// The static fallback deliberately mirrors a recently verified visible
 // model/thinking catalog. It does not guess service-tier availability.
 
 // codexEffortLabel is the human display string for each Codex effort
@@ -379,11 +395,21 @@ func annotateCodexExplicitStandardServiceTier(models []Model, supported bool) []
 // so tests can assert the exact form a real `codex` invocation receives,
 // not just the parser behavior on a fixture string. The argv shape is
 // the contract that broke under PR1 review; the test that pins it sits
-// in thinking_test.go.
-var codexDebugModelsArgs = []string{"debug", "models", "--bundled"}
+// in thinking_test.go. Deliberately no `--bundled`: see the Codex header
+// for why the effective (configured) catalog is what discovery must read.
+var codexDebugModelsArgs = []string{"debug", "models"}
+
+// codexDebugModelsTimeout bounds the discovery call. Without `--bundled`,
+// `codex debug models` may refresh its catalog over the network; discovery
+// runs on every daemon poll, so an unbounded call could block the picker
+// behind the user's connection. On timeout the caller falls back to the
+// static catalog. Matches the opencode/pi discovery caps.
+const codexDebugModelsTimeout = 15 * time.Second
 
 func runCodexDebugModels(ctx context.Context, runtimeCmd Command) ([]byte, error) {
-	cmd := runtimeCmd.exec(ctx, codexDebugModelsArgs...)
+	runCtx, cancel := context.WithTimeout(ctx, codexDebugModelsTimeout)
+	defer cancel()
+	cmd := runtimeCmd.exec(runCtx, codexDebugModelsArgs...)
 	hideAgentWindow(cmd)
 	return outputOwned(cmd, runtimeCmd.logger)
 }

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -132,15 +133,14 @@ func TestProjectClaudeLevels_PerModelSubset(t *testing.T) {
 //
 // Elon's PR1 review found that `codex debug models --output json` is
 // rejected by codex-cli 0.131.0 — there is no `--output` flag on the
-// subcommand. The fix was to drop the flag and add `--bundled` (which
-// just skips network refresh). These two tests pin the contract:
+// subcommand, so discovery must pass a clean `debug models`.
 //
-//   - TestCodexDebugModelsArgs_Pinned asserts the literal argv we pass
-//     so a future "let's add a flag" refactor breaks loudly instead of
-//     silently swallowing the discovery output.
-//   - TestRunCodexDebugModels_ArgvSeenByBinary plugs a fake `codex`
-//     binary on PATH and verifies that what *actually* reaches the
-//     process matches the pinned argv, not just what the var holds.
+// `--bundled` was later dropped too (#8177): it reports the binary's
+// baked-in native catalog and ignores a configured `model_catalog_json`,
+// so discovery must read the effective catalog instead. TestRunCodexDebugModels_ArgvSeenByBinary
+// pins the contract by plugging a fake `codex` binary and verifying what
+// *actually* reaches the process — one argument per element, no `--output`
+// and no `--bundled`.
 
 // TestRunCodexDebugModels_ArgvSeenByBinary executes runCodexDebugModels
 // against a shell-script stand-in for `codex` that records its argv to
@@ -176,7 +176,7 @@ func TestRunCodexDebugModels_ArgvSeenByBinary(t *testing.T) {
 		t.Fatalf("read argv file: %v", err)
 	}
 	got := splitNonEmptyLines(string(data))
-	want := []string{"debug", "models", "--bundled"}
+	want := []string{"debug", "models"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("fake codex received argv %v, want %v", got, want)
 	}
@@ -336,7 +336,7 @@ func TestDiscoverCodexModelsVersionGateAndFallback(t *testing.T) {
 		t.Skip("shell-script fake binary requires a POSIX shell")
 	}
 
-	t.Run("supported version uses bundled catalog", func(t *testing.T) {
+	t.Run("supported version uses discovered catalog", func(t *testing.T) {
 		dir := t.TempDir()
 		fake := filepath.Join(dir, "codex")
 		script := `#!/bin/sh
@@ -391,6 +391,108 @@ echo '{"models":[{"slug":"runtime-model","display_name":"Runtime Model","visibil
 			t.Fatalf("supported Codex version must retain explicit-standard capability through catalog fallback: %+v", got[0])
 		}
 	})
+}
+
+// TestListModelsCodexUsesEffectiveCatalog is the #8177 regression. Codex model
+// discovery must read the runtime command's EFFECTIVE catalog (the configured
+// model_catalog_json), not the binary's bundled native catalog. The stand-in
+// codex returns a DIFFERENT payload for `debug models --bundled` (bundled
+// native IDs only) than for a plain `debug models` (the configured catalog,
+// which adds a custom `gateway/custom-codex` model advertising reasoning `high`
+// and a `priority`/Fast service tier). The old `--bundled` argv would surface
+// the bundled catalog and drop the custom model + its Fast/effort capabilities;
+// this asserts ListModels now receives the configured model instead, for both a
+// plain runtime command and a `-c model_catalog_json=…` runtime prefix.
+func TestListModelsCodexUsesEffectiveCatalog(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+
+	writeFake := func(t *testing.T, argvFile string) string {
+		t.Helper()
+		dir := t.TempDir()
+		fake := filepath.Join(dir, "codex")
+		// Bundled branch: native IDs only, no custom model. Configured branch
+		// (no --bundled): adds gateway/custom-codex with high + priority/Fast.
+		// The version probe (DetectVersion) may carry the runtime prefix, so
+		// `--version` can appear at any argv position — scan for it, don't
+		// assume $1. The bundled branch (old code) omits the custom model; the
+		// plain `debug models` branch returns the effective/configured catalog.
+		script := "#!/bin/sh\n" +
+			"for a in \"$@\"; do\n" +
+			"  if [ \"$a\" = \"--version\" ]; then echo 'codex-cli 0.144.1'; exit 0; fi\n" +
+			"done\n" +
+			"printf '%s\\n' \"$@\" > '" + argvFile + "'\n" +
+			"for a in \"$@\"; do\n" +
+			"  if [ \"$a\" = \"--bundled\" ]; then\n" +
+			"    echo '{\"models\":[{\"slug\":\"gpt-5.6-sol\",\"visibility\":\"list\",\"default_reasoning_level\":\"high\",\"supported_reasoning_levels\":[{\"effort\":\"high\"}]}]}'\n" +
+			"    exit 0\n" +
+			"  fi\n" +
+			"done\n" +
+			"echo '{\"models\":[{\"slug\":\"gateway/custom-codex\",\"display_name\":\"Custom Codex\",\"visibility\":\"list\",\"default_reasoning_level\":\"high\",\"supported_reasoning_levels\":[{\"effort\":\"high\"}],\"service_tiers\":[{\"id\":\"priority\",\"name\":\"Fast\",\"description\":\"1.5x speed\"}]}]}'\n"
+		writeTestExecutable(t, fake, []byte(script))
+		return fake
+	}
+
+	assertCustomModel := func(t *testing.T, catalog Catalog) {
+		t.Helper()
+		var custom *Model
+		for i := range catalog.Models {
+			if catalog.Models[i].ID == "gateway/custom-codex" {
+				custom = &catalog.Models[i]
+				break
+			}
+		}
+		if custom == nil {
+			t.Fatalf("effective custom model missing; got bundled catalog %+v", catalog.Models)
+		}
+		if custom.Thinking == nil || !hasThinkingLevel(custom.Thinking, "high") {
+			t.Errorf("custom model lost its reasoning catalog: %+v", custom.Thinking)
+		}
+		if len(custom.ServiceTiers) != 1 || custom.ServiceTiers[0].ID != "priority" {
+			t.Errorf("custom model lost its Fast/priority service tier: %+v", custom.ServiceTiers)
+		}
+	}
+
+	t.Run("plain runtime config", func(t *testing.T) {
+		argv := filepath.Join(t.TempDir(), "argv.txt")
+		fake := writeFake(t, argv)
+		catalog, err := ListModels(context.Background(), "codex", Command{Path: fake})
+		if err != nil {
+			t.Fatalf("ListModels: %v", err)
+		}
+		assertCustomModel(t, catalog)
+		if strings.Contains(readFileString(t, argv), "--bundled") {
+			t.Errorf("discovery passed --bundled, which ignores the configured catalog")
+		}
+	})
+
+	t.Run("model_catalog_json runtime prefix", func(t *testing.T) {
+		argv := filepath.Join(t.TempDir(), "argv.txt")
+		fake := writeFake(t, argv)
+		cmd := NewCommand(fake, []string{"-c", "model_catalog_json=/tmp/catalog.json"})
+		catalog, err := ListModels(context.Background(), "codex", cmd)
+		if err != nil {
+			t.Fatalf("ListModels: %v", err)
+		}
+		assertCustomModel(t, catalog)
+		gotArgv := readFileString(t, argv)
+		if strings.Contains(gotArgv, "--bundled") {
+			t.Errorf("discovery passed --bundled, which ignores the configured catalog: %q", gotArgv)
+		}
+		if !strings.Contains(gotArgv, "model_catalog_json=/tmp/catalog.json") {
+			t.Errorf("runtime prefix not forwarded to codex: %q", gotArgv)
+		}
+	})
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
 }
 
 func TestValidateThinkingLevelCodexPerModelFallbackCatalog(t *testing.T) {
@@ -965,7 +1067,7 @@ func writeFakeClaudePreEffortHelpBinary(t *testing.T) string {
 }
 
 // writeFakeCodexModelsBinary writes a stand-in `codex` that answers
-// `debug models --bundled` with a Codex 0.144.1-shaped gpt-5.6 catalog
+// `debug models` with a Codex 0.144.1-shaped gpt-5.6 catalog
 // (sol/terra advertise max+ultra, luna tops out at max) and prints a version
 // string for any other invocation (DetectVersion's probe). Used to exercise
 // ValidateThinkingLevel against a real per-model catalog without a codex install.


### PR DESCRIPTION
## Problem

Codex model discovery ran `codex debug models --bundled`. The `--bundled` flag reports the binary's baked-in native catalog and **intentionally ignores a configured `model_catalog_json`**, so Multica's model/effort/service-tier pickers and the daemon's execution-time capability checks could use a different catalog from the one Codex actually runs with.

Consequences (all in #8177):

- A custom catalog model (e.g. `gateway/custom-codex` with reasoning `high` and a `priority`/Fast service tier) was omitted, so Fast was unavailable and persisted `service_tier=priority` / `thinking_level=high` overrides got dropped by daemon validation.
- The inverse: a catalog that *restricts* a native ID's capabilities was over-advertised from the bundled set.

## Fix

Drop `--bundled` so `codex debug models` reports the **effective** catalog Codex executes with. The runtime launch prefix (`Command.Prefix`) is already applied ahead of the subcommand by `Command.exec`, so a catalog supplied via a `-c model_catalog_json=/path` runtime prefix is reflected as well — no provider prefixes are stripped, and capabilities come from the effective per-model entry rather than assuming Fast.

Discovery stays bounded and falls back safely:

- The plain command can refresh over the network (which `--bundled` used to skip), so `runCodexDebugModels` caps it with a 15s timeout, matching the opencode/pi discovery paths.
- A timeout, error, or empty/malformed payload still falls back to `codexStaticModels()`, so behaviour with **no** configured catalog is unchanged.

The code change is two lines (argv + bounded timeout); the rest is the doc comment and tests.

## Test

Adds `TestListModelsCodexUsesEffectiveCatalog`, a regression through the real public `ListModels` entry point using a test-created stand-in `codex` that returns a **different** payload for `debug models --bundled` (bundled native IDs only) than for a plain `debug models` (the configured catalog, which adds `gateway/custom-codex` with `high` + `priority`/Fast). It asserts Multica now receives the configured custom model and its capabilities, covering both:

- plain runtime config, and
- a `-c model_catalog_json=…` runtime prefix (also asserting the prefix reached the binary and `--bundled` did not).

The test fails against the old `--bundled` argv and passes with the fix. The two existing argv-pinning/fallback tests were updated to the new `{"debug", "models"}` contract.

Verification (macOS):

- `gofmt -l` clean on both files
- `go build ./...`
- `go vet ./pkg/agent`
- `go test ./pkg/agent -run 'Codex|ListModels|ServiceTier|ThinkingLevel|Thinking' -count=1 -p 1` — ok

(The full `./pkg/agent` run surfaced only unrelated traecli/kimi ACP handshake timeouts that pass in isolation — load-induced flakes in a 223s fully-parallel run, not this change.)

Closes #8177