### PR TITLE
MUL-7229: index Autopilot task recovery lookup

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -301,6 +301,7 @@ var concurrentIndexCleanups = map[string]string{
 	"452_agent_task_pending_thread_unique":                      "idx_one_pending_task_per_issue_agent_thread",
 	"458_activity_log_member_assignee_frequency_index":          "idx_activity_log_member_assignee_frequency",
 	"459_chat_message_assistant_task_index":                     "idx_chat_message_assistant_task",
+	"460_agent_task_queue_autopilot_run_created_at_index":       "idx_agent_task_queue_autopilot_run_created_at",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction

--- a/server/migrations/460_agent_task_queue_autopilot_run_created_at_index.down.sql
+++ b/server/migrations/460_agent_task_queue_autopilot_run_created_at_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_queue_autopilot_run_created_at;

--- a/server/migrations/460_agent_task_queue_autopilot_run_created_at_index.up.sql
+++ b/server/migrations/460_agent_task_queue_autopilot_run_created_at_index.up.sql
@@ -1,0 +1,11 @@
+-- Single statement: CREATE INDEX CONCURRENTLY cannot run inside a transaction
+-- or share a multi-command migration file.
+--
+-- GetAutopilotTaskByRun recovers run_only dispatches whose task INSERT committed
+-- before autopilot_run.task_id was linked. Without an autopilot_run_id-leading
+-- index, finding the earliest task scans and sorts the entire task queue.
+-- Automatic retries inherit the same autopilot_run_id, so this index must remain
+-- non-unique. The partial predicate avoids indexing ordinary non-Autopilot tasks.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_queue_autopilot_run_created_at
+    ON agent_task_queue (autopilot_run_id, created_at)
+    WHERE autopilot_run_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- add a partial composite index on `agent_task_queue (autopilot_run_id, created_at)` for `GetAutopilotTaskByRun`
- keep the index non-unique because automatic retry tasks inherit the same Autopilot run ID
- register the migration's invalid concurrent-index cleanup and provide a concurrent rollback

## Why

The `run_only` crash-recovery lookup currently filters and sorts the full task queue. On the production read replica, the query used a two-worker parallel sequential scan over nearly all of the 8.9 GB heap and took 27.4 seconds for one matching row. The new index supports the equality filter and earliest-task ordering directly while excluding ordinary tasks whose `autopilot_run_id` is null.

## Safety

- the index is built with `CREATE INDEX CONCURRENTLY` in a single-statement migration
- interrupted builds are covered by the migration runner's invalid-index cleanup hook
- the change is additive and compatible with old and new application versions
- rollback drops only this index with `DROP INDEX CONCURRENTLY`

## Validation

- `go test ./cmd/migrate -count=1`
- migrated a fresh isolated PostgreSQL 17 database from `001` through `460`
- verified the index is valid, ready, non-unique, and has the expected partial predicate
- verified a forced generic prepared form of `GetAutopilotTaskByRun` plans as `Limit -> Index Scan` without a sort
- applied the `460` down migration and then reapplied the up migration successfully

Closes MUL-7229
