### PR TITLE
MUL-7255: keep window navigation fixed on sidebar toggle

### DIFF
--- a/apps/desktop/src/renderer/src/components/window-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/window-toolbar.test.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps } from "react";
+import type { ComponentProps, CSSProperties } from "react";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -157,14 +157,41 @@ describe("WindowToolbar history controls", () => {
     expect(toolbar).not.toHaveClass("transition-[width]");
   });
 
-  it("keeps the controls clear of the traffic lights after toggling the sidebar", () => {
-    const { rerender } = render(<WindowToolbar />);
+  it("keeps controls fixed at a custom sidebar width while toggling", () => {
+    const customSidebarWidth = {
+      "--sidebar-width": "320px",
+    } as CSSProperties;
+    const { rerender } = render(
+      <div style={customSidebarWidth}>
+        <WindowToolbar />
+      </div>,
+    );
+    const expandedWidth = document.querySelector<HTMLElement>(
+      '[data-slot="window-toolbar"]',
+    )?.style.width;
+
     sidebarState.state = "collapsed";
-    rerender(<WindowToolbar />);
+    rerender(
+      <div style={customSidebarWidth}>
+        <WindowToolbar />
+      </div>,
+    );
 
     const toolbar = document.querySelector('[data-slot="window-toolbar"]');
     expect(WINDOW_TOOLBAR_CLEARANCE).toBe(256);
     expect(toolbar).toHaveClass("justify-end");
+    expect(toolbar).toHaveStyle({
+      width:
+        "max(var(--sidebar-live-width, var(--sidebar-width)), 256px)",
+    });
+    expect((toolbar as HTMLElement).style.width).toBe(expandedWidth);
+  });
+
+  it("keeps the traffic-light clearance in compact overlay mode", () => {
+    sidebarState.isCompact = true;
+    render(<WindowToolbar />);
+
+    const toolbar = document.querySelector('[data-slot="window-toolbar"]');
     expect(toolbar).toHaveStyle({ width: "256px" });
   });
 

--- a/apps/desktop/src/renderer/src/components/window-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/window-toolbar.tsx
@@ -180,9 +180,11 @@ function HistoryMenuItem({
 }
 
 export function WindowToolbar() {
-  const { state: sidebarState, isCompact } = useSidebar();
-  const sidebarHidden = sidebarState === "collapsed" || isCompact;
-  const toolbarWidth: React.CSSProperties["width"] = sidebarHidden
+  const { isCompact } = useSidebar();
+  // Collapsing the desktop sidebar changes the content layout, not the window
+  // chrome anchor. Keep the controls at the committed sidebar edge through a
+  // toggle; SidebarRail temporarily overrides that edge while it is dragged.
+  const toolbarWidth: React.CSSProperties["width"] = isCompact
     ? WINDOW_TOOLBAR_CLEARANCE
     : `max(var(--sidebar-live-width, var(--sidebar-width)), ${WINDOW_TOOLBAR_CLEARANCE}px)`;
   const {


### PR DESCRIPTION
## Summary

- keep the Desktop window navigation controls anchored to the committed sidebar width across expand/collapse toggles
- preserve live toolbar tracking during sidebar resize and the 256px compact-window traffic-light clearance
- add a regression test for toggling a 320px custom sidebar width

## Validation

- `pnpm --filter @multica/desktop test` (57 files, 657 tests passed)
- `pnpm --filter @multica/views exec vitest run layout/sidebar-resize.test.tsx` (2 tests passed)
- `pnpm --filter @multica/desktop typecheck`
- `pnpm --filter @multica/desktop lint` (passes with one pre-existing warning in `tab-content.tsx`)
