### PR TITLE
MUL-7261: fix(daemon): inherit Codex native instructions and agent roles

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -240,6 +240,29 @@ You need at least one installed. The daemon registers each detected CLI as an av
 4. Heartbeats are sent periodically (default: 15s) so the server knows the daemon is alive
 5. On shutdown, all runtimes are deregistered
 
+### Codex configuration inheritance
+
+Each task has an isolated `CODEX_HOME`. The daemon copies global `AGENTS.md`,
+`AGENTS.override.md`, and direct `agents/*.toml` native role definitions from its
+own `CODEX_HOME` (or `~/.codex` when unset). Contents are copied unchanged; Codex
+continues to decide instruction precedence, including `AGENTS.override.md`.
+Task edits to these copies do not modify the host files.
+
+On prepare and reuse, the shared source is authoritative: instruction files and
+matching native roles are refreshed, and missing shared instruction files remove
+their task copies. A task-local `.multica-inherited-agents.json` manifest tracks
+copied roles so removed host roles are deleted while unrelated task role files
+remain. Source read errors and invalid manifests fail preparation rather than
+silently continuing with incomplete inheritance.
+
+This copies native role definitions only; it does not recursively copy assets
+referenced by those definitions or install hooks. Native subagent execution still
+uses the existing daemon opt-in, `MULTICA_CODEX_MULTI_AGENT=1`, which stops Multica
+from forcing `features.multi_agent=false` and preserves the user's Codex setting.
+Set it in the daemon environment before starting a new task. The parent agent
+must await its children before finishing because task completion follows the
+parent's lifecycle.
+
 ### Configuration
 
 Daemon behavior is configured via flags or environment variables:

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -1027,9 +1027,10 @@ func materialiseInCodexHome(codexHome, relPath, src, key string) error {
 	mode := os.FileMode(0o644)
 	if info, err := root.Lstat(relPath); err == nil {
 		// A reference may alias a private native instruction or role copy.
-		// Refresh regular files without broadening their existing permissions.
+		// Preserve restrictions for group/other, but restore owner read/write
+		// access if a previous task left an unreadable copy.
 		if info.Mode().IsRegular() {
-			mode &= info.Mode().Perm()
+			mode = (mode & info.Mode().Perm()) | 0o600
 		}
 		if err := root.Remove(relPath); err != nil {
 			return fmt.Errorf("remove stale %s copy %s: %w", key, relPath, err)

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -205,6 +205,9 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	if err := os.MkdirAll(codexHome, 0o755); err != nil {
 		return fmt.Errorf("create codex-home dir: %w", err)
 	}
+	if err := syncCodexNativeConfig(codexHome, sharedHome); err != nil {
+		return fmt.Errorf("sync codex native configuration: %w", err)
+	}
 
 	// Give the task its own local sessions/ directory instead of symlinking the
 	// shared ~/.codex/sessions in — a huge shared history would otherwise stall
@@ -1021,7 +1024,13 @@ func materialiseInCodexHome(codexHome, relPath, src, key string) error {
 			return fmt.Errorf("create %s directory %s: %w", key, dir, err)
 		}
 	}
-	if _, err := root.Lstat(relPath); err == nil {
+	mode := os.FileMode(0o644)
+	if info, err := root.Lstat(relPath); err == nil {
+		// A reference may alias a private native instruction or role copy.
+		// Refresh regular files without broadening their existing permissions.
+		if info.Mode().IsRegular() {
+			mode &= info.Mode().Perm()
+		}
 		if err := root.Remove(relPath); err != nil {
 			return fmt.Errorf("remove stale %s copy %s: %w", key, relPath, err)
 		}
@@ -1035,7 +1044,7 @@ func materialiseInCodexHome(codexHome, relPath, src, key string) error {
 	}
 	defer in.Close()
 
-	out, err := root.OpenFile(relPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	out, err := root.OpenFile(relPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
 	if err != nil {
 		return fmt.Errorf("create %s copy %s: %w", key, relPath, err)
 	}

--- a/server/internal/daemon/execenv/codex_native_config.go
+++ b/server/internal/daemon/execenv/codex_native_config.go
@@ -1,0 +1,185 @@
+package execenv
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const codexNativeAgentsManifest = ".multica-inherited-agents.json"
+
+// syncCodexNativeConfig refreshes host-authoritative instructions and native
+// roles on both prepare and reuse. Only roles recorded in the manifest may be
+// removed when the host stops providing them; unrelated task roles survive.
+func syncCodexNativeConfig(codexHome, sharedHome string) error {
+	root, err := openVerifiedCodexHomeRoot(codexHome, "native configuration")
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	sharedInfo, err := os.Stat(sharedHome)
+	if err != nil {
+		if _, statErr := os.Lstat(sharedHome); !os.IsNotExist(err) || !os.IsNotExist(statErr) {
+			return fmt.Errorf("stat shared codex home: %w", err)
+		}
+	}
+	if err == nil {
+		taskInfo, err := root.Stat(".")
+		if err != nil {
+			return fmt.Errorf("stat task codex home: %w", err)
+		}
+		if os.SameFile(sharedInfo, taskInfo) {
+			return fmt.Errorf("shared and task codex homes must be separate directories")
+		}
+	}
+
+	// Read every source before changing any destination. A read failure must not
+	// look like removal of a host file and silently erase the last good copy.
+	sources := make(map[string][]byte)
+	for _, name := range []string{"AGENTS.md", "AGENTS.override.md"} {
+		src := filepath.Join(sharedHome, name)
+		if _, err := os.Lstat(src); os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("stat global instructions %s: %w", name, err)
+		}
+		data, err := readCodexNativeSource(src)
+		if err != nil {
+			return err
+		}
+		sources[name] = data
+	}
+	entries, err := os.ReadDir(filepath.Join(sharedHome, "agents"))
+	if err != nil {
+		if _, statErr := os.Lstat(filepath.Join(sharedHome, "agents")); !os.IsNotExist(err) || !os.IsNotExist(statErr) {
+			return fmt.Errorf("read shared native agents: %w", err)
+		}
+	}
+	var current []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".toml") {
+			continue
+		}
+		name := entry.Name()
+		if !validCodexNativeAgentName(name) {
+			return fmt.Errorf("invalid shared native agent filename %q", name)
+		}
+		data, err := readCodexNativeSource(filepath.Join(sharedHome, "agents", name))
+		if err != nil {
+			return err
+		}
+		sources[filepath.Join("agents", name)] = data
+		current = append(current, name)
+	}
+
+	var previous []string
+	data, err := root.ReadFile(codexNativeAgentsManifest)
+	if err == nil {
+		if err := json.Unmarshal(data, &previous); err != nil {
+			return fmt.Errorf("read inherited native agents manifest: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read inherited native agents manifest: %w", err)
+	}
+	for _, name := range previous {
+		if !validCodexNativeAgentName(name) {
+			return fmt.Errorf("invalid inherited native agent filename %q", name)
+		}
+	}
+
+	// Record the union before modifying role files so a failed refresh remains
+	// tracked and can be retried, including roles copied for the first time.
+	tracked := append(slices.Clone(previous), current...)
+	slices.Sort(tracked)
+	tracked = slices.Compact(tracked)
+	if len(tracked) > 0 {
+		if err := writeCodexNativeManifest(root, tracked); err != nil {
+			return err
+		}
+	}
+	for _, name := range []string{"AGENTS.md", "AGENTS.override.md"} {
+		if data, ok := sources[name]; ok {
+			if err := replaceCodexNativeFile(root, name, data); err != nil {
+				return err
+			}
+		} else if err := root.Remove(name); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove stale global instructions %s: %w", name, err)
+		}
+	}
+	if len(current) > 0 {
+		if err := root.MkdirAll("agents", 0o755); err != nil {
+			return fmt.Errorf("create native agents directory: %w", err)
+		}
+	}
+	for _, name := range current {
+		path := filepath.Join("agents", name)
+		if err := replaceCodexNativeFile(root, path, sources[path]); err != nil {
+			return err
+		}
+	}
+	for _, name := range previous {
+		if !slices.Contains(current, name) {
+			if err := root.Remove(filepath.Join("agents", name)); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove stale native agent %s: %w", name, err)
+			}
+		}
+	}
+	if len(tracked) > 0 {
+		return writeCodexNativeManifest(root, current)
+	}
+	return nil
+}
+
+func validCodexNativeAgentName(name string) bool {
+	return filepath.IsLocal(name) && filepath.Base(name) == name && !strings.ContainsAny(name, "/\\") && strings.HasSuffix(name, ".toml")
+}
+
+func readCodexNativeSource(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat native configuration %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("native configuration %s is not a regular file", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read native configuration %s: %w", path, err)
+	}
+	return data, nil
+}
+
+func writeCodexNativeManifest(root *os.Root, names []string) error {
+	data, err := json.Marshal(names)
+	if err != nil {
+		return fmt.Errorf("encode inherited native agents manifest: %w", err)
+	}
+	return replaceCodexNativeFile(root, codexNativeAgentsManifest, data)
+}
+
+// Publish complete files by rename, replacing links themselves. All operations
+// use the verified root so a reused task cannot redirect writes outside it.
+// Only the daemon user needs access; native configuration can contain secrets.
+func replaceCodexNativeFile(root *os.Root, name string, data []byte) error {
+	temp := filepath.Join(filepath.Dir(name), ".multica-native-"+rand.Text())
+	out, err := root.OpenFile(temp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create native configuration %s: %w", name, err)
+	}
+	defer out.Close()
+	defer root.Remove(temp)
+	if _, err := out.Write(data); err != nil {
+		return fmt.Errorf("write native configuration %s: %w", name, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close native configuration %s: %w", name, err)
+	}
+	if err := root.Rename(temp, name); err != nil {
+		return fmt.Errorf("replace native configuration %s: %w", name, err)
+	}
+	return nil
+}

--- a/server/internal/daemon/execenv/codex_native_config.go
+++ b/server/internal/daemon/execenv/codex_native_config.go
@@ -115,17 +115,19 @@ func syncCodexNativeConfig(codexHome, sharedHome string) error {
 			return fmt.Errorf("create native agents directory: %w", err)
 		}
 	}
-	for _, name := range current {
-		path := filepath.Join("agents", name)
-		if err := replaceCodexNativeFile(root, path, sources[path]); err != nil {
-			return err
-		}
-	}
+	// Remove stale names before publishing roles: on case-insensitive volumes,
+	// a case-only rename makes the old and new names refer to the same file.
 	for _, name := range previous {
 		if !slices.Contains(current, name) {
 			if err := root.Remove(filepath.Join("agents", name)); err != nil && !os.IsNotExist(err) {
 				return fmt.Errorf("remove stale native agent %s: %w", name, err)
 			}
+		}
+	}
+	for _, name := range current {
+		path := filepath.Join("agents", name)
+		if err := replaceCodexNativeFile(root, path, sources[path]); err != nil {
+			return err
 		}
 	}
 	if len(tracked) > 0 {

--- a/server/internal/daemon/execenv/codex_native_config_test.go
+++ b/server/internal/daemon/execenv/codex_native_config_test.go
@@ -1,0 +1,348 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSyncCodexNativeConfigRestrictsPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not supported on Windows")
+	}
+	shared, task := t.TempDir(), t.TempDir()
+	names := []string{"AGENTS.md", "AGENTS.override.md", "agents/architect.toml"}
+	for _, name := range names {
+		path := filepath.Join(shared, name)
+		writeFile(t, path, "private configuration")
+		if err := os.Chmod(path, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		// Reuse also replaces copies inherited with broader permissions.
+		writeFile(t, filepath.Join(task, name), "old configuration")
+	}
+	for range 2 {
+		if err := syncCodexNativeConfig(task, shared); err != nil {
+			t.Fatal(err)
+		}
+		for _, name := range append(names, codexNativeAgentsManifest) {
+			info, err := os.Stat(filepath.Join(task, name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Errorf("%s permissions = %04o, want 0600", name, got)
+			}
+		}
+	}
+}
+
+func TestPrepareCodexHomeNativeConfig(t *testing.T) {
+	shared, task := t.TempDir(), t.TempDir()
+	t.Setenv("CODEX_HOME", shared)
+	for _, name := range []string{"AGENTS.md", "AGENTS.override.md", "agents/architect.toml", "agents/code-reviewer.toml"} {
+		writeFile(t, filepath.Join(shared, name), "original")
+	}
+	writeFile(t, filepath.Join(shared, "agents/notes.md"), "not a role")
+	writeFile(t, filepath.Join(shared, "agents/nested/private.toml"), "not a direct role")
+	writeFile(t, filepath.Join(task, "agents/local.toml"), "task-owned")
+	if err := prepareCodexHome(task, testLogger()); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"AGENTS.md", "AGENTS.override.md", "agents/architect.toml", "agents/code-reviewer.toml"} {
+		assertNativeConfigContent(t, filepath.Join(task, name), "original")
+	}
+	assertAbsent(t, filepath.Join(task, "agents/notes.md"))
+	assertAbsent(t, filepath.Join(task, "agents/nested"))
+	writeFile(t, filepath.Join(task, "agents/architect.toml"), "task mutation")
+	writeFile(t, filepath.Join(shared, "agents/architect.toml"), "refreshed")
+	for _, name := range []string{"AGENTS.override.md", "agents/code-reviewer.toml"} {
+		if err := os.Remove(filepath.Join(shared, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := prepareCodexHome(task, testLogger()); err != nil {
+		t.Fatal(err)
+	}
+	assertNativeConfigContent(t, filepath.Join(task, "agents/architect.toml"), "refreshed")
+	assertNativeConfigContent(t, filepath.Join(task, "agents/local.toml"), "task-owned")
+	assertAbsent(t, filepath.Join(task, "AGENTS.override.md"))
+	assertAbsent(t, filepath.Join(task, "agents/code-reviewer.toml"))
+	if err := os.RemoveAll(filepath.Join(shared, "agents")); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareCodexHome(task, testLogger()); err != nil {
+		t.Fatal(err)
+	}
+	assertAbsent(t, filepath.Join(task, "agents/architect.toml"))
+	assertNativeConfigContent(t, filepath.Join(task, "agents/local.toml"), "task-owned")
+}
+
+func assertNativeConfigContent(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != want {
+		t.Errorf("%s = %q, want %q", path, data, want)
+	}
+}
+
+func TestSyncCodexNativeConfigRejectsSourceErrors(t *testing.T) {
+	for _, kind := range []string{"instructions directory", "agents file", "broken role link", "broken instructions link", "broken agents link"} {
+		t.Run(kind, func(t *testing.T) {
+			shared, task := t.TempDir(), t.TempDir()
+			writeFile(t, filepath.Join(shared, "AGENTS.md"), "new instructions")
+			writeFile(t, filepath.Join(task, "AGENTS.md"), "last good instructions")
+			writeFile(t, filepath.Join(task, "agents/old.toml"), "last good role")
+			writeFile(t, filepath.Join(task, codexNativeAgentsManifest), `["old.toml"]`)
+			switch kind {
+			case "instructions directory":
+				if err := os.Mkdir(filepath.Join(shared, "AGENTS.override.md"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			case "agents file":
+				writeFile(t, filepath.Join(shared, "agents"), "not a directory")
+			case "broken instructions link", "broken agents link":
+				name := "AGENTS.override.md"
+				if kind == "broken agents link" {
+					name = "agents"
+				}
+				if err := os.Symlink(filepath.Join(shared, "missing"), filepath.Join(shared, name)); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			case "broken role link":
+				if err := os.Mkdir(filepath.Join(shared, "agents"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(filepath.Join(shared, "missing"), filepath.Join(shared, "agents/broken.toml")); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			}
+			if err := syncCodexNativeConfig(task, shared); err == nil {
+				t.Fatal("expected source error")
+			}
+			assertNativeConfigContent(t, filepath.Join(task, "AGENTS.md"), "last good instructions")
+			assertNativeConfigContent(t, filepath.Join(task, "agents/old.toml"), "last good role")
+		})
+	}
+}
+
+func TestSyncCodexNativeConfigConfinesDestinations(t *testing.T) {
+	for _, kind := range []string{"home", "agents", "role", "instructions", "manifest", "manifest traversal"} {
+		t.Run(kind, func(t *testing.T) {
+			shared, task, outside := t.TempDir(), t.TempDir(), t.TempDir()
+			writeFile(t, filepath.Join(shared, "agents/architect.toml"), "host role")
+			writeFile(t, filepath.Join(shared, "AGENTS.md"), "host instructions")
+			writeFile(t, filepath.Join(outside, "architect.toml"), "outside role")
+			writeFile(t, filepath.Join(outside, "AGENTS.md"), "outside instructions")
+			writeFile(t, filepath.Join(outside, codexNativeAgentsManifest), `[]`)
+			var link, target string
+			switch kind {
+			case "home":
+				if err := os.Remove(task); err != nil {
+					t.Fatal(err)
+				}
+				link, target = task, outside
+			case "agents":
+				link, target = filepath.Join(task, "agents"), outside
+			case "role":
+				if err := os.Mkdir(filepath.Join(task, "agents"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				link, target = filepath.Join(task, "agents/architect.toml"), filepath.Join(outside, "architect.toml")
+			case "instructions":
+				link, target = filepath.Join(task, "AGENTS.md"), filepath.Join(outside, "AGENTS.md")
+			case "manifest":
+				link, target = filepath.Join(task, codexNativeAgentsManifest), filepath.Join(outside, codexNativeAgentsManifest)
+			case "manifest traversal":
+				writeFile(t, filepath.Join(task, codexNativeAgentsManifest), `["../architect.toml"]`)
+			}
+			if link != "" {
+				if err := os.Symlink(target, link); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			}
+			err := syncCodexNativeConfig(task, shared)
+			if kind == "role" || kind == "instructions" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertNativeConfigContent(t, filepath.Join(task, "agents/architect.toml"), "host role")
+				assertNativeConfigContent(t, filepath.Join(task, "AGENTS.md"), "host instructions")
+			} else if err == nil {
+				t.Fatal("expected unsafe destination error")
+			}
+			assertNativeConfigContent(t, filepath.Join(outside, "architect.toml"), "outside role")
+			assertNativeConfigContent(t, filepath.Join(outside, "AGENTS.md"), "outside instructions")
+			assertNativeConfigContent(t, filepath.Join(outside, codexNativeAgentsManifest), `[]`)
+		})
+	}
+}
+
+func TestSyncCodexNativeConfigCopiesLinkedSources(t *testing.T) {
+	shared, task, outside := t.TempDir(), t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(outside, "architect.toml"), "host role")
+	if err := os.Mkdir(filepath.Join(shared, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "architect.toml"), filepath.Join(shared, "agents/architect.toml")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := syncCodexNativeConfig(task, shared); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(task, "agents/architect.toml"), "task mutation")
+	assertNativeConfigContent(t, filepath.Join(outside, "architect.toml"), "host role")
+}
+
+func TestSyncCodexNativeConfigRejectsSharedDestination(t *testing.T) {
+	shared := t.TempDir()
+	writeFile(t, filepath.Join(shared, "AGENTS.md"), "host instructions")
+	if err := syncCodexNativeConfig(shared, shared); err == nil {
+		t.Fatal("expected same-directory error")
+	}
+	assertNativeConfigContent(t, filepath.Join(shared, "AGENTS.md"), "host instructions")
+	assertAbsent(t, filepath.Join(shared, codexNativeAgentsManifest))
+}
+
+func TestSyncCodexNativeConfigManifestRetry(t *testing.T) {
+	shared, task := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(shared, "agents/.toml"), "host role")
+	// A blocked destination must not leave a truncated ownership manifest.
+	writeFile(t, filepath.Join(task, "agents/.toml/keep"), "task file")
+	if err := syncCodexNativeConfig(task, shared); err == nil {
+		t.Fatal("expected destination error")
+	}
+	assertNativeConfigContent(t, filepath.Join(task, codexNativeAgentsManifest), `[".toml"]`)
+	if err := os.RemoveAll(filepath.Join(task, "agents/.toml")); err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if err := syncCodexNativeConfig(task, shared); err != nil {
+			t.Fatal(err)
+		}
+	}
+	assertNativeConfigContent(t, filepath.Join(task, "agents/.toml"), "host role")
+}
+
+func TestSyncCodexNativeConfigReplacesHardlinks(t *testing.T) {
+	shared, task := t.TempDir(), t.TempDir()
+	role := "name = 'architect'\ndeveloper_instructions = 'Inspect architecture.'\n"
+	writeFile(t, filepath.Join(shared, "agents/architect.toml"), role)
+	if err := os.Mkdir(filepath.Join(task, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(filepath.Join(shared, "agents/architect.toml"), filepath.Join(task, "agents/architect.toml")); err != nil {
+		t.Skipf("hardlink unavailable: %v", err)
+	}
+	if err := syncCodexNativeConfig(task, shared); err != nil {
+		t.Fatal(err)
+	}
+	assertNativeConfigContent(t, filepath.Join(task, "agents/architect.toml"), role)
+	writeFile(t, filepath.Join(task, "agents/architect.toml"), "task mutation")
+	assertNativeConfigContent(t, filepath.Join(shared, "agents/architect.toml"), role)
+}
+
+func TestPrepareCodexHomeNativeConfigPreservesMultiAgentPolicy(t *testing.T) {
+	for _, optIn := range []string{"", "1"} {
+		t.Run("opt-in="+optIn, func(t *testing.T) {
+			shared, task := t.TempDir(), t.TempDir()
+			t.Setenv("CODEX_HOME", shared)
+			t.Setenv(MulticaCodexMultiAgentEnv, optIn)
+			writeFile(t, filepath.Join(shared, "config.toml"), "[features]\nmulti_agent = true\n")
+			role := "name = 'architect'\ndeveloper_instructions = 'Inspect architecture.'\n"
+			writeFile(t, filepath.Join(shared, "agents/architect.toml"), role)
+			if err := prepareCodexHome(task, testLogger()); err != nil {
+				t.Fatal(err)
+			}
+			assertNativeConfigContent(t, filepath.Join(task, "agents/architect.toml"), role)
+			data, err := os.ReadFile(filepath.Join(task, "config.toml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			config := parseTOML(t, string(data))
+			if optIn == "" {
+				requireMultiAgentDisabled(t, config)
+			} else if config["features"].(map[string]any)["multi_agent"] != true {
+				t.Fatal("opt-in lost shared multi_agent=true")
+			}
+			assertNativeConfigContent(t, filepath.Join(shared, "config.toml"), "[features]\nmulti_agent = true\n")
+		})
+	}
+}
+
+func TestSyncCodexNativeConfigRejectsDanglingSharedHome(t *testing.T) {
+	shared, task := filepath.Join(t.TempDir(), "shared"), t.TempDir()
+	if err := os.Symlink(filepath.Join(t.TempDir(), "missing"), shared); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	for _, name := range []string{"AGENTS.md", "AGENTS.override.md", "agents/architect.toml"} {
+		writeFile(t, filepath.Join(task, name), "last good copy")
+	}
+	writeFile(t, filepath.Join(task, codexNativeAgentsManifest), `["architect.toml"]`)
+	if err := syncCodexNativeConfig(task, shared); err == nil {
+		t.Error("expected dangling shared home error")
+	}
+	for _, name := range []string{"AGENTS.md", "AGENTS.override.md", "agents/architect.toml"} {
+		assertNativeConfigContent(t, filepath.Join(task, name), "last good copy")
+	}
+	assertNativeConfigContent(t, filepath.Join(task, codexNativeAgentsManifest), `["architect.toml"]`)
+}
+
+func TestPrepareCodexHomeNativeConfigReferencedPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not supported on Windows")
+	}
+	for _, key := range []string{"model_instructions_file", "model_catalog_json"} {
+		for _, name := range []string{"AGENTS.md", "AGENTS.override.md", "agents/architect.toml"} {
+			t.Run(key+"/"+name, func(t *testing.T) {
+				shared, task := t.TempDir(), t.TempDir()
+				t.Setenv("CODEX_HOME", shared)
+				writeFile(t, filepath.Join(shared, "config.toml"), key+" = '"+name+"'\n")
+				writeFile(t, filepath.Join(shared, name), "private configuration")
+				if err := os.Chmod(filepath.Join(shared, name), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				for range 2 {
+					if err := prepareCodexHome(task, testLogger()); err != nil {
+						t.Fatal(err)
+					}
+					info, err := os.Stat(filepath.Join(task, name))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if got := info.Mode().Perm(); got != 0o600 {
+						t.Errorf("%s permissions = %04o, want 0600", name, got)
+					}
+					assertNativeConfigContent(t, filepath.Join(task, name), "private configuration")
+				}
+			})
+		}
+	}
+}
+
+func TestMaterialiseInCodexHomeNewReferencePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not supported on Windows")
+	}
+	task, source := t.TempDir(), filepath.Join(t.TempDir(), "instructions.md")
+	writeFile(t, source, "referenced instructions")
+	sourceInfo, err := os.Stat(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := materialiseInCodexHome(task, "instructions.md", source, "model_instructions_file"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(task, "instructions.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// writeFile and new references both use 0644, subject to the same umask.
+	if info.Mode().Perm() != sourceInfo.Mode().Perm() {
+		t.Errorf("new reference permissions = %04o, want %04o", info.Mode().Perm(), sourceInfo.Mode().Perm())
+	}
+}

--- a/server/internal/daemon/execenv/codex_native_config_test.go
+++ b/server/internal/daemon/execenv/codex_native_config_test.go
@@ -38,6 +38,46 @@ func TestSyncCodexNativeConfigRestrictsPermissions(t *testing.T) {
 	}
 }
 
+func TestPrepareCodexHomeRefreshesUnreadableInstructions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not supported on Windows")
+	}
+	for _, tc := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "no permissions", mode: 0o000},
+		{name: "execute only", mode: 0o111},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shared, task := t.TempDir(), t.TempDir()
+			t.Setenv("CODEX_HOME", shared)
+			writeFile(t, filepath.Join(shared, "config.toml"), `model_instructions_file = "custom-instructions.md"`)
+			source := filepath.Join(shared, "custom-instructions.md")
+			destination := filepath.Join(task, "custom-instructions.md")
+			writeFile(t, source, "original")
+			if err := prepareCodexHome(task, testLogger()); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(destination, tc.mode); err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, source, "refreshed")
+			if err := prepareCodexHome(task, testLogger()); err != nil {
+				t.Fatal(err)
+			}
+			info, err := os.Stat(destination)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Errorf("instructions permissions = %04o, want 0600", got)
+			}
+			assertNativeConfigContent(t, destination, "refreshed")
+		})
+	}
+}
+
 func TestPrepareCodexHomeNativeConfig(t *testing.T) {
 	shared, task := t.TempDir(), t.TempDir()
 	t.Setenv("CODEX_HOME", shared)

--- a/server/internal/daemon/execenv/codex_native_rename_test.go
+++ b/server/internal/daemon/execenv/codex_native_rename_test.go
@@ -1,0 +1,38 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSyncCodexNativeConfigCaseOnlyRoleRename(t *testing.T) {
+	shared, task := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(shared, "agents/Architect.toml"), "original")
+	writeFile(t, filepath.Join(task, "agents/local.toml"), "task-owned")
+	if err := syncCodexNativeConfig(task, shared); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove then create the host role to preserve the new spelling even on
+	// case-insensitive volumes. The destination still has the previous spelling.
+	if err := os.Remove(filepath.Join(shared, "agents/Architect.toml")); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(shared, "agents/architect.toml"), "renamed")
+	for range 2 {
+		if err := syncCodexNativeConfig(task, shared); err != nil {
+			t.Fatal(err)
+		}
+		assertNativeConfigContent(t, filepath.Join(task, "agents/architect.toml"), "renamed")
+		assertNativeConfigContent(t, filepath.Join(task, "agents/local.toml"), "task-owned")
+		assertNativeConfigContent(t, filepath.Join(task, codexNativeAgentsManifest), `["architect.toml"]`)
+		entries, err := os.ReadDir(filepath.Join(task, "agents"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 2 || entries[0].Name() != "architect.toml" || entries[1].Name() != "local.toml" {
+			t.Fatalf("native agents after case-only rename = %v, want architect.toml and local.toml", entries)
+		}
+	}
+}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -3281,10 +3281,9 @@ func TestVerifyCodexHomeRootRejectsSymlinkedHome(t *testing.T) {
 // already a link to an outside directory, the referenced-file copy must fail
 // instead of provisioning through the link.
 //
-// Deliberately not asserted: that nothing at all lands in the link target.
-// Earlier steps in prepareCodexHomeWithOpts (config.toml, sessions/, plugin
-// cache) still address codexHome by path and run before this check, so making
-// the whole prepare root-handle safe is a separate, larger change (MUL-5647).
+// Native configuration now checks the task home before referenced-file copies,
+// so this rejects at that earlier guard. Making every prepare operation
+// root-handle safe against concurrent replacement remains separate (MUL-5647).
 func TestPrepareCodexHomeRefusesReferencedFileWriteThroughSymlinkedCodexHome(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
@@ -3311,8 +3310,8 @@ func TestPrepareCodexHomeRefusesReferencedFileWriteThroughSymlinkedCodexHome(t *
 	if err == nil {
 		t.Fatal("expected prepareCodexHome to refuse a symlinked codex home")
 	}
-	if !strings.Contains(err.Error(), "model_instructions_file") {
-		t.Fatalf("error %q does not name the offending key", err)
+	if !strings.Contains(err.Error(), "native configuration") || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error %q does not report the early native configuration symlink guard", err)
 	}
 
 	data, readErr := os.ReadFile(sentinel)

--- a/server/internal/service/builtin_skills/multica-platform/references/agents.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/agents.md
@@ -112,6 +112,21 @@ multica agent copy <source-agent-id> --runtime-id <target> --model <model>  # cr
   `--runtime-config`), or with `agent env set` after the copy exists.
 - `--no-skills` skips copying the source's skill bindings.
 
+## Codex native configuration
+
+Codex tasks inherit byte-for-byte copies of global `AGENTS.md`,
+`AGENTS.override.md`, and direct `agents/*.toml` definitions from the daemon's
+`CODEX_HOME` (default `~/.codex`) into an isolated task home. Codex retains control
+of instruction precedence. Prepare/reuse refreshes shared files and removes
+missing global instructions. `.multica-inherited-agents.json` tracks inherited
+role names so stale host roles are removed while unrelated task roles survive;
+same-name host roles are authoritative. These are copies, not shared symlinks.
+Source errors or an invalid manifest fail preparation. This does not install
+hooks or recursively inherit role-referenced assets. Native multi-agent policy
+is unchanged: set `MULTICA_CODEX_MULTI_AGENT=1` in the daemon environment to
+preserve the user's Codex multi-agent setting, and have the parent await child
+completion before concluding its task.
+
 ## Field contracts
 
 | Field | Stored as | Validated? | Consumed by |


### PR DESCRIPTION
## What does this PR do?

Codex tasks currently inherit the user's configuration and plugin skills but lose global instruction files and native agent definitions when Multica creates an isolated `CODEX_HOME`. A workflow can therefore require an installed reviewer role that the task cannot discover or launch.

Copy `AGENTS.md`, `AGENTS.override.md`, and direct `agents/*.toml` definitions into the task home on preparation and reuse. Preserve file contents and Codex's instruction precedence while refreshing host-owned copies and removing stale inherited definitions.

## Related Issue

Refs #6857. This addresses the global-instructions/native-role subset; hooks and arbitrary referenced assets remain follow-up work.

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Tests

## Changes Made

- Add native-configuration synchronization before other Codex-home preparation steps. Source-read or manifest errors stop preparation instead of silently dropping configuration.
- Track inherited role filenames so deleted host definitions are removed on reuse while unrelated task role files remain. Matching host definitions and both global instruction filenames are authoritative.
- Use a verified `os.Root`, atomic replacement, and owner-only file permissions. A task cannot redirect the new writes or stale deletions outside its home through destination symlinks; task edits do not mutate shared files.
- Keep Multica's existing native multi-agent policy and daemon opt-in unchanged.
- Document inheritance, refresh behavior, and scope limits in the CLI/daemon guide and built-in agent reference.

## How to Test

From `server/`:

```sh
bash ../scripts/go-test-with-agent-cli-guard.sh go test -race ./internal/daemon/execenv -count=1
go vet ./internal/daemon/execenv
go build ./internal/daemon/execenv
```

The new preparation regression failed before the fix because `AGENTS.md` was missing. Coverage includes refresh and removal, unrelated task roles, linked sources, destination symlinks/hardlinks, owner-only permissions, invalid manifests, interrupted-refresh retry, and unchanged default/opt-in policy. The full package race suite passes after the change. Default tests use temporary fixtures and the agent CLI guard, without launching authenticated agents.

The existing symlinked-home regression now expects the earlier native-configuration guard; its assertion that external files remain unchanged is preserved.

## Scope and risks

Only direct native role TOMLs are copied. Files referenced by those definitions, custom `agents.<name>.config_file` locations outside that directory, hooks, and hook trust state are not provisioned by this change. It does not change subagent lifecycle tracking or automatically enable multi-agent execution. Invalid native configuration sources now fail preparation visibly. Unix mode assertions are skipped on Windows; Windows ACL behavior was not exercised locally.

## Checklist

- [x] Included the project context and reasoning for the change above
- [x] Ran local tests and added regression coverage
- [x] Updated relevant documentation
- [x] Documented scope and risks
- [ ] Address upstream reviewer feedback before requesting merge

## AI Disclosure

**AI tool used:** Codex with oh-my-codex.

**Approach:** Reproduced the missing-inheritance behavior, implemented a focused fix using existing filesystem-boundary utilities, added regression tests, and ran cleanup plus independent code and architecture reviews. The PR is intentionally a draft for maintainer feedback on the inheritance contract.
