### PR TITLE
chore(metrics): add published OpenAI rates for gpt-6-astra

### DIFF
--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -284,6 +284,7 @@ describe("estimateCost", () => {
     // can't hide behind an input-only assertion. `total` is 1M of each of the
     // four categories priced at its own rate.
     const cases = [
+      { model: "gpt-6-astra", input: 10, cacheRead: 1, cacheWrite: 12.5, output: 50, total: 73.5 },
       { model: "gpt-5.6-sol", input: 5, cacheRead: 0.5, cacheWrite: 6.25, output: 30, total: 41.75 },
       { model: "gpt-5.6-terra", input: 2.5, cacheRead: 0.25, cacheWrite: 3.125, output: 15, total: 20.875 },
       { model: "gpt-5.6-luna", input: 1, cacheRead: 0.1, cacheWrite: 1.25, output: 6, total: 8.35 },
@@ -340,6 +341,8 @@ describe("estimateCost", () => {
     // literal-dot alias in server/internal/metrics/pricing.go (MUL-4347).
     expect(isModelPriced("gpt-5-6-luna")).toBe(false);
     expect(isModelPriced("gpt-5-6-sol")).toBe(false);
+    expect(isModelPriced("gpt-6-astra")).toBe(true);
+    expect(isModelPriced("gpt-6-astra-pro")).toBe(false);
     expect(
       estimateCost({
         ...zeroUsage,

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -223,12 +223,13 @@ const MODEL_PRICING: Record<
   // -- OpenAI: dotted-minor Codex catalog SKUs. Each generation is priced
   //    independently — no fallback to `gpt-5`. Entries track
   //    `server/pkg/agent/models.go` (Codex provider list).
-  //    gpt-5.6 (sol/terra/luna) uses OpenAI's official announcement rates.
+  //    gpt-6-astra and gpt-5.6 (sol/terra/luna) use OpenAI's official rates.
   //    5.6+ is the first OpenAI generation to bill cache writes separately:
   //    cacheRead = 0.1x input (90% cached-input discount), cacheWrite = 1.25x
   //    input (see the header note above). Codex usage doesn't yet report
   //    cache-write tokens, so cacheWrite isn't exercised today, but the rate
   //    is kept correct for when it is.
+  "gpt-6-astra":        { input: 10,   output: 50,   cacheRead: 1.00,  cacheWrite: 12.50 },
   "gpt-5.6-sol":        { input: 5,    output: 30,   cacheRead: 0.50,  cacheWrite: 6.25 },
   "gpt-5.6-terra":      { input: 2.50, output: 15,   cacheRead: 0.25,  cacheWrite: 3.125 },
   "gpt-5.6-luna":       { input: 1,    output: 6,    cacheRead: 0.10,  cacheWrite: 1.25 },

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -21,13 +21,15 @@ type ModelPrice struct {
 }
 
 var modelPrices = map[string]ModelPrice{
-	// GPT-5.6 series (Codex `codex` provider). Official rates from OpenAI's
-	// GPT-5.6 announcement (openai.com/index/previewing-gpt-5-6-sol). For 5.6+
-	// cache read is the 90%-off cached-input rate (0.1x input) and cache write
-	// is billed at 1.25x the uncached input rate — unlike earlier OpenAI SKUs,
-	// which don't bill cache writes separately. Codex app-server v0.147 reports
-	// cache-write input separately while including it in the raw input total;
-	// the collector normalizes those into mutually exclusive billing buckets.
+	// GPT-5.6 series and GPT-6 Astra (Codex `codex` provider). Official rates
+	// from OpenAI's GPT-5.6 announcement (openai.com/index/previewing-gpt-5-6-sol)
+	// and Astra's published $10 / $50. For 5.6+ (including Astra) cache read is
+	// the 90%-off cached-input rate (0.1x input) and cache write is billed at
+	// 1.25x the uncached input rate — unlike earlier OpenAI SKUs, which don't
+	// bill cache writes separately. Codex app-server v0.147 reports cache-write
+	// input separately while including it in the raw input total; the collector
+	// normalizes those into mutually exclusive billing buckets.
+	"openai:gpt-6-astra":   {Provider: "openai", Model: "gpt-6-astra", InputPerM: 10.00, CacheReadPerM: 1.00, CacheWritePerM: 12.50, OutputPerM: 50.00},
 	"openai:gpt-5.6-sol":   {Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 30.00},
 	"openai:gpt-5.6-terra": {Provider: "openai", Model: "gpt-5.6-terra", InputPerM: 2.50, CacheReadPerM: 0.25, CacheWritePerM: 3.125, OutputPerM: 15.00},
 	"openai:gpt-5.6-luna":  {Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 1.00, CacheReadPerM: 0.10, CacheWritePerM: 1.25, OutputPerM: 6.00},
@@ -140,6 +142,7 @@ var modelAliasRules = []struct {
 	// slug is always dotted (`gpt-5.6-luna`), and the frontend resolver in
 	// utils.ts does NOT dash-normalize, so a dashed `gpt-5-6-luna` must surface
 	// as unmapped on both sides rather than silently borrowing a tier here.
+	{regexp.MustCompile(`(^|/|:)gpt-6-astra$`), "openai:gpt-6-astra"},
 	{regexp.MustCompile(`(^|/|:)gpt-5\.6-sol$`), "openai:gpt-5.6-sol"},
 	{regexp.MustCompile(`(^|/|:)gpt-5\.6-terra$`), "openai:gpt-5.6-terra"},
 	{regexp.MustCompile(`(^|/|:)gpt-5\.6-luna$`), "openai:gpt-5.6-luna"},

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -66,6 +66,10 @@ func TestPriceForModelAliasCodexGPT56(t *testing.T) {
 		want  ModelPrice
 	}{
 		{
+			model: "gpt-6-astra",
+			want:  ModelPrice{Provider: "openai", Model: "gpt-6-astra", InputPerM: 10, CacheReadPerM: 1, CacheWritePerM: 12.5, OutputPerM: 50},
+		},
+		{
 			model: "gpt-5.6-sol",
 			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5, CacheReadPerM: 0.5, CacheWritePerM: 6.25, OutputPerM: 30},
 		},
@@ -95,6 +99,9 @@ func TestPriceForModelAliasCodexGPT56(t *testing.T) {
 	// slug is always dotted and the frontend does not dash-normalize, so both
 	// sides surface these as unmapped instead of silently pricing them.
 	for _, model := range []string{
+		"gpt-6-astra-pro",
+		"gpt-6-astra/unknown",
+		"gpt-6-astra-high",
 		"gpt-5.6-luna-pro",
 		"gpt-5.6-luna/unknown",
 		"gpt-5.6-sol-high",


### PR DESCRIPTION
## Summary

Usage cost estimates currently miss `gpt-6-astra`, so Codex runs on that model stay unmapped.

Adds OpenAI's published GPT-6 Astra rates on both sides:

- input $10 / 1M
- output $50 / 1M
- cache read $1 / 1M (0.1× input)
- cache write $12.50 / 1M (1.25× input)

Aliases are anchored exact-match so unknown variants (`gpt-6-astra-pro`) stay unmapped. The Codex app-server v0.147 cache-write collector note is unchanged.

Fixes #8263

## Test plan

- [x] `go test ./internal/metrics -run TestPriceForModelAliasCodexGPT56`
- [ ] `vitest run packages/views/runtimes/utils.test.ts` (Astra $10/$50 row and unmapped `gpt-6-astra-pro`)
