### PR TITLE
MUL-7239 fix(agents): preserve provider-qualified model ids

### DIFF
--- a/packages/views/agents/components/inspector/model-picker.test.tsx
+++ b/packages/views/agents/components/inspector/model-picker.test.tsx
@@ -87,6 +87,34 @@ describe("ModelPicker (inspector)", () => {
     expect(onChange).toHaveBeenCalledWith("claude-fable-5");
   });
 
+  it("keeps an exact label match available as a verbatim custom model id", async () => {
+    const qualifiedId = "commandcode/deepseek/deepseek-v4.1-flash";
+    discovery = async () => ({
+      models: [
+        {
+          id: "deepseek/deepseek-v4.1-flash",
+          label: qualifiedId,
+          provider: "commandcode",
+        },
+      ],
+      supported: true,
+    });
+
+    const { container, onChange } = renderPicker();
+    openPicker(container);
+    fireEvent.change(
+      await screen.findByPlaceholderText(
+        enAgents.pickers.model_search_placeholder,
+      ),
+      { target: { value: qualifiedId } },
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: `Use "${qualifiedId}"` }),
+    );
+    expect(onChange).toHaveBeenCalledWith(qualifiedId);
+  });
+
   it("shows an unavailable model with its reason and no way to select it", async () => {
     const { container, onChange } = renderPicker();
     openPicker(container);

--- a/packages/views/agents/components/inspector/model-picker.tsx
+++ b/packages/views/agents/components/inspector/model-picker.tsx
@@ -80,10 +80,11 @@ export function ModelPicker({
   }, [models, search]);
 
   const trimmedSearch = search.trim();
-  const exactMatch = models.some(
-    (m) => m.id === trimmedSearch || m.label === trimmedSearch,
-  );
-  const canCreate = trimmedSearch.length > 0 && !exactMatch;
+  // Labels are display copy, not aliases for the persistable model ID. Keep
+  // the verbatim option when only a label matches so a provider-qualified
+  // value cannot be silently replaced with that row's different ID (#8246).
+  const exactIdMatch = models.some((m) => m.id === trimmedSearch);
+  const canCreate = trimmedSearch.length > 0 && !exactIdMatch;
 
   const triggerLabel = value || t(($) => $.pickers.model_default);
   const triggerTitle = t(($) => $.pickers.model_tooltip, { value: triggerLabel });

--- a/packages/views/agents/components/model-dropdown.test.tsx
+++ b/packages/views/agents/components/model-dropdown.test.tsx
@@ -101,6 +101,34 @@ describe("ModelDropdown", () => {
     expect(onChange).toHaveBeenCalledWith("gpt-5.6-terra");
   });
 
+  it("keeps an exact label match available as a verbatim custom model id", async () => {
+    const qualifiedId = "commandcode/deepseek/deepseek-v4.1-flash";
+    discovery = async () => ({
+      models: [
+        {
+          id: "deepseek/deepseek-v4.1-flash",
+          label: qualifiedId,
+          provider: "commandcode",
+        },
+      ],
+      supported: true,
+    });
+
+    const { container, onChange } = renderDropdown();
+    openDropdown(container);
+    fireEvent.change(
+      await screen.findByPlaceholderText(
+        enAgents.pickers.model_search_placeholder,
+      ),
+      { target: { value: qualifiedId } },
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: `Use "${qualifiedId}"` }),
+    );
+    expect(onChange).toHaveBeenCalledWith(qualifiedId);
+  });
+
   it("offers an explicit refresh that requests the runtime's live catalog", async () => {
     const { container } = renderDropdown();
     openDropdown(container);

--- a/packages/views/agents/components/model-dropdown.tsx
+++ b/packages/views/agents/components/model-dropdown.tsx
@@ -100,10 +100,11 @@ export function ModelDropdown({
   }, [grouped, search]);
 
   const trimmedSearch = search.trim();
-  const exactMatch = models.some(
-    (m) => m.id === trimmedSearch || m.label === trimmedSearch,
-  );
-  const canCreate = trimmedSearch.length > 0 && !exactMatch;
+  // Labels are display copy, not aliases for the persistable model ID. Keep
+  // the verbatim option when only a label matches so a provider-qualified
+  // value cannot be silently replaced with that row's different ID (#8246).
+  const exactIdMatch = models.some((m) => m.id === trimmedSearch);
+  const canCreate = trimmedSearch.length > 0 && !exactIdMatch;
 
   const select = (id: string) => {
     onChange(id);


### PR DESCRIPTION
## Summary

- keep the verbatim custom-model option when typed text matches only a catalog label
- continue suppressing the custom option when the typed text exactly matches the canonical model ID
- cover both the create-agent dropdown and inspector picker with the provider-qualified ID regression

Fixes #8246

## Verification

- `pnpm --filter @multica/views exec vitest run agents/components/model-dropdown.test.tsx agents/components/inspector/model-picker.test.tsx` (12 tests)
- `pnpm --filter @multica/views test` (419 files, 5035 tests)
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` (0 errors; 26 warnings outside the changed files)
- `git diff --check origin/main...HEAD`
