### PR TITLE
MUL-7211 fix(issues): order agent run blocks by the time they show

### DIFF
--- a/packages/views/issues/components/comment-runs.test.ts
+++ b/packages/views/issues/components/comment-runs.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { AgentTask, TimelineEntry } from "@multica/core/types";
-import { commentRunOutput, buildCommentRunView } from "./comment-runs";
+import { commentRunOutput, buildCommentRunView, orderTimelineWithRuns, type CommentRun } from "./comment-runs";
 
 const groupCommentRuns = (...args: Parameters<typeof buildCommentRunView>) => buildCommentRunView(...args).runs;
 
@@ -286,5 +286,60 @@ describe("standaloneCommentRuns", () => {
     const reply = comment("answer", { actor_type: "agent", source_task_id: assigned.id });
     expect(buildCommentRunView(tasks, [...timeline, reply]).standaloneRuns)
       .toEqual([{ task: assigned, commentId: reply.id, anchorCommentId: undefined, hasReply: true }]);
+  });
+});
+
+describe("orderTimelineWithRuns", () => {
+  const order = (topLevel: TimelineEntry[], runs: CommentRun[]) =>
+    orderTimelineWithRuns(topLevel, runs, new Map(topLevel.map((entry) => [entry.id, entry])))
+      .map((item) => ("task" in item ? item.task.id : item.id));
+
+  // MUL-7211: the reply, not the enqueue, owns the slot. A run enqueued at
+  // 10:00 that replies at 10:40 must not sit above a comment written at 10:20.
+  it("places a published reply at its own time, not the run's", () => {
+    const run = task("run", { status: "completed", created_at: "2026-09-07T10:00:00Z", completed_at: "2026-09-07T10:40:00Z" });
+    const midway = comment("midway", { created_at: "2026-09-07T10:20:00Z" });
+    const reply = comment("reply", { actor_type: "agent", source_task_id: run.id, created_at: "2026-09-07T10:40:00Z" });
+    expect(order([midway, reply], [{ task: run, commentId: reply.id, hasReply: true }]))
+      .toEqual(["midway", "run"]);
+  });
+
+  it("keeps a queue wait from dragging the reply above earlier comments", () => {
+    // Enqueued at 10:00, but the agent's previous run held the slot until
+    // 11:00 — every comment in between still reads before this reply.
+    const run = task("run", { status: "completed", created_at: "2026-09-07T10:00:00Z",
+      started_at: "2026-09-07T11:00:00Z", completed_at: "2026-09-07T11:05:00Z" });
+    const first = comment("first", { created_at: "2026-09-07T10:30:00Z" });
+    const second = comment("second", { created_at: "2026-09-07T10:45:00Z" });
+    const reply = comment("reply", { actor_type: "agent", source_task_id: run.id, created_at: "2026-09-07T11:05:00Z" });
+    expect(order([first, second, reply], [{ task: run, commentId: reply.id, hasReply: true }]))
+      .toEqual(["first", "second", "run"]);
+  });
+
+  it("parks a working run at the live end and keeps live runs in start order", () => {
+    const earlier = task("earlier", { status: "running", created_at: "2026-09-07T10:00:00Z" });
+    const later = task("later", { status: "queued", created_at: "2026-09-07T10:30:00Z" });
+    const posted = comment("posted", { created_at: "2026-09-07T10:45:00Z" });
+    expect(order([posted], [{ task: earlier, hasReply: false }, { task: later, hasReply: false }]))
+      .toEqual(["posted", "earlier", "later"]);
+  });
+
+  it("settles a run that ended without a reply at the time it ended", () => {
+    const failed = task("failed", { status: "failed", created_at: "2026-09-07T10:00:00Z", completed_at: "2026-09-07T10:10:00Z" });
+    const before = comment("before", { created_at: "2026-09-07T10:05:00Z" });
+    const after = comment("after", { created_at: "2026-09-07T10:20:00Z" });
+    expect(order([before, after], [{ task: failed, hasReply: false }])).toEqual(["before", "failed", "after"]);
+  });
+
+  it("replaces the reply's own slot so the comment is not rendered twice", () => {
+    const run = task("run", { status: "completed", created_at: "2026-09-07T10:00:00Z", completed_at: "2026-09-07T10:40:00Z" });
+    const reply = comment("reply", { actor_type: "agent", source_task_id: run.id, created_at: "2026-09-07T10:40:00Z" });
+    expect(order([reply], [{ task: run, commentId: reply.id, hasReply: true }])).toEqual(["run"]);
+  });
+
+  it("breaks equal timestamps with the server's created_at then id order", () => {
+    const same = "2026-09-07T10:00:00Z";
+    expect(order([comment("b", { created_at: same }), comment("a", { created_at: same })], []))
+      .toEqual(["a", "b"]);
   });
 });

--- a/packages/views/issues/components/comment-runs.test.ts
+++ b/packages/views/issues/components/comment-runs.test.ts
@@ -316,7 +316,7 @@ describe("orderTimelineWithRuns", () => {
       .toEqual(["first", "second", "run"]);
   });
 
-  it("parks a working run at the live end and keeps live runs in start order", () => {
+  it("parks a working run at the live end and keeps live runs in enqueue order", () => {
     const earlier = task("earlier", { status: "running", created_at: "2026-09-07T10:00:00Z" });
     const later = task("later", { status: "queued", created_at: "2026-09-07T10:30:00Z" });
     const posted = comment("posted", { created_at: "2026-09-07T10:45:00Z" });
@@ -341,5 +341,20 @@ describe("orderTimelineWithRuns", () => {
     const same = "2026-09-07T10:00:00Z";
     expect(order([comment("b", { created_at: same }), comment("a", { created_at: same })], []))
       .toEqual(["a", "b"]);
+  });
+
+  // The API serializes timestamps to whole seconds, so a reply sharing one
+  // with a neighbouring comment is routine. The run block must tie-break on
+  // its reply's id — the row that owns the slot — not on the task behind it,
+  // which carries an unrelated enqueue time and id.
+  it("breaks a tie between a reply and a comment on the reply's own row", () => {
+    const same = "2026-09-07T10:40:00Z";
+    const run = task("zzz-task", { status: "completed", created_at: "2026-09-07T10:00:00Z", completed_at: same });
+    const reply = comment("bbb-reply", { actor_type: "agent", source_task_id: run.id, created_at: same });
+    const neighbour = comment("aaa-comment", { created_at: same });
+    const placed: CommentRun = { task: run, commentId: reply.id, hasReply: true };
+    expect(order([neighbour, reply], [placed])).toEqual(["aaa-comment", "zzz-task"]);
+    expect(order([comment("ccc-comment", { created_at: same }), reply], [placed]))
+      .toEqual(["zzz-task", "ccc-comment"]);
   });
 });

--- a/packages/views/issues/components/comment-runs.ts
+++ b/packages/views/issues/components/comment-runs.ts
@@ -169,3 +169,52 @@ export function buildCommentRunView(
     standaloneRuns: placements.filter((run) => !run.anchorCommentId),
   };
 }
+
+/**
+ * Where a standalone run block sits in the timeline.
+ *
+ * A block's slot must agree with the timestamp it renders, or the timeline
+ * stops reading chronologically (MUL-7211): a run enqueued at 10:00 that
+ * replies at 10:40 used to sit in the 10:00 slot while its card showed 10:40,
+ * pushing it above every comment written in between. The sort key is the run's
+ * `created_at` — the moment it was ENQUEUED, not started — and runs serialize
+ * per (issue, agent), so even a five-minute run can carry a slot from far
+ * earlier and bracket several later comments.
+ *
+ * So: once a run has published its reply, the reply's own time owns the slot.
+ * A run still working has no timestamp to show (its card counts elapsed time),
+ * so it parks at the live end and settles in place when the reply lands —
+ * no jump. A run that ended without a reply is history, not live: it sorts at
+ * the moment it ended.
+ */
+function standaloneRunSortTime(run: CommentRun, entryById: ReadonlyMap<string, TimelineEntry>): number {
+  const reply = run.hasReply && run.commentId ? entryById.get(run.commentId) : undefined;
+  if (reply) return Date.parse(reply.created_at);
+  if (isActiveCommentRun(run.task)) return Number.POSITIVE_INFINITY;
+  return Date.parse(run.task.completed_at ?? run.task.created_at);
+}
+
+/**
+ * Merge standalone runs into the top-level timeline in reading order.
+ *
+ * A run that published a reply REPLACES that comment's own top-level slot —
+ * the block renders the comment card, so leaving both would double it.
+ */
+export function orderTimelineWithRuns(
+  topLevel: readonly TimelineEntry[],
+  standaloneRuns: readonly CommentRun[],
+  entryById: ReadonlyMap<string, TimelineEntry>,
+): (TimelineEntry | CommentRun)[] {
+  const slotted = new Set(standaloneRuns.filter((run) => run.hasReply).map((run) => run.commentId));
+  const sortTime = (item: TimelineEntry | CommentRun): number =>
+    "task" in item ? standaloneRunSortTime(item, entryById) : Date.parse(item.created_at);
+  // Ties keep the server's own `created_at ASC, id ASC` order. Compare with
+  // `<` rather than subtraction: two live runs both sort at Infinity, and
+  // Infinity - Infinity is NaN, which would leave the comparator inconsistent.
+  return [...topLevel.filter((entry) => !slotted.has(entry.id)), ...standaloneRuns].sort((a, b) => {
+    const left = sortTime(a), right = sortTime(b);
+    if (left !== right) return left < right ? -1 : 1;
+    const leftRow = "task" in a ? a.task : a, rightRow = "task" in b ? b.task : b;
+    return leftRow.created_at.localeCompare(rightRow.created_at) || leftRow.id.localeCompare(rightRow.id);
+  });
+}

--- a/packages/views/issues/components/comment-runs.ts
+++ b/packages/views/issues/components/comment-runs.ts
@@ -187,8 +187,12 @@ export function buildCommentRunView(
  * no jump. A run that ended without a reply is history, not live: it sorts at
  * the moment it ended.
  */
+function publishedReply(run: CommentRun, entryById: ReadonlyMap<string, TimelineEntry>): TimelineEntry | undefined {
+  return run.hasReply && run.commentId ? entryById.get(run.commentId) : undefined;
+}
+
 function standaloneRunSortTime(run: CommentRun, entryById: ReadonlyMap<string, TimelineEntry>): number {
-  const reply = run.hasReply && run.commentId ? entryById.get(run.commentId) : undefined;
+  const reply = publishedReply(run, entryById);
   if (reply) return Date.parse(reply.created_at);
   if (isActiveCommentRun(run.task)) return Number.POSITIVE_INFINITY;
   return Date.parse(run.task.completed_at ?? run.task.created_at);
@@ -208,13 +212,21 @@ export function orderTimelineWithRuns(
   const slotted = new Set(standaloneRuns.filter((run) => run.hasReply).map((run) => run.commentId));
   const sortTime = (item: TimelineEntry | CommentRun): number =>
     "task" in item ? standaloneRunSortTime(item, entryById) : Date.parse(item.created_at);
-  // Ties keep the server's own `created_at ASC, id ASC` order. Compare with
-  // `<` rather than subtraction: two live runs both sort at Infinity, and
-  // Infinity - Infinity is NaN, which would leave the comparator inconsistent.
+  // Ties are ordinary, not exotic: the API serializes timestamps to whole
+  // seconds (util.TimestampToString), so a reply and the comment next to it
+  // routinely share one. Break them on the row that OWNS the slot — the reply
+  // for a run that published one, never the task behind it — so equal
+  // timestamps keep the server's `created_at ASC, id ASC` order, the same
+  // invariant sortTimelineEntriesAsc holds for the flat cache.
+  const slotRow = (item: TimelineEntry | CommentRun): { created_at: string; id: string } =>
+    "task" in item ? publishedReply(item, entryById) ?? item.task : item;
+  // Compare with `<` rather than subtraction: two live runs both sort at
+  // Infinity, and Infinity - Infinity is NaN, which would leave the
+  // comparator inconsistent.
   return [...topLevel.filter((entry) => !slotted.has(entry.id)), ...standaloneRuns].sort((a, b) => {
     const left = sortTime(a), right = sortTime(b);
     if (left !== right) return left < right ? -1 : 1;
-    const leftRow = "task" in a ? a.task : a, rightRow = "task" in b ? b.task : b;
+    const leftRow = slotRow(a), rightRow = slotRow(b);
     return leftRow.created_at.localeCompare(rightRow.created_at) || leftRow.id.localeCompare(rightRow.id);
   });
 }

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -2888,6 +2888,40 @@ describe("IssueDetail (shared)", () => {
       );
     });
   });
+
+  // MUL-7211 regression: a standalone run's published reply belongs at the
+  // reply's own time. It used to render in the run's ENQUEUE slot while the
+  // card showed the reply time, pushing it above every comment written while
+  // the run worked. Ordering matrix lives in comment-runs.test.ts.
+  it("renders an assignment run's reply after the comments it followed", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      {
+        type: "comment", id: "midway", actor_type: "member", actor_id: "user-1",
+        content: "Remember the E2E pass", parent_id: null,
+        created_at: "2026-01-17T00:00:00Z", updated_at: "2026-01-17T00:00:00Z", comment_type: "comment",
+      },
+      {
+        type: "comment", id: "run-reply", actor_type: "agent", actor_id: "agent-1",
+        content: "step1 done", parent_id: null, source_task_id: "task-early",
+        created_at: "2026-01-18T00:00:00Z", updated_at: "2026-01-18T00:00:00Z", comment_type: "comment",
+      },
+    ]);
+    mockApiObj.listTasksByIssue.mockResolvedValue([{
+      id: "task-early", agent_id: "agent-1", runtime_id: "rt-1", issue_id: "issue-1",
+      kind: "issue", status: "completed", priority: 0,
+      dispatched_at: "2026-01-16T00:00:00Z", started_at: "2026-01-16T00:00:00Z",
+      completed_at: "2026-01-18T00:00:00Z", result: { comment: "step1 done" }, error: null,
+      created_at: "2026-01-16T00:00:00Z", delivered_comment_ids: [],
+    }]);
+
+    const { container } = renderIssueDetail();
+    await screen.findByText("Remember the E2E pass");
+    await screen.findByText("step1 done");
+
+    const rendered = Array.from(container.querySelectorAll("[id^='comment-']")).map((el) => el.id);
+    expect(rendered.indexOf("comment-midway")).toBeLessThan(rendered.indexOf("comment-run-reply"));
+  });
+
 });
 
 describe("groupSubIssuesByStage", () => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -80,7 +80,7 @@ import { ProjectPicker } from "../../projects/components/project-picker";
 import { LocalDirectoryHint } from "../../projects/components/local-directory-hint";
 import { useNewRunIds } from "./use-run-comment-motion";
 import { AgentRunComment, CommentCard } from "./comment-card";
-import { EMPTY_COMMENT_RUNS, buildCommentRunView, type CommentRun } from "./comment-runs";
+import { EMPTY_COMMENT_RUNS, buildCommentRunView, orderTimelineWithRuns, type CommentRun } from "./comment-runs";
 import { issueTasksOptions } from "@multica/core/issues/queries";
 import { SourceContextBadge } from "./source-context-viewer";
 import { RevisionConflictCompare } from "./revision-conflict-compare";
@@ -1508,13 +1508,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     const COALESCE_MS = 2 * 60 * 1000;
     const NO_TIME_LIMIT_ACTIONS = new Set(["task_completed", "task_failed"]);
     const NEVER_COALESCE_ACTIONS = new Set(["squad_leader_evaluated"]);
-    // Unanchored runs separate activity groups at their actual start position.
-    const standaloneReplyIds = new Set(standaloneRuns.filter((run) => run.hasReply).map((run) => run.commentId));
-    const chronological = [...topLevel.filter((entry) => !standaloneReplyIds.has(entry.id)), ...standaloneRuns].sort((a, b) => {
-      const left = "task" in a ? a.task : a;
-      const right = "task" in b ? b.task : b;
-      return Date.parse(left.created_at) - Date.parse(right.created_at);
-    });
+    // Unanchored runs join the timeline at the time their card shows: a
+    // published reply's own time, the live end while still working.
+    const entryById = new Map(displayTimeline.map((entry) => [entry.id, entry]));
+    const chronological = orderTimelineWithRuns(topLevel, standaloneRuns, entryById);
     const coalesced: (TimelineEntry | CommentRun)[] = [];
     for (const entry of chronological) {
       if ("task" in entry) {
@@ -1543,7 +1540,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     const groups: RawTimelineGroup[] = [];
     for (const entry of coalesced) {
       if ("task" in entry) {
-        groups.push({ type: "run", run: entry, entry: entry.hasReply ? displayTimeline.find((comment) => comment.id === entry.commentId) : undefined });
+        groups.push({ type: "run", run: entry, entry: entry.hasReply && entry.commentId ? entryById.get(entry.commentId) : undefined });
       } else if (entry.type === "activity") {
         const last = groups[groups.length - 1];
         if (last?.type === "activities") {


### PR DESCRIPTION
## Problem

Comments in an issue stopped reading in chronological order. Reported with a squad issue where a comment stamped "28 minutes ago" rendered above one stamped "1 hour ago".

A standalone run block — a run with no trigger comment, i.e. triggered by assignment, squad dispatch, or a status change — was sorted on `task.created_at`, while the block itself renders the reply comment's card and therefore shows the *reply's* timestamp. The two disagreed, so a run enqueued at 10:00 that replied at 10:40 held the 10:00 slot and pushed itself above every comment written while it worked.

The sort key was the moment the run was **enqueued**, not started. `ClaimAgentTask` serializes per `(issue, agent)` and the pending-slot unique index covers only `queued`/`dispatched`, so a follow-up run queues while the current one is still `running`. A run that genuinely executes for five minutes can carry a slot from forty minutes earlier and bracket several later comments.

Introduced by #8131, shipped in v0.4.42. Before that the top-level list used the server's `created_at ASC, id ASC` order with no client-side re-sort, so a block's slot and its timestamp agreed by construction.

## Change

Sort a standalone run block by the time its card actually shows:

- **Published a reply** → the reply's own `created_at`.
- **Still working** → the live end. Its card counts elapsed time rather than showing a timestamp, so there is nothing to disagree with, and it settles in place when the reply lands instead of holding a slot it would later jump out of.
- **Ended without a reply** → the moment it ended (`completed_at`), since it is history rather than live.

The ordering moves into `orderTimelineWithRuns` in `comment-runs.ts`, next to the placement logic it belongs with, so the matrix is unit-testable without a DOM mount. Ties fall back to the server's own `created_at ASC, id ASC`. The comparator compares with `<` rather than subtraction because two live runs both sort at `Infinity` and `Infinity - Infinity` is `NaN`.

While in the same block, the `displayTimeline.find(...)` inside the grouping loop now reuses the id map built for the sort.

Thread-anchored runs are untouched: they render nested under their trigger comment and never took part in the top-level sort.

## Verification

- `packages/views/issues/components/comment-runs.test.ts` — 6 ordering cases: reply-owns-slot, the queue-wait case, live runs parking at the end in start order, terminal-without-reply, the slot replacement that keeps a reply from rendering twice, and the tie-break.
- `packages/views/issues/components/issue-detail.test.tsx` — one named DOM regression asserting render order, pointing at the unit file for the matrix.
- Confirmed the tests catch the bug: with the ordering temporarily reverted to `task.created_at`, all 5 behavioural tests fail; they pass on this branch.
- `pnpm test` (4983 tests, 418 files), `pnpm typecheck`, `pnpm lint` — all green locally. Lint reports 0 errors; the 26 warnings are pre-existing and in other files.

## Note for review

There is a related rule I deliberately did **not** change: inside a thread, a comment-triggered run's reply slots directly below the comment that triggered it rather than at its own timestamp, which produces the same non-monotonic timestamps within that thread. Question-then-answer adjacency reads better there, so it seemed worth keeping — happy to revisit if reviewers disagree.
