### PR TITLE
docs(migrations): short maintainer-approved note on 451 backfill removal (HYP-1760)

### DIFF
--- a/server/migrations/451_agent_task_comment_thread.up.sql
+++ b/server/migrations/451_agent_task_comment_thread.up.sql
@@ -32,3 +32,10 @@ FOR EACH ROW EXECUTE FUNCTION set_agent_task_comment_thread();
 
 -- Existing rows intentionally retain a NULL thread scope. Pre-migration tasks
 -- drain under the issue/agent claim fence without rewriting historical data.
+
+-- Do NOT add a backfill here. Migration 451 originally shipped one and it was
+-- removed: rewriting the whole historical queue at startup is unsafe against
+-- production data volume, and there is nothing to gain — the only rows without
+-- a thread scope are the tasks in flight during the rolling deploy, and their
+-- historical thread scope has no value. #8229 proposed doing it again as
+-- migration 457 and was closed for the same reason.


### PR DESCRIPTION
## Summary

Docs-only revision of #8235 per upstream maintainer (Bohan-J) review on the closed PR: **supersedes #8235**. Adds a single short note at the same spot in `server/migrations/451_agent_task_comment_thread.up.sql`, using the maintainer's proposed text — no line-number inventory, no future-fix runbook. Zero behavioral change; the diff touches SQL comments only (+7 lines).

## Why #8235 was closed (maintainer's review, recorded here for the trail)

1. No future backfill to plan for — the only thread-less rows are tasks in flight during the ~1 min rolling deploy; they drain on their own and nothing downstream needs their historical thread scope. A written "future fix path" invites the next person to pick up a path upstream does not want taken.
2. #8229's real rejection reason is safety + zero gain (recursively resolving comment roots across the whole historical queue at startup is unsafe at production data volume, and the rewrite buys nothing) — not a methodology gap to be fixed with guards.
3. Factual fix: `comment_thread_root_id` is `STRICT`, so `EnqueueTaskForIssueWithHandoff` rows (empty UUID trigger comment) keep `comment_thread_id = NULL` permanently — intentional; "NULL selects assignment-level work" (`HasPendingTaskForIssueAndAgentInThread`, agent.sql:1746). The NULL bucket is a permanent, legitimate namespace, not a draining legacy set. The earlier "trigger guarantees every NEW row carries a real thread scope" claim was wrong and is gone.
4. 42 lines of prose with hard-coded drifting line numbers was the wrong size/placement; this is the short note in the same spot the maintainer said they would merge.

## Acceptance evidence

- [x] Diff touches only comments in the 451 up migration (+7 lines, verbatim maintainer text)
- [x] Content consistent with the maintainer's four points — no fence inventory, no runbook, no STRICT-bucket error, correct #8229 attribution
- [x] PR is open, not draft
- [x] Migration-runner safety: ledger is version-keyed, no content checksum (`server/internal/migrations/migrations.go`), so editing comments in an applied migration is safe — same argument the maintainer verified independently on #8235

## Risk and rollback

- **Risk**: none behavioral (comments only).
- **Rollback**: revert the single commit.

Merge per maintainer: "If you'd like to open that, we'll merge it." Final merge confirmation rests with Pojo / upstream (multica-eve holds merge rights).

Refs: HYP-1760 (this change), HYP-1750 (parent audit). Supersedes #8235 per maintainer request.
