### PR TITLE
MUL-7252: chore(codex): add gpt-6-astra to the static fallback catalog

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -600,8 +600,9 @@ func codexStaticModels() []Model {
 	// multica#2009). It is deliberately NOT used to validate effort for an
 	// empty (follow-CLI-config) model: that config can resolve to any model,
 	// so ValidateThinkingLevel fails an empty codex model closed rather than
-	// borrowing this entry's catalog (which alone advertises `ultra`) — see
-	// ValidateThinkingLevel and MUL-4347. Keep exactly one entry flagged.
+	// borrowing this entry's catalog (Astra/Sol/Terra advertise `ultra`; Luna
+	// does not) — see ValidateThinkingLevel and MUL-4347. Keep exactly one
+	// entry flagged.
 	standardThinking := func(defaultLevel string, includeMax, includeUltra bool) *ModelThinking {
 		levels := []ThinkingLevel{
 			{Value: "low", Label: "Low", Description: "Fast responses with lighter reasoning"},
@@ -629,7 +630,8 @@ func codexStaticModels() []Model {
 		}
 	}
 	return []Model{
-		{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Provider: "openai", Default: true, Thinking: standardThinking("low", true, true)},
+		{ID: "gpt-6-astra", Label: "GPT-6 Astra", Provider: "openai", Default: true, Thinking: standardThinking("low", true, true)},
+		{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Provider: "openai", Thinking: standardThinking("low", true, true)},
 		{ID: "gpt-5.6-terra", Label: "GPT-5.6 Terra", Provider: "openai", Thinking: standardThinking("medium", true, true)},
 		{ID: "gpt-5.6-luna", Label: "GPT-5.6 Luna", Provider: "openai", Thinking: standardThinking("medium", true, false)},
 		{ID: "gpt-5.5", Label: "GPT-5.5", Provider: "openai", Thinking: standardThinking("medium", false, false)},

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -494,6 +494,12 @@ func TestModelKnownIncompatibleWithProvider(t *testing.T) {
 			want:     false,
 		},
 		{
+			name:     "codex bundled gpt-6-astra is compatible",
+			provider: "codex",
+			model:    "gpt-6-astra",
+			want:     false,
+		},
+		{
 			name:     "codex model is incompatible with claude",
 			provider: "claude",
 			model:    "o3",

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -422,6 +422,8 @@ func parseCodexModelCatalog(raw []byte) ([]Model, error) {
 
 func normalizeCodexModelLabel(id, label string) string {
 	switch id {
+	case "gpt-6-astra":
+		return "GPT-6 Astra"
 	case "gpt-5.6-sol":
 		return "GPT-5.6 Sol"
 	case "gpt-5.6-terra":

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -277,6 +277,12 @@ func TestParseCodexModelCatalog(t *testing.T) {
 				"display_name": "No Reasoning",
 				"visibility": "list",
 				"supported_reasoning_levels": []
+			},
+			{
+				"slug": "gpt-6-astra",
+				"display_name": "GPT-6-Astra",
+				"visibility": "list",
+				"supported_reasoning_levels": []
 			}
 		]
 	}`)
@@ -284,8 +290,8 @@ func TestParseCodexModelCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseCodexModelCatalog: %v", err)
 	}
-	if len(got) != 4 {
-		t.Fatalf("expected four visible models, got %+v", got)
+	if len(got) != 5 {
+		t.Fatalf("expected five visible models, got %+v", got)
 	}
 	if got[0].ID != "gpt-5.6-sol" || got[0].Label != "GPT-5.6 Sol" || !got[0].Default {
 		t.Errorf("unexpected first model: %+v", got[0])
@@ -297,6 +303,7 @@ func TestParseCodexModelCatalog(t *testing.T) {
 		{"gpt-5.6-sol", "GPT-5.6 Sol"},
 		{"gpt-5.6-terra", "GPT-5.6 Terra"},
 		{"gpt-5.6-luna", "GPT-5.6 Luna"},
+		{"gpt-6-astra", "GPT-6 Astra"},
 	} {
 		var found *Model
 		for i := range got {
@@ -367,7 +374,7 @@ echo '{"models":[{"slug":"runtime-model","display_name":"Runtime Model","visibil
 		writeTestExecutable(t, fake, []byte(script))
 
 		got := discoverCodexModels(context.Background(), Command{Path: fake})
-		if len(got) == 0 || got[0].ID != "gpt-5.6-sol" {
+		if len(got) == 0 || got[0].ID != "gpt-6-astra" {
 			t.Fatalf("expected static fallback, got %+v", got)
 		}
 		if got[0].SupportsExplicitStandardServiceTier {
@@ -384,7 +391,7 @@ echo '{"models":[{"slug":"runtime-model","display_name":"Runtime Model","visibil
 		writeTestExecutable(t, fake, []byte(script))
 
 		got := discoverCodexModels(context.Background(), Command{Path: fake})
-		if len(got) == 0 || got[0].ID != "gpt-5.6-sol" || got[0].Thinking == nil {
+		if len(got) == 0 || got[0].ID != "gpt-6-astra" || got[0].Thinking == nil {
 			t.Fatalf("expected model + thinking fallback, got %+v", got)
 		}
 		if !got[0].SupportsExplicitStandardServiceTier {
@@ -400,6 +407,9 @@ func TestValidateThinkingLevelCodexPerModelFallbackCatalog(t *testing.T) {
 		level string
 		want  bool
 	}{
+		{model: "gpt-6-astra", level: "low", want: true},
+		{model: "gpt-6-astra", level: "max", want: true},
+		{model: "gpt-6-astra", level: "ultra", want: true},
 		{model: "gpt-5.6-sol", level: "ultra", want: true},
 		{model: "gpt-5.6-terra", level: "ultra", want: true},
 		{model: "gpt-5.6-luna", level: "max", want: true},
@@ -791,10 +801,11 @@ func TestValidateThinkingLevel_ExplicitModel(t *testing.T) {
 // fix: an explicit codex model is validated against its own per-model
 // catalog, but an EMPTY model (follow config.toml, which can resolve to any
 // installed model) must NOT borrow the flagged Default entry's catalog. The
-// Default (gpt-5.6-sol) alone advertises `ultra`; letting an empty model
-// inherit it would green-light a level Luna / gpt-5.5 don't support and Codex
-// won't reject. So an empty codex model fails closed for every level and the
-// daemon drops it — users must pick an explicit model to pin an effort.
+// flagged Default (currently Astra) advertises `ultra`; letting an empty
+// model inherit that catalog would green-light a level Luna / gpt-5.5 don't
+// support and Codex won't reject. So an empty codex model fails closed for
+// every level and the daemon drops it — users must pick an explicit model to
+// pin an effort.
 func TestValidateThinkingLevel_CodexEmptyModelFailsClosed(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fake binary requires a POSIX shell")
@@ -822,7 +833,7 @@ func TestValidateThinkingLevel_CodexEmptyModelFailsClosed(t *testing.T) {
 	check("gpt-5.6-luna", "medium", true) // as are the base levels
 
 	// Empty model cannot be validated per-model, so it fails closed for EVERY
-	// level — including `ultra` (must not pass via the Sol Default) and even a
+	// level — including `ultra` (must not pass via the flagged Default) and even a
 	// level every model supports (`medium`). The daemon drops it.
 	check("", "ultra", false)
 	check("", "medium", false)


### PR DESCRIPTION
## Summary

Codex CLI 0.153.4's bundled catalog (`codex debug models --bundled`) already includes `gpt-6-astra` with thinking levels `low` through `ultra`. The static fallback (`codexStaticModels()`) still started at `gpt-5.6-sol`, so a discovery failure omitted a model the current bundled snapshot ships.

This is catalog hygiene against that bundled snapshot:

- add `gpt-6-astra` as the flagged `Default` flagship
- keep Sol/Terra `ultra` and Luna without `ultra`
- preserve the empty-model thinking fail-closed contract (MUL-4347)

Live discovery is unchanged (#8177 / #8205). This does not add a server-side save allowlist.

Fixes #8262

## Test plan

- [x] `go test ./pkg/agent -run 'TestModelKnownIncompatibleWithProvider|TestParseCodexModelCatalog$|TestDiscoverCodexModelsVersionGateAndFallback|TestValidateThinkingLevelCodexPerModelFallbackCatalog|TestStaticModelCatalogsAreValid|TestValidateThinkingLevel_CodexEmptyModelFailsClosed'`
- [ ] Confirm `codex debug models --bundled` on 0.153.4 still lists `gpt-6-astra`
