### PR TITLE
MUL-7142: fix(agent): reap the runtime process group on normal exit (#8153)

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -277,9 +277,16 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// Wait for process exit, then release the cancellation handler.
 		exitErr := cmd.Wait()
 		close(procDone)
-		// The leader is reaped; drop ownership. On Windows that closes the Job
-		// Object, which kills anything still inside it — precisely what should
-		// happen to a descendant that outlived the CLI (GH #7522).
+		// The leader is reaped. Kill its process group before dropping ownership
+		// so a descendant that outlived the CLI on a NORMAL exit dies with it,
+		// not just on cancellation. claude neuters cmd.Cancel (above) to drive its
+		// own SIGTERM→SIGKILL, so the group is never signalled on the normal path;
+		// releaseProcessGroup is a Unix no-op, so before this an orphaned headless
+		// Chrome the agent opened over CDP kept running after the task completed
+		// (#8153). Mirrors runOwned in launch.go. On Windows releaseProcessGroup
+		// then closes the Job Object, which kills anything still inside it — the
+		// same outcome the reap gives on Unix (GH #7522).
+		reapProcessTree(cmd)
 		releaseProcessGroup(cmd)
 		duration := time.Since(startTime)
 		// writeDone is buffered (cap 1) and the writer always sends — by the

--- a/server/pkg/agent/deveco.go
+++ b/server/pkg/agent/deveco.go
@@ -198,6 +198,12 @@ func (b *devecoBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 		exitErr := cmd.Wait()
 		close(procDone)
+		// Reap the group on the normal-exit path: deveco neuters cmd.Cancel to
+		// drive its own shutdown, so nothing signals the group when the leader
+		// exits on its own, and releaseProcessGroup is a Unix no-op — a descendant
+		// the agent left running would otherwise outlive the completed task
+		// (#8153). Mirrors runOwned; harmless if the group is already empty.
+		reapProcessTree(cmd)
 		releaseProcessGroup(cmd)
 		duration := time.Since(startTime)
 

--- a/server/pkg/agent/dsh.go
+++ b/server/pkg/agent/dsh.go
@@ -323,6 +323,12 @@ func (b *dshBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 		}
 		exitErr := cmd.Wait()
 		close(procDone)
+		// Reap the group on the normal-exit path: dsh neuters cmd.Cancel to drive
+		// its own shutdown, so nothing signals the group when the leader exits on
+		// its own, and releaseProcessGroup is a Unix no-op — a descendant the agent
+		// left running would otherwise outlive the completed task (#8153). Mirrors
+		// runOwned and the write-failure path above; harmless if already empty.
+		reapProcessTree(cmd)
 		releaseProcessGroup(cmd)
 
 		result := state.result

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -250,6 +250,12 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		// Wait for process exit, then release the cancellation handler.
 		exitErr := cmd.Wait()
 		close(procDone)
+		// Reap the group on the normal-exit path: opencode neuters cmd.Cancel to
+		// drive its own shutdown, so nothing signals the group when the leader
+		// exits on its own, and releaseProcessGroup is a Unix no-op — a descendant
+		// the agent left running would otherwise outlive the completed task
+		// (#8153). Mirrors runOwned; harmless if the group is already empty.
+		reapProcessTree(cmd)
 		releaseProcessGroup(cmd)
 		duration := time.Since(startTime)
 

--- a/server/pkg/agent/proc_other.go
+++ b/server/pkg/agent/proc_other.go
@@ -42,6 +42,16 @@ func startOwnedProcessTree(cmd *exec.Cmd, _ *slog.Logger) error { return cmd.Sta
 
 // releaseProcessGroup is a no-op on non-Windows platforms: a process group needs
 // no handle and is gone once its members are.
+//
+// It deliberately does NOT reap the group. Reaping here would fire whenever the
+// leader's cmd.Wait returns, which is wrong for the callers that drop ownership
+// while the tree is meant to keep running — the ACP managed terminal keeps a
+// backgrounded child alive between the command's exit and an explicit
+// terminal/release (acp_terminal.go), and the probe helpers already reap before
+// releasing (runOwned in launch.go). The normal-exit descendant leak (#8153)
+// lives only in the backends that neuter cmd.Cancel to drive their own
+// shutdown, and is fixed there with an explicit reapProcessTree before this
+// call — mirroring runOwned — not by overloading this shared no-op.
 func releaseProcessGroup(cmd *exec.Cmd) {}
 
 func codexInitializeRetrySupported() bool { return true }
@@ -52,6 +62,14 @@ func codexInitializeRetrySupported() bool { return true }
 // the descendants the agent spawned, not just the leader.
 func signalProcessGroup(cmd *exec.Cmd, sig syscall.Signal) {
 	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	// Guard the pid before negating it: Kill(-0, sig) hits the caller's (the
+	// daemon's) own process group, and no caller ever wants to signal a
+	// non-positive pgid. A started process always has a positive pid; this only
+	// fires for a zero-value Process, and never lets a group send escape onto
+	// the daemon itself.
+	if cmd.Process.Pid <= 0 {
 		return
 	}
 	if err := syscall.Kill(-cmd.Process.Pid, sig); err != nil {

--- a/server/pkg/agent/proc_reap_unix_test.go
+++ b/server/pkg/agent/proc_reap_unix_test.go
@@ -1,0 +1,79 @@
+//go:build unix
+
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestNormalExitReapsDescendantProcessGroup is the #8153 regression, exercised
+// through a real backend's normal-exit path.
+//
+// #7531 put the runtime CLI in its own process group and signals the whole group
+// on cancellation/timeout. A backend that neuters cmd.Cancel to drive its own
+// shutdown (claude, deveco, opencode, dsh) never signals the group when the
+// leader exits on its own, and releaseProcessGroup is a Unix no-op — so a
+// descendant that inherited the pgid but does not hold the CLI's stdout kept
+// running after the task completed successfully (observed: an orphaned headless
+// Chrome burning cores for hours, reparented to PID 1 in the now-leaderless
+// group). The fix reaps the group right after cmd.Wait, mirroring runOwned.
+//
+// The fake opencode spawns such a descendant — it stays in the group but
+// redirects its own stdio away from the inherited pipes, so the leader reaches
+// EOF and exits 0 normally while it keeps running — then completes. After the
+// run returns, the descendant must be gone. Fails before the fix (it survives
+// its full sleep); passes once the normal-exit path reaps the group.
+//
+// Environment note (from the issue): in a bare container with no init to reap
+// the SIGKILLed descendant it lingers as a zombie and kill(pid, 0) still
+// succeeds; run with `docker run --init`. On a normal host init reaps it.
+func TestNormalExitReapsDescendantProcessGroup(t *testing.T) {
+	tempDir := t.TempDir()
+	pidFile := filepath.Join(tempDir, "pids")
+	fakePath := filepath.Join(tempDir, "opencode")
+
+	script := "#!/bin/sh\n" +
+		"# Descendant stays in the process group but does not hold the leader's\n" +
+		"# stdout, so the leader can reach EOF and exit normally while it runs on.\n" +
+		"( sleep 300 >/dev/null 2>&1 </dev/null ) &\n" +
+		"child=$!\n" +
+		`printf '%s %s\n' "$$" "$child" > "$OPENCODE_PID_FILE"` + "\n" +
+		`printf '{"type":"step_start","timestamp":1,"sessionID":"ses_fake","part":{"type":"step-start"}}\n'` + "\n" +
+		`printf '{"type":"text","timestamp":2,"sessionID":"ses_fake","part":{"type":"text","text":"done"}}\n'` + "\n" +
+		"exit 0\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("opencode", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"OPENCODE_PID_FILE": pidFile},
+	})
+	if err != nil {
+		t.Fatalf("new opencode backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "prompt-ignored", ExecOptions{Cwd: tempDir})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	pids := waitForPids(t, pidFile) // [leaderPID, descendantPID]
+
+	// The run must complete on its own (no cancellation) so the normal-exit path
+	// runs and reaps the group.
+	select {
+	case <-session.Result:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not return after the fake exited normally")
+	}
+
+	waitProcessGone(t, pids[1])
+}


### PR DESCRIPTION
## Problem

On Unix, a task that completes **normally** leaves its descendants running.

#7531 made process-tree ownership structural: each runtime CLI runs in its own process group and the whole group is signalled on cancellation/timeout (`signalProcessGroup(cmd, -pgid)`). That covers cancellation and timeout only.

On the **normal-exit** path nothing signalled the group. The stream-json backends that neuter `cmd.Cancel` to drive their own graceful `SIGTERM → SIGKILL` shutdown — `claude`, `deveco`, `opencode`, `dsh` — get no group signal when the leader exits on its own: their cancellation goroutine returns as soon as `procDone` closes, and after `cmd.Wait()` they only call `releaseProcessGroup`, which is a **no-op on Unix**. On Windows the same call closes the Job Object, which kills anything still inside it — so the guarantee was asymmetric.

Result: a descendant that inherited the pgid but does not hold the CLI's stdout (a headless Chrome opened over CDP, a Playwright `run-server`, a bare `sleep 300 &`) kept running after every successful task, orphaned with PPID 1 in the now-leaderless group — observed burning cores for many hours.

## Fix

Reap the process group right after `cmd.Wait()` on those four normal-exit paths, before `releaseProcessGroup`, via the existing `reapProcessTree` helper — mirroring `runOwned` in `launch.go` and `dsh`'s own write-failure path (`signalProcessGroup(SIGKILL)` then release).

This is deliberately scoped to the backends that actually leak rather than folded into `releaseProcessGroup`. That shared helper is also reached while a tree is meant to keep running — the ACP managed terminal holds a backgrounded child alive between the command's exit and an explicit `terminal/release` — and by the probe helpers (`runOwned`/`outputOwned`) that already reap before releasing. Making `releaseProcessGroup` itself kill would regress those (confirmed: it breaks `TestACPManagedTerminalReleaseTerminatesProcessTreeAfterParentExit` and the probe cancellation tests). Windows is unaffected: its `releaseProcessGroup` already closes the Job Object.

`signalProcessGroup` also gains a guard against a non-positive pid, so a zero-value `Process` can never turn a group send into `Kill(-0, …)`, which would hit the daemon's own process group. Only the runtime's own group (the pgid from `configureProcessGroup`) is ever signalled; cancellation/timeout behaviour is unchanged.

Distinct from #7615 (a descendant that left the group via `setsid` is unreachable); this covers only the in-group case.

## Test

`TestNormalExitReapsDescendantProcessGroup` (Unix) drives a fake `opencode` that spawns a descendant which stays in the group but redirects its own stdio away from the inherited pipes — so the leader reaches EOF and exits `0` while the descendant runs on — then completes. After the run returns the descendant must be gone. It fails on the current normal-exit path and passes with the fix. (No real agent CLI; a test-created fake executable, per the repo testing rules.)

Note for reviewers running `pkg/agent` tests in a bare container with no init to reap the SIGKILLed descendant: it lingers as a zombie and `kill(pid, 0)` still succeeds — use `docker run --init`, as the existing `*KillsDescendants` tests already require.

## Verification

- `gofmt -l` clean on all changed files
- `go build ./...` and `go vet ./pkg/agent` clean
- New test fails without the fix, passes with it
- Focused run of the touched backends plus the ACP-terminal, probe-cancellation and process-group tests passes

Closes #8153
