### PR TITLE
docs(migrations): document NULL-thread transitional window in migration 451 (HYP-1760) (MUL-7225)

### DIFF
--- a/server/migrations/451_agent_task_comment_thread.up.sql
+++ b/server/migrations/451_agent_task_comment_thread.up.sql
@@ -32,3 +32,42 @@ FOR EACH ROW EXECUTE FUNCTION set_agent_task_comment_thread();
 
 -- Existing rows intentionally retain a NULL thread scope. Pre-migration tasks
 -- drain under the issue/agent claim fence without rewriting historical data.
+--
+-- Transitional window (accepted, documented 2026-09; do not "fix" without
+-- reading this): until every pre-migration pending row drains, that legacy
+-- NULL-thread set (queued / dispatched / media-pending deferred) is INVISIBLE
+-- to the thread-scoped `comment_thread_id IS NOT DISTINCT FROM
+-- comment_thread_root_id(...)` fences in server/pkg/db/queries (as of this
+-- writing: agent.sql cancel :643, dedup :1757/:1791, merge :1864/:1947,
+-- RegisterPlannedCommentForActiveTask :1917, active-row :2162, retry lineage
+-- :2246, deferred-promotion occupant checks :2290/:2364, comment.sql :385;
+-- line numbers drift — grep for the predicate). Three consequences while a
+-- legacy row is still pending:
+--   1. A new trigger from ANY thread passes dedup that the backfilled row
+--      would have blocked. Worst case is a DUPLICATE SEQUENTIAL run, not
+--      concurrency — ClaimAgentTask still serializes per (issue, agent).
+--   2. MergeCommentIntoPendingTask does not fold new comments into the NULL
+--      row, and cancel-in-thread cannot match it.
+--   3. A legacy RUNNING row misses the RegisterPlannedCommentForActiveTask
+--      fence, so planned comments can attach without the active-run guard.
+--
+-- Why this is acceptable: the affected set is self-draining and cannot
+-- reproduce. Pre-451 issue-level uniqueness bounds it to AT MOST ONE legacy
+-- pending row per (issue, agent); it shrinks monotonically as live tasks
+-- complete (deferred media-pending rows drain once their media arrives), and
+-- the trigger above guarantees every NEW row carries a real thread scope.
+-- There is no data corruption, no privilege escalation, and no persistently
+-- wrong state — only a narrowing transitional window.
+--
+-- Future fix path, IF evidence ever shows the residual set is material: do
+-- NOT backfill through the startup migration path — upstream rejected that
+-- coupling (startup migrations must not rewrite data; the 451 backfill was
+-- removed for exactly this, and the 457 retry PR #8229 was closed unmerged
+-- for lacking production statistics plus batching/rate-limit/timeout
+-- guards). Instead: (a) run a READ-ONLY candidate count grouped by
+-- (issue, agent) plus EXPLAIN first — the 452 partial index keys on a
+-- COALESCE expression in its third column, so a NULL-bucket probe can only
+-- index-scan + filter, and any production execution needs a low
+-- statement_timeout in an off-peak window; then (b) apply a bounded
+-- operational backfill OUTSIDE the migration framework (batched slices,
+-- row-lock contention checks, idempotent re-runnable).


### PR DESCRIPTION
## Summary

Docs-only: expands the comment at the bottom of `server/migrations/451_agent_task_comment_thread.up.sql` (the note on the intentionally skipped `comment_thread_id` backfill) to fully document the accepted NULL-thread transitional window. Zero behavioral change — no SQL statement is modified, added, or removed; the diff touches SQL comments only.

## Background

- Parent audit: **HYP-1750** (daily audit HYP-1746, 2026-09-09) — migration 451's skipped backfill leaves pre-migration `queued`/`dispatched`/`deferred` rows with `comment_thread_id = NULL`, which the thread-scoped `IS NOT DISTINCT FROM` fences in `server/pkg/db/queries` cannot match.
- Plan A (migration 457 one-shot backfill) was **rejected by upstream multica-eve** — PR #8229 closed unmerged: startup-migration-path data backfill couples to deployment (the original 451 backfill was removed for this in #8216), and 457 had no production statistics, batching, rate-limit, or timeout guards.
- Pojo ruled **Plan C** (decision `approved_plan_C_comment_only`): accept the window, document it, close. This issue: **HYP-1760**.

## What the expanded comment covers

1. **Three fence windows** while a legacy NULL-thread pending row is live: new triggers from any thread bypass thread-level dedup (worst case duplicate *sequential* run — `ClaimAgentTask` still serializes per (issue, agent)); merge does not fold into the NULL row; cancel-in-thread cannot match it; legacy running rows miss the `RegisterPlannedCommentForActiveTask` fence. Fence locations verified at HEAD `9fab6da91` (agent.sql `:643/:1757/:1791/:1864/:1917/:1947/:2162/:2246/:2290/:2364`, comment.sql `:385`).
2. **Self-draining and non-reproducing**: at most one legacy pending row per (issue, agent) by pre-451 issue-level uniqueness; monotonically shrinking; the 451 trigger guarantees all new rows carry a real thread scope.
3. **Future fix path**: never backfill via the startup migration path; first a read-only candidate count + EXPLAIN (the 452 partial index's third key column is a `COALESCE` expression — NULL-bucket probes can only scan+filter; production execution needs a low `statement_timeout` off-peak), then a bounded operational backfill outside the migration framework.

## Acceptance evidence

- [x] PR diff touches only comments in the 451 up migration — zero behavioral change
- [x] Comment covers the three required points
- [x] PR is open, not draft
- [x] Migration-runner safety: the runner records applied migrations in `schema_migrations` by filename version only (`server/internal/migrations/migrations.go` — no content checksum; readiness checks version presence). Already-applied 451 will not re-execute; fresh environments run the identical statements, since comments do not change the SQL.

## Risk and rollback

- **Risk**: none behavioral (comments only). The one structural consideration was editing an already-applied migration file; confirmed safe above because the ledger is version-keyed, not content-hashed.
- **Rollback**: revert the single commit.

## Limitations

- Line numbers cited in the comment are as of HEAD `9fab6da91` and will drift; the comment says to grep for the predicate.
- Merge requires Pojo confirmation (upstream multica-eve holds merge rights on this repository).

Refs: HYP-1760 (this change), HYP-1750 (parent audit and Plan C rationale).
