### PR TITLE
docs(skills): trim redundant platform Skill notes from #8174 and #8192 (MUL-7190)

### DIFF
--- a/server/internal/service/builtin_skills/multica-platform/references/issues.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/issues.md
@@ -281,14 +281,6 @@ multica issue runs <issue-id> --active --output json     # in-flight runs on thi
 multica issue runs <issue-id> --siblings --output json   # ...and across the sub-issue family
 ```
 
-Comment replies stay with the directly replied-to agent or the thread owner;
-they never schedule a delayed run for the issue assignee. Waiting for an offline
-or busy agent does not change the recipient. Explicitly @-mention another agent to
-involve it. New top-level comments without a target still route to the assignee.
-Issue and agent run history omit unused assignee fallbacks from older versions;
-cancelled fallbacks are hidden even if dispatched, provided execution never
-started. Ordinary cancellations and fallbacks that started remain visible.
-
 `--active` drops the execution history and returns only `queued` / `dispatched`
 / `running` / `waiting_local_directory` runs. `--siblings` widens the same read
 to the issue's family — its parent (or itself, when it has no parent) plus every
@@ -334,18 +326,12 @@ Creating every serial step as `todo` enqueues the whole chain at once.
 ### Stages: order sub-issues into barrier groups
 
 `--stage <N>` (N >= 1) groups sub-issues under the same parent into ordered
-stages. The parent assignee is woken **once, when a whole stage finishes** —
-i.e. every sub-issue in the lowest unfinished stage has reached a terminal
-status (`done`/`cancelled`). A completion that does not close a stage is silent
-(no comment, no wake). A sibling set with **no** stages is one implicit stage,
-so the parent is woken once when the *last* sub-issue finishes — not on every
-child.
-
-Completion notifications are best-effort. If the status catalog cannot be read,
-or a custom status needed for the checks cannot be resolved (including a status
-created after the notification pass's catalog snapshot), the server skips that
-parent's notification and wake. The child's committed status change remains
-saved; there is no automatic replay of the skipped notification.
+stages. The server **tries once to wake the parent assignee when a whole stage
+finishes** — i.e. every sub-issue in the lowest unfinished stage has reached a
+terminal status (`done`/`cancelled`); a notification that fails is not replayed.
+A completion that does not close a stage is silent (no comment, no wake). A
+sibling set with **no** stages is one implicit stage, so the parent is woken
+once when the *last* sub-issue finishes — not on every child.
 
 Advancement is agent-driven: the server only detects the closed barrier and
 wakes the parent assignee, who then decides whether to promote the next stage's

--- a/server/internal/service/builtin_skills/multica-platform/references/mentions.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/mentions.md
@@ -150,6 +150,10 @@ not injected into an already running prompt. Different threads queue independent
   `editing_comment_id` ignores pending tasks from the same comment being edited,
   because save cancels those old tasks before it re-computes triggers. It is
   still comment-scoped, not an agent-wide bypass.
+- **A hand-off to the issue assignee because your target is busy.** A reply
+  already routed to an agent stays with that agent; an offline or queued target
+  is waited for, never swapped for the issue assignee. Mention whoever else you
+  need by hand.
 - **An archived agent, or one with no runtime bound** (likewise a squad whose
   leader is): blocked with `target_unavailable` and `runtime_offline`
   respectively. Both are checked only AFTER the invoke gate, so a caller who may


### PR DESCRIPTION
## Summary

Applies the review of the built-in Skill changes in #8174 and #8192. Those two PRs added 14 lines to the `multica-platform` reference set; most of it describes server internals the reading agent cannot act on, and one sentence is wrong for agent readers.

Net effect: **−19 / +10** across two reference files. The two usable rules survive, in better places.

## What changed

**1. Dropped the run-history filtering note** (`references/issues.md`)

> Issue and agent run history omit unused assignee fallbacks from older versions; cancelled fallbacks are hidden even if dispatched, provided execution never started. Ordinary cancellations and fallbacks that started remain visible.

The server performs this filtering. No agent query, handoff, or decision changes based on knowing it.

**2. Moved the surviving routing rule to the mentions trigger rules** (`references/mentions.md`)

It previously sat inside "Who else is running right now", a section about *querying* in-flight runs. The rule is about who a reply reaches, so it belongs in the "What does NOT happen" list, which is where a reader is deciding who to involve. Condensed to:

> **A hand-off to the issue assignee because your target is busy.** A reply already routed to an agent stays with that agent; an offline or queued target is waited for, never swapped for the issue assignee. Mention whoever else you need by hand.

**3. Dropped an over-broad claim** — this is the correctness fix

> New top-level comments without a target still route to the assignee.

Implicit assignee routing is gated on the comment author being a **member**. An agent-authored comment takes an early return well before the assignee fallback is reached, keeping only a narrow squad-leader path. Since this reference is read *by agents*, the sentence stated the opposite of what happens to its own reader: an agent could post a bare top-level comment expecting to wake the assignee, and nothing would run. Removed rather than rewritten — "mention the agent you need" already covers the actionable half, and the general rule lives in `mentions.md`.

**4. Folded the child-done caveat into the stage-wake sentence** (`references/issues.md`)

Replaced the five-line paragraph about status-catalog reads, unresolvable custom statuses, post-snapshot status creation, and non-rollback of committed status, with the part a reader can use:

> The server **tries once to wake the parent assignee when a whole stage finishes** — … ; a notification that fails is not replayed.

This also fixes a second-order problem: the previous wording ("is woken **once, when a whole stage finishes**") reads as a delivery guarantee. It is best-effort, and now says so in the same sentence. The failure mechanism stays in the code comments and the originating PR, which is where a maintainer looks.

## Verification

- `go test ./internal/service/ -run 'BuiltinSkill|PlatformSkill'` — ok

The payload lint (`TestBuiltinSkillPayloadCarriesNoSourceReferences`) passes; no source paths or file names were introduced into shipped skill content. The routing-table test still matches — no reference file was added or removed.

Docs-only change; no Go or TS code touched, so no other suites were run.
