### PR TITLE
fix(MUL-7227): restore comment typing performance during live runs

### DIFF
--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -149,6 +149,46 @@ describe("InlineCommentRun", () => {
     expect(screen.getByRole("dialog")).toHaveTextContent("Full transcript");
   });
 
+  it("updates streamed summaries without replacing their DOM nodes", async () => {
+    const events: TaskMessagePayload[] = [...messages,
+      { task_id: id, issue_id: "issue", seq: 3, type: "tool_result", tool: "exec_command", output: "Passed" },
+    ];
+    vi.mocked(api.listTaskMessages).mockResolvedValue([...events]);
+    const { client } = setup(task());
+    const summary = await screen.findByText("pnpm test");
+    const text = summary.firstChild;
+    const container = summary.closest("[data-run-summary]")!;
+    const mutations: MutationRecord[] = [];
+    const observer = new MutationObserver((records) => mutations.push(...records));
+    observer.observe(container, { childList: true, subtree: true });
+    try {
+      // Cover a new seq with the same label, a changed tool argument, and prose.
+      for (const next of [
+        { type: "tool_use", tool: "exec_command", input: { command: "pnpm test" } },
+        { type: "tool_use", tool: "exec_command", input: { command: "pnpm lint" } },
+        { type: "text", content: "Reviewing the results." },
+      ] as const) {
+        events.push({ task_id: id, issue_id: "issue", seq: events.length + 1, ...next });
+        if (next.type === "tool_use") events.push({
+          task_id: id, issue_id: "issue", seq: events.length + 1,
+          type: "tool_result", tool: next.tool, output: "Passed",
+        });
+        await act(async () => {
+          client.setQueryData(chatKeys.taskMessages(id), [...events]);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+        const label = next.type === "text" ? next.content : next.input.command;
+        await waitFor(() => expect(summary).toHaveTextContent(label));
+        expect(summary.isConnected).toBe(true);
+        expect(summary.firstChild).toBe(text);
+        expect(container).toHaveAttribute("title", label);
+      }
+      expect([...mutations, ...observer.takeRecords()]).toHaveLength(0);
+    } finally {
+      observer.disconnect();
+    }
+  });
+
   it("retains the last meaningful activity between tool results and the next agent message", async () => {
     vi.mocked(api.listTaskMessages).mockResolvedValue([]);
     const { client } = setup(task());

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useId, useMemo, useState } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { AlertCircle, Brain, ChevronRight, CirclePause, Clock3, ExternalLink, Loader2, MessageSquare, RotateCcw, ScrollText, Square, Terminal } from "lucide-react";
 import { toast } from "sonner";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -15,7 +14,6 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import { Button } from "@multica/ui/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { cn } from "@multica/ui/lib/utils";
-import { UI_EASE_IN, UI_EASE_OUT, UI_MOTION_DURATION } from "@multica/ui/lib/motion";
 import { AgentTranscriptDialog, StepBody } from "../../common/task-transcript/agent-transcript-dialog";
 import { buildTimeline } from "../../common/task-transcript/build-timeline";
 import { buildSteps, groupSteps, isCallStep, isGroupRow, type TraceRow } from "../../common/task-transcript/build-steps";
@@ -108,7 +106,6 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
     : task.status === "dispatched" ? t(($) => $.inline_run.starting)
     : task.status === "waiting_local_directory" ? t(($) => $.inline_run.waiting_directory)
     : activitySummary;
-  const summaryMotionKey = `${task.status}:${current?.seq ?? "empty"}`;
   const showProgress = active && !hasReply;
   const activityLabel = t(($) => $.inline_run.view_activity);
   const stepLabel = steps.length > 0 ? t(($) => $.inline_run.steps, { count: steps.length }) : "";
@@ -162,7 +159,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
           onClick={(event) => { state.disclosure.onTrigger(event); setExpanded(!expanded); }}>
           {showProgress
             ? <><RunActivityIndicator status={task.status} animate={animationVisibility.visible} />
-                <RunActivitySummary summary={summary} motionKey={summaryMotionKey} /></>
+                <RunActivitySummary summary={summary} /></>
             : <span className={cn(showIdentity && "@max-[32rem]/run:sr-only")}>{activityLabel}</span>}
           {!showProgress && stepLabel && <span className="text-faint-foreground @max-[32rem]/run:hidden">· {stepLabel}</span>}
           <ChevronRight ref={state.disclosure.chevronRef} aria-hidden className={cn("size-3.5 shrink-0", expanded && "rotate-90")} />
@@ -252,21 +249,10 @@ function RunActivityIndicator({ status, animate }: { status: AgentTask["status"]
   return <Clock3 aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />;
 }
 
-function RunActivitySummary({ summary, motionKey }: { summary: string; motionKey: string }) {
-  const shouldReduceMotion = useReducedMotion() ?? false;
+function RunActivitySummary({ summary }: { summary: string }) {
+  // Update the existing text node. Replacing it for every streamed message
+  // invalidates ancestor :has() styles across the entire issue page.
   return <span data-run-summary className="grid h-[1lh] min-w-0 flex-1 overflow-hidden" title={summary}>
-    <AnimatePresence initial={false}>
-      <motion.span key={motionKey}
-        className="col-start-1 row-start-1 block min-w-0 max-w-full truncate"
-        initial={shouldReduceMotion ? false : { opacity: 0, transform: "translateY(6px)" }}
-        animate={shouldReduceMotion ? undefined : { opacity: 1, transform: "translateY(0)", transition: {
-          duration: UI_MOTION_DURATION.fast, ease: UI_EASE_OUT,
-        } }}
-        exit={shouldReduceMotion ? undefined : { opacity: 0, transform: "translateY(-6px)", transition: {
-          duration: UI_MOTION_DURATION.micro, ease: UI_EASE_IN,
-        } }}>
-        {summary}
-      </motion.span>
-    </AnimatePresence>
+    <span className="col-start-1 row-start-1 block min-w-0 max-w-full truncate">{summary}</span>
   </span>;
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a comment-typing regression on long issue threads while agents stream progress. The summary transition introduced in #8172 keys a new `motion.span` by the current message's seq, replacing DOM nodes on every update even when the displayed label stays the same. Chromium traces show these replacements invalidating ancestor `:has()` styles and repeatedly recalculating styles for roughly 29,000 elements in the reproduction.

Roll back that summary enter/exit transition and update the existing text node. Live summaries, the loading indicator, and activity disclosure continue working. The visible change is that summary text switches immediately.

## Related Issue

MUL-7227. The comparison base includes #8242.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `inline-comment-run.tsx`: remove the seq-keyed summary transition.
- `inline-comment-run.test.tsx`: verify that same-label messages, changed tool arguments, and prose update the summary and tooltip without replacing its element or text node or introducing child-list mutations.

## How to Test

Local Playwright comparison using the real issue page and comment editor: 80 comments with repeated code blocks, three running tasks seeded with the same 951-message transcript, and a new WebSocket message per task every 100 ms. Use the flat timeline via a comment deep link, focus the composer, settle initial rendering, then type 172 characters with a 25 ms key delay. Capture Chromium's `UpdateLayoutTree` events during typing.

| Shared renderer build | Typing elapsed | Total style recalculation | Style recalculations over 50 ms |
| --- | ---: | ---: | ---: |
| v0.4.41 (`4aca890a2`) | 4.890 s | 0.293 s | 1 |
| main including #8242 (`116761e50`) | 23.952 s | 19.157 s | 86 |
| Same main with this change | 4.959 s | 0.297 s | 1 |

These are local Chromium development-build measurements. Confirmation in a rebuilt Desktop client remains part of acceptance.

- `pnpm --filter @multica/views exec vitest run issues/components/inline-comment-run.test.tsx issues/components/use-run-comment-motion.test.tsx`: 23 passed.
- Restoring the original component makes the new regression test fail; the fixed component passes.
- `pnpm --filter @multica/views typecheck`: passed.
- ESLint on both changed files: passed.
- `git diff --check`: passed.

## Checklist

- [x] Traced the change to a version regression and confirmed it with an old/current/fixed comparison.
- [x] Ran relevant tests and added a regression test.
- [x] Documented the visible behavior change and the Desktop validation boundary above.

## AI Disclosure

**AI tool used:** Codex.

**Approach:** Compared versions in isolated local environments, captured browser CPU and rendering traces, isolated the per-message DOM replacement, and verified a narrow rollback with browser measurements and a regression test.
