### PR TITLE
MUL-7188 fix(ui): bound dialog height so long content keeps the footer reachable

### DIFF
--- a/e2e/property-editor-overflow.spec.ts
+++ b/e2e/property-editor-overflow.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+import { loginAsDefault, waitForPageText } from "./helpers";
+
+const OPTION_COUNT = 30;
+
+/**
+ * MUL-7188: the property editor is centred by transform and had no height
+ * bound, so a long option list pushed "Save property" below the viewport
+ * where it could not be reached at all — the property became unsaveable.
+ */
+test("keeps the property editor saveable when the option list is long", async ({
+  page,
+}) => {
+  const workspaceSlug = await loginAsDefault(page);
+  const propertyName = `Overflow ${Date.now().toString(36)}`;
+
+  await page.goto(`/${workspaceSlug}/settings?tab=properties`, {
+    waitUntil: "domcontentloaded",
+  });
+  await waitForPageText(page, "Properties");
+  await page.getByRole("button", { name: "New property" }).click();
+  const dialog = page.getByRole("dialog", { name: "New property" });
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByLabel("Name").fill(propertyName);
+  const addOption = dialog.getByRole("button", { name: "Add option" });
+  for (let i = 0; i < OPTION_COUNT - 1; i++) {
+    await addOption.click();
+  }
+  await expect(dialog.getByPlaceholder("Option name")).toHaveCount(OPTION_COUNT);
+  await dialog.getByPlaceholder("Option name").first().fill("Critical");
+
+  const viewport = page.viewportSize();
+  const box = await dialog.boundingBox();
+  if (!viewport || !box) throw new Error("Could not measure the property editor");
+  expect(box.y).toBeGreaterThanOrEqual(0);
+  expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+
+  // Clicking rather than asserting visibility: an off-screen footer is what
+  // the report was about, and Playwright refuses to click what it cannot
+  // bring into view.
+  await dialog.getByRole("button", { name: "Save property" }).click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByText(propertyName, { exact: true })).toBeVisible();
+});

--- a/packages/ui/components/ui/dialog.tsx
+++ b/packages/ui/components/ui/dialog.tsx
@@ -53,7 +53,15 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-surface-raised p-4 text-body text-popover-foreground shadow-[var(--floating-shadow)] ring-1 ring-surface-border duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          // The popup is centred by transform, so without a height bound it
+          // grows in both directions and pushes its own footer past the
+          // viewport edge — the save button of a content-driven dialog (a
+          // property with many options, say) becomes unclickable. Cap it to
+          // the viewport and let it scroll as a last resort; a dialog that
+          // fits is unaffected. `overflow-auto` shares tailwind-merge's
+          // conflict group with `overflow-hidden`, so a dialog that manages
+          // its own scrolling still opts out by passing that.
+          "fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-auto rounded-xl bg-surface-raised p-4 text-body text-popover-foreground shadow-[var(--floating-shadow)] ring-1 ring-surface-border duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/packages/views/settings/components/properties-tab.tsx
+++ b/packages/views/settings/components/properties-tab.tsx
@@ -452,7 +452,10 @@ function PropertyEditorDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      {/* Options are unbounded, so the form is the part that has to give:
+          header and footer stay put and the fields scroll, keeping "Save
+          property" clickable no matter how many options are on the draft. */}
+      <DialogContent className="flex max-h-[85dvh] flex-col sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
             {property
@@ -463,7 +466,9 @@ function PropertyEditorDialog({
             {t(($) => $.properties.editor.admin_hint)}
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-5 py-2">
+        {/* -mx-1/px-1 keeps the 3px focus ring of an edge-to-edge input from
+            being clipped by the scroll container. */}
+        <div className="-mx-1 min-h-0 flex-1 space-y-5 overflow-y-auto px-1 py-2">
           <div className="grid grid-cols-[4.25rem_minmax(0,1fr)_10rem] gap-3">
             <div className="space-y-2">
               <FieldLabel>{t(($) => $.properties.editor.icon)}</FieldLabel>


### PR DESCRIPTION
## Summary

The Properties config modal grew with its option list until **Save property** sat
below the viewport, where nothing could scroll it back into reach — the property
became unsaveable (reported with ~20 sprint options).

The root cause is in `DialogContent`, not in the property editor: the popup is
centred with `top-1/2 -translate-y-1/2` and has no height bound at all, so any
dialog with content-driven height grows past both viewport edges and takes its
own footer with it. 73 dialogs share that component.

- **`packages/ui/components/ui/dialog.tsx`** — cap the popup at
  `max-h-[calc(100dvh-2rem)]` and let it scroll as a last resort. Inert for a
  dialog that already fits. `overflow-auto` sits in the same tailwind-merge
  conflict group as `overflow-hidden`, so the ~10 dialogs that already declare
  their own overflow keep exactly their current behaviour.
- **`packages/views/settings/components/properties-tab.tsx`** — give the property
  editor the repo's usual tall-dialog treatment (`flex max-h-[85dvh] flex-col`
  plus a `min-h-0 flex-1 overflow-y-auto` body), so header and footer stay put
  and only the fields scroll.

## Verification

`e2e/property-editor-overflow.spec.ts` is a new regression test: it opens the
editor, adds 30 options, asserts the dialog stays inside the viewport, and saves.
Reverting the two source files makes it fail with Playwright's
`element is outside of the viewport` — the reported bug, reproduced.

- `pnpm typecheck` (ui, views, core) — pass
- `pnpm lint` (ui, views) — pass, no new warnings
- `pnpm test --filter=@multica/views` — 4969 tests pass
- Playwright, whole suite against a local stack — 34 pass including the new spec.
  11 failures are pre-existing: reverting this change reproduces the same 11
  (Composio/Google/MCP specs that need external services, plus
  `plugin-surface-document.spec.ts` failing to import a renamed export).
