### PR TITLE
MUL-7201: feat(cli): expose agent conversation starters on create and update

### DIFF
--- a/apps/docs/content/docs/agents-create.ja.mdx
+++ b/apps/docs/content/docs/agents-create.ja.mdx
@@ -71,6 +71,8 @@ Build with AI には、Builder との対話のためにオンラインのラン�
 
 空のままなら、チャットにはローカライズされた汎用の初期値が表示されます。エージェントの役割と境界に合わせた例のほうが通常は役立ちます。
 
+CLI では `agent create` / `agent update` の `--conversation-starters` で設定します（`{"label","prompt"}` オブジェクトの JSON 配列。更新時に `'[]'` を渡すとクリア）。`agent copy` は元の値をコピーするだけで、上書き用のフラグはありません。
+
 ## ランタイム・モデル・思考レベルの選択
 
 ランタイムは、それぞれ 1 つの AI コーディングツールに対応しています。ランタイムを選ぶと、そのツールがサポートするモデルと思考レベルを続けて選べます。一部のツール（Codex など）ではサービスティアも選べます。
@@ -146,7 +148,8 @@ multica agent create \
   --name "Frontend Reviewer" \
   --runtime-id <runtime-id> \
   --description "フロントエンドの Pull Request をレビューする" \
-  --instructions "まず変更とテストを読み、レビュー結果は issue のコメントだけに投稿する。"
+  --instructions "まず変更とテストを読み、レビュー結果は issue のコメントだけに投稿する。" \
+  --conversation-starters '[{"label":"PR をレビュー","prompt":"今いちばん関連する未マージの Pull Request をレビューする。"}]'
 ```
 
 コマンドライン引数の平文はシェル履歴に残ります。stdin と権限を制限したファイルは残りません。

--- a/apps/docs/content/docs/agents-create.ko.mdx
+++ b/apps/docs/content/docs/agents-create.ko.mdx
@@ -71,6 +71,8 @@ AI로 만들려면 Builder 대화를 진행할 온라인 런타임이 필요합�
 
 목록을 비워 두면 채팅에 현지화된 범용 기본값이 표시됩니다. 에이전트의 역할과 경계에 맞춘 예시가 보통 더 유용합니다.
 
+CLI에서는 `agent create` / `agent update`의 `--conversation-starters`로 설정합니다(`{"label","prompt"}` 객체의 JSON 배열, 업데이트 시 `'[]'`를 넘기면 지워집니다). `agent copy`는 원본 값만 복사하며 덮어쓰기 플래그는 없습니다.
+
 ## 런타임, 모델, 사고 강도 선택
 
 런타임은 이미 특정 AI 코딩 도구에 대응합니다. 런타임을 선택한 뒤 해당 도구가 지원하는 모델과 사고 강도를 선택할 수 있습니다. Codex 같은 일부 도구에서는 속도 단계도 선택할 수 있습니다.
@@ -146,7 +148,8 @@ multica agent create \
   --name "Frontend Reviewer" \
   --runtime-id <runtime-id> \
   --description "프런트엔드 Pull Request 검토" \
-  --instructions "먼저 변경 사항과 테스트를 읽고 태스크 댓글에만 검토 결론을 제출하세요."
+  --instructions "먼저 변경 사항과 테스트를 읽고 태스크 댓글에만 검토 결론을 제출하세요." \
+  --conversation-starters '[{"label":"PR 검토","prompt":"가장 관련 있는 미병합 Pull Request를 검토하세요."}]'
 ```
 
 명령줄 인수의 평문은 shell 기록에 남습니다. stdin과 권한이 제한된 파일은 기록에 남지 않습니다.

--- a/apps/docs/content/docs/agents-create.mdx
+++ b/apps/docs/content/docs/agents-create.mdx
@@ -71,6 +71,8 @@ The editor previews exactly what a new chat will show, and anyone who can edit t
 
 If you leave the list empty, Chat shows localized general-purpose defaults. Agent-specific examples are usually more useful because they can reflect the role and boundaries in the instructions.
 
+From the CLI, set them with `--conversation-starters` on `agent create` and `agent update` (a JSON array of `{ "label", "prompt" }` objects; pass `'[]'` on update to clear). `agent copy` still copies the source value and has no override flag.
+
 ## Runtime, model, and thinking level
 
 Each runtime already maps to one AI coding tool. After picking a runtime, you can pick a model and thinking level the tool supports; some tools (such as Codex) also offer a service tier:
@@ -146,7 +148,8 @@ multica agent create \
   --name "Frontend Reviewer" \
   --runtime-id <runtime-id> \
   --description "Reviews frontend pull requests" \
-  --instructions "Read the diff and tests first; post review conclusions only as issue comments."
+  --instructions "Read the diff and tests first; post review conclusions only as issue comments." \
+  --conversation-starters '[{"label":"Review a PR","prompt":"Review the most relevant open pull request."}]'
 ```
 
 Plaintext in command-line arguments ends up in shell history; stdin and permission-restricted files do not.

--- a/apps/docs/content/docs/agents-create.zh.mdx
+++ b/apps/docs/content/docs/agents-create.zh.mdx
@@ -71,6 +71,8 @@ Skill 适合保存可以跨智能体复用的方法和资料；只属于这名�
 
 留空时，对话页会显示本地化的通用默认值。针对智能体职责和边界编写的示例通常更有帮助。
 
+CLI 可用 `agent create` / `agent update` 的 `--conversation-starters` 设置（`{"label","prompt"}` 对象的 JSON 数组；更新时传 `'[]'` 清空）。`agent copy` 仍只搬运源值，没有覆盖 flag。
+
 ## 选择运行时、模型和思考强度
 
 运行时已经对应一款 AI 编程工具。选择运行时后，可以继续选择该工具支持的模型和思考强度；部分工具（如 Codex）还可选择速度档：
@@ -146,7 +148,8 @@ multica agent create \
  --name "Frontend Reviewer" \
  --runtime-id <runtime-id> \
  --description "审查前端 Pull Request" \
- --instructions "先阅读改动和测试，只在 issue 评论中提交审查结论。"
+ --instructions "先阅读改动和测试，只在 issue 评论中提交审查结论。" \
+ --conversation-starters '[{"label":"审查 PR","prompt":"审查当前最相关的未合并 Pull Request。"}]'
 ```
 
 命令行参数中的明文会进入 shell 历史；stdin 和权限受限的文件不会。

--- a/apps/docs/content/docs/cli.ja.mdx
+++ b/apps/docs/content/docs/cli.ja.mdx
@@ -249,7 +249,7 @@ CLI の設定ファイルには、あなたとして Multica にアクセスで�
 | | `resource list/add/update/remove` | プロジェクトの追加リソースを管理 | `--type`、`--url`、`--local-path`、`--daemon-id`、`--execution-mode`（ローカルディレクトリの `in_place` / `worktree`） |
 | `label` | `list/get/create/update/delete` | ワークスペースのラベルを管理 | |
 | `property` | `list/get/create/update/archive/unarchive` | ワークスペースのカスタムプロパティを管理 | `create`: `--name`、`--type`（`text`、`number`、`select`、`multi_select`、`date`、`checkbox`、`url`、`actor`、`multi_actor`）、`--option`（繰り返し可、select 系のみ）；`list`: `--include-archived`；タイプは作成後に変更できません |
-| `agent` | `list/get/create/update/archive/restore` | エージェントを管理 | `--name`、`--runtime-id`（`create` では必須）、`--instructions`、`--model`、`--thinking-level`、`--mcp-config`、`--permission-mode`、`--max-concurrent-tasks` |
+| `agent` | `list/get/create/update/archive/restore` | エージェントを管理 | `--name`、`--runtime-id`（`create` では必須）、`--instructions`、`--conversation-starters`、`--model`、`--thinking-level`、`--mcp-config`、`--permission-mode`、`--max-concurrent-tasks` |
 | | `copy <agent-id>` | 新しいエージェントとして複製。元のエージェントは変更されません | `--name`（デフォルトは元の名前 + ` (copy)`）、`--runtime-id`（別のランタイムへ複製する場合は `--model` の同時指定が必須）、`--no-skills`；`custom_env`、`mcp_config`、`runtime_config` などの機密設定は複製されないため、`create` と同じフラグで再指定してください |
 | | `tasks <id>` | エージェントの実行を表示 | |
 | | `avatar <id>` | アバターをアップロード | |

--- a/apps/docs/content/docs/cli.ko.mdx
+++ b/apps/docs/content/docs/cli.ko.mdx
@@ -249,7 +249,7 @@ CLI 설정 파일에는 사용자를 대신해 Multica에 접근할 수 있는 t
 | | `resource list/add/update/remove` | 프로젝트 추가 리소스 관리 | `--type`, `--url`, `--local-path`, `--daemon-id`, `--execution-mode`(로컬 디렉터리의 `in_place` / `worktree`) |
 | `label` | `list/get/create/update/delete` | 워크스페이스 라벨 관리 | |
 | `property` | `list/get/create/update/archive/unarchive` | 워크스페이스 사용자 지정 속성 관리 | `create`: `--name`, `--type`(`text`, `number`, `select`, `multi_select`, `date`, `checkbox`, `url`, `actor`, `multi_actor`), `--option`(반복 가능, select 유형만). `list`: `--include-archived`. 유형은 생성 후 변경 불가 |
-| `agent` | `list/get/create/update/archive/restore` | 에이전트 관리 | `--name`, `--runtime-id`(`create`에서 필수), `--instructions`, `--model`, `--thinking-level`, `--mcp-config`, `--permission-mode`, `--max-concurrent-tasks` |
+| `agent` | `list/get/create/update/archive/restore` | 에이전트 관리 | `--name`, `--runtime-id`(`create`에서 필수), `--instructions`, `--conversation-starters`, `--model`, `--thinking-level`, `--mcp-config`, `--permission-mode`, `--max-concurrent-tasks` |
 | | `copy <agent-id>` | 원래 에이전트에 영향 없이 새 에이전트로 복사 | `--name`(기본값은 원래 이름 + ` (copy)`), `--runtime-id`(다른 런타임으로 복사할 때 `--model`도 필수), `--no-skills`. `custom_env`, `mcp_config`, `runtime_config` 같은 기밀 설정은 복사되지 않으며 `create`와 같은 flag로 다시 제공해야 함 |
 | | `tasks <id>` | 에이전트 실행 확인 | |
 | | `avatar <id>` | 아바타 업로드 | |

--- a/apps/docs/content/docs/cli.mdx
+++ b/apps/docs/content/docs/cli.mdx
@@ -257,7 +257,7 @@ The tables below cover every current top-level command, grouped the way the CLI 
 | | `resource list/add/update/remove` | Manage project resources | `--type`, `--url`, `--local-path`, `--daemon-id`, `--execution-mode` (`in_place` / `worktree` for a local directory) |
 | `label` | `list/get/create/update/delete` | Manage workspace labels | |
 | `property` | `list/get/create/update/archive/unarchive` | Manage workspace custom properties | `create`: `--name`, `--type` (`text`, `number`, `select`, `multi_select`, `date`, `checkbox`, `url`, `actor`, `multi_actor`), `--option` (repeatable, select types only); `list`: `--include-archived`; the type cannot be changed after creation |
-| `agent` | `list/get/create/update/archive/restore` | Manage agents | `--name`, `--runtime-id` (required for `create`), `--instructions`, `--model`, `--thinking-level`, `--mcp-config`, `--permission-mode`, `--max-concurrent-tasks` |
+| `agent` | `list/get/create/update/archive/restore` | Manage agents | `--name`, `--runtime-id` (required for `create`), `--instructions`, `--conversation-starters`, `--model`, `--thinking-level`, `--mcp-config`, `--permission-mode`, `--max-concurrent-tasks` |
 | | `copy <agent-id>` | Copy into a new agent; the original is untouched | `--name` (defaults to the original name plus ` (copy)`), `--runtime-id` (copying to another runtime also requires `--model`), `--no-skills`; secret configuration such as `custom_env`, `mcp_config`, and `runtime_config` is not copied — re-provide it with the same flags as `create` |
 | | `tasks <id>` | View an agent's runs | |
 | | `avatar <id>` | Upload an avatar | |

--- a/apps/docs/content/docs/cli.zh.mdx
+++ b/apps/docs/content/docs/cli.zh.mdx
@@ -249,7 +249,7 @@ CLI 配置文件包含可代表你访问 Multica 的令牌。不要提交到仓�
 | | `resource list/add/update/remove` | 管理项目附加资源 | `--type`、`--url`、`--local-path`、`--daemon-id`、`--execution-mode`（本地目录的 `in_place` / `worktree`） |
 | `label` | `list/get/create/update/delete` | 管理工作区标签 | |
 | `property` | `list/get/create/update/archive/unarchive` | 管理工作区自定义属性 | `create`：`--name`、`--type`（`text`、`number`、`select`、`multi_select`、`date`、`checkbox`、`url`、`actor`、`multi_actor`）、`--option`（可重复，仅 select 类型）；`list`：`--include-archived`；类型创建后不可修改 |
-| `agent` | `list/get/create/update/archive/restore` | 管理智能体 | `--name`、`--runtime-id`（`create` 必填）、`--instructions`、`--model`、`--thinking-level`、`--mcp-config`、`--permission-mode`、`--max-concurrent-tasks` |
+| `agent` | `list/get/create/update/archive/restore` | 管理智能体 | `--name`、`--runtime-id`（`create` 必填）、`--instructions`、`--conversation-starters`、`--model`、`--thinking-level`、`--mcp-config`、`--permission-mode`、`--max-concurrent-tasks` |
 | | `copy <agent-id>` | 复制为新智能体，原智能体不受影响 | `--name`（默认为原名加 ` (copy)`）、`--runtime-id`（复制到其他运行时时必须同时指定 `--model`）、`--no-skills`；`custom_env`、`mcp_config`、`runtime_config` 等机密配置不会复制，需用与 `create` 相同的 flag 重新提供 |
 | | `tasks <id>` | 查看智能体的运行 | |
 | | `avatar <id>` | 上传头像 | |

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -160,6 +160,7 @@ func init() {
 	agentCreateCmd.Flags().String("name", "", "Agent name (required)")
 	agentCreateCmd.Flags().String("description", "", "Agent description")
 	agentCreateCmd.Flags().String("instructions", "", "Agent instructions")
+	agentCreateCmd.Flags().String("conversation-starters", "", "Conversation starters as a JSON array of {\"label\",\"prompt\"} objects (at most 3; label ≤80, prompt ≤4000). Shown above the Chat composer; selecting one fills the composer and does not start a run. Omit to default to none.")
 	agentCreateCmd.Flags().String("runtime-id", "", "Runtime ID (required)")
 	agentCreateCmd.Flags().String("runtime-config", "", "Runtime config as JSON string")
 	agentCreateCmd.Flags().String("model", "", "Model identifier (e.g. claude-sonnet-4-6, openai/gpt-4o). Prefer this over passing --model in --custom-args.")
@@ -183,6 +184,7 @@ func init() {
 	agentUpdateCmd.Flags().String("name", "", "New name")
 	agentUpdateCmd.Flags().String("description", "", "New description")
 	agentUpdateCmd.Flags().String("instructions", "", "New instructions")
+	agentUpdateCmd.Flags().String("conversation-starters", "", "New conversation starters as a JSON array of {\"label\",\"prompt\"} objects (at most 3; label ≤80, prompt ≤4000). Pass '[]' to clear. Omit to leave the stored value unchanged.")
 	agentUpdateCmd.Flags().String("runtime-id", "", "New runtime ID")
 	agentUpdateCmd.Flags().String("runtime-config", "", "New runtime config as JSON string")
 	agentUpdateCmd.Flags().String("model", "", "New model identifier. Pass an empty string to clear and fall back to the runtime default.")
@@ -653,6 +655,9 @@ func runAgentCreate(cmd *cobra.Command, _ []string) error {
 	if v, _ := cmd.Flags().GetString("instructions"); v != "" {
 		body["instructions"] = v
 	}
+	if err := applyConversationStartersFlag(cmd, body); err != nil {
+		return err
+	}
 	if cmd.Flags().Changed("runtime-config") {
 		v, _ := cmd.Flags().GetString("runtime-config")
 		var rc any
@@ -744,6 +749,9 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("instructions")
 		body["instructions"] = v
 	}
+	if err := applyConversationStartersFlag(cmd, body); err != nil {
+		return err
+	}
 	if cmd.Flags().Changed("runtime-id") {
 		v, _ := cmd.Flags().GetString("runtime-id")
 		body["runtime_id"] = v
@@ -802,7 +810,7 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --thinking-level, --service-tier, --custom-args, --mcp-config, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
+		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --conversation-starters, --runtime-id, --runtime-config, --model, --thinking-level, --service-tier, --custom-args, --mcp-config, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
 	}
 
 	ctx, cancel := cli.APIContext(context.Background())
@@ -1233,6 +1241,48 @@ func parseCustomArgs(raw string) ([]string, error) {
 		return nil, fmt.Errorf("--custom-args must be a valid JSON array of strings")
 	}
 	return ca, nil
+}
+
+// agentConversationStarter is the CLI wire shape for conversation_starters.
+// Limits match the server/handler and packages/core/agents/constants.ts.
+type agentConversationStarter struct {
+	Label  string `json:"label"`
+	Prompt string `json:"prompt"`
+}
+
+func applyConversationStartersFlag(cmd *cobra.Command, body map[string]any) error {
+	if !cmd.Flags().Changed("conversation-starters") {
+		return nil
+	}
+	v, _ := cmd.Flags().GetString("conversation-starters")
+	starters, err := parseConversationStarters(v)
+	if err != nil {
+		return err
+	}
+	body["conversation_starters"] = starters
+	return nil
+}
+
+// parseConversationStarters parses --conversation-starters (a JSON array of
+// {label, prompt} objects). An explicit [] is a valid clear; null/empty input
+// is rejected so it cannot be confused with omit. A nil slice is coerced to
+// empty so encoding/json emits [] rather than null.
+func parseConversationStarters(raw string) ([]agentConversationStarter, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" || strings.EqualFold(trimmed, "null") {
+		return nil, fmt.Errorf("--conversation-starters must be a JSON array of {\"label\",\"prompt\"} objects; pass '[]' to clear")
+	}
+	var starters []agentConversationStarter
+	if err := json.Unmarshal([]byte(raw), &starters); err != nil {
+		return nil, fmt.Errorf("--conversation-starters must be a JSON array of {\"label\",\"prompt\"} objects")
+	}
+	if starters == nil {
+		starters = []agentConversationStarter{}
+	}
+	if len(starters) > 3 {
+		return nil, fmt.Errorf("--conversation-starters must contain at most 3 items")
+	}
+	return starters, nil
 }
 
 // resolveCustomEnv collects the --custom-env, --custom-env-stdin, and

--- a/server/cmd/multica/cmd_agent_copy_test.go
+++ b/server/cmd/multica/cmd_agent_copy_test.go
@@ -355,3 +355,9 @@ func TestAgentCopyAcceptsExplicitCustomEnv(t *testing.T) {
 		t.Errorf("custom_env[API_KEY] = %v, want fresh", ce["API_KEY"])
 	}
 }
+
+func TestAgentCopyDoesNotExposeConversationStartersOverride(t *testing.T) {
+	if agentCopyCmd.Flag("conversation-starters") != nil {
+		t.Error("agent copy must carry conversation_starters without a dedicated override flag")
+	}
+}

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -2063,3 +2063,203 @@ func TestAgentCreateThinkingLevelServerRejectionSurfaces(t *testing.T) {
 		t.Fatalf("server thinking_level rejection should surface to the user; got: %v", err)
 	}
 }
+
+func TestAgentCreateSendsConversationStarters(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": "agent-123", "name": "TestAgent"})
+	}))
+	defer srv.Close()
+
+	t.Chdir(t.TempDir())
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("runtime-id", "", "")
+	cmd.Flags().String("conversation-starters", "", "")
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().String("profile", "", "")
+	_ = cmd.Flags().Set("name", "TestAgent")
+	_ = cmd.Flags().Set("runtime-id", "runtime-1")
+	_ = cmd.Flags().Set("conversation-starters", `[{"label":"Review a PR","prompt":"Review the open pull request."}]`)
+
+	if err := runAgentCreate(cmd, nil); err != nil {
+		t.Fatalf("runAgentCreate: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/api/agents" {
+		t.Fatalf("path = %q, want /api/agents", gotPath)
+	}
+	got, ok := gotBody["conversation_starters"].([]any)
+	if !ok {
+		t.Fatalf("conversation_starters body = %v, want array", gotBody["conversation_starters"])
+	}
+	if !reflect.DeepEqual(got, []any{
+		map[string]any{"label": "Review a PR", "prompt": "Review the open pull request."},
+	}) {
+		t.Fatalf("conversation_starters body = %v", got)
+	}
+}
+
+func TestAgentCreateOmitsConversationStartersWhenUnset(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": "agent-123", "name": "TestAgent"})
+	}))
+	defer srv.Close()
+
+	t.Chdir(t.TempDir())
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("runtime-id", "", "")
+	cmd.Flags().String("conversation-starters", "", "")
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().String("profile", "", "")
+	_ = cmd.Flags().Set("name", "TestAgent")
+	_ = cmd.Flags().Set("runtime-id", "runtime-1")
+
+	if err := runAgentCreate(cmd, nil); err != nil {
+		t.Fatalf("runAgentCreate: %v", err)
+	}
+	if _, ok := gotBody["conversation_starters"]; ok {
+		t.Fatalf("unset --conversation-starters must be omitted from the body; got %v", gotBody)
+	}
+}
+
+func TestAgentUpdateSendsConversationStarters(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  []any
+	}{
+		{
+			name:  "set explicit starters",
+			value: `[{"label":"Review a PR","prompt":"Review the open pull request."}]`,
+			want: []any{
+				map[string]any{"label": "Review a PR", "prompt": "Review the open pull request."},
+			},
+		},
+		{"empty array clears", "[]", []any{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Errorf("decode request body: %v", err)
+				}
+				json.NewEncoder(w).Encode(map[string]any{"id": "agent-123", "name": "TestAgent"})
+			}))
+			defer srv.Close()
+
+			t.Chdir(t.TempDir())
+			t.Setenv("MULTICA_SERVER_URL", srv.URL)
+			t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+			t.Setenv("MULTICA_TOKEN", "test-token")
+			t.Setenv("MULTICA_AGENT_ID", "")
+			t.Setenv("MULTICA_TASK_ID", "")
+
+			cmd := &cobra.Command{Use: "update"}
+			cmd.Flags().String("conversation-starters", "", "")
+			cmd.Flags().String("output", "json", "")
+			cmd.Flags().String("profile", "", "")
+			if err := cmd.Flags().Set("conversation-starters", tc.value); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := runAgentUpdate(cmd, []string{"agent-123"}); err != nil {
+				t.Fatalf("runAgentUpdate: %v", err)
+			}
+			if gotMethod != http.MethodPut {
+				t.Fatalf("method = %s, want PUT", gotMethod)
+			}
+			if gotPath != "/api/agents/agent-123" {
+				t.Fatalf("path = %q, want /api/agents/agent-123", gotPath)
+			}
+			got, ok := gotBody["conversation_starters"].([]any)
+			if !ok {
+				t.Fatalf("body missing conversation_starters array; got %v", gotBody)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("conversation_starters body = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentCreateAndUpdateExposeConversationStartersFlag(t *testing.T) {
+	if agentCreateCmd.Flag("conversation-starters") == nil {
+		t.Error("agent create must expose --conversation-starters")
+	}
+	if agentUpdateCmd.Flag("conversation-starters") == nil {
+		t.Error("agent update must expose --conversation-starters")
+	}
+	for name, usage := range map[string]string{
+		"create": agentCreateCmd.Flag("conversation-starters").Usage,
+		"update": agentUpdateCmd.Flag("conversation-starters").Usage,
+	} {
+		for _, contract := range []string{`{"label","prompt"}`, "3"} {
+			if !strings.Contains(usage, contract) {
+				t.Errorf("agent %s --conversation-starters help = %q, want %q", name, usage, contract)
+			}
+		}
+	}
+	if !strings.Contains(agentUpdateCmd.Flag("conversation-starters").Usage, "[]") {
+		t.Errorf("agent update --conversation-starters help must mention [] to clear; got %q", agentUpdateCmd.Flag("conversation-starters").Usage)
+	}
+}
+
+func TestParseConversationStarters(t *testing.T) {
+	t.Run("empty array", func(t *testing.T) {
+		got, err := parseConversationStarters("[]")
+		if err != nil {
+			t.Fatalf("parseConversationStarters([]): %v", err)
+		}
+		if got == nil || len(got) != 0 {
+			t.Fatalf("got %#v, want empty non-nil slice", got)
+		}
+	})
+	t.Run("rejects null", func(t *testing.T) {
+		_, err := parseConversationStarters("null")
+		if err == nil || !strings.Contains(err.Error(), "[]") {
+			t.Fatalf("expected []-to-clear error, got %v", err)
+		}
+	})
+	t.Run("rejects more than three", func(t *testing.T) {
+		_, err := parseConversationStarters(`[{"label":"a","prompt":"a"},{"label":"b","prompt":"b"},{"label":"c","prompt":"c"},{"label":"d","prompt":"d"}]`)
+		if err == nil || !strings.Contains(err.Error(), "at most 3") {
+			t.Fatalf("expected max-3 error, got %v", err)
+		}
+	})
+	t.Run("rejects object", func(t *testing.T) {
+		_, err := parseConversationStarters(`{"label":"a","prompt":"a"}`)
+		if err == nil || !strings.Contains(err.Error(), "JSON array") {
+			t.Fatalf("expected array error, got %v", err)
+		}
+	})
+}

--- a/server/internal/service/builtin_skills/multica-platform/references/agents.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/agents.md
@@ -65,21 +65,17 @@ multica agent create --name <name> --runtime-id <runtime-id> \
 
 The CLI builds a JSON body and posts it to `/api/agents`. It only adds a key
 when its flag was provided — `description`/`instructions` on a non-empty value,
-the rest (`runtime-config`, `custom-args`, `model`, `thinking-level`,
-`service-tier`, `visibility`, …) on the flag being explicitly set — so omitted
-flags fall through to server defaults rather than sending empty strings.
-`--max-concurrent-tasks` is validated as 1–50 before the request is sent.
+the rest (`runtime-config`, `custom-args`, `conversation-starters`, `model`,
+`thinking-level`, `service-tier`, `visibility`, …) on the flag being explicitly
+set — so omitted flags fall through to server defaults rather than sending
+empty strings. `--max-concurrent-tasks` is validated as 1–50 before the
+request is sent. `--conversation-starters` is a JSON array of `{label, prompt}`
+objects (at most 3); pass `'[]'` on update to clear.
 
 The HTTP body accepts: `name`, `description`, `instructions`,
 `conversation_starters`, `avatar_url`, `runtime_id`, `runtime_config`,
 `custom_env`, `custom_args`, `model`, `thinking_level`, `service_tier`,
 `visibility`, `max_concurrent_tasks`, `mcp_config`, `skill_ids`.
-
-The body accepts more than the CLI exposes. `conversation_starters` has no
-`agent create` / `agent update` flag — the CLI can only carry it across an
-`agent copy`. Setting it for a new agent means either calling `/api/agents`
-directly or telling the human to use the web UI; see below for where they
-will find it.
 
 ## Copying an agent
 
@@ -203,6 +199,11 @@ Omitting the field on create defaults to `[]`; omitting it on update preserves
 the stored value, and an explicit `[]` clears it. An agent with none
 configured still shows three built-in generic defaults in that empty state, so
 "the Chat shows suggestions" does not mean this agent has any of its own.
+
+Set them from the CLI with `--conversation-starters` on `agent create` and
+`agent update`. The flag is Changed-gated like `--custom-args`: omit it to
+leave the server default (create) or the stored value (update); pass `'[]'`
+to clear. `agent copy` still carries the source value and has no override flag.
 
 ### model vs custom_args
 
@@ -368,9 +369,8 @@ State-changing (require an explicit instruction — do not run speculatively):
   clear; only `custom_env` is gated behind the dedicated env endpoint.
 - "`agent get` shows env values." It shows only `has_custom_env` and
   `custom_env_key_count`.
-- "Every accepted body field has a CLI flag." `conversation_starters` does not
-  — `agent create`/`agent update` cannot set it, and `agent copy` only carries
-  an existing value forward.
+- "`agent copy` can override conversation starters." It cannot — create and
+  update take `--conversation-starters`, but copy only carries the source value.
 - "An invalid `thinking_level`/`model` combo is caught at create." Only an
   unknown provider-level literal is — model-specific gaps fail at run time.
 - "`set` and `add` are interchangeable for skills." `set` replaces all


### PR DESCRIPTION
## What does this PR do?

The server already accepts `conversation_starters` on agent create/update, and the web UI can write them. `multica agent create` / `agent update` had no flag, so CLI users had to drop to raw HTTP. This wires `--conversation-starters` in the same Changed-gated style as `--custom-args`.

`agent copy` still copies the source value and does not gain an override flag.

## Related Issue

Closes #8224

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- `server/cmd/multica/cmd_agent.go`: add `--conversation-starters` to create/update, parse a JSON array of `{label, prompt}` objects, send `[]` (never `null`) so update can clear.
- `server/cmd/multica/cmd_agent_test.go` / `cmd_agent_copy_test.go`: cover create, omit, update set/clear, help, invalid JSON, and copy-has-no-override.
- Docs and the platform agents skill: document the flag; copy remains carry-only.

## How to Test

From `server/`:

```sh
../scripts/go-test-with-agent-cli-guard.sh -- go test ./cmd/multica -count=1 -run 'TestAgentCreateSendsConversationStarters|TestAgentCreateOmitsConversationStartersWhenUnset|TestAgentUpdateSendsConversationStarters|TestAgentCreateAndUpdateExposeConversationStartersFlag|TestParseConversationStarters|TestAgentCopyDoesNotExposeConversationStartersOverride|TestAgentCopySameRuntimeCopiesPortableFields'
go vet ./cmd/multica
```

These passed locally.

Manual:

```sh
multica agent create --name "Reviewer" --runtime-id <runtime-id> \
  --conversation-starters '[{"label":"Review a PR","prompt":"Review the most relevant open pull request."}]'
multica agent update <id> --conversation-starters '[]'   # clear
multica agent copy <id>                                 # still copies starters; no override flag
```

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above

## AI Disclosure

**AI tool used:** Cursor / Multica Agent

**Prompt / approach:**
Looked up whether this CLI gap already had an upstream issue/PR, then added a thin flag over the existing HTTP field.

## Thinking path

HTTP create/update already persist conversation starters with omit-vs-`[]` semantics. The CLI already copies the field on `agent copy`. The missing piece is the write flags, matching `--custom-args` / `--thinking-level`: send the key only when the flag is set, keep JSON-shape validation in the CLI, leave label/prompt length to the server.
