### PR TITLE
fix(web): swap Gemini CLI for Antigravity in hero (MUL-7207)

### DIFF
--- a/apps/web/features/landing/components/landing-hero.tsx
+++ b/apps/web/features/landing/components/landing-hero.tsx
@@ -7,9 +7,9 @@ import { useAuthStore } from "@multica/core/auth";
 import { useLocale } from "../i18n";
 import { useDashboardCtaHref } from "../utils/use-dashboard-cta";
 import {
+  AntigravityLogo,
   ClaudeCodeLogo,
   CodexLogo,
-  GeminiCliLogo,
   OpenClawLogo,
   OpenCodeLogo,
   heroButtonClassName,
@@ -78,8 +78,8 @@ export function LandingHero() {
                 <span className="text-body-lg font-medium">Codex</span>
               </div>
               <div className="flex items-center gap-2.5 text-white/80">
-                <GeminiCliLogo className="size-5" />
-                <span className="text-body-lg font-medium">Gemini CLI</span>
+                <AntigravityLogo className="size-5" />
+                <span className="text-body-lg font-medium">Antigravity</span>
               </div>
               <div className="flex items-center gap-2.5 text-white/80">
                 <OpenClawLogo className="size-5" />

--- a/apps/web/features/landing/components/shared.tsx
+++ b/apps/web/features/landing/components/shared.tsx
@@ -63,6 +63,19 @@ export function ImageIcon({ className }: { className?: string }) {
   );
 }
 
+export function AntigravityLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M21.751 22.607c1.34 1.005 3.35.335 1.508-1.508C17.73 15.74 18.904 1 12.037 1 5.17 1 6.342 15.74.815 21.1c-2.01 2.009.167 2.511 1.507 1.506 5.192-3.517 4.857-9.714 9.715-9.714 4.857 0 4.522 6.197 9.714 9.715z" />
+    </svg>
+  );
+}
+
 export function ClaudeCodeLogo({ className }: { className?: string }) {
   return (
     <svg
@@ -146,19 +159,6 @@ export function OpenClawLogo({ className }: { className?: string }) {
         <rect x="6" y="4" width="1" height="1" />
         <rect x="9" y="4" width="1" height="1" />
       </g>
-    </svg>
-  );
-}
-
-export function GeminiCliLogo({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      className={className}
-      fill="currentColor"
-    >
-      <path d="M12 0C12 0 12 8 8 12C12 12 12 12 12 24C12 24 12 16 16 12C12 12 12 12 12 0Z" />
     </svg>
   );
 }


### PR DESCRIPTION
The landing hero's "works with" list still showed the retired Gemini CLI. Align it with the README and runtime provider list by showing Antigravity with its official mark as a monochrome inline SVG, matching the other hero logos.

## What does this PR do?
The landing hero's "works with" row still listed the retired **Gemini CLI**, while the README (`Antigravity | agy`) and the app's runtime-provider list already use **Antigravity**. This PR aligns the homepage with the rest of the repo by replacing that entry with **Antigravity** and its official mark.

The new logo is a monochrome `currentColor` inline SVG (the official Antigravity "A" glyph) in `shared.tsx`, matching how the other hero logos (Claude Code, Codex, OpenCode) are implemented


<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `apps/web/features/landing/components/landing-hero.tsx` — swap the retired "Gemini CLI" hero item for "Antigravity", rendering the new `AntigravityLogo`.
- `apps/web/features/landing/components/shared.tsx` — add `AntigravityLogo` (monochrome `fill="currentColor"` inline SVG of the official Antigravity "A" mark, path sourced from `gilbarbara/logos` `antigravity.svg`); remove the now-unused `GeminiCliLogo`.


## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `pnpm install`
2. `cd apps/web && pnpm exec next dev --webpack --port 3000` (on Windows this bypasses the `sh -c` wrapper that `pnpm dev:web` needs Git Bash's `sh` for)
3. Open http://localhost:3000/ and confirm the "works with" row shows **Antigravity** with a monochrome "A" glyph instead of "Gemini CLI", visually consistent with the neighboring Claude Code / Codex / OpenCode logos.


## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
<img width="905" height="252" alt="image" src="https://github.com/user-attachments/assets/ba9cdabd-2d9a-4cf9-8a96-353cd8e12626" />


<img width="895" height="224" alt="image" src="https://github.com/user-attachments/assets/58a0c644-0f43-45cc-8e50-b15b6a049118" />
