### PR TITLE
MUL-7226 fix(daemon): decline Codex reuse when home preparation fails

### DIFF
--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -293,8 +293,9 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		// so the fail-closed policy just computed above would only exist in
 		// memory while the effective config silently stays loose. Abort rather
 		// than launch Codex with an unenforced sandbox: on fresh Prepare this
-		// fails the task; on Reuse the caller leaves env.CodexHome unset, which
-		// configureCodexTaskShellEnvironment then refuses to start (MUL-4957).
+		// fails the task; on Reuse the caller declines the reuse and falls back
+		// to Prepare, which re-runs this check against a fresh home and fails
+		// the task if the managed block still cannot be written (MUL-4957).
 		return fmt.Errorf("ensure codex sandbox config: %w", err)
 	}
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -915,8 +915,13 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, codexHomeDirName)
 		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
-			// Never return an environment that silently drops the task's home
-			// and launches Codex against an ambient, unrelated session store.
+			// Leaving env.CodexHome empty does not launch Codex against an
+			// ambient home: configureCodexTaskShellEnvironment rejects the empty
+			// value ("task CODEX_HOME is missing") and the run fails before
+			// launch. Decline the reuse instead, so the caller falls back to
+			// Prepare and the task still gets a usable task-local home. The
+			// prior session is not carried over, and a fresh Prepare that fails
+			// the same way still stops the task.
 			logger.Warn("execenv: refresh codex-home failed; forcing fresh prepare", "error", err)
 			return nil
 		} else {

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -804,7 +804,8 @@ type ReuseParams struct {
 }
 
 // Reuse wraps an existing workdir into an Environment and refreshes context files.
-// Returns nil if the workdir does not exist (caller should fall back to Prepare).
+// Returns nil if the workdir does not exist or required provider setup fails
+// (caller should fall back to Prepare).
 func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	if _, err := os.Stat(params.WorkDir); err != nil {
 		return nil
@@ -914,7 +915,10 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, codexHomeDirName)
 		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
-			logger.Warn("execenv: refresh codex-home failed", "error", err)
+			// Never return an environment that silently drops the task's home
+			// and launches Codex against an ambient, unrelated session store.
+			logger.Warn("execenv: refresh codex-home failed; forcing fresh prepare", "error", err)
+			return nil
 		} else {
 			env.CodexHome = codexHome
 			if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -6925,6 +6925,23 @@ func TestClaimEnvRootRecoversOwnerTempLeftBeforeRename(t *testing.T) {
 	}
 }
 
+func TestReuseCodexRejectsUnusableHome(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	root := t.TempDir()
+	workDir := filepath.Join(root, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A regular file blocks home preparation deterministically without relying
+	// on permission checks or accessing a real Codex installation or account.
+	if err := os.WriteFile(filepath.Join(root, codexHomeDirName), []byte("blocked"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if env := Reuse(ReuseParams{WorkDir: workDir, Provider: "codex"}, testLogger()); env != nil {
+		t.Fatalf("unusable Codex home must decline reuse, got environment with CodexHome=%q", env.CodexHome)
+	}
+}
+
 // TestReleaseLockFreesEnvRootForALaterDispatch pins the lifetime rule that
 // Windows CI surfaced: the lock belongs to the task EXECUTION, and nothing in
 // production calls Environment.Cleanup — the GC reclaims env roots on its own

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -4239,8 +4239,8 @@ func TestResolveWindowsSandboxStateFailsClosed(t *testing.T) {
 // warned and returned success, so the task launched with the stale
 // danger-full-access — the decision failed closed while the effective config
 // failed open. prepareCodexHomeWithOpts must now return an error, which blocks
-// startup on both paths (fresh Prepare fails the task; Reuse leaves
-// env.CodexHome unset, which configureCodexTaskShellEnvironment refuses).
+// startup on both paths (fresh Prepare fails the task; Reuse declines the
+// reuse and falls back to Prepare, which re-runs this check on a fresh home).
 func TestPrepareCodexHomeFailsClosedWhenSandboxWriteFails(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("running as root bypasses the read-only permissions this test relies on")
@@ -6925,6 +6925,10 @@ func TestClaimEnvRootRecoversOwnerTempLeftBeforeRename(t *testing.T) {
 	}
 }
 
+// TestReuseCodexRejectsUnusableHome pins the reuse contract for a task-local
+// Codex home that cannot be prepared: Reuse must decline (return nil) so the
+// caller falls back to Prepare, instead of handing back an environment with an
+// empty CodexHome that only fails later at launch.
 func TestReuseCodexRejectsUnusableHome(t *testing.T) {
 	t.Setenv("CODEX_HOME", t.TempDir())
 	root := t.TempDir()


### PR DESCRIPTION
## What does this PR do?

Decline Codex environment reuse when the task-local Codex home cannot be prepared, so the task falls back to a fresh `Prepare` instead of failing outright.

### Context and reasoning

Before launching a follow-up run, the daemon reuses the previous workdir and refreshes that task's Codex home. If `prepareCodexHomeWithOpts` returns an error, `Reuse` used to log a warning and hand back an environment with an empty `CodexHome`.

That environment never actually launched: `configureCodexTaskShellEnvironment` rejects an empty value with `task CODEX_HOME is missing`, so the run failed before Codex started. It did **not** launch against an inherited or default session store — an earlier revision of this description said it did, which was wrong.

The real problem is recovery. A preparation failure that is local to the old environment (for example the `codex-home` path blocked by a regular file) left the task with no path forward, even though a fresh environment would have worked. Returning `nil` uses the existing caller contract — the daemon falls through to fresh `Prepare` — which matches how required setup failures are handled for other providers and avoids a broader API or session-policy change.

The trade-off, accepted deliberately: declining reuse gives up the automatic continuation of the previous Codex session and does not carry the old workdir's checkout or uncommitted files into the new environment. Existing handling already clears a session that cannot be resumed and tells the agent to rebuild context from the issue history. If the fresh `Prepare` fails too — as it will for a bad shared config or a full/read-only disk — the task still stops with an error. Successful reuse is unchanged.

## Related Issue

No separate issue; reproduced directly against main at `9fab6da917953c6f1a967a17beef045aff3d0ce5`.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `server/internal/daemon/execenv/execenv.go`: return nil after a fatal Codex home preparation error, and document the `Reuse` contract.
- `server/internal/daemon/execenv/execenv_test.go`: add a deterministic regression using temporary directories and a regular file blocking the home path. No real Codex executable or account is accessed by the fixture.
- `server/internal/daemon/execenv/codex_home.go`: update the MUL-4957 sandbox comment, which still described the old "Reuse leaves `CodexHome` unset, the launch layer refuses" path. The fail-closed guarantee is unchanged: the fresh `Prepare` re-runs the same check and fails the task if the managed block still cannot be written.

## How to Test

1. Run `go test ./internal/daemon/execenv -run '^TestReuseCodexRejectsUnusableHome$' -count=1` from `server/`.
2. With only the test added to unmodified main, it fails because Reuse returns an environment with `CodexHome=""`.
3. With the fix, it passes because reuse is declined.

Additional local validation:
- `go test ./internal/daemon/execenv ./internal/daemon ./pkg/agent`
- `go test -race ./internal/daemon/execenv -run '^TestReuseCodexRejectsUnusableHome$' -count=1`
- `go vet ./internal/daemon/execenv ./internal/daemon ./pkg/agent`
- `git diff --check`

## Risks and scope

Only the fatal Codex home setup branch changes. Successful reuse and best-effort warnings handled inside home preparation are unchanged. Fresh `Prepare` remains the existing fallback; this patch does not recover missing history or guarantee that an unusable prior session can resume, and it does not retry the old environment. It does not change prompts, execution retry budgets, or session persistence policy.

Nothing here changes how the Retry button picks a workdir/session, or the behavior after a manual cancel.

No UI, schema, runtime registration, or user-facing command changes.

## Checklist

- [x] Included the reasoning from daemon dispatch through home preparation to this change
- [x] Ran local tests
- [x] Added regression coverage, confirmed failing before and passing after the fix
- [x] Updated the relevant function contract comment
- [x] Documented risks and scope above

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Asked to submit the upstream-applicable part of a local daemon fix. Created an isolated branch from upstream main, reproduced the faulty return value with a temporary-filesystem test, applied the minimal error-path change, and ran the relevant Go checks. No fork-specific chat persistence changes are included.

---

*Maintainer note: this description and the related code comments were corrected before merge (commit `83c8857`) — the behavior of the fix itself is unchanged.*
