### PR TITLE
fix(codex): accept gpt-6-astra in the static model catalog

### DIFF
--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -284,6 +284,7 @@ describe("estimateCost", () => {
     // can't hide behind an input-only assertion. `total` is 1M of each of the
     // four categories priced at its own rate.
     const cases = [
+      { model: "gpt-6-astra", input: 10, cacheRead: 1, cacheWrite: 12.5, output: 50, total: 73.5 },
       { model: "gpt-5.6-sol", input: 5, cacheRead: 0.5, cacheWrite: 6.25, output: 30, total: 41.75 },
       { model: "gpt-5.6-terra", input: 2.5, cacheRead: 0.25, cacheWrite: 3.125, output: 15, total: 20.875 },
       { model: "gpt-5.6-luna", input: 1, cacheRead: 0.1, cacheWrite: 1.25, output: 6, total: 8.35 },
@@ -340,6 +341,8 @@ describe("estimateCost", () => {
     // literal-dot alias in server/internal/metrics/pricing.go (MUL-4347).
     expect(isModelPriced("gpt-5-6-luna")).toBe(false);
     expect(isModelPriced("gpt-5-6-sol")).toBe(false);
+    expect(isModelPriced("gpt-6-astra")).toBe(true);
+    expect(isModelPriced("gpt-6-astra-pro")).toBe(false);
     expect(
       estimateCost({
         ...zeroUsage,

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -223,12 +223,13 @@ const MODEL_PRICING: Record<
   // -- OpenAI: dotted-minor Codex catalog SKUs. Each generation is priced
   //    independently — no fallback to `gpt-5`. Entries track
   //    `server/pkg/agent/models.go` (Codex provider list).
-  //    gpt-5.6 (sol/terra/luna) uses OpenAI's official announcement rates.
+  //    gpt-6-astra and gpt-5.6 (sol/terra/luna) use OpenAI's official rates.
   //    5.6+ is the first OpenAI generation to bill cache writes separately:
   //    cacheRead = 0.1x input (90% cached-input discount), cacheWrite = 1.25x
   //    input (see the header note above). Codex usage doesn't yet report
   //    cache-write tokens, so cacheWrite isn't exercised today, but the rate
   //    is kept correct for when it is.
+  "gpt-6-astra":        { input: 10,   output: 50,   cacheRead: 1.00,  cacheWrite: 12.50 },
   "gpt-5.6-sol":        { input: 5,    output: 30,   cacheRead: 0.50,  cacheWrite: 6.25 },
   "gpt-5.6-terra":      { input: 2.50, output: 15,   cacheRead: 0.25,  cacheWrite: 3.125 },
   "gpt-5.6-luna":       { input: 1,    output: 6,    cacheRead: 0.10,  cacheWrite: 1.25 },

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -21,13 +21,14 @@ type ModelPrice struct {
 }
 
 var modelPrices = map[string]ModelPrice{
-	// GPT-5.6 series (Codex `codex` provider). Official rates from OpenAI's
-	// GPT-5.6 announcement (openai.com/index/previewing-gpt-5-6-sol). For 5.6+
-	// cache read is the 90%-off cached-input rate (0.1x input) and cache write
-	// is billed at 1.25x the uncached input rate — unlike earlier OpenAI SKUs,
-	// which don't bill cache writes separately. Codex app-server v0.147 reports
-	// cache-write input separately while including it in the raw input total;
-	// the collector normalizes those into mutually exclusive billing buckets.
+	// GPT-6 Astra and GPT-5.6 series (Codex `codex` provider). Official rates
+	// from OpenAI's announcements. For 5.6+ (including Astra) cache read is the
+	// 90%-off cached-input rate (0.1x input) and cache write is billed at 1.25x
+	// the uncached input rate — unlike earlier OpenAI SKUs, which don't bill
+	// cache writes separately. Codex app-server v0.147 reports cache-write
+	// input separately while including it in the raw input total; the collector
+	// normalizes those into mutually exclusive billing buckets.
+	"openai:gpt-6-astra":   {Provider: "openai", Model: "gpt-6-astra", InputPerM: 10.00, CacheReadPerM: 1.00, CacheWritePerM: 12.50, OutputPerM: 50.00},
 	"openai:gpt-5.6-sol":   {Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 30.00},
 	"openai:gpt-5.6-terra": {Provider: "openai", Model: "gpt-5.6-terra", InputPerM: 2.50, CacheReadPerM: 0.25, CacheWritePerM: 3.125, OutputPerM: 15.00},
 	"openai:gpt-5.6-luna":  {Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 1.00, CacheReadPerM: 0.10, CacheWritePerM: 1.25, OutputPerM: 6.00},
@@ -140,6 +141,7 @@ var modelAliasRules = []struct {
 	// slug is always dotted (`gpt-5.6-luna`), and the frontend resolver in
 	// utils.ts does NOT dash-normalize, so a dashed `gpt-5-6-luna` must surface
 	// as unmapped on both sides rather than silently borrowing a tier here.
+	{regexp.MustCompile(`(^|/|:)gpt-6-astra$`), "openai:gpt-6-astra"},
 	{regexp.MustCompile(`(^|/|:)gpt-5\.6-sol$`), "openai:gpt-5.6-sol"},
 	{regexp.MustCompile(`(^|/|:)gpt-5\.6-terra$`), "openai:gpt-5.6-terra"},
 	{regexp.MustCompile(`(^|/|:)gpt-5\.6-luna$`), "openai:gpt-5.6-luna"},

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -66,6 +66,10 @@ func TestPriceForModelAliasCodexGPT56(t *testing.T) {
 		want  ModelPrice
 	}{
 		{
+			model: "gpt-6-astra",
+			want:  ModelPrice{Provider: "openai", Model: "gpt-6-astra", InputPerM: 10, CacheReadPerM: 1, CacheWritePerM: 12.5, OutputPerM: 50},
+		},
+		{
 			model: "gpt-5.6-sol",
 			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5, CacheReadPerM: 0.5, CacheWritePerM: 6.25, OutputPerM: 30},
 		},
@@ -95,6 +99,9 @@ func TestPriceForModelAliasCodexGPT56(t *testing.T) {
 	// slug is always dotted and the frontend does not dash-normalize, so both
 	// sides surface these as unmapped instead of silently pricing them.
 	for _, model := range []string{
+		"gpt-6-astra-pro",
+		"gpt-6-astra/unknown",
+		"gpt-6-astra-high",
 		"gpt-5.6-luna-pro",
 		"gpt-5.6-luna/unknown",
 		"gpt-5.6-sol-high",

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -600,8 +600,9 @@ func codexStaticModels() []Model {
 	// multica#2009). It is deliberately NOT used to validate effort for an
 	// empty (follow-CLI-config) model: that config can resolve to any model,
 	// so ValidateThinkingLevel fails an empty codex model closed rather than
-	// borrowing this entry's catalog (which alone advertises `ultra`) — see
-	// ValidateThinkingLevel and MUL-4347. Keep exactly one entry flagged.
+	// borrowing this entry's catalog (Astra/Sol/Terra advertise `ultra`; Luna
+	// does not) — see ValidateThinkingLevel and MUL-4347. Keep exactly one
+	// entry flagged.
 	standardThinking := func(defaultLevel string, includeMax, includeUltra bool) *ModelThinking {
 		levels := []ThinkingLevel{
 			{Value: "low", Label: "Low", Description: "Fast responses with lighter reasoning"},
@@ -629,7 +630,8 @@ func codexStaticModels() []Model {
 		}
 	}
 	return []Model{
-		{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Provider: "openai", Default: true, Thinking: standardThinking("low", true, true)},
+		{ID: "gpt-6-astra", Label: "GPT-6 Astra", Provider: "openai", Default: true, Thinking: standardThinking("low", true, true)},
+		{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Provider: "openai", Thinking: standardThinking("low", true, true)},
 		{ID: "gpt-5.6-terra", Label: "GPT-5.6 Terra", Provider: "openai", Thinking: standardThinking("medium", true, true)},
 		{ID: "gpt-5.6-luna", Label: "GPT-5.6 Luna", Provider: "openai", Thinking: standardThinking("medium", true, false)},
 		{ID: "gpt-5.5", Label: "GPT-5.5", Provider: "openai", Thinking: standardThinking("medium", false, false)},

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -494,6 +494,12 @@ func TestModelKnownIncompatibleWithProvider(t *testing.T) {
 			want:     false,
 		},
 		{
+			name:     "codex live-catalog gpt-6-astra is compatible",
+			provider: "codex",
+			model:    "gpt-6-astra",
+			want:     false,
+		},
+		{
 			name:     "codex model is incompatible with claude",
 			provider: "claude",
 			model:    "o3",

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -422,6 +422,8 @@ func parseCodexModelCatalog(raw []byte) ([]Model, error) {
 
 func normalizeCodexModelLabel(id, label string) string {
 	switch id {
+	case "gpt-6-astra":
+		return "GPT-6 Astra"
 	case "gpt-5.6-sol":
 		return "GPT-5.6 Sol"
 	case "gpt-5.6-terra":
@@ -632,9 +634,9 @@ func catalogLoader(ctx context.Context, providerType string, cmd Command) func()
 //
 //   - codex: the effective model comes from the user's local config.toml
 //     and can be ANY installed model, not necessarily the catalog's flagged
-//     Default. Borrowing the Default entry (gpt-5.6-sol, the only one
-//     advertising `ultra`) would green-light levels the actually-configured
-//     model may not support — Luna tops out at `max`, gpt-5.5/5.4 at `xhigh`
+//     Default. Borrowing the Default entry would green-light levels the
+//     actually-configured model may not support — Astra/Sol/Terra advertise
+//     `ultra`, Luna tops out at `max`, gpt-5.5/5.4 at `xhigh`
 //     — and Codex does not reject the mismatch itself. We can't know the
 //     effective model without parsing config.toml in the task cwd (see this
 //     file's Codex header for why that's avoided), so an empty codex model

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -267,6 +267,12 @@ func TestParseCodexModelCatalog(t *testing.T) {
 				"supported_reasoning_levels": []
 			},
 			{
+				"slug": "gpt-6-astra",
+				"display_name": "GPT-6-Astra",
+				"visibility": "list",
+				"supported_reasoning_levels": []
+			},
+			{
 				"slug": "hidden-model",
 				"display_name": "Hidden",
 				"visibility": "hide",
@@ -284,8 +290,8 @@ func TestParseCodexModelCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseCodexModelCatalog: %v", err)
 	}
-	if len(got) != 4 {
-		t.Fatalf("expected four visible models, got %+v", got)
+	if len(got) != 5 {
+		t.Fatalf("expected five visible models, got %+v", got)
 	}
 	if got[0].ID != "gpt-5.6-sol" || got[0].Label != "GPT-5.6 Sol" || !got[0].Default {
 		t.Errorf("unexpected first model: %+v", got[0])
@@ -297,6 +303,7 @@ func TestParseCodexModelCatalog(t *testing.T) {
 		{"gpt-5.6-sol", "GPT-5.6 Sol"},
 		{"gpt-5.6-terra", "GPT-5.6 Terra"},
 		{"gpt-5.6-luna", "GPT-5.6 Luna"},
+		{"gpt-6-astra", "GPT-6 Astra"},
 	} {
 		var found *Model
 		for i := range got {
@@ -319,8 +326,8 @@ func TestParseCodexModelCatalog(t *testing.T) {
 	if len(got[0].ServiceTiers) != 1 || got[0].ServiceTiers[0].ID != "priority" || got[0].ServiceTiers[0].Name != "Fast" {
 		t.Errorf("unexpected service-tier catalog: %+v", got[0].ServiceTiers)
 	}
-	if got[3].ID != "no-reasoning" || got[3].Thinking != nil {
-		t.Errorf("model without reasoning should remain selectable without a thinking picker: %+v", got[3])
+	if got[4].ID != "no-reasoning" || got[4].Thinking != nil {
+		t.Errorf("model without reasoning should remain selectable without a thinking picker: %+v", got[4])
 	}
 }
 
@@ -367,7 +374,7 @@ echo '{"models":[{"slug":"runtime-model","display_name":"Runtime Model","visibil
 		writeTestExecutable(t, fake, []byte(script))
 
 		got := discoverCodexModels(context.Background(), Command{Path: fake})
-		if len(got) == 0 || got[0].ID != "gpt-5.6-sol" {
+		if len(got) == 0 || got[0].ID != "gpt-6-astra" {
 			t.Fatalf("expected static fallback, got %+v", got)
 		}
 		if got[0].SupportsExplicitStandardServiceTier {
@@ -384,7 +391,7 @@ echo '{"models":[{"slug":"runtime-model","display_name":"Runtime Model","visibil
 		writeTestExecutable(t, fake, []byte(script))
 
 		got := discoverCodexModels(context.Background(), Command{Path: fake})
-		if len(got) == 0 || got[0].ID != "gpt-5.6-sol" || got[0].Thinking == nil {
+		if len(got) == 0 || got[0].ID != "gpt-6-astra" || got[0].Thinking == nil {
 			t.Fatalf("expected model + thinking fallback, got %+v", got)
 		}
 		if !got[0].SupportsExplicitStandardServiceTier {
@@ -400,6 +407,9 @@ func TestValidateThinkingLevelCodexPerModelFallbackCatalog(t *testing.T) {
 		level string
 		want  bool
 	}{
+		{model: "gpt-6-astra", level: "low", want: true},
+		{model: "gpt-6-astra", level: "max", want: true},
+		{model: "gpt-6-astra", level: "ultra", want: true},
 		{model: "gpt-5.6-sol", level: "ultra", want: true},
 		{model: "gpt-5.6-terra", level: "ultra", want: true},
 		{model: "gpt-5.6-luna", level: "max", want: true},
@@ -791,10 +801,11 @@ func TestValidateThinkingLevel_ExplicitModel(t *testing.T) {
 // fix: an explicit codex model is validated against its own per-model
 // catalog, but an EMPTY model (follow config.toml, which can resolve to any
 // installed model) must NOT borrow the flagged Default entry's catalog. The
-// Default (gpt-5.6-sol) alone advertises `ultra`; letting an empty model
-// inherit it would green-light a level Luna / gpt-5.5 don't support and Codex
-// won't reject. So an empty codex model fails closed for every level and the
-// daemon drops it — users must pick an explicit model to pin an effort.
+// flagged Default (currently Astra) advertises `ultra`; letting an empty
+// model inherit that catalog would green-light a level Luna / gpt-5.5 don't
+// support and Codex won't reject. So an empty codex model fails closed for
+// every level and the daemon drops it — users must pick an explicit model to
+// pin an effort.
 func TestValidateThinkingLevel_CodexEmptyModelFailsClosed(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fake binary requires a POSIX shell")
@@ -822,7 +833,7 @@ func TestValidateThinkingLevel_CodexEmptyModelFailsClosed(t *testing.T) {
 	check("gpt-5.6-luna", "medium", true) // as are the base levels
 
 	// Empty model cannot be validated per-model, so it fails closed for EVERY
-	// level — including `ultra` (must not pass via the Sol Default) and even a
+	// level — including `ultra` (must not pass via the flagged Default) and even a
 	// level every model supports (`medium`). The daemon drops it.
 	check("", "ultra", false)
 	check("", "medium", false)


### PR DESCRIPTION
## Summary

Codex CLI live catalogs already advertise `gpt-6-astra`. Multica still treats Codex compatibility as an exact match against `codexStaticModels()`, so a `gpt-*` id that is not in that snapshot is rejected as `model_unavailable`.

This adds `gpt-6-astra` to the static Codex catalog (current flagship `Default`; thinking `low`…`ultra`) and syncs the front/back pricing tables to OpenAI's published $10 / $50 rates (cache read $1, cache write $12.50).

Related: #8177 / #8205 switch discovery to the effective catalog. That helps the picker; it does not change this server-side allowlist.

## Test plan

- [ ] `go test ./pkg/agent ./internal/metrics -run 'TestModelKnownIncompatibleWithProvider|TestParseCodexModelCatalog$|TestDiscoverCodexModelsVersionGateAndFallback|TestValidateThinkingLevelCodexPerModelFallbackCatalog|TestStaticModelCatalogsAreValid|TestPriceForModelAliasCodexGPT56' -count=1`
- [ ] On a Codex runtime whose CLI catalog includes `gpt-6-astra`, save that model and confirm `resolution_status=ready` (no "Runtime model unavailable" toast)
- [ ] Settings picker for `gpt-6-astra` lists `ultra`

Fixes #8219
