### PR TITLE
MUL-7236: add anonymous self-host telemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -631,6 +631,16 @@ ALLOWED_EMAILS=
 # so toggling requires a backend restart but not a frontend rebuild.
 DISABLE_WORKSPACE_CREATION=
 
+# ==================== Anonymous Self-host Telemetry ====================
+# The API server sends one first-party, deployment-level anonymous snapshot per
+# UTC day to https://telemetry.multica.ai. It contains the release version,
+# bucketed workspace/member/agent/active-daemon counts, and aggregate run counts
+# for the previous 24 hours. It never includes names, email addresses, content,
+# business IDs, host/device data, prompts, paths, credentials, or error text.
+# Set to 1 or true (case-insensitive) and recreate/restart the backend to disable
+# both collection and delivery. This is separate from ANALYTICS_DISABLED below.
+DO_NOT_TRACK=
+
 # ==================== Analytics (PostHog) ====================
 # Product analytics events feed the acquisition → activation → expansion funnel.
 # Leave POSTHOG_API_KEY empty for local dev / self-hosted instances; the server

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -12,6 +12,14 @@ Deploy Multica on your own infrastructure in minutes.
 
 Each user who runs AI agents locally also installs the **`multica` CLI** and runs the **agent daemon** on their own machine.
 
+## Anonymous Deployment Telemetry
+
+The self-hosted API server sends one first-party, deployment-level anonymous snapshot per UTC day to the fixed Multica endpoint `https://telemetry.multica.ai/v1/telemetry/events`. This helps maintainers understand which release versions are in use, deployment-size ranges, and aggregate run volume. The endpoint is compiled into the server and cannot be redirected through configuration.
+
+The snapshot contains only the release version; bucketed counts of workspaces, distinct human members, active agents, and daemons seen in the previous 24 hours; and aggregate counts of runs started, completed, failed, and cancelled in that window. It does not include names, email addresses or domains, IP addresses, business IDs, host/device details, repository or organization details, model/plugin data, prompts or output, comments or chats, paths, token/cost data, credentials, errors, stacks, or logs. This telemetry is not used for billing, licensing, authentication, or security decisions.
+
+Telemetry is enabled by default. To stop both collection and network delivery, set `DO_NOT_TRACK=1` or `DO_NOT_TRACK=true` on the API server and recreate/restart the backend. The deployment identity remains in PostgreSQL, so enabling it again does not create a new identity. `ANALYTICS_DISABLED` controls the separate PostHog integration and does not disable this first-party telemetry.
+
 ## Quick Install (Recommended)
 
 Two commands to set up everything — server, CLI, and configuration.

--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -303,11 +303,16 @@ multica config show
 
 | 変数 | デフォルト | 説明 |
 |---|---|---|
+| `DO_NOT_TRACK` | 空（テレメトリー有効） | `1` または `true`（大文字小文字を区別しない）で、ファーストパーティの匿名セルフホストテレメトリーの収集と送信を停止 |
 | `ANALYTICS_DISABLED` | `false` | `true` で PostHog への送信を無効化 |
 | `POSTHOG_API_KEY` | 空 | 未設定の場合は分析送信が無効。自前の PostHog プロジェクトを使う場合に設定 |
 | `POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog アドレス |
 | `METRICS_ADDR` | 空 | Prometheus metrics のリッスンアドレス。空なら起動しません |
 | `REALTIME_METRICS_TOKEN` | 空 | `/health/realtime` を保護する bearer token |
+
+ファーストパーティのセルフホストテレメトリーは、UTC 日ごとにデプロイ単位のスナップショットを、固定かつ設定変更不可の `https://telemetry.multica.ai/v1/telemetry/events` へ送信します。正式リリース版、ワークスペース数・重複を除いたメンバー数・アクティブなエージェント数・過去 24 時間のアクティブなデーモン数のバケット、および過去 24 時間に開始・完了・失敗・キャンセルされた実行の集計値だけを含みます。名前、メールアドレスやドメイン、IP、業務 ID、ホストやデバイス情報、リポジトリ、モデルや plugin、prompt/output、コメントやチャット、ファイルパス、token/費用、認証情報、エラー、stack、ログは送信しません。このデータはセルフホスト版の採用状況、デプロイ規模、集計利用量の把握だけに使われ、課金、ライセンス、認証、セキュリティ判断には使われません。
+
+`DO_NOT_TRACK` と `ANALYTICS_DISABLED` は独立しています。前者はこの匿名スナップショットを、後者は任意の PostHog 連携を制御します。
 
 ## 次のステップ
 

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -303,11 +303,16 @@ multica config show
 
 | 변수 | 기본값 | 설명 |
 |---|---|---|
+| `DO_NOT_TRACK` | 비어 있음(텔레메트리 활성화) | `1` 또는 `true`(대소문자 구분 없음)로 설정하면 자사 익명 셀프 호스트 텔레메트리 수집과 전송 중지 |
 | `ANALYTICS_DISABLED` | `false` | `true`로 설정하면 PostHog 전송 비활성화 |
 | `POSTHOG_API_KEY` | 비어 있음 | 설정하지 않으면 통계 전송 비활성화. 자체 PostHog 프로젝트 연결 시 입력 |
 | `POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog 주소 |
 | `METRICS_ADDR` | 비어 있음 | Prometheus metrics listen 주소. 비어 있으면 시작하지 않음 |
 | `REALTIME_METRICS_TOKEN` | 비어 있음 | `/health/realtime`을 보호하는 bearer token |
+
+자사 셀프 호스트 텔레메트리는 UTC 기준 하루에 한 번 배포 단위 스냅샷을 고정되어 설정할 수 없는 `https://telemetry.multica.ai/v1/telemetry/events` 주소로 전송합니다. 정식 릴리스 버전, 작업 공간 수·중복을 제거한 멤버 수·활성 에이전트 수·지난 24시간 활성 데몬 수의 버킷, 그리고 지난 24시간 시작·완료·실패·취소된 실행의 집계만 포함합니다. 이름, 이메일 주소나 도메인, IP, 업무 ID, 호스트나 기기 정보, 저장소, 모델이나 plugin, prompt/output, 댓글이나 채팅, 파일 경로, token/비용, 자격 증명, 오류, stack, 로그는 전송하지 않습니다. 이 데이터는 셀프 호스트 버전 사용 현황, 배포 규모, 집계 사용량을 파악하는 데만 쓰며 결제, 라이선스, 인증, 보안 판단에는 사용하지 않습니다.
+
+`DO_NOT_TRACK`과 `ANALYTICS_DISABLED`는 서로 독립적입니다. 전자는 이 익명 스냅샷을, 후자는 선택 사항인 PostHog 연동을 제어합니다.
 
 ## 다음 단계
 

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -303,11 +303,16 @@ A few value rules:
 
 | Variable | Default | Description |
 |---|---|---|
+| `DO_NOT_TRACK` | empty (telemetry enabled) | Set `1` or `true` (case-insensitive) to stop first-party anonymous self-host telemetry collection and delivery |
 | `ANALYTICS_DISABLED` | `false` | Set `true` to turn off PostHog reporting |
 | `POSTHOG_API_KEY` | empty | Reporting is off when unset; set it to use your own PostHog project |
 | `POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog host |
 | `METRICS_ADDR` | empty | Prometheus metrics listen address; empty means not started |
 | `REALTIME_METRICS_TOKEN` | empty | Bearer token protecting `/health/realtime` |
+
+First-party self-host telemetry sends one deployment-level snapshot per UTC day to the fixed, non-configurable `https://telemetry.multica.ai/v1/telemetry/events` endpoint. It contains the formal release version; bucketed workspace, distinct-human-member, active-agent, and 24-hour active-daemon counts; and aggregate run counts for the previous 24 hours. It never includes names, email addresses or domains, IP addresses, business identifiers, host/device details, repositories, models/plugins, prompts/output, comments/chats, paths, token/cost data, credentials, errors, stacks, or logs. It is used only to understand self-hosted version adoption, deployment-size ranges, and aggregate usage—not for billing, licensing, authentication, or security decisions.
+
+`DO_NOT_TRACK` and `ANALYTICS_DISABLED` are independent. The former controls this first-party anonymous snapshot; the latter controls the optional PostHog integration.
 
 ## Next steps
 

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -303,11 +303,16 @@ multica config show
 
 | 变量 | 默认值 | 说明 |
 |---|---|---|
+| `DO_NOT_TRACK` | 空（默认开启遥测） | 设为 `1` 或 `true`（不区分大小写）后，停止首方匿名自托管遥测的采集与发送 |
 | `ANALYTICS_DISABLED` | `false` | 设为 `true` 关闭 PostHog 上报 |
 | `POSTHOG_API_KEY` | 空 | 不设置时统计上报关闭；接入自己的 PostHog 项目时填写 |
 | `POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog 地址 |
 | `METRICS_ADDR` | 空 | Prometheus metrics 监听地址；空表示不启动 |
 | `REALTIME_METRICS_TOKEN` | 空 | 保护 `/health/realtime` 的 bearer token |
+
+首方自托管遥测每天按 UTC 发送一份部署级快照，固定且不可配置的地址为 `https://telemetry.multica.ai/v1/telemetry/events`。快照只包含正式发布版本、工作区数/去重成员数/活跃智能体数/过去 24 小时活跃守护进程数的分桶，以及过去 24 小时运行的开始、完成、失败和取消总数。不会发送名称、邮箱或域名、IP、业务标识符、主机或设备信息、代码仓库、模型或 plugin、prompt/output、评论或聊天、文件路径、token/费用、凭据、错误文本、stack 或日志。此数据只用于了解自托管版本采用、部署规模区间与聚合使用量，不用于计费、授权、认证或安全决策。
+
+`DO_NOT_TRACK` 与 `ANALYTICS_DISABLED` 相互独立：前者控制这份首方匿名快照，后者控制可选的 PostHog 集成。
 
 ## 接下来
 

--- a/deploy/helm/multica/templates/configmap.yaml
+++ b/deploy/helm/multica/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
   ALLOWED_EMAILS: {{ .Values.backend.config.allowedEmails | quote }}
   ALLOWED_EMAIL_DOMAINS: {{ .Values.backend.config.allowedEmailDomains | quote }}
   DISABLE_WORKSPACE_CREATION: {{ .Values.backend.config.disableWorkspaceCreation | quote }}
+  DO_NOT_TRACK: {{ .Values.backend.config.doNotTrack | quote }}
   MULTICA_VCS_INTEGRATION_ENABLED: {{ .Values.backend.config.vcsIntegrationEnabled | quote }}
   MULTICA_CLOUD_URL: {{ .Values.backend.config.cloud.url | quote }}
   GOOGLE_CLIENT_ID: {{ .Values.backend.config.googleClientId | quote }}

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -134,6 +134,9 @@ backend:
     # every caller. Bootstrap the workspace with this false, then flip to
     # true so users can only join via invitation.
     disableWorkspaceCreation: false
+    # Set to "1" or "true" to disable first-party anonymous self-host
+    # telemetry collection and delivery.
+    doNotTrack: ""
     # Self-host-only VCS integration (Forgejo / Gitea / GitLab). The official
     # chart enables the product surface by default; operators must also provide
     # MULTICA_VCS_SECRET_KEY through existingSecret before connections work.

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -108,6 +108,7 @@ services:
       ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}
       ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-}
       DISABLE_WORKSPACE_CREATION: ${DISABLE_WORKSPACE_CREATION:-}
+      DO_NOT_TRACK: ${DO_NOT_TRACK:-}
       # Managed Cloud stays off for self-hosting. All managed Cloud clients use
       # this single URL when it is configured.
       MULTICA_CLOUD_URL: ${MULTICA_CLOUD_URL:-}

--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -303,6 +303,9 @@ var concurrentIndexCleanups = map[string]string{
 	"460_agent_task_queue_autopilot_run_created_at_index":       "idx_agent_task_queue_autopilot_run_created_at",
 	"465_agent_task_queue_chat_with_session_index":              "idx_agent_task_queue_chat_with_session_created_at",
 	"466_activity_log_member_assignee_frequency_index":          "idx_activity_log_member_assignee_frequency",
+	"468_instance_telemetry_state_singleton_index":              "instance_telemetry_state_singleton_uidx",
+	"470_agent_runtime_telemetry_last_seen_index":               "idx_agent_runtime_telemetry_last_seen",
+	"471_agent_task_queue_telemetry_started_index":              "idx_agent_task_queue_telemetry_started",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction

--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -304,7 +304,6 @@ var concurrentIndexCleanups = map[string]string{
 	"465_agent_task_queue_chat_with_session_index":              "idx_agent_task_queue_chat_with_session_created_at",
 	"466_activity_log_member_assignee_frequency_index":          "idx_activity_log_member_assignee_frequency",
 	"468_instance_telemetry_state_singleton_index":              "instance_telemetry_state_singleton_uidx",
-	"470_agent_runtime_telemetry_last_seen_index":               "idx_agent_runtime_telemetry_last_seen",
 	"471_agent_task_queue_telemetry_started_index":              "idx_agent_task_queue_telemetry_started",
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/profiling"
 	"github.com/multica-ai/multica/server/internal/realtime"
 	"github.com/multica-ai/multica/server/internal/scheduler"
+	"github.com/multica-ai/multica/server/internal/selfhosttelemetry"
 	"github.com/multica-ai/multica/server/internal/service"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/featureflag"
@@ -311,6 +312,9 @@ func newMainHTTPServer(addr string, handler http.Handler) *http.Server {
 
 func main() {
 	logger.Init()
+	// Read the opt-out before constructing any telemetry dependency. In the
+	// disabled case no collector or HTTP client is ever created.
+	telemetryConfig := selfhosttelemetry.ConfigFromDoNotTrack(os.Getenv("DO_NOT_TRACK"))
 	// Warn about missing configuration
 	if err := jwtSecretBootError(os.Getenv("JWT_SECRET"), os.Getenv("APP_ENV")); err != nil {
 		slog.Error(
@@ -682,6 +686,7 @@ func main() {
 	// Start background workers.
 	sweepCtx, sweepCancel := context.WithCancel(context.Background())
 	autopilotCtx, autopilotCancel := context.WithCancel(context.Background())
+	telemetryWorker := selfhosttelemetry.New(pool, version, telemetryConfig, slog.Default())
 	// Reuse the router's services here. In particular, the router wires the
 	// EmptyClaim cache into TaskService; constructing a second TaskService for
 	// scheduled Autopilot dispatch would send the daemon wakeup without bumping
@@ -712,6 +717,9 @@ func main() {
 	// work, so there is no separate queue TTL to tune: a busy runtime keeps its
 	// backlog, and a departed one retires everything it owned at once.
 	go runRuntimeSweeper(sweepCtx, queries, liveness, taskSvc, bus, runtimeReconnectGrace)
+	if telemetryWorker != nil {
+		go telemetryWorker.Run(sweepCtx)
+	}
 	go runDelegatedFailureRecoverySweeper(sweepCtx, taskSvc)
 	// Seven-day runtime retention does not share the 30-second liveness tick:
 	// its bounded transactions run independently once per hour, so a slow GC

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -315,6 +315,7 @@ func main() {
 	// Read the opt-out before constructing any telemetry dependency. In the
 	// disabled case no collector or HTTP client is ever created.
 	telemetryConfig := selfhosttelemetry.ConfigFromDoNotTrack(os.Getenv("DO_NOT_TRACK"))
+	selfhosttelemetry.LogStartupStatus(slog.Default(), telemetryConfig)
 	// Warn about missing configuration
 	if err := jwtSecretBootError(os.Getenv("JWT_SECRET"), os.Getenv("APP_ENV")); err != nil {
 		slog.Error(

--- a/server/internal/handler/workspace_delete_manifest_test.go
+++ b/server/internal/handler/workspace_delete_manifest_test.go
@@ -68,6 +68,7 @@ var workspaceDeletionManifest = map[string]workspaceDeleteAction{
 	"github_pull_request_check_run":      workspaceDelete,
 	"github_pull_request_check_suite":    workspaceDelete,
 	"inbox_item":                         workspaceDelete,
+	"instance_telemetry_state":           workspaceDeleteKeep,
 	"issue":                              workspaceDelete,
 	"issue_view":                         workspaceDelete,
 	"issue_view_preference":              workspaceDelete,

--- a/server/internal/selfhosttelemetry/client.go
+++ b/server/internal/selfhosttelemetry/client.go
@@ -1,0 +1,85 @@
+package selfhosttelemetry
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"time"
+)
+
+const (
+	productionEndpoint = "https://telemetry.multica.ai/v1/telemetry/events"
+	httpTimeout        = 5 * time.Second
+)
+
+type deliveryDisposition int
+
+const (
+	deliveryRetry deliveryDisposition = iota
+	deliverySuccess
+	deliveryStopForDay
+)
+
+type eventSender interface {
+	Send(context.Context, []byte) deliveryDisposition
+	Close()
+}
+
+// HTTPClient only knows the fixed first-party V1 endpoint. The unexported test
+// constructor below permits local fake servers without creating a deployment
+// configuration surface that could redirect production telemetry.
+type HTTPClient struct {
+	endpoint string
+	client   *http.Client
+}
+
+func newHTTPClient() *HTTPClient {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	return &HTTPClient{
+		endpoint: productionEndpoint,
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   httpTimeout,
+			// Never forward the snapshot to a redirect target. Endpoint ownership
+			// is part of the privacy boundary, not merely a convenience default.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+func newHTTPClientForTest(endpoint string, client *http.Client) *HTTPClient {
+	return &HTTPClient{endpoint: endpoint, client: client}
+}
+
+func (c *HTTPClient) Send(ctx context.Context, body []byte) deliveryDisposition {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return deliveryStopForDay
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return deliveryRetry
+	}
+	// The response body is deliberately never read or logged.
+	_ = resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusAccepted:
+		return deliverySuccess
+	case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
+		return deliveryRetry
+	default:
+		return deliveryStopForDay
+	}
+}
+
+func (c *HTTPClient) Close() {
+	if c == nil || c.client == nil {
+		return
+	}
+	c.client.CloseIdleConnections()
+}

--- a/server/internal/selfhosttelemetry/client_test.go
+++ b/server/internal/selfhosttelemetry/client_test.go
@@ -1,0 +1,129 @@
+package selfhosttelemetry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestProductionHTTPClientIsFixedAndBounded(t *testing.T) {
+	t.Parallel()
+	client := newHTTPClient()
+	defer client.Close()
+	if client.endpoint != "https://telemetry.multica.ai/v1/telemetry/events" {
+		t.Fatalf("endpoint = %q", client.endpoint)
+	}
+	if client.client.Timeout != 5*time.Second {
+		t.Fatalf("timeout = %s, want 5s", client.client.Timeout)
+	}
+	if client.client.Jar != nil {
+		t.Fatal("telemetry client must not have a cookie jar")
+	}
+}
+
+func TestHTTPClientRequestAndResponseClassification(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		status int
+		want   deliveryDisposition
+	}{
+		{"accepted", http.StatusAccepted, deliverySuccess},
+		{"rate limited", http.StatusTooManyRequests, deliveryRetry},
+		{"server error", http.StatusServiceUnavailable, deliveryRetry},
+		{"bad request", http.StatusBadRequest, deliveryStopForDay},
+		{"unexpected success", http.StatusOK, deliveryStopForDay},
+		{"redirect", http.StatusTemporaryRedirect, deliveryStopForDay},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var redirected atomic.Bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/redirected" {
+					redirected.Store(true)
+					w.WriteHeader(http.StatusAccepted)
+					return
+				}
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %s", r.Method)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/json" {
+					t.Errorf("Content-Type = %q", got)
+				}
+				if r.Header.Get("Authorization") != "" || r.Header.Get("Cookie") != "" {
+					t.Error("request carried authentication or cookies")
+				}
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Error(err)
+				}
+				if string(body) != `{"safe":true}` {
+					t.Errorf("body = %s", body)
+				}
+				if tt.status == http.StatusTemporaryRedirect {
+					w.Header().Set("Location", "/redirected")
+				}
+				w.WriteHeader(tt.status)
+			}))
+			defer server.Close()
+
+			httpClient := server.Client()
+			httpClient.Timeout = time.Second
+			httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+			client := newHTTPClientForTest(server.URL, httpClient)
+			if got := client.Send(context.Background(), []byte(`{"safe":true}`)); got != tt.want {
+				t.Fatalf("disposition = %v, want %v", got, tt.want)
+			}
+			if redirected.Load() {
+				t.Fatal("telemetry followed a redirect")
+			}
+		})
+	}
+}
+
+type blockingTransport struct {
+	calls atomic.Int32
+}
+
+func (t *blockingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.calls.Add(1)
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+func TestHTTPClientTimeoutAndCancellationRetry(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		timeout time.Duration
+		cancel  bool
+	}{
+		{"timeout", 10 * time.Millisecond, false},
+		{"cancellation", time.Second, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			transport := &blockingTransport{}
+			client := newHTTPClientForTest("https://local.invalid", &http.Client{
+				Transport: transport,
+				Timeout:   tt.timeout,
+			})
+			ctx, cancel := context.WithCancel(context.Background())
+			if tt.cancel {
+				cancel()
+			} else {
+				defer cancel()
+			}
+			if got := client.Send(ctx, []byte(`{}`)); got != deliveryRetry {
+				t.Fatalf("disposition = %v, want retry", got)
+			}
+			if transport.calls.Load() != 1 {
+				t.Fatalf("transport calls = %d, want 1", transport.calls.Load())
+			}
+		})
+	}
+}

--- a/server/internal/selfhosttelemetry/collector.go
+++ b/server/internal/selfhosttelemetry/collector.go
@@ -1,0 +1,87 @@
+package selfhosttelemetry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const collectionSQL = `
+WITH terminal_tasks AS (
+    SELECT count(*) FILTER (WHERE status = 'completed') AS completed,
+           count(*) FILTER (WHERE status = 'failed') AS failed,
+           count(*) FILTER (WHERE status = 'cancelled') AS cancelled
+      FROM agent_task_queue
+     WHERE status IN ('completed', 'failed', 'cancelled')
+       AND completed_at >= $1
+       AND completed_at < $2
+)
+SELECT
+    (SELECT count(*) FROM workspace),
+    (SELECT count(DISTINCT user_id) FROM member),
+    (SELECT count(*) FROM agent WHERE archived_at IS NULL),
+    (SELECT count(DISTINCT daemon_id)
+       FROM agent_runtime
+      WHERE daemon_id IS NOT NULL
+        AND last_seen_at >= $1
+        AND last_seen_at < $2),
+    (SELECT count(*)
+       FROM agent_task_queue
+      WHERE started_at >= $1
+        AND started_at < $2),
+    terminal_tasks.completed,
+    terminal_tasks.failed,
+    terminal_tasks.cancelled
+FROM terminal_tasks`
+
+const collectionStatementTimeout = 2 * time.Second
+
+type eventCollector interface {
+	Collect(context.Context, *pgx.Conn, time.Time) (Counts, error)
+}
+
+type SQLCollector struct{}
+
+// Collect executes all aggregates in one SQL statement, so PostgreSQL uses one
+// statement snapshot and every field shares exactly the same [T-24h, T)
+// boundary. SET LOCAL guarantees the two-second ceiling cannot leak onto the
+// pooled connection after the transaction ends.
+func (SQLCollector) Collect(ctx context.Context, conn *pgx.Conn, at time.Time) (counts Counts, err error) {
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return Counts{}, fmt.Errorf("begin telemetry collection: %w", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+		defer cancel()
+		if rollbackErr := tx.Rollback(cleanupCtx); rollbackErr != nil && rollbackErr != pgx.ErrTxClosed && err == nil {
+			err = fmt.Errorf("rollback telemetry collection: %w", rollbackErr)
+		}
+	}()
+
+	statementTimeoutSQL := fmt.Sprintf("SET LOCAL statement_timeout = '%dms'", collectionStatementTimeout.Milliseconds())
+	if _, err = tx.Exec(ctx, statementTimeoutSQL); err != nil {
+		return Counts{}, fmt.Errorf("set telemetry statement timeout: %w", err)
+	}
+	from := at.UTC().Add(-24 * time.Hour)
+	to := at.UTC()
+	err = tx.QueryRow(ctx, collectionSQL, from, to).Scan(
+		&counts.Workspaces,
+		&counts.HumanMembers,
+		&counts.Agents,
+		&counts.ActiveDaemons,
+		&counts.TasksStarted,
+		&counts.TasksCompleted,
+		&counts.TasksFailed,
+		&counts.TasksCancelled,
+	)
+	if err != nil {
+		return Counts{}, fmt.Errorf("collect telemetry snapshot: %w", err)
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return Counts{}, fmt.Errorf("commit telemetry collection: %w", err)
+	}
+	return counts, nil
+}

--- a/server/internal/selfhosttelemetry/config.go
+++ b/server/internal/selfhosttelemetry/config.go
@@ -1,0 +1,19 @@
+package selfhosttelemetry
+
+import "strings"
+
+// Config is read once during API server startup. Endpoint selection is
+// deliberately absent: self-host telemetry can only be sent to Multica's
+// first-party collector compiled into the client.
+type Config struct {
+	Enabled bool
+}
+
+// ConfigFromDoNotTrack implements the industry-standard opt-out switch used by
+// the self-hosted server. Only 1 and true (case-insensitive), after trimming,
+// disable telemetry; every other value preserves the default-on behavior.
+func ConfigFromDoNotTrack(raw string) Config {
+	raw = strings.TrimSpace(raw)
+	disabled := raw == "1" || strings.EqualFold(raw, "true")
+	return Config{Enabled: !disabled}
+}

--- a/server/internal/selfhosttelemetry/config.go
+++ b/server/internal/selfhosttelemetry/config.go
@@ -1,6 +1,9 @@
 package selfhosttelemetry
 
-import "strings"
+import (
+	"log/slog"
+	"strings"
+)
 
 // Config is read once during API server startup. Endpoint selection is
 // deliberately absent: self-host telemetry can only be sent to Multica's
@@ -16,4 +19,14 @@ func ConfigFromDoNotTrack(raw string) Config {
 	raw = strings.TrimSpace(raw)
 	disabled := raw == "1" || strings.EqualFold(raw, "true")
 	return Config{Enabled: !disabled}
+}
+
+// LogStartupStatus makes the default-on behavior observable without logging
+// the raw environment value or any telemetry data.
+func LogStartupStatus(logger *slog.Logger, config Config) {
+	if config.Enabled {
+		logger.Info("self-host telemetry enabled")
+		return
+	}
+	logger.Info("self-host telemetry disabled via DO_NOT_TRACK")
 }

--- a/server/internal/selfhosttelemetry/event.go
+++ b/server/internal/selfhosttelemetry/event.go
@@ -1,0 +1,121 @@
+package selfhosttelemetry
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	eventName      = "instance_daily_snapshot"
+	schemaVersion  = 1
+	maxRequestSize = 16 * 1024
+	maxTaskCount   = int64(1_000_000)
+)
+
+var releaseVersionPattern = regexp.MustCompile(`^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+
+// Event is the complete V1 wire contract. Keep this strongly typed: the Cloud
+// receiver rejects unknown fields, and arbitrary maps could accidentally turn
+// internal data into an outbound field.
+type Event struct {
+	EventName     string  `json:"event_name"`
+	SchemaVersion int     `json:"schema_version"`
+	InstanceID    string  `json:"instance_id"`
+	OccurredAt    string  `json:"occurred_at"`
+	Payload       Payload `json:"payload"`
+}
+
+type Payload struct {
+	ServerVersion              string `json:"server_version"`
+	WorkspaceCountBucket       string `json:"workspace_count_bucket"`
+	HumanMemberCountBucket     string `json:"human_member_count_bucket"`
+	AgentCountBucket           string `json:"agent_count_bucket"`
+	ActiveDaemonCount24hBucket string `json:"active_daemon_count_24h_bucket"`
+	TasksStarted24h            int64  `json:"tasks_started_24h"`
+	TasksCompleted24h          int64  `json:"tasks_completed_24h"`
+	TasksFailed24h             int64  `json:"tasks_failed_24h"`
+	TasksCancelled24h          int64  `json:"tasks_cancelled_24h"`
+}
+
+// Counts contains deployment-wide aggregates at one snapshot instant.
+type Counts struct {
+	Workspaces     int64
+	HumanMembers   int64
+	Agents         int64
+	ActiveDaemons  int64
+	TasksStarted   int64
+	TasksCompleted int64
+	TasksFailed    int64
+	TasksCancelled int64
+}
+
+func newEvent(instanceID uuid.UUID, occurredAt time.Time, serverVersion string, counts Counts) Event {
+	return Event{
+		EventName:     eventName,
+		SchemaVersion: schemaVersion,
+		InstanceID:    instanceID.String(),
+		OccurredAt:    occurredAt.UTC().Format(time.RFC3339),
+		Payload: Payload{
+			ServerVersion:              normalizeVersion(serverVersion),
+			WorkspaceCountBucket:       countBucket(counts.Workspaces),
+			HumanMemberCountBucket:     countBucket(counts.HumanMembers),
+			AgentCountBucket:           countBucket(counts.Agents),
+			ActiveDaemonCount24hBucket: countBucket(counts.ActiveDaemons),
+			TasksStarted24h:            clampTaskCount(counts.TasksStarted),
+			TasksCompleted24h:          clampTaskCount(counts.TasksCompleted),
+			TasksFailed24h:             clampTaskCount(counts.TasksFailed),
+			TasksCancelled24h:          clampTaskCount(counts.TasksCancelled),
+		},
+	}
+}
+
+func marshalEvent(event Event) ([]byte, error) {
+	body, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxRequestSize {
+		return nil, errors.New("telemetry event exceeds 16 KiB limit")
+	}
+	return body, nil
+}
+
+func countBucket(count int64) string {
+	switch {
+	case count <= 0:
+		return "0"
+	case count == 1:
+		return "1"
+	case count <= 5:
+		return "2-5"
+	case count <= 20:
+		return "6-20"
+	case count <= 100:
+		return "21-100"
+	default:
+		return "101+"
+	}
+}
+
+func clampTaskCount(count int64) int64 {
+	if count < 0 {
+		return 0
+	}
+	if count > maxTaskCount {
+		return maxTaskCount
+	}
+	return count
+}
+
+func normalizeVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if !releaseVersionPattern.MatchString(version) {
+		return "unknown"
+	}
+	return version
+}

--- a/server/internal/selfhosttelemetry/event_test.go
+++ b/server/internal/selfhosttelemetry/event_test.go
@@ -1,7 +1,9 @@
 package selfhosttelemetry
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -28,6 +30,32 @@ func TestConfigFromDoNotTrack(t *testing.T) {
 			t.Parallel()
 			if got := ConfigFromDoNotTrack(tt.raw).Enabled; got != tt.enabled {
 				t.Fatalf("Enabled = %v, want %v", got, tt.enabled)
+			}
+		})
+	}
+}
+
+func TestLogStartupStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		message string
+	}{
+		{name: "enabled", config: Config{Enabled: true}, message: "self-host telemetry enabled"},
+		{name: "disabled", config: Config{Enabled: false}, message: "self-host telemetry disabled via DO_NOT_TRACK"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&output, nil))
+
+			LogStartupStatus(logger, tt.config)
+
+			if got := strings.Count(output.String(), "\n"); got != 1 {
+				t.Fatalf("startup log lines = %d, want 1: %q", got, output.String())
+			}
+			if !strings.Contains(output.String(), "msg=\""+tt.message+"\"") {
+				t.Fatalf("startup log = %q, want message %q", output.String(), tt.message)
 			}
 		})
 	}

--- a/server/internal/selfhosttelemetry/event_test.go
+++ b/server/internal/selfhosttelemetry/event_test.go
@@ -1,0 +1,172 @@
+package selfhosttelemetry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestConfigFromDoNotTrack(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		raw     string
+		enabled bool
+	}{
+		{"", true},
+		{"0", true},
+		{"false", true},
+		{"yes", true},
+		{"1", false},
+		{" true ", false},
+		{"TRUE", false},
+		{" TrUe\t", false},
+	} {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+			if got := ConfigFromDoNotTrack(tt.raw).Enabled; got != tt.enabled {
+				t.Fatalf("Enabled = %v, want %v", got, tt.enabled)
+			}
+		})
+	}
+}
+
+func TestDisabledConfigConstructsNoTelemetryDependencies(t *testing.T) {
+	t.Parallel()
+	constructed := 0
+	factories := workerFactories{
+		store: func() leaderStore {
+			constructed++
+			return nil
+		},
+		collector: func() eventCollector {
+			constructed++
+			return nil
+		},
+		sender: func() eventSender {
+			constructed++
+			return nil
+		},
+	}
+	worker := newWithFactories(ConfigFromDoNotTrack(" TRUE "), "v1.0.0", nil, factories)
+	if worker != nil {
+		t.Fatal("disabled telemetry constructed a worker")
+	}
+	if constructed != 0 {
+		t.Fatalf("disabled telemetry constructed %d dependencies, want 0 DB collectors and 0 HTTP clients", constructed)
+	}
+}
+
+func TestEventGoldenJSON(t *testing.T) {
+	t.Parallel()
+	event := newEvent(
+		uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+		time.Date(2026, 9, 10, 0, 0, 0, 987, time.FixedZone("offset", 8*60*60)),
+		"v1.0.0",
+		Counts{
+			Workspaces: 2, HumanMembers: 6, Agents: 20, ActiveDaemons: 1,
+			TasksStarted: 12, TasksCompleted: 10, TasksFailed: 1, TasksCancelled: 1,
+		},
+	)
+	body, err := marshalEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"event_name":"instance_daily_snapshot","schema_version":1,"instance_id":"11111111-2222-3333-4444-555555555555","occurred_at":"2026-09-09T16:00:00Z","payload":{"server_version":"v1.0.0","workspace_count_bucket":"2-5","human_member_count_bucket":"6-20","agent_count_bucket":"6-20","active_daemon_count_24h_bucket":"1","tasks_started_24h":12,"tasks_completed_24h":10,"tasks_failed_24h":1,"tasks_cancelled_24h":1}}`
+	if string(body) != want {
+		t.Fatalf("body mismatch\n got: %s\nwant: %s", body, want)
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(body, &top); err != nil {
+		t.Fatal(err)
+	}
+	if len(top) != 5 {
+		t.Fatalf("top-level key count = %d, want exactly 5", len(top))
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(top["payload"], &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) != 9 {
+		t.Fatalf("payload key count = %d, want exactly 9", len(payload))
+	}
+}
+
+func TestEventCannotPassFreeTextOrIdentifiers(t *testing.T) {
+	t.Parallel()
+	forbidden := []string{
+		"person@example.test", "private.example.test", "192.0.2.10",
+		"workspace-secret", "agent-secret", "daemon-secret", "task-secret",
+		"hostname-secret", "repo-secret", "plugin-secret", "model-secret",
+		"prompt-secret", "output-secret", "/private/file", "token-secret",
+		"cost-secret", "credential-secret", "error-secret", "stack-secret",
+		"log-secret",
+	}
+	event := newEvent(uuid.MustParse("11111111-2222-3333-4444-555555555555"), time.Now(), strings.Join(forbidden, ":"), Counts{})
+	body, err := marshalEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range forbidden {
+		if strings.Contains(string(body), value) {
+			t.Errorf("body contains prohibited value %q: %s", value, body)
+		}
+	}
+	if !strings.Contains(string(body), `"server_version":"unknown"`) {
+		t.Fatalf("untrusted build string was not normalized: %s", body)
+	}
+}
+
+func TestCountBucketBoundaries(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		count int64
+		want  string
+	}{
+		{-1, "0"}, {0, "0"}, {1, "1"}, {2, "2-5"}, {5, "2-5"},
+		{6, "6-20"}, {20, "6-20"}, {21, "21-100"}, {100, "21-100"}, {101, "101+"},
+	} {
+		if got := countBucket(tt.count); got != tt.want {
+			t.Errorf("countBucket(%d) = %q, want %q", tt.count, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		input string
+		want  string
+	}{
+		{"v1.2.3", "v1.2.3"},
+		{"1.2.3", "1.2.3"},
+		{" v0.4.30 ", "v0.4.30"},
+		{"dev", "unknown"},
+		{"", "unknown"},
+		{"v1.2.3-dirty", "unknown"},
+		{"v1.2.3-4-gabcdef", "unknown"},
+		{"abcdef012345", "unknown"},
+		{"v01.2.3", "unknown"},
+	} {
+		if got := normalizeVersion(tt.input); got != tt.want {
+			t.Errorf("normalizeVersion(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestClampTaskCount(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		input int64
+		want  int64
+	}{
+		{-1, 0}, {0, 0}, {999_999, 999_999}, {1_000_000, 1_000_000}, {1_000_001, 1_000_000},
+	} {
+		if got := clampTaskCount(tt.input); got != tt.want {
+			t.Errorf("clampTaskCount(%d) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}

--- a/server/internal/selfhosttelemetry/postgres_test.go
+++ b/server/internal/selfhosttelemetry/postgres_test.go
@@ -136,7 +136,6 @@ func TestTelemetryMigrationsUpAndDown(t *testing.T) {
 		"467_instance_telemetry_state.up.sql",
 		"468_instance_telemetry_state_singleton_index.up.sql",
 		"469_instance_telemetry_state_primary_key.up.sql",
-		"470_agent_runtime_telemetry_last_seen_index.up.sql",
 		"471_agent_task_queue_telemetry_started_index.up.sql",
 	}
 	for _, name := range up {
@@ -167,7 +166,6 @@ func TestTelemetryMigrationsUpAndDown(t *testing.T) {
 
 	down := []string{
 		"471_agent_task_queue_telemetry_started_index.down.sql",
-		"470_agent_runtime_telemetry_last_seen_index.down.sql",
 		"469_instance_telemetry_state_primary_key.down.sql",
 		"468_instance_telemetry_state_singleton_index.down.sql",
 		"467_instance_telemetry_state.down.sql",
@@ -305,8 +303,6 @@ func TestSQLCollectorUsesOneBoundaryAndWindowIndexes(t *testing.T) {
 		CREATE TABLE agent (archived_at timestamptz);
 		CREATE TABLE agent_runtime (daemon_id text, last_seen_at timestamptz);
 		CREATE TABLE agent_task_queue (status text, started_at timestamptz, completed_at timestamptz);
-		CREATE INDEX idx_agent_runtime_telemetry_last_seen
-			ON agent_runtime (last_seen_at, daemon_id) WHERE daemon_id IS NOT NULL;
 		CREATE INDEX idx_agent_task_queue_telemetry_started
 			ON agent_task_queue (started_at) WHERE started_at IS NOT NULL;
 		CREATE INDEX idx_agent_task_queue_terminal_completed_at_v2
@@ -344,8 +340,10 @@ func TestSQLCollectorUsesOneBoundaryAndWindowIndexes(t *testing.T) {
 	}
 	// Keep almost all rows outside the reporting window so this exercises the
 	// production shape: lifetime tables are large while one UTC day's slice is
-	// small. The planner should choose the three time-window indexes naturally,
-	// without the test disabling sequential scans.
+	// small. The runtime query deliberately accepts a sequential scan because a
+	// last_seen_at index would be rewritten by every online-runtime heartbeat.
+	// The planner should choose both task time-window indexes naturally, without
+	// the test disabling sequential scans.
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO agent_runtime (daemon_id, last_seen_at)
 		SELECT 'historical-daemon-' || n, $1::timestamptz - interval '30 days'
@@ -409,7 +407,6 @@ func TestSQLCollectorUsesOneBoundaryAndWindowIndexes(t *testing.T) {
 	}
 	plan := strings.Join(planLines, "\n")
 	for _, index := range []string{
-		"idx_agent_runtime_telemetry_last_seen",
 		"idx_agent_task_queue_telemetry_started",
 		"idx_agent_task_queue_terminal_completed_at_v2",
 	} {

--- a/server/internal/selfhosttelemetry/postgres_test.go
+++ b/server/internal/selfhosttelemetry/postgres_test.go
@@ -1,0 +1,420 @@
+package selfhosttelemetry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func telemetryTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping live-Postgres telemetry test")
+	}
+	ctx := context.Background()
+	admin, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := fmt.Sprintf("selfhost_telemetry_%d_%d", time.Now().UnixNano(), rand.Uint32())
+	if _, err := admin.Exec(ctx, "CREATE SCHEMA "+schema); err != nil {
+		admin.Close()
+		t.Fatal(err)
+	}
+
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		admin.Close()
+		t.Fatal(err)
+	}
+	if config.ConnConfig.RuntimeParams == nil {
+		config.ConnConfig.RuntimeParams = make(map[string]string)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = schema
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		admin.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		pool.Close()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := admin.Exec(cleanupCtx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE"); err != nil {
+			t.Logf("drop telemetry test schema: %v", err)
+		}
+		admin.Close()
+	})
+	return pool
+}
+
+func TestPostgresStoreIdentityAndLeaderLock(t *testing.T) {
+	pool := telemetryTestPool(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE instance_telemetry_state (
+			singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+			instance_id uuid NOT NULL DEFAULT gen_random_uuid(),
+			last_successful_day date,
+			pending_day date,
+			pending_body bytea,
+			next_attempt_at timestamptz,
+			attempt_count integer NOT NULL DEFAULT 0,
+			updated_at timestamptz NOT NULL DEFAULT now()
+		);
+		INSERT INTO instance_telemetry_state (singleton) VALUES (true)`); err != nil {
+		t.Fatal(err)
+	}
+
+	firstStore := newPostgresStore(pool)
+	first, leader, err := firstStore.TryLeader(ctx)
+	if err != nil || !leader {
+		t.Fatalf("first leader = %v, err = %v", leader, err)
+	}
+	firstState, err := first.LoadOrCreate(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondStore := newPostgresStore(pool)
+	contender, leader, err := secondStore.TryLeader(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leader || contender != nil {
+		t.Fatal("second replica acquired the telemetry lock while the first held it")
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	second, leader, err := secondStore.TryLeader(ctx)
+	if err != nil || !leader {
+		t.Fatalf("second leader after release = %v, err = %v", leader, err)
+	}
+	secondState, err := second.LoadOrCreate(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstState.InstanceID != secondState.InstanceID {
+		t.Fatalf("instance identity changed across replica/restart: %s != %s", firstState.InstanceID, secondState.InstanceID)
+	}
+	if _, err := second.Connection().Exec(ctx, "DELETE FROM instance_telemetry_state"); err != nil {
+		t.Fatal(err)
+	}
+	recreated, err := second.LoadOrCreate(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recreated.InstanceID == firstState.InstanceID {
+		t.Fatal("explicit state deletion did not create a new deployment identity")
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTelemetryMigrationsUpAndDown(t *testing.T) {
+	pool := telemetryTestPool(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE agent_runtime (daemon_id text, last_seen_at timestamptz);
+		CREATE TABLE agent_task_queue (started_at timestamptz)`); err != nil {
+		t.Fatal(err)
+	}
+	up := []string{
+		"467_instance_telemetry_state.up.sql",
+		"468_instance_telemetry_state_singleton_index.up.sql",
+		"469_instance_telemetry_state_primary_key.up.sql",
+		"470_agent_runtime_telemetry_last_seen_index.up.sql",
+		"471_agent_task_queue_telemetry_started_index.up.sql",
+	}
+	for _, name := range up {
+		applyTelemetryMigration(t, pool, name)
+	}
+	var rows int
+	if err := pool.QueryRow(ctx, "SELECT count(*) FROM instance_telemetry_state").Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Fatalf("singleton rows = %d, want 1", rows)
+	}
+	var originalInstanceID string
+	if err := pool.QueryRow(ctx, "SELECT instance_id::text FROM instance_telemetry_state").Scan(&originalInstanceID); err != nil {
+		t.Fatal(err)
+	}
+	var hasPrimaryKey bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM pg_constraint
+			WHERE conrelid = 'instance_telemetry_state'::regclass AND contype = 'p'
+		)`).Scan(&hasPrimaryKey); err != nil {
+		t.Fatal(err)
+	}
+	if !hasPrimaryKey {
+		t.Fatal("telemetry state primary key was not attached")
+	}
+
+	down := []string{
+		"471_agent_task_queue_telemetry_started_index.down.sql",
+		"470_agent_runtime_telemetry_last_seen_index.down.sql",
+		"469_instance_telemetry_state_primary_key.down.sql",
+		"468_instance_telemetry_state_singleton_index.down.sql",
+		"467_instance_telemetry_state.down.sql",
+	}
+	for _, name := range down {
+		applyTelemetryMigration(t, pool, name)
+	}
+	var stateTable *string
+	if err := pool.QueryRow(ctx, "SELECT to_regclass('instance_telemetry_state')::text").Scan(&stateTable); err != nil {
+		t.Fatal(err)
+	}
+	if stateTable != nil {
+		t.Fatalf("state table remains after down migrations: %s", *stateTable)
+	}
+
+	for _, name := range up {
+		applyTelemetryMigration(t, pool, name)
+	}
+	var rebuiltInstanceID string
+	if err := pool.QueryRow(ctx, "SELECT instance_id::text FROM instance_telemetry_state").Scan(&rebuiltInstanceID); err != nil {
+		t.Fatal(err)
+	}
+	if rebuiltInstanceID == originalInstanceID {
+		t.Fatalf("database rebuild reused deployment identity %s", originalInstanceID)
+	}
+}
+
+type concurrentCollector struct {
+	calls atomic.Int32
+}
+
+func (c *concurrentCollector) Collect(context.Context, *pgx.Conn, time.Time) (Counts, error) {
+	c.calls.Add(1)
+	return Counts{}, nil
+}
+
+type gatedSender struct {
+	calls   atomic.Int32
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *gatedSender) Send(context.Context, []byte) deliveryDisposition {
+	if s.calls.Add(1) == 1 {
+		close(s.started)
+	}
+	<-s.release
+	return deliverySuccess
+}
+
+func (*gatedSender) Close() {}
+
+func TestTwoPostgresBackedWorkersProduceOnePendingAndDelivery(t *testing.T) {
+	pool := telemetryTestPool(t)
+	ctx := context.Background()
+	for _, name := range []string{
+		"467_instance_telemetry_state.up.sql",
+		"468_instance_telemetry_state_singleton_index.up.sql",
+		"469_instance_telemetry_state_primary_key.up.sql",
+	} {
+		applyTelemetryMigration(t, pool, name)
+	}
+
+	identitySession, leader, err := newPostgresStore(pool).TryLeader(ctx)
+	if err != nil || !leader {
+		t.Fatalf("load identity leader = %v, err = %v", leader, err)
+	}
+	state, err := identitySession.LoadOrCreate(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := identitySession.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	collector := &concurrentCollector{}
+	sender := &gatedSender{started: make(chan struct{}), release: make(chan struct{})}
+	now := scheduledAt(state.InstanceID, time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)).Add(time.Minute)
+	newWorker := func() *Worker {
+		return &Worker{
+			store: newPostgresStore(pool), collector: collector, sender: sender,
+			serverVersion: "v1.2.3", logger: slog.Default(), now: time.Now,
+		}
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, runErr := newWorker().runOnce(ctx, now)
+		firstDone <- runErr
+	}()
+	select {
+	case <-sender.started:
+	case <-time.After(time.Second):
+		close(sender.release)
+		t.Fatal("first worker did not reach delivery")
+	}
+	if _, err := newWorker().runOnce(ctx, now); err != nil {
+		close(sender.release)
+		t.Fatal(err)
+	}
+	close(sender.release)
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first worker did not finish")
+	}
+	if got := collector.calls.Load(); got != 1 {
+		t.Fatalf("collection calls = %d, want 1", got)
+	}
+	if got := sender.calls.Load(); got != 1 {
+		t.Fatalf("delivery calls = %d, want 1", got)
+	}
+}
+
+func applyTelemetryMigration(t *testing.T, pool *pgxpool.Pool, name string) {
+	t.Helper()
+	body, err := os.ReadFile("../../migrations/" + name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(context.Background(), string(body)); err != nil {
+		t.Fatalf("apply %s: %v", name, err)
+	}
+}
+
+func TestSQLCollectorUsesOneBoundaryAndWindowIndexes(t *testing.T) {
+	pool := telemetryTestPool(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE workspace (id uuid PRIMARY KEY);
+		CREATE TABLE member (user_id uuid NOT NULL);
+		CREATE TABLE agent (archived_at timestamptz);
+		CREATE TABLE agent_runtime (daemon_id text, last_seen_at timestamptz);
+		CREATE TABLE agent_task_queue (status text, started_at timestamptz, completed_at timestamptz);
+		CREATE INDEX idx_agent_runtime_telemetry_last_seen
+			ON agent_runtime (last_seen_at, daemon_id) WHERE daemon_id IS NOT NULL;
+		CREATE INDEX idx_agent_task_queue_telemetry_started
+			ON agent_task_queue (started_at) WHERE started_at IS NOT NULL;
+		CREATE INDEX idx_agent_task_queue_terminal_completed_at_v2
+			ON agent_task_queue (completed_at) WHERE status IN ('completed', 'failed', 'cancelled')`); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	from := at.Add(-24 * time.Hour)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO workspace VALUES (gen_random_uuid()), (gen_random_uuid()), (gen_random_uuid());
+		INSERT INTO member VALUES
+			('10000000-0000-0000-0000-000000000001'),
+			('10000000-0000-0000-0000-000000000001'),
+			('10000000-0000-0000-0000-000000000002')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO agent VALUES (NULL), (NULL), ($1)`, at.Add(-time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO agent_runtime VALUES
+			('daemon-a', $1::timestamptz), ('daemon-a', $1::timestamptz + interval '1 hour'),
+			('daemon-b', $2::timestamptz - interval '1 second'), ('daemon-old', $1::timestamptz - interval '1 second'),
+			(NULL, $1::timestamptz + interval '2 hours')`, from, at); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO agent_task_queue VALUES
+			('completed', $1::timestamptz, $1::timestamptz),
+			('failed', $1::timestamptz + interval '1 hour', $1::timestamptz + interval '1 hour'),
+			('cancelled', $2::timestamptz - interval '1 second', $2::timestamptz - interval '1 second'),
+			('completed', $2::timestamptz, $2::timestamptz),
+			('running', NULL, NULL)`, from, at); err != nil {
+		t.Fatal(err)
+	}
+	// Keep almost all rows outside the reporting window so this exercises the
+	// production shape: lifetime tables are large while one UTC day's slice is
+	// small. The planner should choose the three time-window indexes naturally,
+	// without the test disabling sequential scans.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO agent_runtime (daemon_id, last_seen_at)
+		SELECT 'historical-daemon-' || n, $1::timestamptz - interval '30 days'
+		  FROM generate_series(1, 50000) AS n`, from); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO agent_task_queue (status, started_at, completed_at)
+		SELECT 'completed', $1::timestamptz - interval '30 days', $1::timestamptz - interval '30 days'
+		  FROM generate_series(1, 50000)`, from); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, "ANALYZE agent_runtime"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, "ANALYZE agent_task_queue"); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Release()
+	counts, err := (SQLCollector{}).Collect(ctx, conn.Conn(), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := (Counts{
+		Workspaces: 3, HumanMembers: 2, Agents: 2, ActiveDaemons: 2,
+		TasksStarted: 3, TasksCompleted: 1, TasksFailed: 1, TasksCancelled: 1,
+	})
+	if counts != want {
+		t.Fatalf("counts = %#v, want %#v", counts, want)
+	}
+
+	var timeout string
+	if err := conn.QueryRow(ctx, "SHOW statement_timeout").Scan(&timeout); err != nil {
+		t.Fatal(err)
+	}
+	if timeout != "0" {
+		t.Fatalf("statement_timeout leaked onto pooled connection: %q", timeout)
+	}
+
+	rows, err := conn.Query(ctx, "EXPLAIN (ANALYZE, COSTS OFF, FORMAT TEXT) "+collectionSQL, from, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var planLines []string
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			rows.Close()
+			t.Fatal(err)
+		}
+		planLines = append(planLines, line)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	plan := strings.Join(planLines, "\n")
+	for _, index := range []string{
+		"idx_agent_runtime_telemetry_last_seen",
+		"idx_agent_task_queue_telemetry_started",
+		"idx_agent_task_queue_terminal_completed_at_v2",
+	} {
+		if !strings.Contains(plan, index) {
+			t.Errorf("EXPLAIN ANALYZE did not use %s:\n%s", index, plan)
+		}
+	}
+}

--- a/server/internal/selfhosttelemetry/store.go
+++ b/server/internal/selfhosttelemetry/store.go
@@ -1,0 +1,201 @@
+package selfhosttelemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Fixed across processes and releases. It is session-scoped because the same
+// exclusive connection must remain leader through collection, persistence and
+// delivery.
+const advisoryLockKey int64 = 0x4d554c54454c45
+
+type telemetryState struct {
+	InstanceID        uuid.UUID
+	LastSuccessfulDay *time.Time
+	PendingDay        *time.Time
+	PendingBody       []byte
+	NextAttemptAt     *time.Time
+	AttemptCount      int
+}
+
+type leaderStore interface {
+	TryLeader(context.Context) (leaderSession, bool, error)
+}
+
+type leaderSession interface {
+	Connection() *pgx.Conn
+	LoadOrCreate(context.Context) (telemetryState, error)
+	SavePending(context.Context, time.Time, []byte, time.Time) error
+	DropPending(context.Context) error
+	MarkSuccessful(context.Context, time.Time) error
+	ScheduleRetry(context.Context, time.Time, int) error
+	Close() error
+}
+
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+func newPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{pool: pool}
+}
+
+func (s *PostgresStore) TryLeader(ctx context.Context) (leaderSession, bool, error) {
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("acquire telemetry connection: %w", err)
+	}
+	var locked bool
+	if err := conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", advisoryLockKey).Scan(&locked); err != nil {
+		conn.Release()
+		return nil, false, fmt.Errorf("acquire telemetry advisory lock: %w", err)
+	}
+	if !locked {
+		conn.Release()
+		return nil, false, nil
+	}
+	return &postgresSession{conn: conn}, true, nil
+}
+
+type postgresSession struct {
+	conn      *pgxpool.Conn
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (s *postgresSession) Connection() *pgx.Conn {
+	return s.conn.Conn()
+}
+
+func (s *postgresSession) LoadOrCreate(ctx context.Context) (telemetryState, error) {
+	// Recreate only after an operator explicitly deletes the singleton row.
+	// ON CONFLICT also makes first boot safe if migration/application startup
+	// overlap unusually across replicas.
+	if _, err := s.conn.Exec(ctx, `
+		INSERT INTO instance_telemetry_state (singleton)
+		VALUES (true)
+		ON CONFLICT (singleton) DO NOTHING`); err != nil {
+		return telemetryState{}, fmt.Errorf("ensure telemetry state: %w", err)
+	}
+
+	var (
+		instanceID                    uuid.UUID
+		lastSuccessfulDay, pendingDay pgtype.Date
+		nextAttemptAt                 pgtype.Timestamptz
+		pendingBody                   []byte
+		attemptCount                  int32
+	)
+	if err := s.conn.QueryRow(ctx, `
+		SELECT instance_id, last_successful_day, pending_day, pending_body,
+		       next_attempt_at, attempt_count
+		  FROM instance_telemetry_state
+		 WHERE singleton = true`).Scan(
+		&instanceID,
+		&lastSuccessfulDay,
+		&pendingDay,
+		&pendingBody,
+		&nextAttemptAt,
+		&attemptCount,
+	); err != nil {
+		return telemetryState{}, fmt.Errorf("load telemetry state: %w", err)
+	}
+
+	state := telemetryState{
+		InstanceID:   instanceID,
+		PendingBody:  append([]byte(nil), pendingBody...),
+		AttemptCount: int(attemptCount),
+	}
+	if lastSuccessfulDay.Valid {
+		day := utcDay(lastSuccessfulDay.Time)
+		state.LastSuccessfulDay = &day
+	}
+	if pendingDay.Valid {
+		day := utcDay(pendingDay.Time)
+		state.PendingDay = &day
+	}
+	if nextAttemptAt.Valid {
+		next := nextAttemptAt.Time.UTC()
+		state.NextAttemptAt = &next
+	}
+	return state, nil
+}
+
+func (s *postgresSession) SavePending(ctx context.Context, day time.Time, body []byte, next time.Time) error {
+	_, err := s.conn.Exec(ctx, `
+		UPDATE instance_telemetry_state
+		   SET pending_day = $1, pending_body = $2, next_attempt_at = $3,
+		       attempt_count = 0, updated_at = now()
+		 WHERE singleton = true`, utcDay(day), body, next.UTC())
+	return wrapStoreError("save telemetry pending event", err)
+}
+
+func (s *postgresSession) DropPending(ctx context.Context) error {
+	_, err := s.conn.Exec(ctx, `
+		UPDATE instance_telemetry_state
+		   SET pending_day = NULL, pending_body = NULL, next_attempt_at = NULL,
+		       attempt_count = 0, updated_at = now()
+		 WHERE singleton = true`)
+	return wrapStoreError("drop telemetry pending event", err)
+}
+
+func (s *postgresSession) MarkSuccessful(ctx context.Context, day time.Time) error {
+	_, err := s.conn.Exec(ctx, `
+		UPDATE instance_telemetry_state
+		   SET last_successful_day = $1, pending_day = NULL, pending_body = NULL,
+		       next_attempt_at = NULL, attempt_count = 0, updated_at = now()
+		 WHERE singleton = true`, utcDay(day))
+	return wrapStoreError("mark telemetry event successful", err)
+}
+
+func (s *postgresSession) ScheduleRetry(ctx context.Context, next time.Time, attempt int) error {
+	_, err := s.conn.Exec(ctx, `
+		UPDATE instance_telemetry_state
+		   SET next_attempt_at = $1, attempt_count = $2, updated_at = now()
+		 WHERE singleton = true`, next.UTC(), attempt)
+	return wrapStoreError("schedule telemetry retry", err)
+}
+
+func (s *postgresSession) Close() error {
+	s.closeOnce.Do(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		var unlocked bool
+		err := s.conn.QueryRow(cleanupCtx, "SELECT pg_advisory_unlock($1)", advisoryLockKey).Scan(&unlocked)
+		if err == nil && unlocked {
+			s.conn.Release()
+			return
+		}
+
+		// Never return a possibly locked session to the pool. Closing the
+		// physical connection releases all PostgreSQL session locks even when
+		// the explicit unlock failed during cancellation or a network fault.
+		raw := s.conn.Hijack()
+		closeErr := raw.Close(cleanupCtx)
+		if err == nil && !unlocked {
+			err = errors.New("telemetry advisory lock was not held during release")
+		}
+		s.closeErr = errors.Join(err, closeErr)
+	})
+	return s.closeErr
+}
+
+func wrapStoreError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", operation, err)
+}
+
+func utcDay(at time.Time) time.Time {
+	year, month, day := at.UTC().Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}

--- a/server/internal/selfhosttelemetry/worker.go
+++ b/server/internal/selfhosttelemetry/worker.go
@@ -1,0 +1,242 @@
+package selfhosttelemetry
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	dailyJitterWindow = 6 * time.Hour
+	minRetryBackoff   = time.Minute
+	maxRetryBackoff   = 6 * time.Hour
+	leaderRetryDelay  = time.Minute
+	collectionRetry   = time.Hour
+	logRateLimit      = time.Hour
+)
+
+type Worker struct {
+	store         leaderStore
+	collector     eventCollector
+	sender        eventSender
+	serverVersion string
+	logger        *slog.Logger
+	now           func() time.Time
+
+	logMu     sync.Mutex
+	nextLogAt time.Time
+}
+
+type workerFactories struct {
+	store     func() leaderStore
+	collector func() eventCollector
+	sender    func() eventSender
+}
+
+// New performs no database, DNS or HTTP work. When DO_NOT_TRACK disabled the
+// feature, it also returns before constructing any collector or HTTP client.
+func New(pool *pgxpool.Pool, serverVersion string, config Config, logger *slog.Logger) *Worker {
+	return newWithFactories(config, serverVersion, logger, workerFactories{
+		store:     func() leaderStore { return newPostgresStore(pool) },
+		collector: func() eventCollector { return SQLCollector{} },
+		sender:    func() eventSender { return newHTTPClient() },
+	})
+}
+
+func newWithFactories(config Config, serverVersion string, logger *slog.Logger, factories workerFactories) *Worker {
+	if !config.Enabled {
+		return nil
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Worker{
+		store:         factories.store(),
+		collector:     factories.collector(),
+		sender:        factories.sender(),
+		serverVersion: serverVersion,
+		logger:        logger,
+		now:           time.Now,
+	}
+}
+
+func (w *Worker) Run(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	defer w.sender.Close()
+	for {
+		now := w.now().UTC()
+		next, err := w.runOnce(ctx, now)
+		if err != nil && ctx.Err() == nil {
+			w.logFailure(now)
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		delay := next.Sub(w.now().UTC())
+		if delay < 0 {
+			delay = 0
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+// runOnce performs at most one collection/delivery attempt while holding the
+// deployment-wide leader lock. It returns the earliest useful next wake time.
+func (w *Worker) runOnce(ctx context.Context, now time.Time) (next time.Time, err error) {
+	session, leader, err := w.store.TryLeader(ctx)
+	if err != nil {
+		return now.Add(leaderRetryDelay), err
+	}
+	if !leader {
+		return now.Add(leaderRetryDelay), nil
+	}
+	defer func() {
+		if closeErr := session.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	state, err := session.LoadOrCreate(ctx)
+	if err != nil {
+		return now.Add(leaderRetryDelay), err
+	}
+	today := utcDay(now)
+	tomorrow := today.AddDate(0, 0, 1)
+
+	if state.LastSuccessfulDay != nil && sameDay(*state.LastSuccessfulDay, today) {
+		if state.PendingDay != nil {
+			if err := session.DropPending(ctx); err != nil {
+				return now.Add(leaderRetryDelay), err
+			}
+		}
+		return scheduledAt(state.InstanceID, tomorrow), nil
+	}
+
+	if state.PendingDay != nil && (!sameDay(*state.PendingDay, today) || now.Sub(utcDay(*state.PendingDay)) >= 72*time.Hour) {
+		if err := session.DropPending(ctx); err != nil {
+			return now.Add(leaderRetryDelay), err
+		}
+		state.PendingDay = nil
+		state.PendingBody = nil
+		state.NextAttemptAt = nil
+		state.AttemptCount = 0
+	}
+
+	if state.PendingDay == nil {
+		firstAttempt := scheduledAt(state.InstanceID, today)
+		if now.Before(firstAttempt) {
+			return firstAttempt, nil
+		}
+		counts, collectErr := w.collector.Collect(ctx, session.Connection(), now)
+		if collectErr != nil {
+			return now.Add(collectionRetry), collectErr
+		}
+		body, marshalErr := marshalEvent(newEvent(state.InstanceID, now, w.serverVersion, counts))
+		if marshalErr != nil {
+			return now.Add(collectionRetry), marshalErr
+		}
+		if err := session.SavePending(ctx, today, body, now); err != nil {
+			return now.Add(leaderRetryDelay), err
+		}
+		state.PendingDay = &today
+		state.PendingBody = body
+		state.NextAttemptAt = nil
+		state.AttemptCount = 0
+	}
+
+	if len(state.PendingBody) == 0 || len(state.PendingBody) > maxRequestSize {
+		if err := session.DropPending(ctx); err != nil {
+			return now.Add(leaderRetryDelay), err
+		}
+		return now.Add(collectionRetry), errors.New("stored telemetry event has invalid size")
+	}
+	if state.NextAttemptAt != nil && now.Before(*state.NextAttemptAt) {
+		return *state.NextAttemptAt, nil
+	}
+
+	switch w.sender.Send(ctx, state.PendingBody) {
+	case deliverySuccess:
+		if err := session.MarkSuccessful(ctx, today); err != nil {
+			return now.Add(leaderRetryDelay), err
+		}
+		return scheduledAt(state.InstanceID, tomorrow), nil
+	case deliveryRetry:
+		attempt := state.AttemptCount + 1
+		next = now.Add(retryBackoff(state.InstanceID, today, attempt))
+		if err := session.ScheduleRetry(ctx, next, attempt); err != nil {
+			return now.Add(leaderRetryDelay), err
+		}
+		return next, nil
+	default:
+		next = scheduledAt(state.InstanceID, tomorrow)
+		if err := session.ScheduleRetry(ctx, next, state.AttemptCount+1); err != nil {
+			return now.Add(leaderRetryDelay), err
+		}
+		return next, nil
+	}
+}
+
+func (w *Worker) logFailure(now time.Time) {
+	w.logMu.Lock()
+	defer w.logMu.Unlock()
+	if now.Before(w.nextLogAt) {
+		return
+	}
+	w.nextLogAt = now.Add(logRateLimit)
+	// Intentionally omit errors, request bodies, response bodies and instance
+	// identity. Operators only need to know this optional path degraded.
+	w.logger.Warn("self-host telemetry attempt failed; normal server operation continues")
+}
+
+func scheduledAt(instanceID uuid.UUID, day time.Time) time.Time {
+	sum := sha256.Sum256(instanceID[:])
+	offset := time.Duration(binary.BigEndian.Uint64(sum[:8]) % uint64(dailyJitterWindow))
+	return utcDay(day).Add(offset)
+}
+
+func retryBackoff(instanceID uuid.UUID, day time.Time, attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	base := minRetryBackoff
+	for i := 1; i < attempt && base < maxRetryBackoff; i++ {
+		base *= 2
+		if base >= maxRetryBackoff {
+			return maxRetryBackoff
+		}
+	}
+	seed := make([]byte, 0, 16+8+8)
+	seed = append(seed, instanceID[:]...)
+	var encoded [16]byte
+	binary.BigEndian.PutUint64(encoded[:8], uint64(utcDay(day).Unix()))
+	binary.BigEndian.PutUint64(encoded[8:], uint64(attempt))
+	seed = append(seed, encoded[:]...)
+	sum := sha256.Sum256(seed)
+	// [1.0, 1.25) jitter keeps the documented one-minute lower bound.
+	jitter := time.Duration(binary.BigEndian.Uint64(sum[:8]) % uint64(base/4))
+	if base+jitter > maxRetryBackoff {
+		return maxRetryBackoff
+	}
+	return base + jitter
+}
+
+func sameDay(a, b time.Time) bool {
+	return utcDay(a).Equal(utcDay(b))
+}

--- a/server/internal/selfhosttelemetry/worker_test.go
+++ b/server/internal/selfhosttelemetry/worker_test.go
@@ -1,0 +1,444 @@
+package selfhosttelemetry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type fakeStore struct {
+	session leaderSession
+	leader  bool
+	err     error
+	calls   int
+}
+
+func (s *fakeStore) TryLeader(context.Context) (leaderSession, bool, error) {
+	s.calls++
+	return s.session, s.leader, s.err
+}
+
+type fakeSession struct {
+	state       telemetryState
+	savedBodies [][]byte
+	dropped     int
+	succeeded   int
+	closed      int
+}
+
+func (s *fakeSession) Connection() *pgx.Conn { return nil }
+
+func (s *fakeSession) LoadOrCreate(context.Context) (telemetryState, error) {
+	state := s.state
+	state.PendingBody = slices.Clone(state.PendingBody)
+	return state, nil
+}
+
+func (s *fakeSession) SavePending(_ context.Context, day time.Time, body []byte, next time.Time) error {
+	day = utcDay(day)
+	next = next.UTC()
+	s.state.PendingDay = &day
+	s.state.PendingBody = slices.Clone(body)
+	s.state.NextAttemptAt = &next
+	s.state.AttemptCount = 0
+	s.savedBodies = append(s.savedBodies, slices.Clone(body))
+	return nil
+}
+
+func (s *fakeSession) DropPending(context.Context) error {
+	s.dropped++
+	s.state.PendingDay = nil
+	s.state.PendingBody = nil
+	s.state.NextAttemptAt = nil
+	s.state.AttemptCount = 0
+	return nil
+}
+
+func (s *fakeSession) MarkSuccessful(_ context.Context, day time.Time) error {
+	s.succeeded++
+	day = utcDay(day)
+	s.state.LastSuccessfulDay = &day
+	return s.DropPending(context.Background())
+}
+
+func (s *fakeSession) ScheduleRetry(_ context.Context, next time.Time, attempt int) error {
+	next = next.UTC()
+	s.state.NextAttemptAt = &next
+	s.state.AttemptCount = attempt
+	return nil
+}
+
+func (s *fakeSession) Close() error {
+	s.closed++
+	return nil
+}
+
+type fakeCollector struct {
+	counts Counts
+	err    error
+	calls  int
+}
+
+func (c *fakeCollector) Collect(context.Context, *pgx.Conn, time.Time) (Counts, error) {
+	c.calls++
+	return c.counts, c.err
+}
+
+type fakeSender struct {
+	dispositions []deliveryDisposition
+	bodies       [][]byte
+	closed       int
+}
+
+func (s *fakeSender) Send(_ context.Context, body []byte) deliveryDisposition {
+	s.bodies = append(s.bodies, slices.Clone(body))
+	if len(s.dispositions) == 0 {
+		return deliverySuccess
+	}
+	result := s.dispositions[0]
+	s.dispositions = s.dispositions[1:]
+	return result
+}
+
+func (s *fakeSender) Close() { s.closed++ }
+
+func testWorker(state telemetryState, collector *fakeCollector, sender *fakeSender) (*Worker, *fakeSession) {
+	session := &fakeSession{state: state}
+	return &Worker{
+		store:         &fakeStore{session: session, leader: true},
+		collector:     collector,
+		sender:        sender,
+		serverVersion: "v1.2.3",
+		logger:        slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		now:           time.Now,
+	}, session
+}
+
+func TestDefaultConfigCollectsAndSends(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("01010101-2222-3333-4444-555555555555")
+	today := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	now := scheduledAt(id, today).Add(time.Minute)
+	session := &fakeSession{state: telemetryState{InstanceID: id}}
+	collector := &fakeCollector{}
+	sender := &fakeSender{}
+	worker := newWithFactories(ConfigFromDoNotTrack(""), "v1.2.3", nil, workerFactories{
+		store:     func() leaderStore { return &fakeStore{session: session, leader: true} },
+		collector: func() eventCollector { return collector },
+		sender:    func() eventSender { return sender },
+	})
+	if worker == nil {
+		t.Fatal("default configuration did not construct telemetry worker")
+	}
+	if _, err := worker.runOnce(context.Background(), now); err != nil {
+		t.Fatal(err)
+	}
+	if collector.calls != 1 || len(sender.bodies) != 1 {
+		t.Fatalf("default collector/sender calls = %d/%d, want 1/1", collector.calls, len(sender.bodies))
+	}
+}
+
+func TestWorkerGeneratesPersistsAndSendsOneDailySnapshot(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	today := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	now := scheduledAt(id, today).Add(time.Minute)
+	collector := &fakeCollector{counts: Counts{Workspaces: 3, TasksStarted: 12}}
+	sender := &fakeSender{dispositions: []deliveryDisposition{deliverySuccess}}
+	worker, session := testWorker(telemetryState{InstanceID: id}, collector, sender)
+
+	next, err := worker.runOnce(context.Background(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if collector.calls != 1 || len(sender.bodies) != 1 {
+		t.Fatalf("collector/sender calls = %d/%d, want 1/1", collector.calls, len(sender.bodies))
+	}
+	if len(session.savedBodies) != 1 || session.succeeded != 1 || session.closed != 1 {
+		t.Fatalf("saved/succeeded/closed = %d/%d/%d, want 1/1/1", len(session.savedBodies), session.succeeded, session.closed)
+	}
+	if !bytes.Equal(session.savedBodies[0], sender.bodies[0]) {
+		t.Fatal("sent body differs from the once-persisted body")
+	}
+	if want := scheduledAt(id, today.AddDate(0, 0, 1)); !next.Equal(want) {
+		t.Fatalf("next = %s, want %s", next, want)
+	}
+
+	// A second replica/process round sees the durable success and does nothing.
+	if _, err := worker.runOnce(context.Background(), now.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if collector.calls != 1 || len(sender.bodies) != 1 {
+		t.Fatalf("same-day success collected/sent again: %d/%d", collector.calls, len(sender.bodies))
+	}
+}
+
+func TestWorkerWaitsForDeterministicDailyJitter(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	today := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	wake := scheduledAt(id, today)
+	collector := &fakeCollector{}
+	sender := &fakeSender{}
+	worker, _ := testWorker(telemetryState{InstanceID: id}, collector, sender)
+
+	next, err := worker.runOnce(context.Background(), today)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !next.Equal(wake) {
+		t.Fatalf("next = %s, want deterministic wake %s", next, wake)
+	}
+	if collector.calls != 0 || len(sender.bodies) != 0 {
+		t.Fatal("worker collected or sent before its jittered daily slot")
+	}
+	if offset := wake.Sub(today); offset < 0 || offset >= 6*time.Hour {
+		t.Fatalf("daily jitter = %s, want [0, 6h)", offset)
+	}
+}
+
+func TestWorkerRetriesWithTheExactPersistedBodyAcrossRestart(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("22222222-2222-3333-4444-555555555555")
+	today := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	now := scheduledAt(id, today).Add(time.Minute)
+	collector := &fakeCollector{counts: Counts{TasksCompleted: 7}}
+	sender := &fakeSender{dispositions: []deliveryDisposition{deliveryRetry, deliverySuccess}}
+	worker, session := testWorker(telemetryState{InstanceID: id}, collector, sender)
+
+	next, err := worker.runOnce(context.Background(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.state.AttemptCount != 1 || session.state.NextAttemptAt == nil {
+		t.Fatalf("retry state not persisted: %#v", session.state)
+	}
+	if delay := next.Sub(now); delay < time.Minute || delay > 75*time.Second {
+		t.Fatalf("first retry delay = %s, want [1m, 1m15s]", delay)
+	}
+
+	// A newly constructed worker represents a process restart. It receives only
+	// the persisted state and must not collect/marshal a replacement body.
+	restartedSession := &fakeSession{state: session.state}
+	restarted := &Worker{
+		store: &fakeStore{session: restartedSession, leader: true}, collector: collector,
+		sender: sender, serverVersion: "v9.9.9", logger: worker.logger, now: time.Now,
+	}
+	if _, err := restarted.runOnce(context.Background(), next); err != nil {
+		t.Fatal(err)
+	}
+	if collector.calls != 1 {
+		t.Fatalf("collector calls = %d, retry regenerated the body", collector.calls)
+	}
+	if len(sender.bodies) != 2 || !bytes.Equal(sender.bodies[0], sender.bodies[1]) {
+		t.Fatal("response-loss retry did not reuse the byte-identical persisted body")
+	}
+}
+
+func TestWorkerDropsPreviousDayPendingInsteadOfBuildingAnOfflineQueue(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("33333333-2222-3333-4444-555555555555")
+	today := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	yesterday := today.AddDate(0, 0, -1)
+	now := scheduledAt(id, today).Add(time.Minute)
+	nextAttempt := now.Add(time.Hour)
+	collector := &fakeCollector{counts: Counts{TasksCancelled: 2}}
+	sender := &fakeSender{}
+	worker, session := testWorker(telemetryState{
+		InstanceID: id, PendingDay: &yesterday, PendingBody: []byte(`{"old":true}`),
+		NextAttemptAt: &nextAttempt, AttemptCount: 4,
+	}, collector, sender)
+
+	if _, err := worker.runOnce(context.Background(), now); err != nil {
+		t.Fatal(err)
+	}
+	if session.dropped < 1 || collector.calls != 1 || len(sender.bodies) != 1 {
+		t.Fatalf("dropped/collected/sent = %d/%d/%d", session.dropped, collector.calls, len(sender.bodies))
+	}
+	if bytes.Contains(sender.bodies[0], []byte(`"old"`)) {
+		t.Fatal("old pending body was sent after a new UTC day began")
+	}
+}
+
+func TestWorkerProtocolErrorStopsUntilNextUTCDay(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("44444444-2222-3333-4444-555555555555")
+	today := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	now := scheduledAt(id, today).Add(time.Minute)
+	collector := &fakeCollector{}
+	sender := &fakeSender{dispositions: []deliveryDisposition{deliveryStopForDay, deliverySuccess}}
+	worker, session := testWorker(telemetryState{InstanceID: id}, collector, sender)
+
+	next, err := worker.runOnce(context.Background(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := scheduledAt(id, today.AddDate(0, 0, 1)); !next.Equal(want) {
+		t.Fatalf("protocol retry = %s, want next day %s", next, want)
+	}
+	if _, err := worker.runOnce(context.Background(), now.Add(2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.bodies) != 1 {
+		t.Fatal("protocol error retried again on the same UTC day")
+	}
+	if _, err := worker.runOnce(context.Background(), next); err != nil {
+		t.Fatal(err)
+	}
+	if len(sender.bodies) != 2 || collector.calls != 2 || session.dropped < 1 {
+		t.Fatalf("next day sent/collected/dropped = %d/%d/%d", len(sender.bodies), collector.calls, session.dropped)
+	}
+}
+
+func TestWorkerSkipsDeliveryWhenCollectionFails(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("55555555-2222-3333-4444-555555555555")
+	today := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	now := scheduledAt(id, today).Add(time.Minute)
+	collector := &fakeCollector{err: errors.New("statement timeout")}
+	sender := &fakeSender{}
+	worker, session := testWorker(telemetryState{InstanceID: id}, collector, sender)
+
+	next, err := worker.runOnce(context.Background(), now)
+	if err == nil {
+		t.Fatal("collection failure was hidden")
+	}
+	if !next.Equal(now.Add(time.Hour)) || len(sender.bodies) != 0 || len(session.savedBodies) != 0 {
+		t.Fatalf("failure next/sent/saved = %s/%d/%d", next, len(sender.bodies), len(session.savedBodies))
+	}
+}
+
+func TestWorkerDropsInvalidStoredPendingWithoutDelivery(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("56565656-2222-3333-4444-555555555555")
+	today := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	now := scheduledAt(id, today).Add(time.Minute)
+	nextAttempt := now
+	collector := &fakeCollector{}
+	sender := &fakeSender{}
+	worker, session := testWorker(telemetryState{
+		InstanceID: id, PendingDay: &today, PendingBody: make([]byte, maxRequestSize+1),
+		NextAttemptAt: &nextAttempt,
+	}, collector, sender)
+
+	if _, err := worker.runOnce(context.Background(), now); err == nil {
+		t.Fatal("oversized stored pending event was accepted")
+	}
+	if session.dropped != 1 || collector.calls != 0 || len(sender.bodies) != 0 {
+		t.Fatalf("dropped/collected/sent = %d/%d/%d, want 1/0/0", session.dropped, collector.calls, len(sender.bodies))
+	}
+}
+
+func TestWorkerNonLeaderDoesNoCollectionOrNetwork(t *testing.T) {
+	t.Parallel()
+	collector := &fakeCollector{}
+	sender := &fakeSender{}
+	store := &fakeStore{leader: false}
+	worker := &Worker{store: store, collector: collector, sender: sender, logger: slog.Default(), now: time.Now}
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	if _, err := worker.runOnce(context.Background(), now); err != nil {
+		t.Fatal(err)
+	}
+	if collector.calls != 0 || len(sender.bodies) != 0 {
+		t.Fatalf("non-leader collector/sender calls = %d/%d", collector.calls, len(sender.bodies))
+	}
+}
+
+func TestRetryBackoffIsDeterministicBoundedAndExponential(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("66666666-2222-3333-4444-555555555555")
+	day := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	previous := time.Duration(0)
+	for attempt := 1; attempt <= 20; attempt++ {
+		got := retryBackoff(id, day, attempt)
+		if got < time.Minute || got > 6*time.Hour {
+			t.Fatalf("attempt %d backoff = %s", attempt, got)
+		}
+		if got != retryBackoff(id, day, attempt) {
+			t.Fatalf("attempt %d backoff is not deterministic", attempt)
+		}
+		if attempt < 10 && got < previous {
+			t.Fatalf("backoff decreased: attempt %d = %s after %s", attempt, got, previous)
+		}
+		previous = got
+	}
+	if got := retryBackoff(id, day, 20); got != 6*time.Hour {
+		t.Fatalf("capped backoff = %s, want 6h", got)
+	}
+}
+
+func TestWorkerFailureLogIsRateLimitedAndDataFree(t *testing.T) {
+	t.Parallel()
+	var output bytes.Buffer
+	worker := &Worker{logger: slog.New(slog.NewTextHandler(&output, nil))}
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	worker.logFailure(now)
+	worker.logFailure(now.Add(30 * time.Minute))
+	worker.logFailure(now.Add(time.Hour))
+
+	logText := output.String()
+	if got := bytes.Count(output.Bytes(), []byte("self-host telemetry attempt failed")); got != 2 {
+		t.Fatalf("failure log count = %d, want 2: %s", got, logText)
+	}
+	for _, forbidden := range []string{"instance_id", "request", "response", "error", "body"} {
+		if bytes.Contains(output.Bytes(), []byte(forbidden)) {
+			t.Fatalf("failure log contains prohibited %q data: %s", forbidden, logText)
+		}
+	}
+}
+
+type blockingSender struct {
+	started chan struct{}
+	done    chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingSender) Send(ctx context.Context, _ []byte) deliveryDisposition {
+	s.once.Do(func() { close(s.started) })
+	<-ctx.Done()
+	close(s.done)
+	return deliveryRetry
+}
+
+func (*blockingSender) Close() {}
+
+func TestWorkerCancellationCancelsInFlightDelivery(t *testing.T) {
+	id := uuid.MustParse("77777777-2222-3333-4444-555555555555")
+	today := utcDay(time.Now())
+	now := scheduledAt(id, today).Add(time.Minute)
+	sender := &blockingSender{started: make(chan struct{}), done: make(chan struct{})}
+	worker, _ := testWorker(telemetryState{InstanceID: id}, &fakeCollector{}, &fakeSender{})
+	worker.sender = sender
+	worker.now = func() time.Time { return now }
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		worker.Run(ctx)
+	}()
+
+	select {
+	case <-sender.started:
+	case <-time.After(time.Second):
+		t.Fatal("delivery did not start")
+	}
+	cancel()
+	select {
+	case <-sender.done:
+	case <-time.After(time.Second):
+		t.Fatal("delivery context was not cancelled")
+	}
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not stop promptly after cancellation")
+	}
+}

--- a/server/migrations/467_instance_telemetry_state.down.sql
+++ b/server/migrations/467_instance_telemetry_state.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS instance_telemetry_state;

--- a/server/migrations/467_instance_telemetry_state.up.sql
+++ b/server/migrations/467_instance_telemetry_state.up.sql
@@ -1,0 +1,19 @@
+-- One deployment identity and at most one durable pending snapshot. No user,
+-- workspace or runtime identifier is referenced from this table.
+CREATE TABLE instance_telemetry_state (
+    singleton             BOOLEAN NOT NULL DEFAULT true CHECK (singleton),
+    instance_id           UUID NOT NULL DEFAULT gen_random_uuid(),
+    last_successful_day   DATE,
+    pending_day           DATE,
+    pending_body          BYTEA,
+    next_attempt_at       TIMESTAMPTZ,
+    attempt_count         INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (
+        (pending_day IS NULL AND pending_body IS NULL AND next_attempt_at IS NULL AND attempt_count = 0)
+        OR
+        (pending_day IS NOT NULL AND pending_body IS NOT NULL AND next_attempt_at IS NOT NULL)
+    )
+);
+
+INSERT INTO instance_telemetry_state (singleton) VALUES (true);

--- a/server/migrations/468_instance_telemetry_state_singleton_index.down.sql
+++ b/server/migrations/468_instance_telemetry_state_singleton_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS instance_telemetry_state_singleton_uidx;

--- a/server/migrations/468_instance_telemetry_state_singleton_index.up.sql
+++ b/server/migrations/468_instance_telemetry_state_singleton_index.up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS instance_telemetry_state_singleton_uidx
+    ON instance_telemetry_state (singleton);

--- a/server/migrations/469_instance_telemetry_state_primary_key.down.sql
+++ b/server/migrations/469_instance_telemetry_state_primary_key.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instance_telemetry_state DROP CONSTRAINT IF EXISTS instance_telemetry_state_pkey;

--- a/server/migrations/469_instance_telemetry_state_primary_key.up.sql
+++ b/server/migrations/469_instance_telemetry_state_primary_key.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE instance_telemetry_state
+    ADD CONSTRAINT instance_telemetry_state_pkey PRIMARY KEY USING INDEX instance_telemetry_state_singleton_uidx;

--- a/server/migrations/470_agent_runtime_telemetry_last_seen_index.down.sql
+++ b/server/migrations/470_agent_runtime_telemetry_last_seen_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_runtime_telemetry_last_seen;

--- a/server/migrations/470_agent_runtime_telemetry_last_seen_index.down.sql
+++ b/server/migrations/470_agent_runtime_telemetry_last_seen_index.down.sql
@@ -1,1 +1,0 @@
-DROP INDEX CONCURRENTLY IF EXISTS idx_agent_runtime_telemetry_last_seen;

--- a/server/migrations/470_agent_runtime_telemetry_last_seen_index.up.sql
+++ b/server/migrations/470_agent_runtime_telemetry_last_seen_index.up.sql
@@ -1,3 +1,0 @@
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_runtime_telemetry_last_seen
-    ON agent_runtime (last_seen_at, daemon_id)
-    WHERE daemon_id IS NOT NULL;

--- a/server/migrations/470_agent_runtime_telemetry_last_seen_index.up.sql
+++ b/server/migrations/470_agent_runtime_telemetry_last_seen_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_runtime_telemetry_last_seen
+    ON agent_runtime (last_seen_at, daemon_id)
+    WHERE daemon_id IS NOT NULL;

--- a/server/migrations/471_agent_task_queue_telemetry_started_index.down.sql
+++ b/server/migrations/471_agent_task_queue_telemetry_started_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_queue_telemetry_started;

--- a/server/migrations/471_agent_task_queue_telemetry_started_index.up.sql
+++ b/server/migrations/471_agent_task_queue_telemetry_started_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_queue_telemetry_started
+    ON agent_task_queue (started_at)
+    WHERE started_at IS NOT NULL;

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -761,6 +761,17 @@ type InboxItem struct {
 	Details       []byte             `json:"details"`
 }
 
+type InstanceTelemetryState struct {
+	Singleton         bool               `json:"singleton"`
+	InstanceID        pgtype.UUID        `json:"instance_id"`
+	LastSuccessfulDay pgtype.Date        `json:"last_successful_day"`
+	PendingDay        pgtype.Date        `json:"pending_day"`
+	PendingBody       []byte             `json:"pending_body"`
+	NextAttemptAt     pgtype.Timestamptz `json:"next_attempt_at"`
+	AttemptCount      int32              `json:"attempt_count"`
+	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+}
+
 type Issue struct {
 	ID                 pgtype.UUID        `json:"id"`
 	WorkspaceID        pgtype.UUID        `json:"workspace_id"`


### PR DESCRIPTION
## Summary

- add default-on anonymous daily telemetry for API Server deployments, including Multica's official managed cloud, with `DO_NOT_TRACK=1|true` as the startup-time opt-out
- log one INFO line at startup stating whether telemetry is enabled or disabled, without including the raw environment value or telemetry data
- compile the only production destination, `https://telemetry.multica.ai/v1/telemetry/events`, into the client with redirects disabled and no configuration override
- persist one deployment UUID and one exact pending V1 payload in PostgreSQL, coordinate replicas with a session advisory lock, and retry transient delivery failures with bounded jitter
- collect one deployment-wide PostgreSQL snapshot over `[T-24h, T)` with a 2-second statement timeout and bounded fields; add only the task-start window index, avoiding a write-amplifying general runtime-heartbeat index
- document the exact outbound fields, purpose, exclusions, and opt-out across self-host deployment surfaces and localized environment docs

## Privacy and reliability

- the outbound schema is strongly typed and capped at 16 KiB; counts are bucketed or clamped and non-release versions become `unknown`
- names, email/domain data, IPs, business identifiers, host/device data, repositories, models/plugins, prompts/outputs, comments/chats, paths, usage cost/tokens, credentials, errors, stacks, and logs are never selected or serialized
- only HTTP 202 marks a day successful; network errors, timeouts, 429, and 5xx retry, while other 4xx responses stop attempts for that UTC day
- collection and delivery failures are isolated from the server, failure logs are generic and rate-limited, and shutdown cancellation is propagated

## Validation

- `make test` — passed on the review-update commit in a clean worktree and fresh database, including the full Go race suite
- `go vet ./internal/selfhosttelemetry ./cmd/server ./cmd/migrate` — passed
- targeted PostgreSQL integration coverage verifies migration up/down, stable identity, cross-replica locking, exact time boundaries, retry persistence, timeout locality, and task-window index plans against 100k historical rows
- `make check` reached E2E collection after typecheck, TypeScript unit tests, and Go tests passed; collection is currently blocked by the pre-existing `e2e/plugin-surface-document.spec.ts` import of `buildSurfaceDocument`, while the implementation exports `buildSurfaceFrameDocument`

## Rollout

Deploy the already-merged Cloud receiver/TLS/DNS/ingress/WAF path before releasing this sender. The database changes are additive; the hot-table index uses a standalone concurrent migration, and an older binary safely ignores the retained telemetry state during rollback.
