### PR TITLE
MUL-7244 test: fix the two flakes that turned main red

### DIFF
--- a/server/internal/daemon/workdir_race_test.go
+++ b/server/internal/daemon/workdir_race_test.go
@@ -662,6 +662,17 @@ func (t *prepareLeaseCountingTransport) RoundTrip(req *http.Request) (*http.Resp
 	return t.base.RoundTrip(req)
 }
 
+// prepareBudgetForBlockedStart is the prepare deadline the blocked-/start test
+// arms. It has to outlast everything runTask does before it calls /start — the
+// isolated execution environment, its sidecars, and the task temp dir are all
+// real filesystem work — because a deadline that expires during preparation
+// never reaches the /start this test is about. That preparation costs ~15ms on
+// an idle developer machine but an order of magnitude more on a loaded CI
+// runner under -race, which is why the original 150ms turned main red
+// (MUL-7244). Two seconds keeps ~20x headroom over the observed CI cost while
+// still bounding the test at roughly the budget itself.
+const prepareBudgetForBlockedStart = 2 * time.Second
+
 func TestRunTask_PrepareTimeoutStopsLeaseDuringBlockedStartTask(t *testing.T) {
 	oldRefresh := taskPrepareLeaseRefresh
 	oldTimeout := taskPrepareLeaseTimeout
@@ -712,7 +723,7 @@ func TestRunTask_PrepareTimeoutStopsLeaseDuringBlockedStartTask(t *testing.T) {
 		workspaces:         make(map[string]*workspaceState),
 		runtimeIndex:       map[string]Runtime{"rt-1": {ID: "rt-1", Provider: "claude"}},
 		activeEnvRoots:     make(map[string]int),
-		taskPrepareTimeout: 150 * time.Millisecond,
+		taskPrepareTimeout: prepareBudgetForBlockedStart,
 		cfg: Config{
 			WorkspacesRoot: workspacesRoot,
 			Agents: map[string]AgentEntry{
@@ -735,13 +746,19 @@ func TestRunTask_PrepareTimeoutStopsLeaseDuringBlockedStartTask(t *testing.T) {
 	if !errors.Is(err, errTaskPrepareTimeout) {
 		t.Fatalf("runTask error = %v, want task prepare timeout", err)
 	}
-	if elapsed := time.Since(startedAt); elapsed > time.Second {
+	if elapsed := time.Since(startedAt); elapsed > prepareBudgetForBlockedStart+time.Second {
 		t.Fatalf("runTask took %s, want prepare deadline to stop blocked /start", elapsed)
 	}
+	// Wait for the handler rather than sampling it: runTask returns as soon as
+	// the deadline cancels the in-flight RoundTrip, which can beat httptest
+	// scheduling the handler goroutine that closes startEntered. The wait only
+	// slows the failing path — when /start was reached the channel is already
+	// closed, and when it was not the budget above was too small to survive
+	// preparation on this machine.
 	select {
 	case <-startEntered:
-	default:
-		t.Fatal("runTask did not reach /start")
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runTask did not reach /start: the %s prepare budget expired during preparation", prepareBudgetForBlockedStart)
 	}
 	releaseStartOnce.Do(func() { close(releaseStart) })
 	if got := leaseCalls.Load(); got == 0 {

--- a/server/pkg/agent/omp_test.go
+++ b/server/pkg/agent/omp_test.go
@@ -85,8 +85,17 @@ func TestOmpExecuteDefaultsToOmpBinary(t *testing.T) {
 
 	fakeDir := t.TempDir()
 	fakePath := filepath.Join(fakeDir, "omp")
+	// Real omp reads the piped prompt to EOF before emitting events, so the
+	// fake has to drain stdin too: one that exits without reading closes the
+	// read end while the backend is still writing, and the EPIPE surfaces as
+	// "omp prompt write failed: broken pipe" (MUL-7244). It must drain with a
+	// shell builtin, not `cat` — PATH is replaced with fakeDir below so the
+	// backend has to resolve "omp" by name, which leaves no external command
+	// on PATH for the fixture to call. A `cat` drain here fails silently with
+	// "cat: not found" and the script runs straight through to its exit,
+	// reopening the very race the drain was added to close.
 	script := "#!/bin/sh\n" +
-		"cat > /dev/null\n" +
+		"while IFS= read -r _; do :; done\n" +
 		"printf '%s\\n' '{\"type\":\"agent_start\"}'\n" +
 		"printf '%s\\n' '{\"type\":\"turn_end\",\"message\":{\"role\":\"assistant\",\"model\":\"test\",\"usage\":{\"input\":1,\"output\":1}}}'\n" +
 		"exit 0\n"


### PR DESCRIPTION
## Summary

`main` is red. Two backend tests flaked in the last 50 CI runs, and both are test-side races — neither is a product bug:

- **`TestOmpExecuteDefaultsToOmpBinary`** (run 34446291545) — `omp prompt write failed: write |1: broken pipe`
- **`TestRunTask_PrepareTimeoutStopsLeaseDuringBlockedStartTask`** (run 34456935979, tip of `main`) — `runTask did not reach /start`

## The omp fixture never drained stdin

The test replaces `PATH` with the fixture directory so the backend must resolve `omp` by name. That leaves no external command on `PATH`, so the fixture's `cat > /dev/null` drain failed with `cat: not found` and the script ran straight through to its exit, closing the read end while the backend was still writing the prompt. Winning that race hid it; losing it failed the run.

Reproduced directly — the old fixture under an isolated `PATH`:

```
/tmp/.../omp: line 2: cat: command not found
```

Fixed by draining with a shell builtin (`while IFS= read -r _; do :; done`), which honours the same read-to-EOF contract as real omp with no `PATH` dependency. The same idiom is already used by the fixture in `workdir_race_test.go:182`.

## The prepare budget was smaller than preparation itself

The test armed a 150ms prepare deadline and then required `runTask` to reach `/start` before it expired. Everything `runTask` does first — the isolated execution environment, its sidecars, the task temp dir — is real filesystem work. Measured at ~15ms on an idle machine, but the `internal/daemon` package takes ~37s in CI against a few seconds locally, so on a loaded runner under `-race` that preparation lands close to the 150ms budget. When it overran, the deadline fired before `/start` and the test failed exactly as CI reported.

Confirmed the failure mode by shrinking the budget below the prepare cost:

```
workdir_race_test.go:761: runTask did not reach /start: the 5ms prepare budget expired during preparation
```

Two changes:

- Budget raised to 2s — ~20x headroom over the observed CI cost, and the test still bounds itself at roughly the budget (2.03s per run).
- The `/start` assertion now waits for the handler instead of sampling it. `runTask` returns as soon as the deadline cancels the in-flight `RoundTrip`, which can beat httptest scheduling the goroutine that records the entry — the same observation race the `prepareLeaseCountingTransport` comment right above already documents for prepare-lease. The wait only slows the failing path.

Both tests keep asserting exactly what they asserted before; nothing was weakened or skipped.

## Verification

- `go test -race ./internal/daemon/ -count 1` — full package green.
- Both fixed tests, `-race`, `-count 10`, with the machine under CPU load — green.
- `go test -race -p 2 -parallel 2 ./pkg/agent/...` (CI's exact flags) — the omp test passes. Four Codex wall-clock tests (`TestCodexCancellation*`, `TestCodexNonResponsiveInterrupt*`, `TestCodexExecuteCleansUpWhenScannerOverflowsOnResume`) fail on this macOS machine under load; they reproduce identically on unmodified `main` at 091d3ce5d and are green on CI's Linux runners, so they are pre-existing and out of scope here.
- `gofmt` / `go vet` clean.
