### PR TITLE
fix(migrations): backfill pre-451 NULL comment_thread_id on pending/in-flight tasks (457) (HYP-1754)

### DIFF
--- a/server/internal/handler/comment_thread_backfill_test.go
+++ b/server/internal/handler/comment_thread_backfill_test.go
@@ -1,0 +1,418 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// Regression tests for migration 457 (HYP-1750 / HYP-1754): the one-shot
+// backfill of comment_thread_id for pre-451 legacy pending/in-flight rows.
+// Each test simulates a legacy row the way the Tech Lead verified is
+// faithful: INSERT through the normal path (the 451 trigger fills the thread
+// scope), then UPDATE ... SET comment_thread_id = NULL — the trigger only
+// listens to INSERT / UPDATE OF trigger_comment_id, so it does not re-fire —
+// and executes the real migration file against the shared test database.
+// Only this file ever NULLs comment_thread_id on a trigger-bearing row, and
+// tests in a package run sequentially, so the migration's global UPDATE only
+// ever touches the fixture rows of the test currently running.
+
+const backfill457File = "457_agent_task_comment_thread_backfill.up.sql"
+
+func backfill457SQL(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test file path")
+	}
+	contents, err := os.ReadFile(filepath.Join(filepath.Dir(self), "..", "..", "migrations", backfill457File))
+	if err != nil {
+		t.Fatalf("read migration %s: %v", backfill457File, err)
+	}
+	return string(contents)
+}
+
+// runThreadBackfill457 executes the real 457 up migration on the shared pool.
+func runThreadBackfill457(t *testing.T) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(), backfill457SQL(t)); err != nil {
+		t.Fatalf("run migration 457: %v", err)
+	}
+}
+
+// backfillNoticeConn opens a dedicated connection that records NOTICE
+// messages, so tests can assert the migration's backfill/collision counts.
+func backfillNoticeConn(t *testing.T, notices *[]string) *pgx.Conn {
+	t.Helper()
+	cfg, err := pgx.ParseConfig(testPool.Config().ConnString())
+	if err != nil {
+		t.Fatalf("parse pool conn string: %v", err)
+	}
+	cfg.OnNotice = func(_ *pgconn.PgConn, n *pgconn.Notice) {
+		*notices = append(*notices, n.Message)
+	}
+	conn, err := pgx.ConnectConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("connect for notice capture: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(context.Background()) })
+	return conn
+}
+
+// legacyNullThreadTask inserts a task through the normal path, asserts the
+// 451 trigger filled its thread scope, then NULLs the scope to simulate a
+// pre-451 legacy row.
+func legacyNullThreadTask(t *testing.T, agentID string, over testutil.Cols) string {
+	t.Helper()
+	taskID := dbfx.Task(t, agentID, over)
+	if got := threadScopeOf(t, taskID); got == "" {
+		t.Fatalf("451 trigger did not fill comment_thread_id on insert of %s; legacy simulation impossible", taskID)
+	}
+	dbfx.Exec(t, "UPDATE agent_task_queue SET comment_thread_id = NULL WHERE id = $1", taskID)
+	if got := threadScopeOf(t, taskID); got != "" {
+		t.Fatalf("legacy simulation failed: comment_thread_id = %s, want NULL", got)
+	}
+	return taskID
+}
+
+// threadScopeOf returns the task's comment_thread_id, "" when NULL.
+func threadScopeOf(t *testing.T, taskID string) string {
+	t.Helper()
+	var scope string
+	if err := testPool.QueryRow(context.Background(),
+		"SELECT COALESCE(comment_thread_id::text, '') FROM agent_task_queue WHERE id = $1", taskID).Scan(&scope); err != nil {
+		t.Fatalf("read thread scope of %s: %v", taskID, err)
+	}
+	return scope
+}
+
+// 457 ruling §4.1: after the backfill, the 452 partial unique index intercepts
+// a new pending row in the same (issue, agent, thread).
+func TestThreadBackfill457RestoresPendingUniqueFence(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "457 unique-fence runtime")
+	agentID := dbfx.Agent(t, "457 unique-fence agent", runtimeID)
+	issueID := dbfx.Issue(t, "457 unique-fence issue")
+	rootA := dbfx.Comment(t, issueID, "thread A")
+	replyA := dbfx.Comment(t, issueID, "A supplement", testutil.Cols{"parent_id": rootA})
+	rootB := dbfx.Comment(t, issueID, "thread B")
+
+	legacyNullThreadTask(t, agentID, testutil.Cols{"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": rootA})
+
+	// Pre-backfill the fence gap is real: the legacy row sits in the zero-UUID
+	// bucket, so a same-thread insert does NOT conflict with it.
+	preFillID := dbfx.Task(t, agentID, testutil.Cols{"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": replyA})
+	dbfx.Exec(t, "DELETE FROM agent_task_queue WHERE id = $1", preFillID)
+
+	runThreadBackfill457(t)
+
+	var pgErr *pgconn.PgError
+	_, err := testPool.Exec(ctx,
+		"INSERT INTO agent_task_queue (agent_id, issue_id, runtime_id, status, trigger_comment_id) VALUES ($1, $2, $3, 'queued', $4)",
+		agentID, issueID, runtimeID, replyA)
+	if !errors.As(err, &pgErr) || pgErr.Code != "23505" || pgErr.ConstraintName != "idx_one_pending_task_per_issue_agent_thread" {
+		t.Fatalf("same-thread insert after backfill: got %v, want 23505 from idx_one_pending_task_per_issue_agent_thread", err)
+	}
+	// The index stays per-thread: another thread for the same issue+agent is
+	// not over-blocked.
+	dbfx.Task(t, agentID, testutil.Cols{"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": rootB})
+}
+
+// 457 ruling §4.2 + §4.3: after the backfill, MergeCommentIntoPendingTask
+// folds a same-thread comment into the legacy row and
+// CancelPendingTasksByIssueAndAgentInThread cancels it. Both calls miss the
+// row before the backfill (the fence gap), which pins the regression.
+func TestThreadBackfill457MergeAndCancelHitBackfilledRow(t *testing.T) {
+	ctx := context.Background()
+	q := db.New(testPool)
+	runtimeID := dbfx.Runtime(t, "457 merge/cancel runtime")
+	agentID := dbfx.Agent(t, "457 merge/cancel agent", runtimeID)
+	issueID := dbfx.Issue(t, "457 merge/cancel issue")
+	root := dbfx.Comment(t, issueID, "thread root")
+	reply := dbfx.Comment(t, issueID, "reply", testutil.Cols{"parent_id": root})
+
+	legacyID := legacyNullThreadTask(t, agentID, testutil.Cols{"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": root})
+
+	merge := db.MergeCommentIntoPendingTaskParams{IssueID: parseUUID(issueID), AgentID: parseUUID(agentID)}
+	cancel := db.CancelPendingTasksByIssueAndAgentInThreadParams{IssueID: parseUUID(issueID), AgentID: parseUUID(agentID)}
+
+	// Before the backfill both fences miss the NULL-thread legacy row.
+	merge.NewTriggerCommentID = parseUUID(reply)
+	if _, err := q.MergeCommentIntoPendingTask(ctx, merge); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("pre-backfill merge: got %v, want pgx.ErrNoRows (fence gap)", err)
+	}
+	cancel.ThreadCommentID = parseUUID(reply)
+	if rows, err := q.CancelPendingTasksByIssueAndAgentInThread(ctx, cancel); err != nil || len(rows) != 0 {
+		t.Fatalf("pre-backfill cancel: got %d rows / %v, want 0 rows (fence gap)", len(rows), err)
+	}
+
+	runThreadBackfill457(t)
+	if got := threadScopeOf(t, legacyID); got != root {
+		t.Fatalf("backfilled thread scope = %s, want root %s", got, root)
+	}
+
+	merged, err := q.MergeCommentIntoPendingTask(ctx, merge)
+	if err != nil {
+		t.Fatalf("post-backfill merge: %v", err)
+	}
+	if merged.ID != parseUUID(legacyID) {
+		t.Fatalf("merge hit task %s, want legacy row %s", uuidToString(merged.ID), legacyID)
+	}
+	if len(merged.CoalescedCommentIds) != 1 || merged.CoalescedCommentIds[0] != parseUUID(root) {
+		t.Fatalf("merge coalesced %v, want [%s]", merged.CoalescedCommentIds, root)
+	}
+
+	cancelled, err := q.CancelPendingTasksByIssueAndAgentInThread(ctx, cancel)
+	if err != nil {
+		t.Fatalf("post-backfill cancel: %v", err)
+	}
+	if len(cancelled) != 1 || cancelled[0].ID != parseUUID(legacyID) || cancelled[0].Status != "cancelled" {
+		t.Fatalf("cancel returned %+v, want exactly the legacy row cancelled", cancelled)
+	}
+}
+
+// 457 ruling §4.4: assignment-level rows (STRICT trigger → NULL thread scope
+// by design) are not backfilled and stay in the NULL bucket.
+func TestThreadBackfill457LeavesAssignmentLevelRowsNull(t *testing.T) {
+	runtimeID := dbfx.Runtime(t, "457 assignment runtime")
+	agentID := dbfx.Agent(t, "457 assignment agent", runtimeID)
+	issueID := dbfx.Issue(t, "457 assignment issue")
+
+	// No trigger_comment_id: the assignment-level task path.
+	assignmentID := dbfx.Task(t, agentID, testutil.Cols{"issue_id": issueID, "runtime_id": runtimeID})
+	if got := threadScopeOf(t, assignmentID); got != "" {
+		t.Fatalf("assignment-level task has thread scope %s, want NULL by design", got)
+	}
+
+	runThreadBackfill457(t)
+
+	if got := threadScopeOf(t, assignmentID); got != "" {
+		t.Fatalf("assignment-level task backfilled to %s, want NULL untouched", got)
+	}
+}
+
+// 457 ruling §4.5: the collision guard mirrors the 452 partial-index WHERE
+// clause verbatim — a dispatched occupant blocks the backfill, a
+// deferred+media_pending occupant blocks it, and a plain deferred occupant
+// (out of index scope) does not.
+func TestThreadBackfill457GuardMirrorsIndexPredicate(t *testing.T) {
+	variants := []struct {
+		name           string
+		occupantStatus string
+		occupantCtx    testutil.Raw
+		wantBlocked    bool
+	}{
+		{"dispatched occupant blocks", "dispatched", `'{}'::jsonb`, true},
+		{"deferred+media occupant blocks", "deferred", `'{"channel_issue_media_pending":"true"}'::jsonb`, true},
+		{"plain deferred occupant does not block", "deferred", `'{}'::jsonb`, false},
+	}
+	for _, v := range variants {
+		t.Run(v.name, func(t *testing.T) {
+			runtimeID := dbfx.Runtime(t, "457 guard runtime "+v.name)
+			agentID := dbfx.Agent(t, "457 guard agent "+v.name, runtimeID)
+			issueID := dbfx.Issue(t, "457 guard issue "+v.name)
+			root := dbfx.Comment(t, issueID, "thread root")
+
+			legacyID := legacyNullThreadTask(t, agentID, testutil.Cols{"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": root})
+			// The occupant is a post-451 row: the trigger fills its thread
+			// scope, and it coexists with the legacy row because the legacy
+			// row sits in the zero-UUID bucket (the audit's gap).
+			occupantID := dbfx.Task(t, agentID, testutil.Cols{
+				"issue_id":           issueID,
+				"runtime_id":         runtimeID,
+				"trigger_comment_id": root,
+				"status":             v.occupantStatus,
+				"context":            v.occupantCtx,
+			})
+
+			runThreadBackfill457(t)
+
+			got := threadScopeOf(t, legacyID)
+			if v.wantBlocked && got != "" {
+				t.Fatalf("collision guard failed: legacy row backfilled to %s over a %s occupant", got, v.occupantStatus)
+			}
+			if !v.wantBlocked && got != root {
+				t.Fatalf("guard over-blocked: legacy row scope = %q, want %s (occupant is out of index scope)", got, root)
+			}
+			if got := threadScopeOf(t, occupantID); got != root {
+				t.Fatalf("occupant scope = %q, want untouched %s", got, root)
+			}
+		})
+	}
+}
+
+// 457 ruling §4.6: a task triggered by a deeply nested reply is backfilled to
+// the thread ROOT id, not its direct parent (exercises the recursive CTE).
+func TestThreadBackfill457BackfillsNestedReplyToRootID(t *testing.T) {
+	runtimeID := dbfx.Runtime(t, "457 nested runtime")
+	agentID := dbfx.Agent(t, "457 nested agent", runtimeID)
+	issueID := dbfx.Issue(t, "457 nested issue")
+	root := dbfx.Comment(t, issueID, "root")
+	reply := dbfx.Comment(t, issueID, "reply", testutil.Cols{"parent_id": root})
+	nested := dbfx.Comment(t, issueID, "nested reply", testutil.Cols{"parent_id": reply})
+
+	legacyID := legacyNullThreadTask(t, agentID, testutil.Cols{"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": nested})
+
+	runThreadBackfill457(t)
+
+	if got := threadScopeOf(t, legacyID); got != root {
+		t.Fatalf("nested-reply legacy row backfilled to %s, want thread root %s (not parent %s)", got, root, reply)
+	}
+}
+
+// 457 ruling §4.7: the conditional UPDATE is idempotent — a second run
+// changes nothing, errors on nothing, and reports 0/0 in its NOTICE counts.
+func TestThreadBackfill457SecondRunIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "457 idempotent runtime")
+	agentID := dbfx.Agent(t, "457 idempotent agent", runtimeID)
+	issueID := dbfx.Issue(t, "457 idempotent issue")
+	root := dbfx.Comment(t, issueID, "thread root")
+
+	legacyID := legacyNullThreadTask(t, agentID, testutil.Cols{"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": root})
+
+	var firstNotices []string
+	if _, err := backfillNoticeConn(t, &firstNotices).Exec(ctx, backfill457SQL(t)); err != nil {
+		t.Fatalf("first backfill run: %v", err)
+	}
+	if len(firstNotices) != 1 || !strings.Contains(firstNotices[0], "backfilled 1 legacy row(s)") || !strings.Contains(firstNotices[0], "skipped 0 collision row(s)") {
+		t.Fatalf("first run notices = %v, want one notice reporting backfilled 1 / skipped 0", firstNotices)
+	}
+	if got := threadScopeOf(t, legacyID); got != root {
+		t.Fatalf("after first run scope = %q, want %s", got, root)
+	}
+
+	var secondNotices []string
+	if _, err := backfillNoticeConn(t, &secondNotices).Exec(ctx, backfill457SQL(t)); err != nil {
+		t.Fatalf("second backfill run: %v", err)
+	}
+	if len(secondNotices) != 1 || !strings.Contains(secondNotices[0], "backfilled 0 legacy row(s)") || !strings.Contains(secondNotices[0], "skipped 0 collision row(s)") {
+		t.Fatalf("second run notices = %v, want one notice reporting backfilled 0 / skipped 0", secondNotices)
+	}
+	if got := threadScopeOf(t, legacyID); got != root {
+		t.Fatalf("second run changed scope to %q, want stable %s", got, root)
+	}
+}
+
+// 457 ruling §4.8: a deferred+media_pending legacy row (the longest-lingering
+// class) is backfilled; terminal legacy rows are excluded; a backfilled
+// running row is hit by the RegisterPlannedCommentForActiveTask fence.
+func TestThreadBackfill457ScopeVariantsAndRunningFence(t *testing.T) {
+	ctx := context.Background()
+	q := db.New(testPool)
+	runtimeID := dbfx.Runtime(t, "457 scope runtime")
+	agentID := dbfx.Agent(t, "457 scope agent", runtimeID)
+	issueID := dbfx.Issue(t, "457 scope issue")
+	root := dbfx.Comment(t, issueID, "thread root")
+	followup := dbfx.Comment(t, issueID, "follow-up", testutil.Cols{"parent_id": root})
+
+	deferredID := legacyNullThreadTask(t, agentID, testutil.Cols{
+		"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": root,
+		"status": "deferred", "context": testutil.Raw(`'{"channel_issue_media_pending":"true"}'::jsonb`),
+	})
+	runningID := legacyNullThreadTask(t, agentID, testutil.Cols{
+		"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": root, "status": "running",
+	})
+	terminalIDs := map[string]string{}
+	for _, status := range []string{"completed", "cancelled", "failed"} {
+		terminalIDs[status] = legacyNullThreadTask(t, agentID, testutil.Cols{
+			"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": root, "status": status,
+		})
+	}
+
+	// Pre-backfill the active-task fence misses the NULL running row too.
+	planned := db.RegisterPlannedCommentForActiveTaskParams{
+		CommentID: parseUUID(followup), IssueID: parseUUID(issueID), AgentID: parseUUID(agentID),
+	}
+	if _, err := q.RegisterPlannedCommentForActiveTask(ctx, planned); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("pre-backfill RegisterPlannedCommentForActiveTask: got %v, want pgx.ErrNoRows (fence gap)", err)
+	}
+
+	runThreadBackfill457(t)
+
+	if got := threadScopeOf(t, deferredID); got != root {
+		t.Fatalf("deferred+media legacy row scope = %q, want backfilled to %s", got, root)
+	}
+	if got := threadScopeOf(t, runningID); got != root {
+		t.Fatalf("running legacy row scope = %q, want backfilled to %s", got, root)
+	}
+	for status, id := range terminalIDs {
+		if got := threadScopeOf(t, id); got != "" {
+			t.Fatalf("terminal (%s) legacy row backfilled to %s, want excluded / NULL", status, got)
+		}
+	}
+
+	registered, err := q.RegisterPlannedCommentForActiveTask(ctx, planned)
+	if err != nil {
+		t.Fatalf("post-backfill RegisterPlannedCommentForActiveTask: %v", err)
+	}
+	if registered.ID != parseUUID(runningID) {
+		t.Fatalf("planned comment registered on %s, want running legacy row %s", uuidToString(registered.ID), runningID)
+	}
+	if len(registered.CoalescedCommentIds) != 1 || registered.CoalescedCommentIds[0] != parseUUID(followup) {
+		t.Fatalf("registered planned ids %v, want [%s]", registered.CoalescedCommentIds, followup)
+	}
+}
+
+// 457 ruling §4 addendum: a legacy row whose trigger comment was hard-deleted
+// (anchor missing) leaves the NULL bucket deterministically —
+// comment_thread_root_id COALESCEs back to the comment id itself. Normally the
+// ON DELETE SET NULL FK clears trigger_comment_id first and excludes the row;
+// the dangling-anchor path needs the FK bypassed, so the test skips when the
+// test role cannot toggle session_replication_role.
+func TestThreadBackfill457DeletedTriggerCoalesceFallback(t *testing.T) {
+	ctx := context.Background()
+
+	// The function-level fallback needs no privileges: an anchor that never
+	// existed resolves to the id itself.
+	dangling := "00000000-0000-0000-0000-000000000042"
+	var resolved string
+	if err := testPool.QueryRow(ctx, "SELECT comment_thread_root_id($1)::text", dangling).Scan(&resolved); err != nil {
+		t.Fatalf("comment_thread_root_id on dangling anchor: %v", err)
+	}
+	if resolved != dangling {
+		t.Fatalf("comment_thread_root_id(%s) = %s, want COALESCE fallback to the id itself", dangling, resolved)
+	}
+
+	runtimeID := dbfx.Runtime(t, "457 dangling runtime")
+	agentID := dbfx.Agent(t, "457 dangling agent", runtimeID)
+	issueID := dbfx.Issue(t, "457 dangling issue")
+	trigger := dbfx.Comment(t, issueID, "soon deleted trigger")
+	legacyID := legacyNullThreadTask(t, agentID, testutil.Cols{"issue_id": issueID, "runtime_id": runtimeID, "trigger_comment_id": trigger})
+
+	var notices []string
+	conn := backfillNoticeConn(t, &notices)
+	if _, err := conn.Exec(ctx, "SET session_replication_role = replica"); err != nil {
+		t.Skipf("cannot bypass the FK to simulate a hard-deleted trigger comment: %v", err)
+	}
+	// Bypass the ON DELETE SET NULL FK so trigger_comment_id keeps pointing at
+	// the deleted comment — the dangling-anchor case the migration documents.
+	if _, err := conn.Exec(ctx, "DELETE FROM comment WHERE id = $1", trigger); err != nil {
+		t.Fatalf("hard-delete trigger comment: %v", err)
+	}
+	if _, err := conn.Exec(ctx, "SET session_replication_role = DEFAULT"); err != nil {
+		t.Fatalf("reset session_replication_role: %v", err)
+	}
+	var stillPointing string
+	if err := testPool.QueryRow(ctx, "SELECT COALESCE(trigger_comment_id::text, '') FROM agent_task_queue WHERE id = $1", legacyID).Scan(&stillPointing); err != nil {
+		t.Fatalf("read trigger_comment_id: %v", err)
+	}
+	if stillPointing != trigger {
+		t.Fatalf("trigger_comment_id = %q after hard delete, want dangling %s", stillPointing, trigger)
+	}
+
+	runThreadBackfill457(t)
+
+	if got := threadScopeOf(t, legacyID); got != trigger {
+		t.Fatalf("dangling-anchor legacy row scope = %q, want %s (deterministic singleton bucket, out of the NULL bucket)", got, trigger)
+	}
+}

--- a/server/migrations/457_agent_task_comment_thread_backfill.down.sql
+++ b/server/migrations/457_agent_task_comment_thread_backfill.down.sql
@@ -1,0 +1,6 @@
+-- The 457 backfill is intentionally irreversible: it restored derived fence
+-- data (comment_thread_id is derived, not a FK) on legacy rows to the values
+-- the 451 trigger would have written. Re-NULLing them would reopen the
+-- pending-task fence gap the backfill closed, so there is nothing to roll
+-- back. Explicit no-op.
+SELECT 1;

--- a/server/migrations/457_agent_task_comment_thread_backfill.up.sql
+++ b/server/migrations/457_agent_task_comment_thread_backfill.up.sql
@@ -1,0 +1,112 @@
+-- One-shot backfill of comment_thread_id for legacy pre-451 pending and
+-- in-flight rows (HYP-1750 / HYP-1754).
+--
+-- Why: migration 451 deliberately skipped the existing-row backfill
+-- (76f59f5f1), so tasks created before it kept comment_thread_id = NULL.
+-- Migration 452's partial unique index folds NULL into the zero-UUID bucket,
+-- which left every IS NOT DISTINCT FROM thread fence in agent.sql matching
+-- those legacy rows only against assignment-level (NULL-thread) work:
+--   * a new trigger in any thread slipped past the pending dedup fence and
+--     could produce a duplicate SEQUENTIAL run (ClaimAgentTask still
+--     serializes per issue+agent, so never a concurrent one);
+--   * MergeCommentIntoPendingTask would not fold new comments into the
+--     legacy row;
+--   * CancelPendingTasksByIssueAndAgentInThread could not cancel it;
+--   * a legacy running / waiting_local_directory row missed
+--     RegisterPlannedCommentForActiveTask's fence, so a same-thread comment
+--     fell back to enqueueing a fresh task and ran twice in sequence.
+-- This backfill returns legacy rows to the standard semantics every post-451
+-- row already has. comment_thread_id is derived fence data, not a FK (451),
+-- so rewriting it is safe.
+--
+-- Scope (deliberate):
+--   * comment_thread_id IS NULL AND trigger_comment_id IS NOT NULL — the 451
+--     trigger function is STRICT, so assignment-level tasks (no trigger
+--     comment) legitimately keep a NULL thread scope and must never be
+--     backfilled;
+--   * statuses queued / dispatched / deferred+channel_issue_media_pending
+--     (the 452 index scope — rows a new pending insert can collide with)
+--     PLUS running / waiting_local_directory (the
+--     RegisterPlannedCommentForActiveTask fence scope — closes the
+--     duplicate-sequential-run gap for in-flight rows too);
+--   * terminal rows (completed / cancelled / failed) are excluded: a fence
+--     value on them has no effect and history is unbounded.
+--
+-- Behaviour change to be aware of (standard semantics, not a regression): a
+-- backfilled running / waiting_local_directory legacy row narrows its
+-- reconcileCommentsOnCompletion reconciliation scope from issue-level to
+-- thread-level on completion — the same semantics every post-451 task already
+-- runs under.
+--
+-- Collision guard: a same-(issue, agent, thread) pending row created in the
+-- 453→457 window (the exact duplicate this fix addresses) already occupies
+-- the target 452-index bucket. The NOT EXISTS guard below mirrors the 452
+-- partial-index WHERE clause VERBATIM, plus id self-exclusion, so the
+-- backfill can never trip the unique index. A colliding legacy row keeps its
+-- NULL thread scope and is NOT cancelled — a migration must not silently drop
+-- user work — and is counted in the RAISE NOTICE below so the deploy log
+-- answers "how many rows backfilled, how many skipped on collision".
+--
+-- Concurrency: the candidate scan, the guard, and the UPDATE share one
+-- statement snapshot, so a concurrent INSERT can still slip into a bucket
+-- after the guard evaluated it; the 452 unique index backstops that race by
+-- rejecting one of the two writers. A failure here is therefore LOUD and the
+-- migration is safe to re-run — the conditional UPDATE is idempotent. Retry
+-- on failure; deployment tooling must not skip it silently.
+--
+-- Deleted trigger comments: comment_thread_root_id() COALESCEs a missing
+-- anchor back to the comment id itself, so a legacy row whose trigger comment
+-- row is gone is backfilled to that (dead) id. That moves the row out of the
+-- shared NULL bucket into a deterministic singleton bucket — harmless and
+-- explicit, not an error. (Normally the ON DELETE SET NULL FK clears
+-- trigger_comment_id first, which excludes the row from this backfill
+-- entirely.)
+DO $$
+DECLARE
+    v_backfilled int;
+    v_collisions int;
+BEGIN
+    WITH legacy AS (
+        SELECT t.id, t.issue_id, t.agent_id,
+               comment_thread_root_id(t.trigger_comment_id) AS thread_root_id
+        FROM agent_task_queue t
+        WHERE t.comment_thread_id IS NULL
+          AND t.trigger_comment_id IS NOT NULL
+          AND (
+                t.status IN ('queued', 'dispatched')
+             OR (t.status = 'deferred' AND t.context->>'channel_issue_media_pending' = 'true')
+             OR t.status IN ('running', 'waiting_local_directory')
+          )
+    ),
+    collision AS (
+        SELECT l.id
+        FROM legacy l
+        WHERE EXISTS (
+            SELECT 1
+            FROM agent_task_queue occupant
+            WHERE occupant.id <> l.id
+              AND occupant.issue_id = l.issue_id
+              AND occupant.agent_id = l.agent_id
+              AND COALESCE(occupant.comment_thread_id, '00000000-0000-0000-0000-000000000000'::uuid)
+                  = l.thread_root_id
+              -- Verbatim mirror of the 452 partial-index WHERE clause:
+              AND (
+                    occupant.status IN ('queued', 'dispatched')
+                 OR (occupant.status = 'deferred' AND occupant.context->>'channel_issue_media_pending' = 'true')
+              )
+        )
+    ),
+    backfilled AS (
+        UPDATE agent_task_queue t
+        SET comment_thread_id = l.thread_root_id
+        FROM legacy l
+        WHERE t.id = l.id
+          AND NOT EXISTS (SELECT 1 FROM collision c WHERE c.id = l.id)
+        RETURNING t.id
+    )
+    SELECT (SELECT count(*) FROM backfilled), (SELECT count(*) FROM collision)
+      INTO v_backfilled, v_collisions;
+
+    RAISE NOTICE '457_agent_task_comment_thread_backfill: backfilled % legacy row(s); skipped % collision row(s) left NULL (bucket occupied by a newer pending task)',
+        v_backfilled, v_collisions;
+END $$;


### PR DESCRIPTION
## Summary

Implements the HYP-1750 ruling (Plan A, debate-approved 3/3) via **migration 457**: a one-shot, idempotent, re-runnable conditional UPDATE that backfills `comment_thread_id` for pre-451 legacy rows that kept `NULL` thread scope when migration 451 deliberately skipped the existing-row backfill (`76f59f5f1`).

Under migration 452's partial unique index, `NULL` folds into the zero-UUID bucket, so every `IS NOT DISTINCT FROM` thread fence in `agent.sql` was blind to those legacy rows:

- a new trigger in any thread slipped past the pending dedup fence → duplicate **sequential** run (`ClaimAgentTask` still serializes per issue+agent, so never concurrent);
- `MergeCommentIntoPendingTask` would not fold new comments into the legacy row;
- `CancelPendingTasksByIssueAndAgentInThread` could not cancel it;
- a legacy `running` / `waiting_local_directory` row missed `RegisterPlannedCommentForActiveTask`'s fence → same-thread comments fell back to enqueue → duplicate sequential run.

## What the migration does (per the ruling, point by point)

1. **Scope** — `comment_thread_id IS NULL AND trigger_comment_id IS NOT NULL` (assignment-level rows are NULL by design via the STRICT trigger and are never touched) AND status in `queued` / `dispatched` / `deferred`+`channel_issue_media_pending` / `running` / `waiting_local_directory`; terminal rows (`completed` / `cancelled` / `failed`) excluded.
2. **Collision guard** — `NOT EXISTS` predicate **verbatim-mirrors** the 452 partial-index WHERE clause (`status IN ('queued','dispatched') OR (status='deferred' AND context->>'channel_issue_media_pending'='true')`) plus `id <>` self-exclusion, so the backfill can never trip the unique index. Colliding legacy rows **stay NULL and are NOT cancelled**, and the migration reports the collision count via `RAISE NOTICE` alongside the backfill count.
3. **Migration-file comments** document: concurrency semantics (candidate scan + guard + UPDATE share one statement snapshot; concurrent INSERTs are backstopped by the 452 unique index), the "fail loud, safe to re-run, never skip silently" policy, the reconcile-narrowing behavior increment (backfilled running rows reconcile at thread scope — standard post-451 semantics), and the deleted-trigger-comment COALESCE fallback (anchor missing → thread = the dead comment id, row leaves the NULL bucket deterministically).
4. **Down migration** — explicit no-op (`SELECT 1;`) with a "backfill is irreversible, no rollback needed" comment, following the `065` convention.
5. **Backfill value** — the thread **root** comment id via `comment_thread_root_id(trigger_comment_id)` (recursive CTE; nested replies get the root, not the direct parent).

## Regression tests

`server/internal/handler/comment_thread_backfill_test.go` — 8 test functions (10 cases) covering the ruling's §4 list plus the deleted-trigger addendum. Legacy rows are simulated faithfully: insert via the normal path (451 trigger fills the scope), then `UPDATE ... SET comment_thread_id = NULL` (the trigger only listens to `UPDATE OF trigger_comment_id`). Tests execute the **real migration file** against the shared test DB:

1. unique index intercepts a same-(issue, agent, thread) pending insert after backfill (23505 from `idx_one_pending_task_per_issue_agent_thread`; different thread not over-blocked);
2. `MergeCommentIntoPendingTask` hits the backfilled row (misses it pre-backfill — pins the regression);
3. `CancelPendingTasksByIssueAndAgentInThread` cancels the backfilled row (misses pre-backfill);
4. assignment-level rows stay NULL;
5. guard fidelity ×3: `dispatched` occupant blocks, `deferred`+media occupant blocks, plain `deferred` occupant does not;
6. nested reply (3rd level) backfills to the thread root id;
7. idempotency: second run reports `backfilled 0 / skipped 0` via captured NOTICE and changes nothing;
8. `deferred`+media legacy row backfilled + terminal rows excluded + backfilled `running` row hit by `RegisterPlannedCommentForActiveTask` (misses pre-backfill);
9. hard-deleted trigger comment: `comment_thread_root_id` COALESCE fallback lands the row in a deterministic singleton bucket (FK bypass simulated with `session_replication_role`; skips gracefully without privileges).

Mutation-checked: dropping `running` from the scope fails test 8; dropping the `deferred`+media arm from the guard fails test 5 with exactly the unique violation the guard exists to prevent.

## Verification (backfill / collision counts)

The migration emits one NOTICE, e.g. `457_agent_task_comment_thread_backfill: backfilled N legacy row(s); skipped M collision row(s) left NULL ...` — visible in the migrate output / Postgres log at deploy time, and asserted in test 7. Post-deploy audit query:

```sql
SELECT count(*) FROM agent_task_queue
WHERE comment_thread_id IS NULL AND trigger_comment_id IS NOT NULL
  AND (status IN ('queued','dispatched','running','waiting_local_directory')
       OR (status = 'deferred' AND context->>'channel_issue_media_pending' = 'true'));
-- expect: the M collision rows reported by the NOTICE (or 0)
```

## Test evidence (local, Postgres 17 via docker compose)

- `go test ./internal/handler/ -run TestThreadBackfill457 -count=1` — **ok** (also with `-race`)
- `go test ./internal/handler/` — **ok** (full package, 34s)
- `go test ./internal/service/ ./internal/migrations/ ./cmd/migrate/` — **ok**
- `go vet ./internal/handler/ ./internal/migrations/ ./cmd/migrate/` and `go vet -tags agentintegration ./internal/handler/` — clean; new file gofmt-clean
- `bash scripts/test-go.sh` (full server suite): 62 packages **ok**; the only failing package, `cmd/multica`, fails **identically on the base commit** (159 tests) because the run environment is itself a Multica daemon task — the CLI suite fail-closes on the runtime's own `.multica/daemon_task_context.json` marker and `MULTICA_*` env vars. Unrelated to this diff (no shared dependencies touched). `internal/daemon/execenv` similarly passes once `MULTICA_TASK_CONFIG_ROOT` is unset.

## Risk & rollback

Low: a single conditional UPDATE over a bounded row set (pending/in-flight legacy rows only; terminal history untouched), no locks held across statements, idempotent and safe to re-run on failure. Rollback is intentionally a no-op — the backfill restores derived fence data to what the 451 trigger would have written.

## Limitations

- Legacy rows that collide with a newer same-thread pending row are intentionally left NULL (counted in the NOTICE); their merge/cancel fence gap remains for that row only — the newer row covers the thread's work.
- `cmd/multica` test package could not be validated locally for the environmental reason above; it is untouched by this diff and covered by CI.

Links: HYP-1754 (implementation), HYP-1750 (audit + ruling).
