### PR TITLE
MUL-7262: BHI-16123: refuse duplicate workspace daemons

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -375,6 +375,90 @@ func daemonIdentityMismatch(health map[string]any, profile string, port int) err
 	return &daemonProfileMismatchError{Want: profile, Got: got, Port: port}
 }
 
+type sameWorkspaceDaemonConflictError struct {
+	WorkspaceID string
+	WantProfile string
+	GotProfile  string
+	Port        int
+	PID         int
+}
+
+func (e *sameWorkspaceDaemonConflictError) Error() string {
+	pid := "unknown"
+	if e.PID > 0 {
+		pid = strconv.Itoa(e.PID)
+	}
+	return fmt.Sprintf(
+		"refusing to start %s: %s already has a live daemon for workspace_id %s on port %d (pid %s)",
+		describeProfile(e.WantProfile), describeProfile(e.GotProfile), e.WorkspaceID, e.Port, pid)
+}
+
+func healthIncludesWorkspace(health map[string]any, workspaceID string) bool {
+	workspaces, ok := health["workspaces"].([]any)
+	if !ok {
+		return false
+	}
+	for _, rawWorkspace := range workspaces {
+		workspace, ok := rawWorkspace.(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, _ := workspace["id"].(string); id == workspaceID {
+			return true
+		}
+	}
+	return false
+}
+
+// requireNoSameWorkspaceDaemon refuses a second daemon identity for a workspace
+// already managed by another live local daemon. Health ports are profile-scoped,
+// so the ordinary same-port liveness check misses the default/profile split that
+// launches two daemons against one workspace_id.
+func requireNoSameWorkspaceDaemon(profile, workspaceID string) error {
+	if workspaceID == "" {
+		return nil
+	}
+	profiles := []string{""}
+	known, err := knownProfiles()
+	if err != nil {
+		return fmt.Errorf("list profiles for daemon workspace guard: %w", err)
+	}
+	profiles = append(profiles, known...)
+	seenPorts := make(map[int]bool, len(profiles))
+	for _, candidate := range profiles {
+		if candidate == profile {
+			continue
+		}
+		port := healthPortForProfile(candidate)
+		if seenPorts[port] {
+			continue
+		}
+		seenPorts[port] = true
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		health := checkDaemonHealthOnPort(ctx, port)
+		cancel()
+		if !daemonAlive(health) || !healthIncludesWorkspace(health, workspaceID) {
+			continue
+		}
+		pid := 0
+		if rawPID, ok := health["pid"].(float64); ok {
+			pid = int(rawPID)
+		}
+		gotProfile := candidate
+		if reported, ok := health["profile"].(string); ok {
+			gotProfile = reported
+		}
+		return &sameWorkspaceDaemonConflictError{
+			WorkspaceID: workspaceID,
+			WantProfile: profile,
+			GotProfile:  gotProfile,
+			Port:        port,
+			PID:         pid,
+		}
+	}
+	return nil
+}
+
 // unknownProfileError reports an explicitly named --profile that has no
 // directory under ~/.multica/profiles. It carries the known profile names so
 // both the text and JSON renderings can list them without re-reading the disk.
@@ -577,6 +661,13 @@ func runDaemonBackground(cmd *cobra.Command) error {
 	}
 
 	if err := requireDaemonAuth(profile); err != nil {
+		return err
+	}
+	fileCfg, err := cli.LoadCLIConfigForProfile(profile)
+	if err != nil {
+		return fmt.Errorf("load CLI config: %w", err)
+	}
+	if err := requireNoSameWorkspaceDaemon(profile, fileCfg.WorkspaceID); err != nil {
 		return err
 	}
 
@@ -924,6 +1015,9 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	// than server URL: an unreadable / missing config only means "no
 	// persisted overrides", not "cannot start".
 	fileCfg, _ := cli.LoadCLIConfigForProfile(profile)
+	if err := requireNoSameWorkspaceDaemon(profile, fileCfg.WorkspaceID); err != nil {
+		return err
+	}
 	// Pick the log sink. A user who runs `daemon start --foreground` in a shell
 	// keeps live, colored logging on their terminal (a documented debugging
 	// path — see docs troubleshooting). A detached/background child, whose

--- a/server/cmd/multica/cmd_daemon_identity_test.go
+++ b/server/cmd/multica/cmd_daemon_identity_test.go
@@ -17,6 +17,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func freeProfileName(t *testing.T, prefix string, used map[int]bool) string {
+	t.Helper()
+	for i := 0; i < 2000; i++ {
+		name := fmt.Sprintf("%s-%d-%d", prefix, time.Now().UnixNano(), i)
+		port := healthPortForProfile(name)
+		if used[port] {
+			continue
+		}
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			continue
+		}
+		_ = ln.Close()
+		used[port] = true
+		return name
+	}
+	t.Fatal("could not find an unused daemon health port for test profile")
+	return ""
+}
+
 // blockingChildEnv marks a re-executed copy of this test binary as the
 // stand-in daemon process rather than a normal test run.
 const blockingChildEnv = "MULTICA_TEST_BLOCKING_CHILD"
@@ -152,6 +172,64 @@ func TestDaemonIdentityMismatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequireNoSameWorkspaceDaemon(t *testing.T) {
+	t.Run("named profile refuses another profile daemon on same workspace", func(t *testing.T) {
+		usedPorts := make(map[int]bool)
+		ownerProfile := freeProfileName(t, "same-workspace-owner", usedPorts)
+		targetProfile := freeProfileName(t, "same-workspace-target", usedPorts)
+		mkProfiles(t, ownerProfile, targetProfile)
+		serveHealthAs(t, ownerProfile, map[string]any{
+			"profile":    ownerProfile,
+			"workspaces": []any{map[string]any{"id": "ws-1"}},
+		})
+
+		err := requireNoSameWorkspaceDaemon(targetProfile, "ws-1")
+		var conflict *sameWorkspaceDaemonConflictError
+		if !errors.As(err, &conflict) {
+			t.Fatalf("requireNoSameWorkspaceDaemon = %v, want same-workspace conflict", err)
+		}
+		if conflict.WorkspaceID != "ws-1" || conflict.GotProfile != ownerProfile || conflict.WantProfile != targetProfile {
+			t.Fatalf("conflict = %+v, want ws-1/%s/%s", conflict, ownerProfile, targetProfile)
+		}
+		if !strings.Contains(err.Error(), "refusing to start") || !strings.Contains(err.Error(), "already has a live daemon for workspace_id ws-1") {
+			t.Fatalf("error = %q, want actionable same-workspace refusal", err.Error())
+		}
+	})
+
+	t.Run("default profile refuses named daemon on same workspace", func(t *testing.T) {
+		usedPorts := make(map[int]bool)
+		ownerProfile := freeProfileName(t, "same-workspace-owner", usedPorts)
+		mkProfiles(t, ownerProfile)
+		serveHealthAs(t, ownerProfile, map[string]any{
+			"profile":    ownerProfile,
+			"workspaces": []any{map[string]any{"id": "ws-1"}},
+		})
+
+		err := requireNoSameWorkspaceDaemon("", "ws-1")
+		var conflict *sameWorkspaceDaemonConflictError
+		if !errors.As(err, &conflict) {
+			t.Fatalf("requireNoSameWorkspaceDaemon = %v, want same-workspace conflict", err)
+		}
+		if conflict.GotProfile != ownerProfile || conflict.WantProfile != "" {
+			t.Fatalf("conflict = %+v, want %s/default", conflict, ownerProfile)
+		}
+	})
+
+	t.Run("different workspace does not block", func(t *testing.T) {
+		usedPorts := make(map[int]bool)
+		otherProfile := freeProfileName(t, "same-workspace-other", usedPorts)
+		mkProfiles(t, otherProfile)
+		serveHealthAs(t, otherProfile, map[string]any{
+			"profile":    otherProfile,
+			"workspaces": []any{map[string]any{"id": "ws-2"}},
+		})
+
+		if err := requireNoSameWorkspaceDaemon("", "ws-1"); err != nil {
+			t.Fatalf("requireNoSameWorkspaceDaemon = %v, want nil for different workspace", err)
+		}
+	})
 }
 
 func TestDaemonProfileMismatchErrorNamesBothSides(t *testing.T) {


### PR DESCRIPTION
Closes BHI-16123

## What changed
- Adds a daemon start guard that scans known local profiles and refuses to start a second live daemon for the same workspace_id.
- Applies the guard to both background and foreground daemon starts.
- Adds regression coverage for same-workspace profile co-tenancy, including default-profile starts.

## Verification
- `go test ./cmd/multica -run 'TestRequireNoSameWorkspaceDaemon|TestDaemonLifecycleRefusesForeignDaemon|TestDaemonStatusReportsPortConflictInsteadOfClaimingItsOwn' -count=1 -v`
- `go build -buildvcs=false -ldflags "-X main.version=$VERSION -X main.commit=$COMMIT -X main.date=$DATE" -o bin/multica ./cmd/multica`
- `strings ./bin/multica | /usr/bin/grep -c requireNoSameWorkspaceDaemon` returned `1`

## Notes
- Full `go test ./cmd/multica -count=1` currently fails under this daemon-managed task shell because command tests detect the active task environment as agent execution context. The new daemon regression tests pass in the targeted run.
