### PR TITLE
MUL-7228: index assignee frequency history

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -299,6 +299,7 @@ var concurrentIndexCleanups = map[string]string{
 	"445_comment_delegated_failure_unsettled_index":             "idx_comment_delegated_failure_unsettled",
 	"446_issue_properties_bigm_index":                           "idx_issue_properties_bigm",
 	"452_agent_task_pending_thread_unique":                      "idx_one_pending_task_per_issue_agent_thread",
+	"458_activity_log_member_assignee_frequency_index":          "idx_activity_log_member_assignee_frequency",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction

--- a/server/migrations/458_activity_log_member_assignee_frequency_index.down.sql
+++ b/server/migrations/458_activity_log_member_assignee_frequency_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_activity_log_member_assignee_frequency;

--- a/server/migrations/458_activity_log_member_assignee_frequency_index.up.sql
+++ b/server/migrations/458_activity_log_member_assignee_frequency_index.up.sql
@@ -1,0 +1,15 @@
+-- CountAssigneeChangesByActor filters by workspace and member actor, then
+-- groups on the assignment target stored in details. Keep the expressions in
+-- key order so PostgreSQL can aggregate the matching history directly from
+-- this targeted partial index instead of scanning the full activity log.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_log_member_assignee_frequency
+    ON activity_log (
+        workspace_id,
+        actor_id,
+        (details->>'to_type'),
+        (details->>'to_id')
+    )
+    WHERE actor_type = 'member'
+      AND action = 'assignee_changed'
+      AND details->>'to_type' IS NOT NULL
+      AND details->>'to_id' IS NOT NULL;


### PR DESCRIPTION
## Summary

- add a partial expression index for `CountAssigneeChangesByActor`
- align the index keys with the query's workspace/actor filters and assignment-target grouping
- register the concurrent build for invalid-index cleanup on migration retry

## Why

The production query currently performs a two-worker parallel sequential scan over about 13.33 million `activity_log` rows. A representative read-only production run took 7.49 seconds and read about 2.07 GiB of buffers to retain 3,858 rows.

The partial predicate limits the new index to member-authored `assignee_changed` rows with a target. Production sampling estimates roughly 177,000 qualifying entries (about 1.33% of the table), so the index can remove the full-table scan without changing ranking semantics.

## Validation

- `go test ./cmd/migrate -count=1`
- `go test ./internal/migrations -count=1`
- `git diff --check`
- isolated PostgreSQL 17 dry-run:
  - before migration: `Parallel Seq Scan` plus sort
  - after migration: `Index Scan using idx_activity_log_member_assignee_frequency`, 100 candidate rows grouped into 3 targets, 10 shared buffers, 0.025 ms in the synthetic fixture
  - index reported `indisready = true` and `indisvalid = true`
  - down migration removed the index successfully

## Rollout notes

The build uses `CREATE INDEX CONCURRENTLY`, so existing reads and writes remain compatible and application rollback is independent of the index. Building it still reads the full table once and should be monitored for I/O pressure. The migration runner cleanup registration removes an invalid leftover before retrying an interrupted concurrent build.

Closes MUL-7228
