### PR TITLE
MUL-7230: index assistant chat messages by task

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -300,6 +300,7 @@ var concurrentIndexCleanups = map[string]string{
 	"446_issue_properties_bigm_index":                           "idx_issue_properties_bigm",
 	"452_agent_task_pending_thread_unique":                      "idx_one_pending_task_per_issue_agent_thread",
 	"458_activity_log_member_assignee_frequency_index":          "idx_activity_log_member_assignee_frequency",
+	"459_chat_message_assistant_task_index":                     "idx_chat_message_assistant_task",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction

--- a/server/migrations/459_chat_message_assistant_task_index.down.sql
+++ b/server/migrations/459_chat_message_assistant_task_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_chat_message_assistant_task;

--- a/server/migrations/459_chat_message_assistant_task_index.up.sql
+++ b/server/migrations/459_chat_message_assistant_task_index.up.sql
@@ -1,0 +1,11 @@
+-- Index the task-owned assistant lookup used by quick-action generation.
+--
+-- GetChatMessageByTaskAssistant and SetChatMessageQuickActionsByTask both find
+-- the newest assistant row for one task. The existing task_id index is partial
+-- on role = 'user', so neither query can use it and both scan chat_message.
+--
+-- Single-statement migration: CREATE INDEX CONCURRENTLY cannot run inside a
+-- transaction or a multi-command string.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chat_message_assistant_task
+    ON chat_message (task_id, created_at DESC)
+    WHERE role = 'assistant';


### PR DESCRIPTION
## Summary

- add a concurrent partial index for assistant chat messages keyed by task and recency
- register migration 459 with the invalid concurrent-index cleanup hook
- provide a concurrent rollback that removes only the new index
- use migration 459 after migration 458 landed in #8243

## Why

Quick-action generation loads the latest assistant message by `task_id` and then repeats the same lookup inside `SetChatMessageQuickActionsByTask`. The existing task index is partial on `role = 'user'`, so both assistant lookups scan the full `chat_message` table.

A production read-only plan on roughly 1.47 million rows scanned about 1.05 GiB and took 3.32 seconds for one assistant lookup. The analogous user lookup used the existing partial index and touched four pages. The new assistant index gives both quick-action queries the same indexed access path without changing query semantics.

## Validation

- `go test ./cmd/migrate -count=1`
- `go test ./internal/migrations -count=1`
- applied all migrations through 459 to an isolated fresh PostgreSQL 17 database
- verified migrations 458 and 459 are both recorded in the migration ledger
- verified both concurrent indexes are valid and ready
- `git diff --check`

## Rollout

The change is additive and compatible with old and new server versions. `CREATE INDEX CONCURRENTLY` avoids blocking normal writes, but building the estimated 49–50 MB index on the production table will still consume database I/O and should be monitored during rollout. The cleanup registration makes an interrupted build repairable on migration retry.
