### PR TITLE
perf(migrations): skip agent task thread backfill (MUL-7190)

### DIFF
--- a/server/migrations/451_agent_task_comment_thread.up.sql
+++ b/server/migrations/451_agent_task_comment_thread.up.sql
@@ -30,6 +30,5 @@ CREATE TRIGGER agent_task_comment_thread
 BEFORE INSERT OR UPDATE OF trigger_comment_id ON agent_task_queue
 FOR EACH ROW EXECUTE FUNCTION set_agent_task_comment_thread();
 
-UPDATE agent_task_queue
-SET comment_thread_id = comment_thread_root_id(trigger_comment_id)
-WHERE trigger_comment_id IS NOT NULL;
+-- Existing rows intentionally retain a NULL thread scope. Pre-migration tasks
+-- drain under the issue/agent claim fence without rewriting historical data.


### PR DESCRIPTION
## Summary

- remove migration 451's historical `agent_task_queue` backfill
- keep the derived thread column, root resolver, and write trigger unchanged
- document that pre-migration rows intentionally retain a null thread scope

## Why

The backfill recursively resolves the comment root for every historical comment-triggered task during startup. The rollout decision in MUL-7190 is to avoid that unbounded rewrite and accept the bounded transition behavior for pre-migration non-terminal tasks. New inserts and trigger-comment updates remain populated by the database trigger.

## Validation

- `go test ./internal/migrations`
- `make migrate-up` on a fresh isolated worktree database (migrations 001–456)
- `go test ./internal/handler -run '^TestCommentThreadQueuesMergeAndExecuteIndependently$' -count=1`
- `go test ./internal/handler -run '^TestDeferredCommentThreadsPromoteIndependently$' -count=1`
- `git diff --check`

## Rollout note

Pre-migration non-terminal comment tasks can temporarily behave as null/assignment-scoped rows until they finish or are cancelled. Claiming remains serialized per issue and agent; all post-migration writes receive the correct thread root from the trigger.
