### PR TITLE
MUL-7263: feat(selfhost): refuse to start when a host port is already in use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
               - 'scripts/dev-env.sh'
               - 'scripts/dev-env.test.sh'
               - 'scripts/selfhost-wait.sh'
+              - 'scripts/selfhost-preflight.sh'
               # selfhost-config.test.sh asserts on the installers' side of
               # the port contract, so a change to either must run it.
               - 'scripts/install.sh'

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,17 @@ define REQUIRE_COMPOSE
 	esac
 endef
 
+# Both self-host recipes check the host ports before anything else costly, via
+# scripts/selfhost-preflight.sh. A busy port used to surface as Docker's own
+# "port is already allocated" after the image pull, or worse as a
+# successful-looking run (scripts/selfhost-wait.sh reports "still starting" and
+# exits 0), so the check pays for itself the first time 8080 or 3000 is taken.
+#
+# The .env bootstrap then records PORT and FRONTEND_PORT as the recipe resolved
+# them, so `make selfhost PORT=9090` is remembered. Without it the generated
+# .env always says 8080/3000 and the next bare `make selfhost` walks back into
+# the conflict the operator just worked around.
+
 # Default target changed from selfhost to help: bare `make` now prints this help
 # instead of launching a full Docker Compose build, which is safer for onboarding.
 .DEFAULT_GOAL := help
@@ -81,6 +92,7 @@ makehelp: help ## Alias for `make help`
 
 selfhost: ## Create .env if needed, then pull and start the official self-hosted images
 	$(REQUIRE_COMPOSE)
+	@bash scripts/selfhost-preflight.sh official
 	@if [ ! -f .env ]; then \
 		echo "==> Creating .env from .env.example..."; \
 		cp .env.example .env; \
@@ -92,13 +104,18 @@ selfhost: ## Create .env if needed, then pull and start the official self-hosted
 			sed -i '' "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$$PGPASS/" .env; \
 			sed -i '' -E "s#^(DATABASE_URL=postgres://[^:]+:)[^@]*(@.*)#\1$$PGPASS\2#" .env; \
 			sed -i '' "s#^MULTICA_VCS_SECRET_KEY=.*#MULTICA_VCS_SECRET_KEY=$$VCSKEY#" .env; \
+			sed -i '' "s/^PORT=.*/PORT=$(PORT)/" .env; \
+			sed -i '' "s/^FRONTEND_PORT=.*/FRONTEND_PORT=$(FRONTEND_PORT)/" .env; \
 		else \
 			sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
 			sed -i "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$$PGPASS/" .env; \
 			sed -i -E "s#^(DATABASE_URL=postgres://[^:]+:)[^@]*(@.*)#\1$$PGPASS\2#" .env; \
 			sed -i "s#^MULTICA_VCS_SECRET_KEY=.*#MULTICA_VCS_SECRET_KEY=$$VCSKEY#" .env; \
+			sed -i "s/^PORT=.*/PORT=$(PORT)/" .env; \
+			sed -i "s/^FRONTEND_PORT=.*/FRONTEND_PORT=$(FRONTEND_PORT)/" .env; \
 		fi; \
 		echo "==> Generated random JWT_SECRET, POSTGRES_PASSWORD, and MULTICA_VCS_SECRET_KEY"; \
+		echo "==> Recorded PORT=$(PORT) and FRONTEND_PORT=$(FRONTEND_PORT) in .env"; \
 	fi
 	@echo "==> Pulling official Multica images..."
 	@if ! $(COMPOSE) -f docker-compose.selfhost.yml pull; then \
@@ -114,6 +131,7 @@ selfhost: ## Create .env if needed, then pull and start the official self-hosted
 
 selfhost-build: ## Build backend/web from the current checkout and start the self-hosted stack
 	$(REQUIRE_COMPOSE)
+	@bash scripts/selfhost-preflight.sh build
 	@if [ ! -f .env ]; then \
 		echo "==> Creating .env from .env.example..."; \
 		cp .env.example .env; \
@@ -125,13 +143,18 @@ selfhost-build: ## Build backend/web from the current checkout and start the sel
 			sed -i '' "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$$PGPASS/" .env; \
 			sed -i '' -E "s#^(DATABASE_URL=postgres://[^:]+:)[^@]*(@.*)#\1$$PGPASS\2#" .env; \
 			sed -i '' "s#^MULTICA_VCS_SECRET_KEY=.*#MULTICA_VCS_SECRET_KEY=$$VCSKEY#" .env; \
+			sed -i '' "s/^PORT=.*/PORT=$(PORT)/" .env; \
+			sed -i '' "s/^FRONTEND_PORT=.*/FRONTEND_PORT=$(FRONTEND_PORT)/" .env; \
 		else \
 			sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
 			sed -i "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$$PGPASS/" .env; \
 			sed -i -E "s#^(DATABASE_URL=postgres://[^:]+:)[^@]*(@.*)#\1$$PGPASS\2#" .env; \
 			sed -i "s#^MULTICA_VCS_SECRET_KEY=.*#MULTICA_VCS_SECRET_KEY=$$VCSKEY#" .env; \
+			sed -i "s/^PORT=.*/PORT=$(PORT)/" .env; \
+			sed -i "s/^FRONTEND_PORT=.*/FRONTEND_PORT=$(FRONTEND_PORT)/" .env; \
 		fi; \
 		echo "==> Generated random JWT_SECRET, POSTGRES_PASSWORD, and MULTICA_VCS_SECRET_KEY"; \
+		echo "==> Recorded PORT=$(PORT) and FRONTEND_PORT=$(FRONTEND_PORT) in .env"; \
 	fi
 	@echo "==> Building Multica from the current checkout..."
 	$(COMPOSE) -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -169,7 +169,10 @@ If the frontend and backend are served from different hostnames, `COOKIE_DOMAIN`
 > the same everywhere. None of this affects whether the reported port is correct:
 > `make selfhost` and both installers read the published port back from
 > `docker compose port`, so the health check and the printed URL always match
-> what Compose actually published.
+> what Compose actually published. It asks the same question before starting:
+> `make selfhost` refuses to run when a host port it would publish is already
+> taken, naming the port and its holder before any image is pulled, and records
+> the ports it used in a `.env` it creates.
 
 The web development server is one intentional exception to the generic `PORT`
 fallback: Next uses `PORT` for its own frontend listener before it evaluates the

--- a/SELF_HOSTING_AI.md
+++ b/SELF_HOSTING_AI.md
@@ -80,6 +80,14 @@ invoked directly is the reverse again — there the environment outranks `.env`.
 startup output is read back from Docker Compose, so the address it prints is the
 one the stack is actually published on.
 
+`make selfhost` checks those host ports before it pulls anything. If one is
+taken it names the port, names the process or container holding it when it can,
+and exits without starting or downloading — so a conflict costs a second rather
+than a full image pull ending in Docker's `port is already allocated`. When the
+run is also the one that creates `.env`, it records `PORT` and `FRONTEND_PORT`
+there, so `make selfhost PORT=9090 FRONTEND_PORT=9071` is remembered by later
+bare runs. An existing `.env` is left untouched.
+
 ## Troubleshooting
 
 - **Backend not ready:** `docker compose -f docker-compose.selfhost.yml logs backend`

--- a/apps/docs/content/docs/self-host-quickstart.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.mdx
@@ -22,7 +22,7 @@ The machine running the Multica service needs:
 
 - Docker Engine or Docker Desktop, with `docker compose` working
 - Git, Make, curl, and OpenSSL
-- Ports `3000` and `8080` free on the machine
+- Two free ports for the web app and the API. The defaults are `3000` and `8080`; if either is taken, startup stops and tells you, and you can pick others with `make selfhost PORT=… FRONTEND_PORT=…`
 
 Confirm Docker and Compose are available first:
 

--- a/apps/docs/content/docs/troubleshooting.mdx
+++ b/apps/docs/content/docs/troubleshooting.mdx
@@ -207,6 +207,29 @@ netstat -ano | findstr :8080       # Windows
 
 If it is another Multica checkout, run `make stop` in that directory first. Otherwise stop the offending program normally, or change the current service's port. Public ports 80/443 are listened on by a reverse proxy such as Caddy or Nginx.
 
+### The self-hosted stack
+
+`make selfhost` and `make selfhost-build` check the host ports they are about to publish before doing anything else, so a conflict is reported in a second instead of after several hundred megabytes of images have been pulled:
+
+```
+  Port 3000 (frontend) is already in use by the Docker container my-other-app.
+
+Multica was not started; no images were pulled.
+
+Pick free ports and run again:
+  make selfhost FRONTEND_PORT=<free port>
+```
+
+Every conflicting port is listed at once, and the offender is named when the machine can identify it. Pass free ports as the message suggests:
+
+```bash
+make selfhost PORT=9090 FRONTEND_PORT=9071
+```
+
+If that run is the one that creates `.env`, both ports are written into it, so later bare `make selfhost` runs stay on them. An existing `.env` is never rewritten — set `PORT` and `FRONTEND_PORT` in it yourself, or the command-line values apply to that run only.
+
+Only listeners the stack would actually collide with count: it publishes on `127.0.0.1`, so a service bound to another interface is not a conflict, and neither is a Multica container of this project already sitting on the port — re-running `make selfhost` is how the stack picks up a new image.
+
 ## Log locations
 
 | Component | How to view |

--- a/scripts/selfhost-config.test.sh
+++ b/scripts/selfhost-config.test.sh
@@ -205,7 +205,7 @@ sub=""
 subidx=0
 for ((i = 0; i < ${#args[@]}; i++)); do
   case "${args[i]}" in
-  up | pull | port | version | logs | down | build)
+  up | pull | port | version | logs | down | build | config)
     sub=${args[i]}
     subidx=$i
     break
@@ -218,6 +218,12 @@ for ((i = 0; i < ${#args[@]}; i++)); do
 done
 case "$sub" in
 version) echo "2.30.0" ;;
+config)
+  # scripts/selfhost-preflight.sh reads the ports to check from here, so the
+  # stub must answer with the real interpolation of the environment the recipe
+  # handed it — same reason `up` does below.
+  "$REAL_DOCKER" compose "${files[@]}" config
+  ;;
 up)
   "$REAL_DOCKER" compose "${files[@]}" config --format json 2>/dev/null | node -e '
 let raw = "";
@@ -259,7 +265,7 @@ chmod +x "$stub_dir/docker" "$stub_dir/curl"
 recipe_dir="$tmp_dir/recipe"
 mkdir -p "$recipe_dir/scripts"
 cp Makefile .env.example docker-compose.selfhost.yml docker-compose.selfhost.build.yml "$recipe_dir/"
-cp scripts/selfhost-wait.sh "$recipe_dir/scripts/"
+cp scripts/selfhost-wait.sh scripts/selfhost-preflight.sh "$recipe_dir/scripts/"
 
 record="$tmp_dir/published"
 curl_log="$tmp_dir/probed"
@@ -268,8 +274,33 @@ real_docker="$(command -v docker)"
 # Runs `make <target>` against the stubs after applying a sed script to .env.
 # Remaining args are passed through to make (environment assignments must be
 # given as VAR=value before the target via `env`, make variables after it).
+#
+# The host port preflight is skipped unless RECIPE_SKIP_PORT_CHECK=0: these
+# cases assert how a port is *resolved* and drive fixed numbers (9100, 8080,
+# 3000 ...) through the recipe, so they must not depend on which ports the
+# machine running the tests happens to have free. The preflight's own cases
+# below turn it back on against ports they control.
+#
+# A fifth argument of `fresh` runs the recipe with no .env at all, which is the
+# only way to reach the block that creates one.
 run_recipe() {
-  local target=$1 env_mutation=$2 shell_env=$3 make_args=$4
+  local target=$1 env_mutation=$2 shell_env=$3 make_args=$4 env_state=${5:-existing}
+
+  if [ "$env_state" = "fresh" ]; then
+    rm -f "$recipe_dir/.env"
+    : >"$record"
+    : >"$curl_log"
+    (
+      cd "$recipe_dir" || exit 1
+      eval "env PATH=\"$stub_dir:\$PATH\" \
+        REAL_DOCKER=\"$real_docker\" \
+        STUB_PUBLISHED_RECORD=\"$record\" \
+        STUB_CURL_LOG=\"$curl_log\" \
+        MULTICA_SELFHOST_SKIP_PORT_CHECK=\"${RECIPE_SKIP_PORT_CHECK:-1}\" \
+        $shell_env make $target $make_args"
+    )
+    return
+  fi
 
   cp "$recipe_dir/.env.example" "$recipe_dir/.env"
   # The Makefile includes .env and bare-`export`s every variable to the
@@ -292,6 +323,7 @@ run_recipe() {
       REAL_DOCKER=\"$real_docker\" \
       STUB_PUBLISHED_RECORD=\"$record\" \
       STUB_CURL_LOG=\"$curl_log\" \
+      MULTICA_SELFHOST_SKIP_PORT_CHECK=\"${RECIPE_SKIP_PORT_CHECK:-1}\" \
       $shell_env make $target $make_args"
   )
 }
@@ -523,6 +555,111 @@ for shadowed_alias in BACKEND_PORT API_PORT SERVER_PORT; do
   run_recipe selfhost "s/^# ${shadowed_alias}=8080/${shadowed_alias}=9700/" \
     "${shadowed_alias}=9600" '' >/dev/null
   require_consistent "env-file ${shadowed_alias} over the same shell variable" 9700
+done
+
+# ---------------------------------------------------------------------------
+# scripts/selfhost-preflight.sh: refusing a host port that is already taken
+#
+# The only cases here that run with the check enabled. They claim the ports they
+# need from the kernel rather than naming numbers, so they assert the behaviour
+# without assuming anything about what the machine running them has free.
+# ---------------------------------------------------------------------------
+
+# Three loopback ports claimed in one go: the first stays held for the conflict
+# case, the other two are handed straight back and reused as the free pair.
+# Claiming them together is what keeps the "free" pair out of the held port.
+reserved_ports="$tmp_dir/reserved-ports"
+node -e '
+const fs = require("fs");
+const net = require("net");
+const out = process.argv[1];
+const servers = [net.createServer(), net.createServer(), net.createServer()];
+let pending = servers.length;
+for (const server of servers) {
+  server.listen(0, "127.0.0.1", () => {
+    if (--pending > 0) return;
+    fs.writeFileSync(out + ".tmp", servers.map((s) => s.address().port).join("\n") + "\n");
+    fs.renameSync(out + ".tmp", out);
+    servers[1].close();
+    servers[2].close();
+  });
+}
+' "$reserved_ports" &
+held_port_pid=$!
+trap 'kill "$held_port_pid" 2>/dev/null || true; rm -f "$tmp_env"; rm -rf "$tmp_dir"' EXIT
+
+for _ in $(seq 1 100); do
+  [ -s "$reserved_ports" ] && break
+  sleep 0.1
+done
+if [ ! -s "$reserved_ports" ]; then
+  echo "could not claim loopback ports for the port preflight cases"
+  exit 1
+fi
+{
+  read -r held_port
+  read -r free_backend_port
+  read -r free_frontend_port
+} <"$reserved_ports"
+
+# From here on the recipes run with the preflight enabled.
+RECIPE_SKIP_PORT_CHECK=0
+preflight_log="$tmp_dir/preflight.log"
+
+# A taken port is refused, and refused early: nothing pulled, nothing started,
+# no .env left behind. What this replaces is a few hundred megabytes of images
+# followed by Docker's own "port is already allocated" -- or worse, a partially
+# started stack that scripts/selfhost-wait.sh reports as "Services are still
+# starting" and exits 0 on, so the conflict reads as a successful install.
+if run_recipe selfhost '' '' \
+  "PORT=$held_port FRONTEND_PORT=$free_frontend_port" fresh >"$preflight_log" 2>&1; then
+  echo "make selfhost must fail when a host port it would publish is already in use"
+  cat "$preflight_log"
+  exit 1
+fi
+if ! grep -Fq "Port $held_port (backend) is already in use" "$preflight_log"; then
+  echo "the conflict message must name the port and the service that wanted it"
+  cat "$preflight_log"
+  exit 1
+fi
+if grep -Fq 'Pulling official Multica images' "$preflight_log"; then
+  echo "the port check must run before the images are pulled"
+  cat "$preflight_log"
+  exit 1
+fi
+if [ -s "$record" ]; then
+  echo "a refused run must not start anything, but compose was asked to publish:"
+  cat "$record"
+  exit 1
+fi
+if [ -f "$recipe_dir/.env" ]; then
+  echo "a refused run must not leave a generated .env behind"
+  exit 1
+fi
+
+# Free ports chosen on the command line pass the check, and are what Compose
+# publishes for both services.
+if ! run_recipe selfhost '' '' \
+  "PORT=$free_backend_port FRONTEND_PORT=$free_frontend_port" fresh >"$preflight_log" 2>&1; then
+  echo "make selfhost must start on free ports chosen on the command line"
+  cat "$preflight_log"
+  exit 1
+fi
+require_consistent 'free ports chosen on the command line' "$free_backend_port"
+if [ "$(published_port frontend)" != "$free_frontend_port" ]; then
+  echo "expected the frontend on $free_frontend_port, got $(published_port frontend)"
+  exit 1
+fi
+
+# ...and the recipe records them in the .env it creates, so the next bare
+# `make selfhost` keeps the ports the operator picked instead of walking back
+# into the conflict they just worked around.
+for expected_line in "PORT=$free_backend_port" "FRONTEND_PORT=$free_frontend_port"; do
+  if ! grep -Fxq "$expected_line" "$recipe_dir/.env"; then
+    echo "the generated .env must record the ports the run used: $expected_line"
+    grep -nE '^(PORT|FRONTEND_PORT)=' "$recipe_dir/.env" || true
+    exit 1
+  fi
 done
 
 echo "self-host env derivation ok"

--- a/scripts/selfhost-preflight.sh
+++ b/scripts/selfhost-preflight.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Refuse to start the self-hosted stack when a host port it would publish is
+# already taken. Shared by `make selfhost` and `make selfhost-build`.
+#
+# Why this runs before `docker compose pull`: without it, the first sign of a
+# port conflict is Docker's own "Bind for 127.0.0.1:3000 failed: port is already
+# allocated", raised only after several hundred megabytes of images have been
+# pulled. And a partially failed `up` still ends in scripts/selfhost-wait.sh
+# printing "Services are still starting" and exiting 0, so the conflict can even
+# look like a successful install. Checking first costs one `docker compose
+# config` call and turns both outcomes into one actionable message.
+#
+# MULTICA_SELFHOST_SKIP_PORT_CHECK=1 bypasses the check. It exists for
+# scripts/selfhost-config.test.sh, which drives these recipes with fixed port
+# numbers to assert how a port is *resolved*, and so cannot depend on which
+# ports the machine running the tests happens to have free.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+mode=${1:-official}
+case "$mode" in
+official)
+  compose_files=(-f docker-compose.selfhost.yml)
+  make_target="make selfhost"
+  ;;
+build)
+  compose_files=(-f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml)
+  make_target="make selfhost-build"
+  ;;
+*)
+  echo "usage: ${BASH_SOURCE[0]} [official|build]" >&2
+  exit 2
+  ;;
+esac
+
+if [ "${MULTICA_SELFHOST_SKIP_PORT_CHECK:-}" = "1" ]; then
+  exit 0
+fi
+
+# The Makefile exports COMPOSE; keep the same default when run standalone.
+read -r -a compose_cmd <<<"${COMPOSE:-docker compose}"
+
+# Which ports to check comes from Compose, never from re-deriving
+# ${BACKEND_PORT:-${API_PORT:-${SERVER_PORT:-${PORT:-8080}}}} a third time here.
+# Two sources of truth for the published port is #6145, and the alias chain is
+# only half of it: which source wins (env file, environment, make command line)
+# differs per entry point. Compose is the only authority on what it will
+# publish, so ask it. scripts/selfhost-wait.sh carries the same rule for the
+# health probe.
+#
+# docker-compose.selfhost.yml requires JWT_SECRET (${JWT_SECRET:?...}) and this
+# runs before the recipe has created .env, so `config` gets a throwaway value
+# purely so the file interpolates. Nothing is started with it.
+#
+# A `config` that fails for any other reason prints nothing, which reports no
+# conflicts and lets the real `pull`/`up` surface the error with its own
+# message: this check only ever adds a failure it can explain.
+compose_published_ports() {
+  JWT_SECRET="${JWT_SECRET:-selfhost-preflight}" \
+    "${compose_cmd[@]}" "${compose_files[@]}" config 2>/dev/null | awk '
+    /^[a-zA-Z0-9_-]+:/ { in_services = ($0 == "services:"); next }
+    !in_services { next }
+    /^  [a-zA-Z0-9_.-]+:$/ { service = substr($1, 1, length($1) - 1); next }
+    /^        target: / { target = $2; next }
+    /^        published: / {
+      published = $2
+      gsub(/"/, "", published)
+      print service, target, published
+    }
+  '
+}
+
+# A connect probe on 127.0.0.1 rather than `lsof`, because that is the question
+# being asked: docker-compose.selfhost.yml publishes on 127.0.0.1 only, so a
+# listener bound to another interface (192.168.1.10:8080, say) does not collide
+# and must not be reported as a conflict. port_free() in scripts/dev-env.sh uses
+# `lsof -sTCP:LISTEN`, which lists listeners on every interface — right for that
+# script, wrong here — and reports "free" on a host with no lsof installed,
+# which is the common case on a small self-host server. bash's /dev/tcp is
+# always present, sees listeners on both 127.0.0.1 and 0.0.0.0, and misses
+# exactly the ones that genuinely do not conflict.
+port_in_use() {
+  (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+}
+
+# Best-effort name for the offender, in the spirit of describe_port_owner() in
+# scripts/dev-env.sh. Decoration only: when nothing can name the holder there is
+# no name, and the verdict is unchanged.
+describe_port_owner() {
+  local port=$1 container pid comm
+
+  # Ask Docker first. On a self-host box the holder is usually another
+  # container, and that is the case lsof describes worst: the listening socket
+  # belongs to root's docker-proxy, so a non-root lsof sees nothing at all and a
+  # root one reports "docker-proxy", which names no container.
+  container=$(docker ps --filter "publish=${port}" --format '{{.Names}}' 2>/dev/null | head -1 || true)
+  if [ -n "$container" ]; then
+    printf ' by the Docker container %s' "$container"
+    return 0
+  fi
+
+  command -v lsof >/dev/null 2>&1 || return 0
+  pid=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -1 || true)
+  [ -n "$pid" ] || return 0
+
+  comm=$(ps -p "$pid" -o comm= 2>/dev/null | tr -d '[:space:]' || true)
+  if [ -n "$comm" ]; then
+    printf ' by %s (pid %s)' "$comm" "$pid"
+  else
+    printf ' by pid %s' "$pid"
+  fi
+}
+
+# A port this project's own container already publishes is not a conflict:
+# re-running `make selfhost` is how the stack picks up a new image, and it has
+# to stay idempotent. `docker compose port` answers for the running container
+# only, which is the same primitive scripts/selfhost-wait.sh uses.
+already_published_by_us() {
+  local service=$1 container_port=$2 port=$3 published
+
+  published=$(
+    JWT_SECRET="${JWT_SECRET:-selfhost-preflight}" \
+      "${compose_cmd[@]}" "${compose_files[@]}" port "$service" "$container_port" 2>/dev/null | tail -n 1
+  ) || published=""
+  published=${published##*:}
+  published=${published%$'\r'}
+
+  [ -n "$published" ] && [ "$published" = "$port" ]
+}
+
+# The variable an operator sets to move each service. Keep this in step with
+# docker-compose.selfhost.yml: the backend reads the PORT alias chain, and PORT
+# is the documented one to edit.
+port_variable() {
+  case "$1" in
+  frontend) printf 'FRONTEND_PORT' ;;
+  *) printf 'PORT' ;;
+  esac
+}
+
+# Plain strings, not arrays: `${#array[@]}` on an empty array is an unbound
+# variable error under `set -u` in bash 3.2, which is what macOS still ships.
+conflict_count=0
+conflict_lines=""
+suggestion=""
+
+while read -r service target published; do
+  [ -n "${published:-}" ] || continue
+  port_in_use "$published" || continue
+  if already_published_by_us "$service" "$target" "$published"; then
+    continue
+  fi
+
+  conflict_count=$((conflict_count + 1))
+  conflict_lines="${conflict_lines}  Port ${published} (${service}) is already in use$(describe_port_owner "$published").
+"
+  suggestion="${suggestion} $(port_variable "$service")=<free port>"
+done < <(compose_published_ports)
+
+if [ "$conflict_count" -eq 0 ]; then
+  exit 0
+fi
+
+echo "" >&2
+printf '%s' "$conflict_lines" >&2
+echo "" >&2
+echo "Multica was not started; no images were pulled." >&2
+echo "" >&2
+echo "Pick free ports and run again:" >&2
+echo "  ${make_target}${suggestion}" >&2
+echo "" >&2
+if [ -f .env ]; then
+  # The recipe only writes ports into a .env it creates, so an existing file
+  # keeps whatever it already says and a command-line port would last one run.
+  echo "Set the same values in .env to keep them." >&2
+else
+  echo "They are written to the .env that run creates, so later runs keep them." >&2
+fi
+exit 1


### PR DESCRIPTION
## What does this PR do?

`make selfhost` had no defence against a host port it publishes already being in use.

Today the first sign of a conflict is Docker's own `Bind for 127.0.0.1:3000 failed: port is already allocated` — raised only *after* `docker compose pull` has downloaded several hundred megabytes of images. And when `up -d` fails only partially, `scripts/selfhost-wait.sh:71-75` still ends on `Services are still starting. Check logs` and **exits 0**, so a port conflict can read as a successful install.

Manually working around it did not stick either. `make selfhost PORT=9090 FRONTEND_PORT=9071` works for that run, but the `.env` the recipe generates is a straight copy of `.env.example` with `PORT=8080` / `FRONTEND_PORT=3000`, so the next bare `make selfhost` walks right back into the conflict the operator just worked around.

This PR adds a preflight that runs before the `.env` bootstrap, the pull and the up, and makes a manually chosen port persist.

**Which ports get checked comes from Compose, not from re-deriving the chain.** `scripts/selfhost-preflight.sh` asks `docker compose config` which host ports the stack would publish. Re-deriving `BACKEND_PORT → API_PORT → SERVER_PORT → PORT → 8080` a third time is #6145, and the alias order is only half of that bug — which source wins (env file, environment, make command line) differs per entry point too. `scripts/selfhost-wait.sh` already carries this rule for the health probe; the preflight follows it.

**How a port is tested.** A connect probe on `127.0.0.1` via bash's `/dev/tcp`, because that is the question being asked: `docker-compose.selfhost.yml` publishes on `127.0.0.1` only, so a listener on another interface does not collide and must not be reported. `port_free()` in `scripts/dev-env.sh` uses `lsof -sTCP:LISTEN`, which lists every interface — right for that script, wrong here — and silently reports "free" on a host with no `lsof`, the common case on a small self-host server. `lsof` is used only to decorate the message with a name.

**What is deliberately not a conflict:** a port already published by this project's own container. Re-running `make selfhost` is how the stack picks up a new image, so it stays idempotent. Checked with `docker compose port`, the same primitive `selfhost-wait.sh` uses.

The message lists every conflicting port at once — a machine with both 8080 and 3000 taken should not discover them one run at a time:

```
  Port 8080 (backend) is already in use by the Docker container qbittorrent.
  Port 3000 (frontend) is already in use by the Docker container gitea.

Multica was not started; no images were pulled.

Pick free ports and run again:
  make selfhost PORT=<free port> FRONTEND_PORT=<free port>

They are written to the .env that run creates, so later runs keep them.
```

Docker is asked to name the holder before `lsof` is, because that is the case `lsof` describes worst: the listening socket belongs to root's `docker-proxy`, so a non-root `lsof` sees nothing at all and a root one reports `docker-proxy`, which names no container.

An escape hatch, `MULTICA_SELFHOST_SKIP_PORT_CHECK=1`, exists for the test suite and is documented in the script header.

The `.env` bootstrap in both recipes now also records `PORT` and `FRONTEND_PORT` as the recipe resolved them. An existing `.env` is still never rewritten. If maintainers would rather not persist the ports, that part is a self-contained hunk and can be dropped without touching the rest.

## Related Issue

No existing issue — happy to open one if you would like this tracked. Context is #6145, whose rule ("nothing re-derives the published port from the inputs") this change extends from the health probe to the pre-start check.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `scripts/selfhost-preflight.sh` (new) — reads the host ports from `docker compose config`, probes each on `127.0.0.1`, skips ports this project already publishes, and exits 1 listing every conflict with its holder.
- `Makefile` — `selfhost` and `selfhost-build` call it right after `$(REQUIRE_COMPOSE)`, before the `.env` bootstrap, the pull and the up. Both `.env` bootstraps now write `PORT` and `FRONTEND_PORT`.
- `scripts/selfhost-config.test.sh` — the `docker` stub learns `config`; the throwaway checkout gets the new script; `run_recipe` gains a no-`.env` mode and skips the check by default; three new cases.
- `.github/workflows/ci.yml` — `scripts/selfhost-preflight.sh` added to the path filter that runs the suite.
- Docs — `apps/docs/content/docs/troubleshooting.mdx` (the canonical "Port already in use" section), `apps/docs/content/docs/self-host-quickstart.mdx`, `SELF_HOSTING_AI.md`, `SELF_HOSTING_ADVANCED.md`.

## How to Test

1. `bash scripts/selfhost-config.test.sh` — the suite CI already runs; the three new cases claim their own loopback ports from the kernel, so they assert the behaviour without assuming anything about what the machine has free.
2. Occupy a default port (`docker run -d -p 3000:80 --name port-hog nginx`) and run `make selfhost`. It must fail in about a second, name port 3000 and `port-hog`, and pull nothing. `.env` must not be created.
3. `make selfhost PORT=<free> FRONTEND_PORT=<free>` starts normally; `grep -E '^(PORT|FRONTEND_PORT)=' .env` shows the chosen ports, and a later bare `make selfhost` stays on them.
4. With the stack up, `make selfhost` again must still work — its own published ports are not treated as a conflict.

Verified on a machine where 8080 and 3000 were genuinely taken (by qbittorrent and gitea), which is what prompted this.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs — N/A
- [ ] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` — N/A, English pages only
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Notes for reviewers

- **Localized docs.** The `zh`/`ja`/`ko` twins of `troubleshooting.mdx` and `self-host-quickstart.mdx` are untouched, on the assumption they follow your translation flow. Happy to include them if you would rather they land together.
- **Out of scope, but related:** `scripts/install.sh:389` and `scripts/install.ps1:445` bring the stack up without a port check either — and `install.ps1` does not check `$LASTEXITCODE` after `up -d`, so on Windows a failed `up` continues to the wrong message ("could not read the backend host port"). Pre-existing and independent of this change; I can send a follow-up.

## AI Disclosure

**AI tool used:** Claude Code (Opus 5)

**Prompt / approach:** I asked for a plan first: check the port before anything else, exit immediately with an explanation if it is taken, then let the port be chosen manually — and update the docs if needed. I reviewed and approved the plan (fail-fast with instructions, no interactive prompt and no silently picking a free port, so it stays deterministic in CI and under `curl | bash`) before any code was written. Each behaviour was verified against the real `make` recipes, and the two Makefile changes were mutation-checked: removing the preflight call and removing the `PORT` persistence each make a new test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7WdJxpcXN6i8MMzfBpNX7
