### PR TITLE
MUL-7180 fix(issues): anchor merged runs after latest input

### DIFF
--- a/packages/views/issues/components/comment-runs.test.ts
+++ b/packages/views/issues/components/comment-runs.test.ts
@@ -40,11 +40,11 @@ describe("groupCommentRuns", () => {
     expect(before.standaloneRuns).toEqual([]);
     expect(before.runs.size).toBe(0);
     const after = buildCommentRunView([original, retry], [old, next]);
-    expect(after.runs.get(old.id)?.map((run) => run.anchorCommentId)).toEqual([old.id, old.id]);
+    expect(after.runs.get(old.id)?.map((run) => run.anchorCommentId)).toEqual([next.id, next.id]);
     expect(after.standaloneRuns).toEqual([]);
   });
 
-  it("keeps a queued run in place as its thread receives more instructions and its answer", () => {
+  it("moves a queued run after the latest instruction and keeps the answer there", () => {
     const root = comment("root");
     const first = comment("first", { parent_id: root.id });
     const other = comment("other-thread");
@@ -55,11 +55,64 @@ describe("groupCommentRuns", () => {
     const awaitingComment = buildCommentRunView([merged], [root, first, other], before.runs);
     expect(awaitingComment.runs.get(root.id)?.[0]?.anchorCommentId).toBe(first.id);
     const after = buildCommentRunView([merged], [root, first, other, second], before.runs);
-    expect(after.runs.get(root.id)?.[0]?.anchorCommentId).toBe(first.id);
+    expect(after.runs.get(root.id)?.[0]?.anchorCommentId).toBe(second.id);
     expect(after.runs.has(other.id)).toBe(false);
     const answer = comment("answer", { actor_type: "agent", source_task_id: run.id });
     const complete = buildCommentRunView([{ ...merged, status: "completed", delivered_comment_ids: [first.id, second.id] }], [root, first, other, second, answer]);
-    expect(complete.runs.get(root.id)?.[0]).toMatchObject({ anchorCommentId: first.id, commentId: answer.id, hasReply: true });
+    expect(complete.runs.get(root.id)?.[0]).toMatchObject({ anchorCommentId: second.id, commentId: answer.id, hasReply: true });
+  });
+
+  it.each([
+    { status: "queued" as const, deliveredCommentIds: [] },
+    { status: "running" as const, deliveredCommentIds: ["first", "latest"] },
+  ])("falls back to the latest remaining input when a $status batch anchor is deleted", ({ status, deliveredCommentIds }) => {
+    const first = comment("first");
+    const latest = comment("latest", { parent_id: first.id, created_at: "2026-09-07T00:01:00Z" });
+    const run = task("run", {
+      status,
+      trigger_comment_id: latest.id,
+      coalesced_comment_ids: [first.id],
+      delivered_comment_ids: deliveredCommentIds,
+    });
+    const beforeDelete = buildCommentRunView([run], [first, latest]);
+    expect(beforeDelete.runs.get(first.id)?.[0]?.anchorCommentId).toBe(latest.id);
+
+    const afterDelete = buildCommentRunView([run], [first], beforeDelete.runs);
+    expect(afterDelete.runs.get(first.id)?.[0])
+      .toMatchObject({ anchorCommentId: first.id, commentId: first.id });
+    expect(afterDelete.standaloneRuns).toEqual([]);
+  });
+
+  it("projects a run reply onto the latest remaining input when its deleted anchor disappears", () => {
+    const first = comment("first");
+    const latest = comment("latest", { parent_id: first.id, created_at: "2026-09-07T00:01:00Z" });
+    const run = task("run", {
+      trigger_comment_id: latest.id,
+      coalesced_comment_ids: [first.id],
+      delivered_comment_ids: [first.id, latest.id],
+    });
+    const beforeDelete = buildCommentRunView([run], [first, latest]);
+    const answer = comment("answer", { actor_type: "agent", source_task_id: run.id });
+
+    const afterDelete = buildCommentRunView([run], [first, answer], beforeDelete.runs);
+    expect(afterDelete.runs.get(first.id)?.[0])
+      .toMatchObject({ anchorCommentId: first.id, commentId: answer.id, hasReply: true });
+    expect(afterDelete.timeline.find((entry) => entry.id === answer.id)?.parent_id).toBe(first.id);
+  });
+
+  it("uses timeline order to break ties between same-time inputs", () => {
+    const root = comment("root");
+    const first = comment("first", { parent_id: root.id });
+    const latest = comment("latest", { parent_id: root.id });
+    const run = task("run", {
+      status: "queued",
+      trigger_comment_id: latest.id,
+      coalesced_comment_ids: [first.id],
+      delivered_comment_ids: [],
+    });
+
+    expect(buildCommentRunView([run], [root, first, latest]).runs.get(root.id)?.[0]?.anchorCommentId)
+      .toBe(latest.id);
   });
 
   it("projects chained answers and assignment subtrees before finding run roots", () => {
@@ -121,10 +174,27 @@ describe("groupCommentRuns", () => {
     expect(buildCommentRunView([run], [reply]).standaloneRuns).toHaveLength(1);
     expect(buildCommentRunView([run], []).standaloneRuns).toEqual([]);
   });
-  it("keeps merged runs at their earliest input, including nested replies", () => {
+  it("keeps merged runs after their latest delivered input, including nested replies", () => {
     const timeline = [comment("root"), comment("reply", { parent_id: "root" }), comment("nested", { parent_id: "reply" })];
     const run = task("run", { trigger_comment_id: "nested", coalesced_comment_ids: ["root", "reply"], delivered_comment_ids: ["root", "reply", "nested"] });
-    expect([...groupCommentRuns([run], timeline)]).toEqual([["root", [{ task: run, commentId: "root", anchorCommentId: "root", hasReply: false }]]]);
+    expect([...groupCommentRuns([run], timeline)]).toEqual([["root", [{ task: run, commentId: "nested", anchorCommentId: "nested", hasReply: false }]]]);
+  });
+
+  it("freezes a claimed run after the latest comment in its delivery receipt", () => {
+    const timeline = [
+      comment("root"),
+      comment("first", { parent_id: "root", created_at: "2026-09-07T00:01:00Z" }),
+      comment("second", { parent_id: "root", created_at: "2026-09-07T00:02:00Z" }),
+      comment("next-run", { parent_id: "root", created_at: "2026-09-07T00:03:00Z" }),
+    ];
+    const run = task("run", {
+      status: "running",
+      trigger_comment_id: "next-run",
+      coalesced_comment_ids: ["first", "second"],
+      delivered_comment_ids: ["first", "second"],
+    });
+    expect(groupCommentRuns([run], timeline).get("root")?.[0])
+      .toMatchObject({ anchorCommentId: "second", commentId: "second" });
   });
 
   it.each([{ receipt: [] }, { receipt: ["old"] }])("uses planned comment coverage while queued, even with a delivery receipt of $receipt", ({ receipt }) => {

--- a/packages/views/issues/components/comment-runs.ts
+++ b/packages/views/issues/components/comment-runs.ts
@@ -3,7 +3,7 @@ import type { AgentTask, TimelineEntry } from "@multica/core/types";
 export interface CommentRun {
   task: AgentTask;
   commentId?: string;
-  /** Stable trigger location; absent for issue-level runs such as assignment. */
+  /** Last input this run covers; absent for issue-level runs such as assignment. */
   anchorCommentId?: string;
   /** The comment already contains this run's reply; only append its activity. */
   hasReply: boolean;
@@ -33,7 +33,7 @@ function isObsoleteCommentRun(task: AgentTask): boolean {
     && !task.dispatched_at && !task.started_at && !task.delivered_comment_ids?.length;
 }
 
-/** Keep each run at its trigger; associate replies by task identity, never arrival order. */
+/** Place each run after its latest covered input; associate replies by task identity. */
 export function buildCommentRunView(
   tasks: readonly AgentTask[],
   timeline: readonly TimelineEntry[],
@@ -44,6 +44,7 @@ export function buildCommentRunView(
   // in Execution history, but it must not become an unanchored Activity block.
   const inlineTasks = tasks.filter((task) => task.kind !== "quick_create");
   const comments = new Map(timeline.filter((entry) => entry.type === "comment").map((entry) => [entry.id, entry]));
+  const timelineOrder = new Map(timeline.map((entry, index) => [entry.id, index]));
   const threadRoot = (id: string): string | undefined => {
     const seen = new Set<string>();
     let entry = comments.get(id);
@@ -84,24 +85,31 @@ export function buildCommentRunView(
         ? source.delivered_comment_ids
         : [source.trigger_comment_id, ...(source.coalesced_comment_ids ?? [])];
       const candidates = ids.flatMap((id) => id && comments.has(id) ? [comments.get(id)!] : []);
+      const latestCandidateId = () => [...candidates].sort((a, b) => b.created_at.localeCompare(a.created_at)
+        || (timelineOrder.get(b.id) ?? -1) - (timelineOrder.get(a.id) ?? -1))[0]?.id;
       // Task events can arrive before their comments. Preserve the intended
       // anchor even when it cannot be rendered yet; it is not an assignment.
       anchorId = source.trigger_comment_id && ids.includes(source.trigger_comment_id)
         ? source.trigger_comment_id
-        : candidates.sort((a, b) => b.created_at.localeCompare(a.created_at))[0]?.id
-          ?? ids.find((id) => !!id);
-      // Same-thread batches retain their first input's slot as newer replies
-      // coalesce. Wait for missing comments instead of guessing their thread;
-      // historical batches spanning several threads retain their trigger.
+        : latestCandidateId() ?? ids.find((id) => !!id);
+      // A same-thread batch belongs after its latest covered input, so the
+      // timeline reads "these comments → this run". Before claim, a newly
+      // coalesced trigger moves the queued block down. After claim, `ids` comes
+      // from delivered_comment_ids and freezes the running block at the actual
+      // delivery boundary. Wait for missing comments instead of guessing their
+      // thread; historical batches spanning several threads retain their trigger.
       const root = candidates[0] && threadRoot(candidates[0].id);
       if (root && candidates.length === ids.filter(Boolean).length
         && candidates.every((entry) => threadRoot(entry.id) === root)) {
-        anchorId = candidates.sort((a, b) => a.created_at.localeCompare(b.created_at)
-          || timeline.indexOf(a) - timeline.indexOf(b))[0]?.id;
+        anchorId = latestCandidateId();
       }
       const priorAnchor = priorAnchors.get(source.id);
       if (priorAnchor && ids.includes(priorAnchor) && candidates.length < ids.filter(Boolean).length) {
-        anchorId = priorAnchor;
+        // Realtime task metadata can arrive before a new trigger comment; keep
+        // the existing visible slot in that window. If the prior slot itself
+        // disappeared, the comment was deleted, so fall back to the latest
+        // remaining covered input instead of hiding the run and its reply.
+        anchorId = comments.has(priorAnchor) ? priorAnchor : latestCandidateId() ?? priorAnchor;
       }
       source = source.parent_task_id ? byTask.get(source.parent_task_id) : undefined;
     }

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1282,6 +1282,76 @@ describe("IssueDetail (shared)", () => {
     expect(mockApiObj.listTaskMessages).toHaveBeenCalledWith(taskId);
   });
 
+  it("places one coalesced queued block after the batch's latest reply", async () => {
+    const root = mockTimeline[0]!;
+    const first = { ...mockTimeline[1]!, id: "queued-first", parent_id: root.id,
+      content: "First queued instruction", created_at: "2026-01-16T00:00:01Z" };
+    const latest = { ...first, id: "queued-latest", content: "Latest queued instruction",
+      created_at: "2026-01-16T00:00:02Z" };
+    const task: AgentTask = {
+      id: "4a2e8d1c-7f9b-4e2a-9c1d-123456789abd", agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",
+      status: "queued", priority: 0, created_at: root.created_at,
+      started_at: null, dispatched_at: null, completed_at: null, result: null, error: null,
+      trigger_comment_id: latest.id, coalesced_comment_ids: [first.id], delivered_comment_ids: [],
+    };
+    mockApiObj.listTimeline.mockResolvedValue([root, first, latest]);
+    mockApiObj.listTasksByIssue.mockResolvedValue([task]);
+    const { container } = renderIssueDetail();
+
+    await screen.findByText("Waiting for an available agent.");
+    const run = container.querySelector(`[data-run-comment-id="${task.id}"]`)!;
+    expect(run).not.toBeNull();
+    const latestComment = container.querySelector(`#comment-${latest.id}`);
+    const firstComment = container.querySelector(`#comment-${first.id}`);
+    expect(latestComment).not.toBeNull();
+    expect(firstComment).not.toBeNull();
+    expect(latestComment!.nextElementSibling).toBe(run);
+    expect(firstComment!.nextElementSibling).not.toBe(run);
+  });
+
+  it("keeps the running block after its delivered comment and one queued block after later replies", async () => {
+    const root = mockTimeline[0]!;
+    const first = { ...mockTimeline[1]!, id: "successor-first", parent_id: root.id,
+      content: "First successor instruction", created_at: "2026-01-16T00:00:01Z" };
+    const latest = { ...first, id: "successor-latest", content: "Latest successor instruction",
+      created_at: "2026-01-16T00:00:02Z" };
+    const running: AgentTask = {
+      id: "4a2e8d1c-7f9b-4e2a-9c1d-123456789ab0", agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",
+      status: "running", priority: 0, created_at: root.created_at,
+      started_at: root.created_at, dispatched_at: root.created_at, completed_at: null, result: null, error: null,
+      trigger_comment_id: root.id, delivered_comment_ids: [root.id],
+    };
+    const queued: AgentTask = {
+      ...running,
+      id: "4a2e8d1c-7f9b-4e2a-9c1d-123456789ab1",
+      status: "queued", started_at: null, dispatched_at: null,
+      trigger_comment_id: latest.id, coalesced_comment_ids: [first.id], delivered_comment_ids: [],
+    };
+    mockApiObj.listTimeline.mockResolvedValue([root, first, latest]);
+    mockApiObj.listTasksByIssue.mockResolvedValue([running, queued]);
+    const { container } = renderIssueDetail();
+
+    await waitFor(() => {
+      expect(container.querySelector(`[data-run-comment-id="${running.id}"]`)).not.toBeNull();
+      expect(container.querySelector(`[data-run-comment-id="${queued.id}"]`)).not.toBeNull();
+    });
+    const rootContent = container.querySelector(`[data-comment-content="${root.id}"]`);
+    const runningBlock = container.querySelector(`[data-run-comment-id="${running.id}"]`);
+    const firstComment = container.querySelector(`#comment-${first.id}`);
+    const latestComment = container.querySelector(`#comment-${latest.id}`);
+    const queuedBlock = container.querySelector(`[data-run-comment-id="${queued.id}"]`);
+    expect(rootContent).not.toBeNull();
+    expect(runningBlock).not.toBeNull();
+    expect(firstComment).not.toBeNull();
+    expect(latestComment).not.toBeNull();
+    expect(queuedBlock).not.toBeNull();
+    expect(rootContent!.compareDocumentPosition(runningBlock!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(runningBlock!.compareDocumentPosition(firstComment!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(firstComment!.compareDocumentPosition(latestComment!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(latestComment!.nextElementSibling).toBe(queuedBlock);
+    expect(container.querySelectorAll(`[data-run-comment-id="${queued.id}"]`)).toHaveLength(1);
+  });
+
   it.each([null, "comment-1"])("shows an assignment reply once in its run slot when posted under %s", async (parentId) => {
     const task: AgentTask = {
       id: "ba2e8d1c-7f9b-4e2a-9c1d-123456789abc", agent_id: "agent-1", runtime_id: "runtime-1", issue_id: "issue-1",


### PR DESCRIPTION
## Summary

- place a coalesced same-thread run after its latest covered comment while queued
- freeze claimed/running placement using `delivered_comment_ids`
- keep the run and any task-owned reply visible when the latest covered comment is deleted by falling back to the latest remaining input
- cover equal timestamps, deleted queued/running anchors, reply projection, and the combined running-plus-queued DOM order

## Scope

This is the first-step interaction change agreed in MUL-7180. Persisted comments remain independent. The proposed clickable “includes N comments” association and dispatched-window “next run” label are intentionally a separate second phase because they add new UI and, for refresh-safe deferred coverage, may require a backend contract.

Queued blocks can remount as their anchor moves to a newly coalesced input; queued runs have no transcript history to lose. Once delivery is known, the receipt freezes the running block. Preserving disclosure/dialog state across arbitrary DOM parents would require a broader keyed view-state owner and is not included here.

## Validation

- focused Vitest: 2 files, 116 tests passed
- `pnpm --filter @multica/views typecheck`: passed
- `pnpm --filter @multica/views lint`: 0 errors, 26 warnings in unchanged files
- full `@multica/views`: 4975 passed, 1 unrelated existing failure in `layout/sidebar-resize.test.tsx`; isolated rerun reproduces the same failure
- `git diff --check`: passed
- real local API + Web + daemon + Codex execution was verified and captured on MUL-7180 before this review fix
