### PR TITLE
MUL-7249: protect Inbox detail pane width

### DIFF
--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -139,8 +139,27 @@ vi.mock("@multica/ui/components/ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  ResizablePanel: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+  ResizablePanel: ({
+    children,
+    id,
+    defaultSize,
+    minSize,
+    maxSize,
+  }: {
+    children: React.ReactNode;
+    id: string;
+    defaultSize?: number;
+    minSize?: number | string;
+    maxSize?: number | string;
+  }) => (
+    <div
+      data-testid={`panel-${id}`}
+      data-default-size={defaultSize}
+      data-min-size={minSize}
+      data-max-size={maxSize}
+    >
+      {children}
+    </div>
   ),
   ResizableHandle: () => null,
 }));
@@ -257,6 +276,18 @@ function reset() {
 }
 
 describe("InboxPage", () => {
+  it("keeps the list subordinate to the detail pane on desktop", () => {
+    reset();
+    layout.width = DESKTOP;
+
+    render(<InboxPage />);
+
+    const listPanel = screen.getByTestId("panel-list");
+    expect(listPanel).toHaveAttribute("data-default-size", "280");
+    expect(listPanel).toHaveAttribute("data-min-size", "240");
+    expect(listPanel).toHaveAttribute("data-max-size", "400");
+  });
+
   it("keeps the title unread count static", () => {
     reset();
     const { container } = render(<InboxPage />);

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -283,7 +283,7 @@ describe("InboxPage", () => {
     render(<InboxPage />);
 
     const listPanel = screen.getByTestId("panel-list");
-    expect(listPanel).toHaveAttribute("data-default-size", "280");
+    expect(listPanel).toHaveAttribute("data-default-size", "260");
     expect(listPanel).toHaveAttribute("data-min-size", "240");
     expect(listPanel).toHaveAttribute("data-max-size", "400");
   });

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -100,6 +100,10 @@ import { AutopilotQuotaNotice } from "./autopilot-quota-notice";
 import { useT } from "../../i18n";
 import { useIssueLimitUpgradePrompt } from "../../modals/use-issue-limit-upgrade-prompt";
 
+const INBOX_LIST_DEFAULT_SIZE = 280;
+const INBOX_LIST_MIN_SIZE = 240;
+const INBOX_LIST_MAX_SIZE = 400;
+
 export function InboxPage() {
   const { t } = useT("inbox");
   const showIssueLimitUpgradePrompt = useIssueLimitUpgradePrompt();
@@ -880,7 +884,13 @@ export function InboxPage() {
   if (viewLoading) {
     return (
       <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
-        <ResizablePanel id="list" defaultSize={280} minSize={240} maxSize={480} groupResizeBehavior="preserve-pixel-size">
+        <ResizablePanel
+          id="list"
+          defaultSize={INBOX_LIST_DEFAULT_SIZE}
+          minSize={INBOX_LIST_MIN_SIZE}
+          maxSize={INBOX_LIST_MAX_SIZE}
+          groupResizeBehavior="preserve-pixel-size"
+        >
           <div className="flex flex-col border-r h-full">
             <div className={cn("flex h-12 shrink-0 items-center border-b", PAGE_GUTTER)}>
               <Skeleton className="h-5 w-16" />
@@ -911,7 +921,13 @@ export function InboxPage() {
 
   return (
     <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
-      <ResizablePanel id="list" defaultSize={280} minSize={240} maxSize={480} groupResizeBehavior="preserve-pixel-size">
+      <ResizablePanel
+        id="list"
+        defaultSize={INBOX_LIST_DEFAULT_SIZE}
+        minSize={INBOX_LIST_MIN_SIZE}
+        maxSize={INBOX_LIST_MAX_SIZE}
+        groupResizeBehavior="preserve-pixel-size"
+      >
       <div className="flex flex-col border-r h-full">
         {listPanel}
       </div>

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -100,7 +100,7 @@ import { AutopilotQuotaNotice } from "./autopilot-quota-notice";
 import { useT } from "../../i18n";
 import { useIssueLimitUpgradePrompt } from "../../modals/use-issue-limit-upgrade-prompt";
 
-const INBOX_LIST_DEFAULT_SIZE = 280;
+const INBOX_LIST_DEFAULT_SIZE = 260;
 const INBOX_LIST_MIN_SIZE = 240;
 const INBOX_LIST_MAX_SIZE = 400;
 


### PR DESCRIPTION
## Summary

- reduce the Inbox list's default width from 280px to 260px and keep its 240px minimum
- reduce its maximum width from 480px to 400px so persisted wide layouts leave more room for the detail pane
- cover the desktop list sizing contract with a regression test

## Validation

- `pnpm --filter @multica/views exec vitest run inbox/components/inbox-page.test.tsx` (40 passed)
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint inbox/components/inbox-page.tsx inbox/components/inbox-page.test.tsx`
- `git diff --check`
- Earlier full Views run on this PR: 5,006 passed; one failure in the untouched `layout/sidebar-resize.test.tsx`, reproduced in isolation

Closes MUL-7249
