### PR TITLE
MUL-7259, MUL-7199: fix(server,daemon): converge tasks whose runtime stopped executing them

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -482,6 +482,13 @@ type Daemon struct {
 	// (watchTaskCancellation, workspaceSyncLoop) so the WS connect/reconnect
 	// path can shrink coarse fallback reconciliation gaps to sub-second. See
 	// reconcile.go and runTaskWakeupConnection.
+	// terminalOutbox holds complete/fail reports whose in-process retry
+	// schedule was exhausted while the server was unreachable. Without it those
+	// reports are dropped and the task row stays 'running' forever, because a
+	// still-heartbeating daemon is exactly what the stale-task sweeper skips
+	// (GH #8221).
+	terminalOutbox *terminalOutbox
+
 	reconcile *reconcileBroadcaster
 	// workspaceChanges is the account-scoped server hint for membership-set
 	// changes. It stays separate from reconcile because a membership hint only
@@ -667,6 +674,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		cancelPollInterval:        5 * time.Second,
 		envRootBusyWait:           15 * time.Second,
 		taskPrepareTimeout:        defaultTaskPrepareTimeout,
+		terminalOutbox:            newTerminalOutbox(filepath.Join(cfg.WorkspacesRoot, ".terminal-outbox")),
 		reconcile:                 newReconcileBroadcaster(),
 		workspaceChanges:          newWorkspaceChangeSignal(),
 		wsRPC:                     newWSRPCClient(wsRPCResponseGrace),
@@ -5067,6 +5075,13 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 			return
 		}
 
+		// Replay any terminal report a previous run could not deliver. This runs
+		// before the claim, and on the same loop that proves the server is
+		// reachable, so a task finished during an outage is finalized as soon as
+		// connectivity returns instead of sitting 'running' until someone
+		// notices. Cheap when the queue is empty: one directory read.
+		d.drainTerminalOutbox(pollerCtx)
+
 		runtimeIDs := d.allRuntimeIDs()
 		if len(runtimeIDs) == 0 {
 			if err := sleepWithContextOrWakeup(pollerCtx, d.cfg.PollInterval, wakeup); err != nil {
@@ -5917,15 +5932,18 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 		// error reaching us here means the schedule was exhausted while
 		// the upstream was still 5xx / unreachable. Converting that into
 		// a fail would lose the agent's actual result and surface a
-		// misleading red badge in the UI — leave the task in running
-		// instead so a future fix (server-side stuck-task reaper, or a
-		// daemon-side persistent pending queue) can recover it. Only
-		// permanent server-side rejections (4xx other than 408/429)
-		// warrant the legacy fallback, because at that point the server
-		// has already refused this task and the only useful UI signal
-		// left is a concrete failure.
+		// misleading red badge in the UI. Only permanent server-side
+		// rejections (4xx other than 408/429) warrant the legacy
+		// fallback, because at that point the server has already refused
+		// this task and the only useful UI signal left is a concrete
+		// failure.
+		//
+		// reportTerminalTask has already queued this report durably, so the
+		// run is no longer lost when the schedule runs out: the poll loop
+		// replays it once the server is reachable. This used to be the point
+		// where a finished run became a permanently 'running' row (GH #8221).
 		if isTransientError(err) {
-			taskLog.Error("complete task failed after retries; leaving task in running rather than falling back to fail", "error", err)
+			taskLog.Error("complete task failed after retries; queued for replay rather than falling back to fail", "error", err)
 			return
 		}
 		taskLog.Error("complete task rejected by server, falling back to fail", "error", err)
@@ -6002,6 +6020,42 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 // 30-second drain, but terminal callbacks must still use that remaining window.
 // The explicit timeout keeps this detached work bounded during normal runs.
 func (d *Daemon) reportTerminalTask(parentCtx context.Context, report terminalTaskReport) error {
+	err := d.sendTerminalTask(parentCtx, report)
+	if err == nil {
+		// A queued copy from an earlier attempt is now redundant. Dropping it
+		// here (rather than only in the drain) keeps a report that succeeded on
+		// its second in-process attempt from being replayed later.
+		d.forgetQueuedTerminalTask(report.taskID)
+		return nil
+	}
+	if !isTransientError(err) {
+		// The server refused this report on its merits; replaying it would only
+		// reproduce the refusal. The caller handles the rejection — for a
+		// completion that means downgrading to a fail report, which arrives
+		// here as its own report and gets its own durability.
+		d.forgetQueuedTerminalTask(report.taskID)
+		return err
+	}
+	// Transient: the outcome is real and unreported. Persist before returning so
+	// it survives both the caller giving up and the daemon exiting.
+	d.queueTerminalTask(report)
+	return err
+}
+
+// queueTerminalTask persists a report for later replay. The outbox is nil only
+// in tests that build a Daemon literal; losing durability there is harmless,
+// and panicking on it would be worse than the gap this whole mechanism closes.
+func (d *Daemon) queueTerminalTask(report terminalTaskReport) {
+	if d.terminalOutbox == nil {
+		return
+	}
+	if err := d.terminalOutbox.persist(report); err != nil {
+		d.logger.Error("could not persist terminal task report; it will be lost if the daemon exits",
+			"task", report.taskID, "error", err)
+	}
+}
+
+func (d *Daemon) sendTerminalTask(parentCtx context.Context, report terminalTaskReport) error {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(parentCtx), terminalTaskReportTimeout)
 	defer cancel()
 
@@ -6012,6 +6066,62 @@ func (d *Daemon) reportTerminalTask(parentCtx context.Context, report terminalTa
 		return d.client.FailTask(ctx, report.taskID, report.errorMessage, report.sessionID, report.workDir, report.branchName, report.failureReason, report.sessionRolloutMissing, report.retiredSessionID, report.durableWorkDir)
 	default:
 		return fmt.Errorf("unsupported terminal task report kind %d", report.kind)
+	}
+}
+
+func (d *Daemon) forgetQueuedTerminalTask(taskID string) {
+	if d.terminalOutbox == nil {
+		return
+	}
+	if err := d.terminalOutbox.remove(taskID); err != nil {
+		d.logger.Warn("could not clear queued terminal task report", "task", taskID, "error", err)
+	}
+}
+
+// drainTerminalOutbox replays terminal reports whose original delivery failed.
+// Called on startup and on the poll loop's tick, so a task finished during an
+// outage is finalized as soon as the server is reachable again instead of
+// waiting for a human to notice a permanently 'running' row.
+//
+// Replay is safe because the server treats an already-finalized terminal
+// callback as idempotent success; a report that did land simply confirms.
+func (d *Daemon) drainTerminalOutbox(ctx context.Context) {
+	if d.terminalOutbox == nil {
+		return
+	}
+	pending, err := d.terminalOutbox.list()
+	if err != nil {
+		d.logger.Warn("could not read queued terminal task reports", "error", err)
+		return
+	}
+	for _, p := range pending {
+		if ctx.Err() != nil {
+			return
+		}
+		if age := time.Since(p.QueuedAt); age > terminalOutboxMaxAge {
+			d.logger.Error("abandoning queued terminal task report after repeated failures",
+				"task", p.TaskID, "age", age.Round(time.Minute), "kind", p.Kind)
+			d.forgetQueuedTerminalTask(p.TaskID)
+			continue
+		}
+		err := d.sendTerminalTask(ctx, p.report())
+		if err == nil {
+			d.logger.Info("delivered queued terminal task report",
+				"task", p.TaskID, "kind", p.Kind, "queued_for", time.Since(p.QueuedAt).Round(time.Second))
+			d.forgetQueuedTerminalTask(p.TaskID)
+			continue
+		}
+		if !isTransientError(err) {
+			d.logger.Error("server permanently rejected queued terminal task report; dropping",
+				"task", p.TaskID, "kind", p.Kind, "error", err)
+			d.forgetQueuedTerminalTask(p.TaskID)
+			continue
+		}
+		// Still unreachable. Keep it and stop for this tick — the rest of the
+		// queue is almost certainly blocked on the same outage, and hammering it
+		// adds nothing.
+		d.logger.Debug("queued terminal task report still undeliverable", "task", p.TaskID, "error", err)
+		return
 	}
 }
 

--- a/server/internal/daemon/terminal_outbox.go
+++ b/server/internal/daemon/terminal_outbox.go
@@ -1,0 +1,217 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// A terminal callback is the only thing that moves a task out of 'running'
+// server-side. When one is lost, the row stays 'running' forever: the daemon
+// keeps heartbeating, so the stale-task sweeper deliberately skips it, and the
+// retry budget is unreachable because retries are gated on 'failed'. The agent
+// shows 'working' and one of its max_concurrent_tasks slots is consumed for
+// good. That is GH #8221 (a partition exhausted the /complete retries, and the
+// daemon deliberately left the task running rather than reporting a successful
+// run as a failure) and the second half of GH #8272.
+//
+// The retry schedule inside CompleteTask/FailTask only covers outages shorter
+// than its budget (~124s). Anything longer used to end with the report being
+// dropped in memory. This outbox is the durable half: a report that survives
+// the in-process schedule is written to disk and replayed once the server is
+// reachable again, including across a daemon restart.
+//
+// Safety rests on the server side already being idempotent — CompleteTask
+// treats an already-finalized callback as success, and the terminal writes CAS
+// on the non-terminal status — so replaying a report that actually landed is a
+// no-op rather than a double-finalize.
+
+const (
+	terminalOutboxDirName = "pending-terminal-reports"
+
+	// A report is retried for this long before it is abandoned. The window is
+	// generous because the whole point is surviving a long outage, and the cost
+	// of holding one small file is far below the cost of losing the record of a
+	// finished run. Past it, the server-side sweeper is the remaining backstop:
+	// a daemon down that long stops heartbeating and its rows become sweepable.
+	terminalOutboxMaxAge = 7 * 24 * time.Hour
+
+	terminalOutboxFileMode = 0o600
+	terminalOutboxDirMode  = 0o700
+)
+
+// pendingTerminalReport is the on-disk form of a terminalTaskReport. It is a
+// separate type on purpose: this is a persisted format that must stay readable
+// by a later daemon build, so it carries explicit JSON tags rather than
+// inheriting whatever the in-memory struct's fields happen to be called.
+type pendingTerminalReport struct {
+	Kind                  terminalTaskReportKind `json:"kind"`
+	TaskID                string                 `json:"task_id"`
+	Output                string                 `json:"output,omitempty"`
+	BranchName            string                 `json:"branch_name,omitempty"`
+	ErrorMessage          string                 `json:"error_message,omitempty"`
+	SessionID             string                 `json:"session_id,omitempty"`
+	WorkDir               string                 `json:"work_dir,omitempty"`
+	DurableWorkDir        string                 `json:"durable_work_dir,omitempty"`
+	FailureReason         string                 `json:"failure_reason,omitempty"`
+	SessionRolloutMissing bool                   `json:"session_rollout_missing,omitempty"`
+	RetiredSessionID      string                 `json:"retired_session_id,omitempty"`
+	QueuedAt              time.Time              `json:"queued_at"`
+}
+
+func (p pendingTerminalReport) report() terminalTaskReport {
+	return terminalTaskReport{
+		kind:                  p.Kind,
+		taskID:                p.TaskID,
+		output:                p.Output,
+		branchName:            p.BranchName,
+		errorMessage:          p.ErrorMessage,
+		sessionID:             p.SessionID,
+		workDir:               p.WorkDir,
+		durableWorkDir:        p.DurableWorkDir,
+		failureReason:         p.FailureReason,
+		sessionRolloutMissing: p.SessionRolloutMissing,
+		retiredSessionID:      p.RetiredSessionID,
+	}
+}
+
+func newPendingTerminalReport(r terminalTaskReport) pendingTerminalReport {
+	return pendingTerminalReport{
+		Kind:                  r.kind,
+		TaskID:                r.taskID,
+		Output:                r.output,
+		BranchName:            r.branchName,
+		ErrorMessage:          r.errorMessage,
+		SessionID:             r.sessionID,
+		WorkDir:               r.workDir,
+		DurableWorkDir:        r.durableWorkDir,
+		FailureReason:         r.failureReason,
+		SessionRolloutMissing: r.sessionRolloutMissing,
+		RetiredSessionID:      r.retiredSessionID,
+		QueuedAt:              time.Now().UTC(),
+	}
+}
+
+// terminalOutbox is a small file-per-task queue. One task has exactly one
+// terminal outcome, so a later report for the same task legitimately replaces
+// an earlier one (the complete → fail downgrade when the server permanently
+// rejects a completion) rather than queueing behind it.
+type terminalOutbox struct {
+	dir string
+	mu  sync.Mutex
+}
+
+func newTerminalOutbox(stateDir string) *terminalOutbox {
+	return &terminalOutbox{dir: filepath.Join(stateDir, terminalOutboxDirName)}
+}
+
+// path keeps the task ID out of the filesystem's hands: task IDs are UUIDs, but
+// this is a value that arrives from the server, and a "../" in it would let a
+// malformed ID write outside the outbox.
+func (o *terminalOutbox) path(taskID string) (string, error) {
+	clean := strings.TrimSpace(taskID)
+	if clean == "" || strings.ContainsAny(clean, `/\`) || clean == "." || clean == ".." {
+		return "", fmt.Errorf("refusing to use %q as an outbox filename", taskID)
+	}
+	return filepath.Join(o.dir, clean+".json"), nil
+}
+
+// persist writes the report durably enough to survive a crash: a temp file in
+// the same directory, fsynced, then renamed over the target. A half-written
+// terminal report that failed to parse on restart would be the same lost
+// callback this exists to prevent.
+func (o *terminalOutbox) persist(r terminalTaskReport) error {
+	target, err := o.path(r.taskID)
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(newPendingTerminalReport(r))
+	if err != nil {
+		return fmt.Errorf("marshal pending terminal report: %w", err)
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if err := os.MkdirAll(o.dir, terminalOutboxDirMode); err != nil {
+		return fmt.Errorf("create terminal outbox dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(o.dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create terminal outbox temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename succeeds
+	if _, err := tmp.Write(payload); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write terminal outbox temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync terminal outbox temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close terminal outbox temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, terminalOutboxFileMode); err != nil {
+		return fmt.Errorf("chmod terminal outbox temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		return fmt.Errorf("rename terminal outbox file: %w", err)
+	}
+	return nil
+}
+
+// list returns the queued reports oldest-first. Unreadable entries are dropped
+// rather than failing the whole drain — one corrupt file must not block every
+// other pending report.
+func (o *terminalOutbox) list() ([]pendingTerminalReport, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	entries, err := os.ReadDir(o.dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read terminal outbox dir: %w", err)
+	}
+
+	var out []pendingTerminalReport
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		full := filepath.Join(o.dir, e.Name())
+		data, readErr := os.ReadFile(full)
+		if readErr != nil {
+			continue
+		}
+		var p pendingTerminalReport
+		if json.Unmarshal(data, &p) != nil || p.TaskID == "" || p.Kind == 0 {
+			os.Remove(full)
+			continue
+		}
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].QueuedAt.Before(out[j].QueuedAt) })
+	return out, nil
+}
+
+func (o *terminalOutbox) remove(taskID string) error {
+	target, err := o.path(taskID)
+	if err != nil {
+		return err
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if err := os.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove terminal outbox file: %w", err)
+	}
+	return nil
+}

--- a/server/internal/daemon/terminal_outbox_test.go
+++ b/server/internal/daemon/terminal_outbox_test.go
@@ -1,0 +1,323 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testOutboxDaemon(t *testing.T, baseURL string) *Daemon {
+	t.Helper()
+	return &Daemon{
+		client:         NewClient(baseURL),
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		terminalOutbox: newTerminalOutbox(t.TempDir()),
+	}
+}
+
+// noTerminalBackoff collapses the client's in-process retry schedule so these
+// tests exercise the durable layer rather than sitting through ~124s of
+// backoff. The schedule itself is covered by the client's own tests.
+func noTerminalBackoff(t *testing.T) {
+	t.Helper()
+	original := defaultTerminalRetrySchedule
+	defaultTerminalRetrySchedule = []time.Duration{}
+	t.Cleanup(func() { defaultTerminalRetrySchedule = original })
+}
+
+func TestTerminalOutbox_PersistListRemove(t *testing.T) {
+	o := newTerminalOutbox(t.TempDir())
+
+	if got, err := o.list(); err != nil || len(got) != 0 {
+		t.Fatalf("empty outbox: got %d reports, err %v", len(got), err)
+	}
+
+	report := terminalTaskReport{
+		kind: terminalTaskReportComplete, taskID: "task-1",
+		output: "the agent's answer", branchName: "fix/thing",
+		sessionID: "sess-1", workDir: "/w", durableWorkDir: "/d",
+		retiredSessionID: "old-sess", sessionRolloutMissing: true,
+	}
+	if err := o.persist(report); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := o.list()
+	if err != nil || len(got) != 1 {
+		t.Fatalf("got %d reports, err %v, want 1", len(got), err)
+	}
+	// Every field must survive the round trip: this payload is the agent's only
+	// surviving output once the in-memory result is discarded.
+	if rt := got[0].report(); rt != report {
+		t.Fatalf("round trip lost data:\n got %+v\nwant %+v", rt, report)
+	}
+
+	if err := o.remove("task-1"); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := o.list(); err != nil || len(got) != 0 {
+		t.Fatalf("after remove: got %d reports, err %v", len(got), err)
+	}
+	// Removing an absent entry is normal — success and drain both call it.
+	if err := o.remove("task-1"); err != nil {
+		t.Fatalf("removing a missing report should be a no-op, got %v", err)
+	}
+}
+
+// One task has exactly one terminal outcome, so a later report replaces an
+// earlier one rather than queueing behind it.
+func TestTerminalOutbox_LaterReportReplacesEarlier(t *testing.T) {
+	o := newTerminalOutbox(t.TempDir())
+	if err := o.persist(terminalTaskReport{kind: terminalTaskReportComplete, taskID: "task-1", output: "first"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.persist(terminalTaskReport{kind: terminalTaskReportFail, taskID: "task-1", errorMessage: "second"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := o.list()
+	if err != nil || len(got) != 1 {
+		t.Fatalf("got %d reports, err %v, want 1", len(got), err)
+	}
+	if got[0].Kind != terminalTaskReportFail || got[0].ErrorMessage != "second" {
+		t.Fatalf("got %+v, want the later fail report", got[0])
+	}
+}
+
+func TestTerminalOutbox_SkipsUnreadableEntries(t *testing.T) {
+	dir := t.TempDir()
+	o := newTerminalOutbox(dir)
+	if err := o.persist(terminalTaskReport{kind: terminalTaskReportComplete, taskID: "good"}); err != nil {
+		t.Fatal(err)
+	}
+	// A truncated file from a crash mid-write must not block the queue.
+	if err := os.WriteFile(filepath.Join(o.dir, "corrupt.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := o.list()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].TaskID != "good" {
+		t.Fatalf("got %+v, want only the readable report", got)
+	}
+	if _, err := os.Stat(filepath.Join(o.dir, "corrupt.json")); !os.IsNotExist(err) {
+		t.Fatal("an unparseable entry should be discarded, not retried forever")
+	}
+}
+
+func TestTerminalOutbox_RejectsUnsafeTaskID(t *testing.T) {
+	o := newTerminalOutbox(t.TempDir())
+	for _, id := range []string{"", "  ", "..", ".", "../escape", `sub\escape`, "a/b"} {
+		if err := o.persist(terminalTaskReport{kind: terminalTaskReportComplete, taskID: id}); err == nil {
+			t.Fatalf("persist(%q) should be refused as a filename", id)
+		}
+	}
+}
+
+// TestReportTerminalTask_QueuesTransientFailure is the GH #8221 shape: the run
+// finished, the callback could not be delivered, and before this the report was
+// dropped in memory and the row stayed 'running' forever.
+func TestReportTerminalTask_QueuesTransientFailure(t *testing.T) {
+	noTerminalBackoff(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream down", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	d := testOutboxDaemon(t, srv.URL)
+	err := d.reportTerminalTask(context.Background(), terminalTaskReport{
+		kind: terminalTaskReportComplete, taskID: "task-1", output: "finished work",
+	})
+	if err == nil {
+		t.Fatal("expected the delivery failure to be reported to the caller")
+	}
+
+	queued, listErr := d.terminalOutbox.list()
+	if listErr != nil || len(queued) != 1 {
+		t.Fatalf("got %d queued reports, err %v, want 1", len(queued), listErr)
+	}
+	if queued[0].Output != "finished work" {
+		t.Fatalf("queued output = %q, want the agent's result preserved", queued[0].Output)
+	}
+}
+
+// A 4xx is the server refusing this report on its merits. Replaying it would
+// only reproduce the refusal, and the caller already downgrades a rejected
+// completion to a fail report that gets its own durability.
+func TestReportTerminalTask_DoesNotQueuePermanentRejection(t *testing.T) {
+	noTerminalBackoff(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	d := testOutboxDaemon(t, srv.URL)
+	if err := d.reportTerminalTask(context.Background(), terminalTaskReport{
+		kind: terminalTaskReportComplete, taskID: "task-1",
+	}); err == nil {
+		t.Fatal("expected the rejection to reach the caller")
+	}
+	queued, err := d.terminalOutbox.list()
+	if err != nil || len(queued) != 0 {
+		t.Fatalf("got %d queued reports, err %v, want 0", len(queued), err)
+	}
+}
+
+// A report that succeeds on a later in-process attempt must not leave a queued
+// copy behind, or the drain would replay an outcome that already landed.
+func TestReportTerminalTask_ClearsQueueOnSuccess(t *testing.T) {
+	noTerminalBackoff(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	d := testOutboxDaemon(t, srv.URL)
+	if err := d.terminalOutbox.persist(terminalTaskReport{kind: terminalTaskReportComplete, taskID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.reportTerminalTask(context.Background(), terminalTaskReport{
+		kind: terminalTaskReportComplete, taskID: "task-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	queued, err := d.terminalOutbox.list()
+	if err != nil || len(queued) != 0 {
+		t.Fatalf("got %d queued reports, err %v, want 0", len(queued), err)
+	}
+}
+
+// TestDrainTerminalOutbox_ReplaysAfterRecovery is the end-to-end recovery: the
+// report is queued while the server is unreachable, then delivered intact on
+// the first poll after connectivity returns.
+func TestDrainTerminalOutbox_ReplaysAfterRecovery(t *testing.T) {
+	noTerminalBackoff(t)
+	var down atomic.Bool
+	down.Store(true)
+	var delivered atomic.Int32
+	var gotPath, gotOutput atomic.Value
+	gotPath.Store("")
+	gotOutput.Store("")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if down.Load() {
+			http.Error(w, "partitioned", http.StatusServiceUnavailable)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]any
+		json.Unmarshal(body, &parsed)
+		if out, ok := parsed["output"].(string); ok {
+			gotOutput.Store(out)
+		}
+		gotPath.Store(r.URL.Path)
+		delivered.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	d := testOutboxDaemon(t, srv.URL)
+	ctx := context.Background()
+
+	if err := d.reportTerminalTask(ctx, terminalTaskReport{
+		kind: terminalTaskReportComplete, taskID: "task-1", output: "the deliverable",
+	}); err == nil {
+		t.Fatal("expected delivery to fail while the server is down")
+	}
+
+	// Draining during the outage must keep the report, not discard it.
+	d.drainTerminalOutbox(ctx)
+	if queued, _ := d.terminalOutbox.list(); len(queued) != 1 {
+		t.Fatalf("got %d queued reports during outage, want 1 (it must not be dropped)", len(queued))
+	}
+	if delivered.Load() != 0 {
+		t.Fatalf("delivered %d reports during the outage, want 0", delivered.Load())
+	}
+
+	down.Store(false)
+	d.drainTerminalOutbox(ctx)
+
+	if delivered.Load() != 1 {
+		t.Fatalf("delivered %d reports after recovery, want 1", delivered.Load())
+	}
+	if got := gotPath.Load().(string); got != "/api/daemon/tasks/task-1/complete" {
+		t.Fatalf("replayed to %q, want the complete callback", got)
+	}
+	if got := gotOutput.Load().(string); got != "the deliverable" {
+		t.Fatalf("replayed output = %q, want the agent's result", got)
+	}
+	if queued, _ := d.terminalOutbox.list(); len(queued) != 0 {
+		t.Fatalf("got %d queued reports after delivery, want 0", len(queued))
+	}
+
+	// A second drain must not re-send: the queue is the only thing preventing a
+	// duplicate, since the server accepts replays idempotently and would not
+	// complain.
+	d.drainTerminalOutbox(ctx)
+	if delivered.Load() != 1 {
+		t.Fatalf("delivered %d reports after a second drain, want 1", delivered.Load())
+	}
+}
+
+func TestDrainTerminalOutbox_DropsPermanentlyRejected(t *testing.T) {
+	noTerminalBackoff(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "gone for good", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	d := testOutboxDaemon(t, srv.URL)
+	if err := d.terminalOutbox.persist(terminalTaskReport{kind: terminalTaskReportFail, taskID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	d.drainTerminalOutbox(context.Background())
+
+	queued, err := d.terminalOutbox.list()
+	if err != nil || len(queued) != 0 {
+		t.Fatalf("got %d queued reports, err %v, want 0 — a refused report must not be retried forever", len(queued), err)
+	}
+}
+
+func TestDrainTerminalOutbox_AbandonsExpiredReports(t *testing.T) {
+	noTerminalBackoff(t)
+	var called atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	d := testOutboxDaemon(t, srv.URL)
+	stale := newPendingTerminalReport(terminalTaskReport{kind: terminalTaskReportComplete, taskID: "task-1"})
+	stale.QueuedAt = time.Now().Add(-terminalOutboxMaxAge - time.Hour)
+	payload, err := json.Marshal(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(d.terminalOutbox.dir, terminalOutboxDirMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d.terminalOutbox.dir, "task-1.json"), payload, terminalOutboxFileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	d.drainTerminalOutbox(context.Background())
+
+	if called.Load() != 0 {
+		t.Fatalf("sent %d expired reports, want 0", called.Load())
+	}
+	if queued, _ := d.terminalOutbox.list(); len(queued) != 0 {
+		t.Fatalf("got %d queued reports, want 0 — an expired report must not grow the queue forever", len(queued))
+	}
+}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -4891,6 +4891,46 @@ func (h *Handler) AckTaskCancelled(w http.ResponseWriter, r *http.Request) {
 	req.BranchName = util.SanitizeTextForPostgres(req.BranchName)
 	req.DurableWorkDir = util.SanitizeTextForPostgres(req.DurableWorkDir)
 
+	// A daemon only acks after its run has stopped. If the row is still
+	// non-terminal at that point the server's view is stale and nothing else
+	// will ever fix it: FailStaleTasks skips rows whose runtime is still
+	// heartbeating, which is exactly what a healthy daemon does forever. This
+	// endpoint's original contract assumed cancellation was always
+	// server-initiated (row already terminal, only pointers left to record),
+	// which held for user cancels and left every abnormal abort stranded in
+	// 'running' — agent pinned at 'working', a concurrency slot gone for good,
+	// retry budget unreachable (GH #8272).
+	//
+	// The CAS inside ConvergeAbandonedTask is what keeps this safe: a real user
+	// cancel has already written 'cancelled' before the ack arrives, so it
+	// converges nothing and falls through to the record-only path below. A
+	// replayed ack finds a terminal row and does likewise.
+	converged, err := h.TaskService.ConvergeAbandonedTask(r.Context(), task.ID,
+		req.ErrorMessage, req.FailureReason, req.BranchName, req.DurableWorkDir)
+	if err != nil {
+		// Fail LOUD, like the pointer writes below: the daemon retries this ack,
+		// and swallowing the error here would put the row back in the exact
+		// permanent-'running' state this call exists to prevent.
+		slog.Error("cancel ack: converge abandoned task failed", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to finalize task")
+		return
+	}
+	if converged != nil {
+		slog.Info("cancel ack: converged abandoned task",
+			"task_id", taskID,
+			"failure_reason", converged.FailureReason.String,
+			"attempt", converged.Attempt,
+			"max_attempts", converged.MaxAttempts,
+		)
+		// The pointer writes below CAS on status='cancelled' and would all miss
+		// on the row we just failed; FinalizeAbandonedTask already persisted the
+		// branch and workdir in the same statement. Settling the deferred chat
+		// stays, so a cancelled chat still finalizes exactly as before.
+		h.TaskService.FinalizeDeferredCancelledChat(r.Context(), task.ID)
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
 	// Terminal deliveries first, failing LOUD on persistence errors: these
 	// fields are the only pointer to a cancelled task's work, and the daemon
 	// retries this ack on transient failures — a warn-and-200 would turn one

--- a/server/internal/handler/daemon_cancel_ack_converge_test.go
+++ b/server/internal/handler/daemon_cancel_ack_converge_test.go
@@ -1,0 +1,304 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+// A daemon only acks after its run has stopped. These tests cover what the
+// server does with that fact when its own row never reached a terminal state —
+// the second half of GH #8272, where such a row stayed 'running' forever
+// because the stale-task sweeper skips rows whose runtime is still
+// heartbeating.
+
+func ackRequest(t *testing.T, taskID string, body map[string]any) *http.Request {
+	t.Helper()
+	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/cancel-ack", body, testWorkspaceID, "test-daemon")
+	return withURLParam(req, "taskId", taskID)
+}
+
+// TestAckTaskCancelled_ConvergesAbandonedRunningTask is the exact shape the
+// reproduction probe pinned: a long-running row, a live heartbeat, an ack that
+// used to return 200 and change nothing.
+func TestAckTaskCancelled_ConvergesAbandonedRunningTask(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "MUL-7259 converge runtime")
+	agentID := dbfx.Agent(t, "MUL-7259 converge agent", runtimeID)
+	issueID := dbfx.Issue(t, "MUL-7259 converge issue")
+	taskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": runtimeID, "issue_id": issueID, "status": "running",
+		"started_at": testutil.Raw("now() - interval '5 hours'"),
+		"attempt":    1, "max_attempts": 2,
+	})
+
+	testutil.Call(t, testHandler.AckTaskCancelled, ackRequest(t, taskID, map[string]any{
+		"branch_name": "fix/mul7259-preserved-work", "durable_work_dir": "/test/preserved",
+	})).Want(http.StatusOK)
+
+	q := testHandler.Queries
+	task, err := q.GetAgentTask(ctx, parseUUID(taskID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Status != "failed" {
+		t.Fatalf("status = %q, want failed — an abandoned row must not stay running", task.Status)
+	}
+	if task.FailureReason.String != string(taskfailure.ReasonRuntimeAbandoned) {
+		t.Fatalf("failure_reason = %q, want %q", task.FailureReason.String, taskfailure.ReasonRuntimeAbandoned)
+	}
+	if !task.CompletedAt.Valid {
+		t.Fatal("completed_at must be set so the row reads as finished")
+	}
+	// The branch is the only pointer to what the run committed. Convergence
+	// writes it in the same statement, because the pointer CASes below it in the
+	// handler key on status='cancelled' and would miss the row we just failed.
+	if task.BranchName.String != "fix/mul7259-preserved-work" {
+		t.Fatalf("branch_name = %q, want the delivered branch", task.BranchName.String)
+	}
+	if task.DurableWorkDir.String != "/test/preserved" {
+		t.Fatalf("durable_work_dir = %q, want the delivered workdir", task.DurableWorkDir.String)
+	}
+}
+
+// TestAckTaskCancelled_ReleasesCapacityAndAgent covers the damage the stuck row
+// actually did: it counted against max_concurrent_tasks forever and pinned the
+// agent at 'working'. Rarity never protected anyone here, because the loss
+// accumulated across incidents.
+func TestAckTaskCancelled_ReleasesCapacityAndAgent(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "MUL-7259 capacity runtime")
+	agentID := dbfx.Agent(t, "MUL-7259 capacity agent", runtimeID)
+	issueID := dbfx.Issue(t, "MUL-7259 capacity issue")
+	taskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": runtimeID, "issue_id": issueID, "status": "running",
+		"started_at": testutil.Raw("now() - interval '5 hours'"),
+		"attempt":    1, "max_attempts": 2,
+	})
+
+	q := testHandler.Queries
+	if n, err := q.CountRunningTasks(ctx, parseUUID(agentID)); err != nil || n != 1 {
+		t.Fatalf("precondition: running capacity = %d, err = %v, want 1", n, err)
+	}
+
+	testutil.Call(t, testHandler.AckTaskCancelled, ackRequest(t, taskID, map[string]any{})).Want(http.StatusOK)
+
+	if n, err := q.CountRunningTasks(ctx, parseUUID(agentID)); err != nil || n != 0 {
+		t.Fatalf("running capacity = %d, err = %v, want 0 — the slot must come back", n, err)
+	}
+	agent, err := q.GetAgent(ctx, parseUUID(agentID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agent.Status != "idle" {
+		t.Fatalf("agent status = %q, want idle", agent.Status)
+	}
+}
+
+// TestAckTaskCancelled_SpendsRemainingRetry: converging to 'failed' rather than
+// 'cancelled' is what makes this a recovery. Retries are gated on 'failed' plus
+// a retryable reason, so a 'cancelled' convergence would tidy the row and still
+// lose the run.
+func TestAckTaskCancelled_SpendsRemainingRetry(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "MUL-7259 retry runtime")
+	agentID := dbfx.Agent(t, "MUL-7259 retry agent", runtimeID)
+	issueID := dbfx.Issue(t, "MUL-7259 retry issue")
+	taskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": runtimeID, "issue_id": issueID, "status": "running",
+		"started_at": testutil.Raw("now() - interval '5 hours'"),
+		"attempt":    1, "max_attempts": 2,
+	})
+
+	testutil.Call(t, testHandler.AckTaskCancelled, ackRequest(t, taskID, map[string]any{})).Want(http.StatusOK)
+
+	tasks, err := testHandler.Queries.ListTasksByIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var retry *db.AgentTaskQueue
+	for i := range tasks {
+		if uuidToString(tasks[i].ID) != taskID {
+			retry = &tasks[i]
+		}
+	}
+	if retry == nil {
+		t.Fatal("no retry was enqueued; the remaining attempt was lost")
+	}
+	if retry.Attempt != 2 {
+		t.Fatalf("retry attempt = %d, want 2", retry.Attempt)
+	}
+}
+
+// TestAckTaskCancelled_ExhaustedBudgetDoesNotRetry: convergence must not invent
+// retries beyond the existing rules.
+func TestAckTaskCancelled_ExhaustedBudgetDoesNotRetry(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "MUL-7259 budget runtime")
+	agentID := dbfx.Agent(t, "MUL-7259 budget agent", runtimeID)
+	issueID := dbfx.Issue(t, "MUL-7259 budget issue")
+	taskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": runtimeID, "issue_id": issueID, "status": "running",
+		"started_at": testutil.Raw("now() - interval '5 hours'"),
+		"attempt":    2, "max_attempts": 2,
+	})
+
+	testutil.Call(t, testHandler.AckTaskCancelled, ackRequest(t, taskID, map[string]any{})).Want(http.StatusOK)
+
+	tasks, err := testHandler.Queries.ListTasksByIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1 — an exhausted budget must not produce a retry", len(tasks))
+	}
+}
+
+// TestAckTaskCancelled_UserCancelStaysCancelled is the safety property the whole
+// design rests on. A user cancel writes 'cancelled' before the daemon acks, so
+// the CAS must refuse and the row must keep reading as a cancellation, not a
+// failure — and must not be retried.
+func TestAckTaskCancelled_UserCancelStaysCancelled(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "MUL-7259 usercancel runtime")
+	agentID := dbfx.Agent(t, "MUL-7259 usercancel agent", runtimeID)
+	issueID := dbfx.Issue(t, "MUL-7259 usercancel issue")
+	taskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": runtimeID, "issue_id": issueID, "status": "cancelled",
+		"started_at": testutil.Raw("now() - interval '1 hour'"),
+		"attempt":    1, "max_attempts": 2,
+	})
+
+	testutil.Call(t, testHandler.AckTaskCancelled, ackRequest(t, taskID, map[string]any{
+		"branch_name": "fix/mul7259-user-cancel", "error_message": "worktree preserved",
+		"failure_reason": "local_directory_error",
+	})).Want(http.StatusOK)
+
+	q := testHandler.Queries
+	task, err := q.GetAgentTask(ctx, parseUUID(taskID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Status != "cancelled" {
+		t.Fatalf("status = %q, want cancelled — a user cancel must never be rewritten as a failure", task.Status)
+	}
+	// The pre-existing record-only path must still deliver its pointers.
+	if task.BranchName.String != "fix/mul7259-user-cancel" {
+		t.Fatalf("branch_name = %q, want the delivered branch", task.BranchName.String)
+	}
+	if task.Error.String != "worktree preserved" {
+		t.Fatalf("error = %q, want the preserved-work pointer", task.Error.String)
+	}
+	tasks, err := q.ListTasksByIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1 — a user cancel must not be retried", len(tasks))
+	}
+}
+
+// TestAckTaskCancelled_CompletedTaskIsUntouched: a completion that raced ahead of
+// the ack owns the row. Convergence must not downgrade a success.
+func TestAckTaskCancelled_CompletedTaskIsUntouched(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "MUL-7259 completed runtime")
+	agentID := dbfx.Agent(t, "MUL-7259 completed agent", runtimeID)
+	issueID := dbfx.Issue(t, "MUL-7259 completed issue")
+	taskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": runtimeID, "issue_id": issueID, "status": "completed",
+		"started_at": testutil.Raw("now() - interval '1 hour'"),
+		"attempt":    1, "max_attempts": 2,
+	})
+
+	testutil.Call(t, testHandler.AckTaskCancelled, ackRequest(t, taskID, map[string]any{})).Want(http.StatusOK)
+
+	task, err := testHandler.Queries.GetAgentTask(ctx, parseUUID(taskID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Status != "completed" {
+		t.Fatalf("status = %q, want completed", task.Status)
+	}
+}
+
+// TestAckTaskCancelled_ReplayIsIdempotent: the daemon retries this ack, and the
+// durable outbox replays it after a restart, so at-least-once delivery must not
+// produce a second failure, a second retry, or a changed row.
+func TestAckTaskCancelled_ReplayIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "MUL-7259 replay runtime")
+	agentID := dbfx.Agent(t, "MUL-7259 replay agent", runtimeID)
+	issueID := dbfx.Issue(t, "MUL-7259 replay issue")
+	taskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": runtimeID, "issue_id": issueID, "status": "running",
+		"started_at": testutil.Raw("now() - interval '5 hours'"),
+		"attempt":    1, "max_attempts": 2,
+	})
+
+	for i := 0; i < 3; i++ {
+		testutil.Call(t, testHandler.AckTaskCancelled, ackRequest(t, taskID, map[string]any{
+			"branch_name": "fix/mul7259-replay",
+		})).Want(http.StatusOK)
+	}
+
+	q := testHandler.Queries
+	task, err := q.GetAgentTask(ctx, parseUUID(taskID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Status != "failed" || task.FailureReason.String != string(taskfailure.ReasonRuntimeAbandoned) {
+		t.Fatalf("status=%q reason=%q, want failed/%s", task.Status, task.FailureReason.String, taskfailure.ReasonRuntimeAbandoned)
+	}
+	tasks, err := q.ListTasksByIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Original + exactly one retry, however many times the ack was replayed.
+	if len(tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2 — replayed acks must not fan out retries", len(tasks))
+	}
+}
+
+// TestAckTaskCancelled_DaemonReportedReasonWins: when the daemon knows why it
+// stopped, that reason must survive. local_directory_error is deliberately not
+// retryable — the same local problem would recur — so this also proves the retry
+// decision follows the reason rather than the convergence path.
+func TestAckTaskCancelled_DaemonReportedReasonWins(t *testing.T) {
+	ctx := context.Background()
+	runtimeID := dbfx.Runtime(t, "MUL-7259 reason runtime")
+	agentID := dbfx.Agent(t, "MUL-7259 reason agent", runtimeID)
+	issueID := dbfx.Issue(t, "MUL-7259 reason issue")
+	taskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": runtimeID, "issue_id": issueID, "status": "running",
+		"started_at": testutil.Raw("now() - interval '5 hours'"),
+		"attempt":    1, "max_attempts": 2,
+	})
+
+	testutil.Call(t, testHandler.AckTaskCancelled, ackRequest(t, taskID, map[string]any{
+		"error_message": "worktree preserved at /tmp/wt", "failure_reason": "local_directory_error",
+	})).Want(http.StatusOK)
+
+	q := testHandler.Queries
+	task, err := q.GetAgentTask(ctx, parseUUID(taskID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.FailureReason.String != "local_directory_error" {
+		t.Fatalf("failure_reason = %q, want the daemon's own reason", task.FailureReason.String)
+	}
+	if task.Error.String != "worktree preserved at /tmp/wt" {
+		t.Fatalf("error = %q, want the preserved-work pointer", task.Error.String)
+	}
+	tasks, err := q.ListTasksByIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1 — a non-retryable reason must not be retried", len(tasks))
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2559,6 +2559,69 @@ func (s *TaskService) OpenMikaOnboardingChat(ctx context.Context, session db.Cha
 // agent stuck at status="working" indefinitely, requiring a manual
 // `multica agent update <id> --status idle` to unwedge. It now reconciles agent
 // status and broadcasts task:cancelled, matching CancelTask and RerunIssue.
+// ConvergeAbandonedTask finalizes a task its owning daemon has reported it is
+// no longer executing, when the server row never reached a terminal state.
+//
+// The daemon's acknowledgement is the evidence: it only sends one after the run
+// has stopped and its transcript is flushed. If the row is still
+// running/dispatched at that point, nothing else will ever reclaim it — the
+// stale-task sweeper deliberately skips rows whose runtime is still
+// heartbeating, and a healthy daemon heartbeats forever. Before this, such a
+// row stayed 'running' permanently: the agent showed 'working', one of its
+// max_concurrent_tasks slots was consumed for good, and the remaining retry
+// budget was unreachable because retries are gated on 'failed' (GH #8272).
+//
+// Returns (nil, nil) when the row was already terminal — a user-initiated
+// cancel, a completion that landed first, or a replayed ack. That case keeps
+// the caller's existing record-only behaviour, which is what guarantees a real
+// user cancel is never rewritten into a failure.
+func (s *TaskService) ConvergeAbandonedTask(ctx context.Context, taskID pgtype.UUID, errMsg, failureReason, branchName, durableWorkDir string) (*db.AgentTaskQueue, error) {
+	if strings.TrimSpace(failureReason) == "" {
+		failureReason = string(taskfailure.ReasonRuntimeAbandoned)
+	}
+	if strings.TrimSpace(errMsg) == "" {
+		errMsg = "runtime stopped executing this task without reporting a terminal state"
+	}
+
+	var converged *db.AgentTaskQueue
+	err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		task, err := qtx.FinalizeAbandonedTask(ctx, db.FinalizeAbandonedTaskParams{
+			ID:             taskID,
+			Error:          pgtype.Text{String: errMsg, Valid: true},
+			FailureReason:  pgtype.Text{String: failureReason, Valid: true},
+			BranchName:     pgtype.Text{String: branchName, Valid: strings.TrimSpace(branchName) != ""},
+			DurableWorkDir: pgtype.Text{String: durableWorkDir, Valid: strings.TrimSpace(durableWorkDir) != ""},
+		})
+		if err != nil {
+			// No rows means the CAS refused: the row is already terminal.
+			// That is the expected, common case, not a failure.
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return err
+		}
+		converged = &task
+		// Same invariant every other terminal write obeys: the settlement must
+		// commit with the status change, or a delivered recovery comment is
+		// stranded in the partial index forever.
+		return SettleDeliveredDelegatedFailureRecoveries(ctx, qtx, task)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if converged == nil {
+		return nil, nil
+	}
+
+	// HandleFailedTasks owns everything a newly-failed task needs: the retry
+	// (gated on retryableReasons + the attempt budget, so this spends the
+	// remaining attempt only when the reason warrants it), delegated-failure
+	// recovery, the stuck-issue reset, the task:failed broadcast, and the agent
+	// status reconcile that finally releases the concurrency slot.
+	s.HandleFailedTasks(ctx, []db.AgentTaskQueue{*converged})
+	return converged, nil
+}
+
 func (s *TaskService) CancelTasksForIssue(ctx context.Context, issueID pgtype.UUID) error {
 	var cancelled []db.AgentTaskQueue
 	// The cancel and its settlement commit together: a settlement that failed
@@ -5049,8 +5112,14 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 // that did download is already cached on disk — a retry resumes from there
 // instead of re-fetching the whole set (MUL-5370).
 var retryableReasons = map[string]bool{
-	string(taskfailure.ReasonRuntimeOffline):         true,
-	string(taskfailure.ReasonRuntimeRecovery):        true,
+	string(taskfailure.ReasonRuntimeOffline):  true,
+	string(taskfailure.ReasonRuntimeRecovery): true,
+	// runtime_abandoned is infrastructure-shaped in exactly the way this set
+	// exists for: the run stopped for a reason unrelated to the agent's work,
+	// so the remaining max_attempts budget should be spent rather than
+	// stranding the task. This is what makes convergence a recovery instead of
+	// merely a tidier tombstone.
+	string(taskfailure.ReasonRuntimeAbandoned):       true,
 	string(taskfailure.ReasonTimeout):                true,
 	"codex_semantic_inactivity":                      true,
 	string(taskfailure.ReasonAgentProviderNetwork):   true,

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -3842,6 +3842,122 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 	return items, nil
 }
 
+const finalizeAbandonedTask = `-- name: FinalizeAbandonedTask :one
+UPDATE agent_task_queue
+SET status = 'failed',
+    completed_at = now(),
+    error = COALESCE(NULLIF(error, ''), $1),
+    failure_reason = COALESCE(failure_reason, $2),
+    branch_name = COALESCE(branch_name, $3),
+    durable_work_dir = COALESCE(durable_work_dir, $4),
+    prepare_lease_expires_at = NULL
+WHERE id = $5
+  AND status IN ('dispatched', 'running', 'waiting_local_directory')
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision, comment_thread_id, cancelled_by_type, cancelled_by_id, cancelled_by_name
+`
+
+type FinalizeAbandonedTaskParams struct {
+	Error          pgtype.Text `json:"error"`
+	FailureReason  pgtype.Text `json:"failure_reason"`
+	BranchName     pgtype.Text `json:"branch_name"`
+	DurableWorkDir pgtype.Text `json:"durable_work_dir"`
+	ID             pgtype.UUID `json:"id"`
+}
+
+// Converges a row whose owning daemon has reported it stopped executing while
+// the row was still non-terminal.
+//
+// The cancel-ack endpoint was built on the assumption that cancellation is
+// always server-initiated, so by ack time the row is already terminal and only
+// the branch / error pointers remain to be recorded. That holds for a user
+// cancel and breaks for every abnormal abort: the daemon stops first, the row
+// stays 'running', and nothing else can reclaim it — FailStaleTasks explicitly
+// excludes rows whose runtime is still heartbeating, which a healthy daemon is.
+// The result was a permanent zombie that pinned the agent at 'working' and
+// consumed one of its max_concurrent_tasks slots forever (GH #8272).
+//
+// The status CAS is the whole safety argument, in both directions:
+//   - A user cancel commits 'cancelled' BEFORE the daemon acks, so this
+//     matches nothing and the ack falls through to today's record-only path.
+//     A real cancel can never be rewritten into a failure.
+//   - A replayed or duplicated ack finds a terminal row and is a no-op, so
+//     at-least-once delivery from the daemon stays safe.
+//
+// error / failure_reason use COALESCE so a reason the daemon actually reported
+// (a preserved-worktree local_directory_error, say) wins over the generic
+// abandonment reason the caller passes as a default.
+func (q *Queries) FinalizeAbandonedTask(ctx context.Context, arg FinalizeAbandonedTaskParams) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, finalizeAbandonedTask,
+		arg.Error,
+		arg.FailureReason,
+		arg.BranchName,
+		arg.DurableWorkDir,
+		arg.ID,
+	)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ChatSessionID,
+		&i.AutopilotRunID,
+		&i.Attempt,
+		&i.MaxAttempts,
+		&i.ParentTaskID,
+		&i.FailureReason,
+		&i.TriggerSummary,
+		&i.ForceFreshSession,
+		&i.IsLeaderTask,
+		&i.WaitReason,
+		&i.InitiatorUserID,
+		&i.HandoffNote,
+		&i.PrepareLeaseExpiresAt,
+		&i.SquadID,
+		&i.RuntimeMcpOverlay,
+		&i.EscalationForTaskID,
+		&i.FireAt,
+		&i.OriginatorUserID,
+		&i.RuntimeConnectedApps,
+		&i.CoalescedCommentIds,
+		&i.DeliveredCommentIds,
+		&i.ChatInputTaskID,
+		&i.ChatFinalizeDeferredAt,
+		&i.OriginatorSource,
+		&i.DelegatedFromTaskID,
+		&i.RetryOfTaskID,
+		&i.RerunOfTaskID,
+		&i.RuleVersionID,
+		&i.TriggerEvidenceKind,
+		&i.TriggerEvidenceRefID,
+		&i.AccountableUserID,
+		&i.SessionRolloutMissing,
+		&i.RetiredSessionID,
+		&i.QuickActionsDisabled,
+		&i.RegenerateQuickActionsFor,
+		&i.BranchName,
+		&i.DurableWorkDir,
+		&i.ChannelContextRevision,
+		&i.CommentThreadID,
+		&i.CancelledByType,
+		&i.CancelledByID,
+		&i.CancelledByName,
+	)
+	return i, err
+}
+
 const getAgent = `-- name: GetAgent :one
 SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
 WHERE id = $1

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -1619,6 +1619,41 @@ SET error = sqlc.arg('error'),
     failure_reason = COALESCE(failure_reason, sqlc.arg('failure_reason'))
 WHERE id = sqlc.arg('id') AND (error IS NULL OR error = '') AND status = 'cancelled';
 
+-- name: FinalizeAbandonedTask :one
+-- Converges a row whose owning daemon has reported it stopped executing while
+-- the row was still non-terminal.
+--
+-- The cancel-ack endpoint was built on the assumption that cancellation is
+-- always server-initiated, so by ack time the row is already terminal and only
+-- the branch / error pointers remain to be recorded. That holds for a user
+-- cancel and breaks for every abnormal abort: the daemon stops first, the row
+-- stays 'running', and nothing else can reclaim it — FailStaleTasks explicitly
+-- excludes rows whose runtime is still heartbeating, which a healthy daemon is.
+-- The result was a permanent zombie that pinned the agent at 'working' and
+-- consumed one of its max_concurrent_tasks slots forever (GH #8272).
+--
+-- The status CAS is the whole safety argument, in both directions:
+--   * A user cancel commits 'cancelled' BEFORE the daemon acks, so this
+--     matches nothing and the ack falls through to today's record-only path.
+--     A real cancel can never be rewritten into a failure.
+--   * A replayed or duplicated ack finds a terminal row and is a no-op, so
+--     at-least-once delivery from the daemon stays safe.
+--
+-- error / failure_reason use COALESCE so a reason the daemon actually reported
+-- (a preserved-worktree local_directory_error, say) wins over the generic
+-- abandonment reason the caller passes as a default.
+UPDATE agent_task_queue
+SET status = 'failed',
+    completed_at = now(),
+    error = COALESCE(NULLIF(error, ''), sqlc.arg('error')),
+    failure_reason = COALESCE(failure_reason, sqlc.arg('failure_reason')),
+    branch_name = COALESCE(branch_name, sqlc.narg('branch_name')),
+    durable_work_dir = COALESCE(durable_work_dir, sqlc.narg('durable_work_dir')),
+    prepare_lease_expires_at = NULL
+WHERE id = sqlc.arg('id')
+  AND status IN ('dispatched', 'running', 'waiting_local_directory')
+RETURNING *;
+
 -- name: CancelAgentTaskWithReason :one
 -- Cancels a task AND records why, for cancellations the user did not ask for.
 --

--- a/server/pkg/taskfailure/failure.go
+++ b/server/pkg/taskfailure/failure.go
@@ -84,6 +84,16 @@ const (
 	// RecoverOrphanedTasksForRuntime at daemon startup.
 	ReasonRuntimeRecovery Reason = "runtime_recovery"
 
+	// ReasonRuntimeAbandoned: a still-live daemon reported it stopped
+	// executing a task whose row was not terminal yet — it acknowledged a
+	// cancellation it had already acted on. Distinct from
+	// ReasonRuntimeRecovery, which is specifically a daemon RESTART: here the
+	// runtime never went away, so no sweeper will ever reclaim the row
+	// (FailStaleTasks excludes rows whose runtime is still heartbeating) and
+	// the daemon's own ack is the only evidence the work stopped. Written by
+	// AckTaskCancelled when it converges an abandoned row (GH #8272).
+	ReasonRuntimeAbandoned Reason = "runtime_abandoned"
+
 	// ReasonTimeout: server-side or runtime-side hard timeout.
 	// Written by FailStaleTasks (server) and the daemon's per-task
 	// agent timeout path.
@@ -266,6 +276,7 @@ var allReasons = []Reason{
 	ReasonRuntimeOffline,
 	ReasonRuntimeReconnectTimeout,
 	ReasonRuntimeRecovery,
+	ReasonRuntimeAbandoned,
 	ReasonTimeout,
 	ReasonIterationLimit,
 	ReasonAgentBlocked,


### PR DESCRIPTION
> Part 2 of MUL-7259. Part 1 (#8279, error classification) is merged; this branch was rebased onto `main` after it, so the diff is Part 2 only.

## Summary

A terminal callback is the only thing that moves a task out of `running`. When one is lost or never sent, the row stays `running` **forever** — `FailStaleTasks` deliberately skips rows whose runtime is still heartbeating, and a healthy daemon heartbeats indefinitely. The perverse property is that the healthier the daemon, the less recoverable the row.

The damage is not just an untidy row:

- the agent stays `working` (`RefreshAgentStatusFromTasks` derives status from `dispatched`/`running`),
- **one of the agent's `max_concurrent_tasks` slots is consumed permanently** (`CountRunningTasks` gates claiming on the same statuses) — this accumulates across incidents, so with the default of 6 an agent stops claiming entirely after six,
- the retry budget is unreachable, because `MaybeRetryFailedTask` opens with `if parent.Status != "failed"`.

Manual `cancel-task` was the only recovery. There are two entrances to that state; this fixes both, because closing only one leaves the other wide open.

## Server — cancel-ack converges an abandoned row

`AckTaskCancelled` assumed cancellation is always server-initiated, so by ack time the row is terminal and only the branch/error pointers remain to record. All three of its writes CAS on `status='cancelled'`. Against a `running` row they were silent no-ops and the endpoint returned `200` having changed nothing — the reproduction probe shows two consecutive 200s leaving a five-hour-old task untouched.

A daemon only acks after its run has stopped and its transcript is flushed, so a non-terminal row at that moment is stale by definition. `FinalizeAbandonedTask` converges it to `failed` with a new `runtime_abandoned` reason, carrying branch and durable workdir in the same statement (the pointer CASes below it would miss the row we just failed).

**The status CAS is the whole safety argument, in both directions:**

- a user cancel commits `cancelled` *before* the daemon acks, so this converges nothing and falls through to the existing record-only path — a real cancel can never be rewritten as a failure;
- a replayed or duplicated ack finds a terminal row and is a no-op, so at-least-once delivery stays safe.

`runtime_abandoned` is in `retryableReasons`, and that is what makes this a recovery rather than a tidier tombstone: converging to `cancelled` would free the slot and still lose the run. `HandleFailedTasks` then applies the existing rules unchanged — exhausted budget or a non-retryable reason still does not retry.

New reason rather than reusing `runtime_recovery`, which is documented as specifically a daemon *restart*. Here the runtime never went away, which is exactly why no sweeper reclaims the row.

## Daemon — durable outbox for terminal reports

The cancel-ack fix alone would not touch #8221, where **no 404 is involved at all**: a partition exhausted the `/complete` retries and the daemon deliberately left the task running rather than reporting a successful run as a failure. That call is right on its own; nothing reconciled it afterwards. The existing code comment said as much — *"leave the task in running instead so a future fix (server-side stuck-task reaper, or a daemon-side persistent pending queue) can recover it"*.

`reportTerminalTask` now persists a transiently-failed report to disk and the poll loop replays it once the server is reachable, including across a restart. `terminalTaskReport` already existed as the single choke point for exactly this ("gives the durable outbox one insertion point without revisiting every task exit when it is added").

- Atomic writes: temp file, fsync, rename — a half-written report on restart would be the same lost callback this prevents.
- Replay is safe because `CompleteTask` already treats an already-finalized callback as idempotent success.
- Permanent 4xx are dropped rather than retried forever; the caller's existing complete→fail downgrade gets its own durability.
- Reports are abandoned after 7 days so the queue cannot grow without bound.
- One file per task, so the complete→fail downgrade replaces rather than queues behind.

## Testing

Postgres 17 via `docker compose`, migrations applied to a scratch database. Both probes attached to MUL-7259 confirmed reproducing on `b36906e6d` first; both now fail against these branches.

Server (`internal/handler`):

- converges an abandoned `running` row to `failed`, with `completed_at`, branch and workdir preserved
- **releases the concurrency slot** (`CountRunningTasks` 1 → 0) and returns the agent to `idle`
- spends the remaining retry (attempt 1/2 → a child at attempt 2)
- exhausted budget does not retry; a daemon-reported non-retryable reason (`local_directory_error`) does not retry and wins over the default
- **a user cancel stays `cancelled`**, still receives its branch/error pointers, and is not retried
- a `completed` row is untouched — convergence never downgrades a success
- three replayed acks produce exactly one failure and one retry

Daemon (`internal/daemon`):

- persist/list/remove round-trip preserving every field; later report replaces earlier
- corrupt entries are discarded, not retried forever; unsafe task IDs (`../escape`) are refused as filenames
- transient failure is queued; permanent rejection is not; success clears a stale queued copy
- **end-to-end recovery**: queued while the server returns 503, kept (not dropped) on a drain during the outage, delivered intact to the right endpoint after recovery, and a second drain does not re-send
- expired reports are abandoned without being sent

```
go build ./...                                     ok
go vet ./...                                       ok
go test ./internal/handler/ -count=1               ok (full suite)
go test ./internal/service/ -count=1               ok
go test ./pkg/taskfailure/ -count=1                ok
go test -race ./internal/daemon/ -count=1          7 failures, identical set on b36906e6d
```

The 7 daemon failures are pre-existing sandbox issues (HOME/profile-dir resolution), verified by running the same suite on the base commit. An earlier run of this suite surfaced a genuine 8th failure — `TestReportTaskResult_TransientCompleteExhaustedDoesNotFallback` builds a `Daemon` literal with no outbox and my persist path lacked the nil guard I had added elsewhere. Fixed; the count is back to the baseline set.

CI will run these against its own PostgreSQL service.

## Risks

- Tasks that would previously hang in `running` now become `failed` and may auto-retry. That is the intent, and the retry stays behind the existing budget and reason gates.
- Convergence is reachable only through a daemon's own cancel-ack on a non-terminal row; a user cancel and a completion are both protected by the CAS and covered by tests.
- The outbox writes under `WorkspacesRoot/.terminal-outbox`, alongside the existing `.repos` and `.skill-cache`. No migration; the new column values are existing columns.

