### PR TITLE
MUL-7265: feat(lark): add agent-scoped Feishu document tools

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -601,6 +601,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				// backfills) take it directly; the constructor-based services
 				// wrap *db.Queries internally, so they keep taking queries.
 				cs := lark.NewChannelStore(queries)
+				h.LarkDocuments = lark.NewDocumentService(cs, installSvc, larkClient, slog.Default())
 				patcher := lark.NewPatcher(cs, installSvc, larkClient, lark.PatcherConfig{})
 				patcher.Register(bus)
 
@@ -1449,6 +1450,10 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		// The broker asks for an mcp hook's credential at connection time, so
 		// a secret never sits in a task record.
 		r.Get("/tasks/{id}/plugin-mcp/{contributionId}/credential", h.ResolvePluginMCPCredential)
+		// Built-in Feishu document MCP: both the credential exchange and every
+		// call revalidate the exact live task, daemon, Agent and installation.
+		r.Get("/tasks/{id}/remote-mcp/{contributionId}/credential", h.ResolveRemoteMCPCredential)
+		r.Post("/tasks/{id}/feishu-documents/{contributionId}/mcp", h.ServeFeishuDocumentsMCP)
 
 		r.Post("/runtimes/{runtimeId}/tasks/claim", h.ClaimTaskByRuntime)
 		// Canonical machine-level batch claim (MUL-4257). `/claim` is a

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -601,6 +601,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				// backfills) take it directly; the constructor-based services
 				// wrap *db.Queries internally, so they keep taking queries.
 				cs := lark.NewChannelStore(queries)
+				h.LarkDocumentInstallations = cs
 				h.LarkDocuments = lark.NewDocumentService(cs, installSvc, larkClient, slog.Default())
 				patcher := lark.NewPatcher(cs, installSvc, larkClient, lark.PatcherConfig{})
 				patcher.Register(bus)

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -204,6 +204,7 @@ func BuildConnectedAppsBlock(apps []runtimeapps.ConnectedApp) string {
 	}
 	var b strings.Builder
 	var lines strings.Builder
+	hasFeishuDocuments := false
 	for _, app := range apps {
 		serverName := sanitizeBriefCodeToken(app.ServerName)
 		toolkitSlug := sanitizeBriefCodeToken(app.ToolkitSlug)
@@ -217,6 +218,9 @@ func BuildConnectedAppsBlock(apps []runtimeapps.ConnectedApp) string {
 		if name == "" {
 			name = toolkitSlug
 		}
+		if serverName == "feishu-documents" && toolkitSlug == "feishu-documents" {
+			hasFeishuDocuments = true
+		}
 		fmt.Fprintf(&lines, "- %s (`%s`) via MCP server `%s`\n", name, toolkitSlug, serverName)
 	}
 	if lines.Len() == 0 {
@@ -225,6 +229,9 @@ func BuildConnectedAppsBlock(apps []runtimeapps.ConnectedApp) string {
 	b.WriteString("## Connected Apps\n\n")
 	b.WriteString(lines.String())
 	b.WriteString("\nUse the listed MCP server when the task asks to read or act in one of these apps.\n\n")
+	if hasFeishuDocuments {
+		b.WriteString("For Feishu Documents, use the current Agent's connected Feishu bot identity and only an explicit Feishu document URL. If a tool returns `permission_denied`, ask the user to grant that bot access to the document. Preview destructive or large edits and get explicit confirmation before applying them.\n\n")
+	}
 	return b.String()
 }
 

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -855,6 +855,22 @@ func TestConnectedAppsBlockLivesOutsideBrief(t *testing.T) {
 	}
 }
 
+func TestConnectedAppsBlockAddsFeishuDocumentSafetyGuidanceOnlyWhenMounted(t *testing.T) {
+	app := runtimeapps.ConnectedApp{
+		Provider: "feishu", ServerName: "feishu-documents", ToolkitSlug: "feishu-documents",
+	}
+	block := BuildConnectedAppsBlock([]runtimeapps.ConnectedApp{app})
+	for _, want := range []string{"current Agent's connected Feishu bot identity", "explicit Feishu document URL", "permission_denied", "Preview destructive or large edits"} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("Feishu guidance missing %q\n---\n%s", want, block)
+		}
+	}
+	ordinary := BuildConnectedAppsBlock([]runtimeapps.ConnectedApp{{Provider: "composio", ServerName: "composio", ToolkitSlug: "notion"}})
+	if strings.Contains(ordinary, "permission_denied") {
+		t.Fatalf("Feishu-only guidance leaked into ordinary app block\n---\n%s", ordinary)
+	}
+}
+
 func TestConnectedAppsHeadingSkippedWhenEmpty(t *testing.T) {
 	t.Parallel()
 	out := buildMetaSkillContent("claude", TaskContextForEnv{IssueID: "11111111-2222-3333-4444-555555555555"})

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -1772,6 +1772,34 @@ func TestPerTurnContextBlocksCarryMovedBriefSections(t *testing.T) {
 	}
 }
 
+func TestFeishuDocumentsConnectedAppGuidanceIsScopedAndSecretFree(t *testing.T) {
+	prompt := BuildPrompt(Task{
+		IssueID: "issue-feishu-documents",
+		ConnectedApps: []ConnectedAppData{{
+			Provider:    "feishu",
+			ServerName:  "feishu-documents",
+			ToolkitSlug: "feishu-documents",
+			ToolkitName: "Feishu Documents",
+		}},
+	}, "codex")
+	for _, want := range []string{
+		"Feishu Documents",
+		"current Agent's connected Feishu bot identity",
+		"explicit Feishu document URL",
+		"permission_denied",
+		"Preview destructive or large edits",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("Feishu document prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+	for _, banned := range []string{"app_secret", "tenant_access_token", "mdt_", "cli_pikachu_secret"} {
+		if strings.Contains(prompt, banned) {
+			t.Fatalf("Feishu document prompt leaked %q\n---\n%s", banned, prompt)
+		}
+	}
+}
+
 // The blocks are per-run, so they must be absent when their preconditions are.
 func TestPerTurnContextBlocksOmittedWhenEmpty(t *testing.T) {
 	t.Parallel()

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -22,6 +22,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
+	"github.com/multica-ai/multica/server/internal/integrations/lark"
 	"github.com/multica-ai/multica/server/internal/integrations/slack"
 	"github.com/multica-ai/multica/server/internal/issuestatus"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
@@ -2140,6 +2141,68 @@ func claimResponseAgentIdentityMatches(resp AgentTaskResponse) bool {
 	return resp.AgentID != "" && resp.Agent != nil && resp.Agent.ID == resp.AgentID
 }
 
+func claimFeishuInstallationMatchesAgent(installation lark.Installation, agent db.Agent) bool {
+	if !installation.ID.Valid || !installation.UpdatedAt.Valid || installation.UpdatedAt.Time.UnixNano() <= 0 ||
+		installation.Status != "active" || installation.WorkspaceID != agent.WorkspaceID || installation.AgentID != agent.ID {
+		return false
+	}
+	switch lark.Region(installation.Region) {
+	case "", lark.RegionFeishu, lark.RegionLark:
+		return true
+	default:
+		return false
+	}
+}
+
+func hasConnectedApp(apps []ConnectedAppData, serverName string) bool {
+	for _, app := range apps {
+		if app.ServerName == serverName {
+			return true
+		}
+	}
+	return false
+}
+
+// mountAgentScopedFeishuDocuments appends a built-in Remote MCP connection
+// only for a daemon that advertises the broker protocol and only from the
+// active installation owned by the freshly loaded Agent. Lookup and connection
+// construction failures deliberately degrade to no document tools: an optional
+// integration must not cancel otherwise runnable work.
+func (h *Handler) mountAgentScopedFeishuDocuments(r *http.Request, task db.AgentTaskQueue, agent db.Agent, response *AgentTaskResponse) {
+	if response == nil || !requestHasClientCapability(r, protocol.DaemonCapabilityRemoteMCPV1) ||
+		h.LarkDocumentInstallations == nil || h.LarkDocuments == nil ||
+		!task.ID.Valid || task.AgentID != agent.ID || task.RuntimeID != agent.RuntimeID ||
+		!agent.ID.Valid || !agent.WorkspaceID.Valid || agent.ArchivedAt.Valid {
+		return
+	}
+	installation, err := h.LarkDocumentInstallations.GetActiveLarkInstallationForAgent(r.Context(), agent.WorkspaceID, agent.ID)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			slog.Warn("daemon claim: Feishu document installation lookup failed; omitting tools",
+				"task_id", uuidToString(task.ID), "agent_id", uuidToString(agent.ID), "error", err)
+		}
+		return
+	}
+	if !claimFeishuInstallationMatchesAgent(installation, agent) {
+		return
+	}
+	connection, err := FeishuDocumentsConnection(h.cfg.PublicURL, uuidToString(task.ID), installation)
+	if err != nil {
+		slog.Warn("daemon claim: Feishu document connection unavailable; omitting tools",
+			"task_id", uuidToString(task.ID), "agent_id", uuidToString(agent.ID))
+		return
+	}
+	response.RemoteMCPConnections = append(response.RemoteMCPConnections, connection)
+	if !hasConnectedApp(response.ConnectedApps, "feishu-documents") {
+		response.ConnectedApps = append(response.ConnectedApps, ConnectedAppData{
+			Provider:    "feishu",
+			ServerName:  "feishu-documents",
+			ToolkitSlug: "feishu-documents",
+			ToolkitName: "Feishu Documents",
+		})
+	}
+}
+
 // buildClaimedTaskResponse assembles the full daemon claim payload for a
 // single already-claimed task and computes the exact comment ids embedded in
 // it (deliveredCommentIDs). Shared by the per-runtime handler
@@ -2251,6 +2314,9 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			taskfailure.ReasonInvalidTaskIdentity,
 			"error_runtime_access_denied", http.StatusForbidden, "private runtime does not permit task agent",
 		)
+	}
+	if uuidToString(agent.WorkspaceID) == runtimeWorkspaceID {
+		h.mountAgentScopedFeishuDocuments(r, *task, agent, &resp)
 	}
 	useSkillRefs := requestHasClientCapability(r, protocol.DaemonCapabilitySkillBundlesV1)
 	// A daemon older than the multica-platform merge assembles a brief that

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -4599,3 +4599,40 @@ func TestClaimOmitsFeishuDocumentsWhenUnsupportedUnboundRevokedOrUnavailable(t *
 		})
 	}
 }
+
+func TestReconnectingFeishuBotChangesOnlyTheNextClaim(t *testing.T) {
+	workspaceID := util.MustParseUUID("10000000-0000-4000-8000-000000000041")
+	agentID := util.MustParseUUID("30000000-0000-4000-8000-000000000041")
+	runtimeID := util.MustParseUUID("40000000-0000-4000-8000-000000000041")
+	task := db.AgentTaskQueue{
+		ID:      util.MustParseUUID("20000000-0000-4000-8000-000000000041"),
+		AgentID: agentID, RuntimeID: runtimeID,
+	}
+	agent := db.Agent{ID: agentID, WorkspaceID: workspaceID, RuntimeID: runtimeID}
+	oldInstallation := claimFeishuInstallation(
+		util.MustParseUUID("50000000-0000-4000-8000-000000000041"), workspaceID, agentID, 1_700_000_000_000_000_041)
+	store := &fakeClaimFeishuDocumentsStore{installations: map[string]lark.Installation{
+		util.UUIDToString(agentID): oldInstallation,
+	}}
+	h := newFeishuDocumentsClaimHandler(store)
+	oldClaim := AgentTaskResponse{}
+	h.mountAgentScopedFeishuDocuments(remoteMCPClaimRequest(), task, agent, &oldClaim)
+	if len(oldClaim.RemoteMCPConnections) != 1 {
+		t.Fatalf("old claim connections=%+v", oldClaim.RemoteMCPConnections)
+	}
+
+	newInstallation := claimFeishuInstallation(
+		util.MustParseUUID("50000000-0000-4000-8000-000000000042"), workspaceID, agentID, 1_700_000_000_000_000_042)
+	store.installations[util.UUIDToString(agentID)] = newInstallation
+	newClaim := AgentTaskResponse{}
+	h.mountAgentScopedFeishuDocuments(remoteMCPClaimRequest(), task, agent, &newClaim)
+	if len(newClaim.RemoteMCPConnections) != 1 || newClaim.RemoteMCPConnections[0].InstallationID != util.UUIDToString(newInstallation.ID) {
+		t.Fatalf("new claim did not use reconnected installation: %+v", newClaim.RemoteMCPConnections)
+	}
+	if oldClaim.RemoteMCPConnections[0].InstallationID != util.UUIDToString(oldInstallation.ID) {
+		t.Fatalf("existing claim was mutated after reconnect: %+v", oldClaim.RemoteMCPConnections)
+	}
+	if oldClaim.RemoteMCPConnections[0].ContributionID == newClaim.RemoteMCPConnections[0].ContributionID {
+		t.Fatal("reconnect did not produce a new pinned contribution")
+	}
+}

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -15,12 +15,15 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
+	"github.com/multica-ai/multica/server/internal/integrations/lark"
 	"github.com/multica-ai/multica/server/internal/issuestatus"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/internal/testutil"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 	"github.com/multica-ai/multica/server/pkg/remotemcp"
@@ -4463,5 +4466,136 @@ func TestBatchIssueGCCheckReadsNoCatalogForBuiltInStatuses(t *testing.T) {
 	if counter.entryReads != 0 || counter.keyReads != 0 {
 		t.Fatalf("built-in batch read the catalog (%d entry, %d key), want 0 — a built-in key IS its own category",
 			counter.entryReads, counter.keyReads)
+	}
+}
+
+type fakeClaimFeishuDocumentsStore struct {
+	installations map[string]lark.Installation
+	err           error
+	calls         int
+}
+
+func (s *fakeClaimFeishuDocumentsStore) GetActiveLarkInstallationForAgent(_ context.Context, _, agentID pgtype.UUID) (lark.Installation, error) {
+	s.calls++
+	if s.err != nil {
+		return lark.Installation{}, s.err
+	}
+	installation, ok := s.installations[util.UUIDToString(agentID)]
+	if !ok {
+		return lark.Installation{}, pgx.ErrNoRows
+	}
+	return installation, nil
+}
+
+func claimFeishuInstallation(id, workspaceID, agentID pgtype.UUID, revision int64) lark.Installation {
+	return lark.Installation{
+		ID: id, WorkspaceID: workspaceID, AgentID: agentID, Status: "active",
+		UpdatedAt: pgtype.Timestamptz{Time: time.Unix(0, revision), Valid: true},
+	}
+}
+
+func newFeishuDocumentsClaimHandler(store *fakeClaimFeishuDocumentsStore) *Handler {
+	h := &Handler{
+		LarkDocumentInstallations: store,
+		LarkDocuments:             &fakeFeishuDocumentExecutor{},
+	}
+	h.cfg.PublicURL = "https://agents.example.com"
+	return h
+}
+
+func remoteMCPClaimRequest() *http.Request {
+	request := httptest.NewRequest(http.MethodPost, "/claim", nil)
+	request.Header.Set("X-Client-Capabilities", protocol.DaemonCapabilityRemoteMCPV1)
+	return request
+}
+
+func TestClaimAddsAgentScopedFeishuDocumentsForEveryTaskSource(t *testing.T) {
+	workspaceID := util.MustParseUUID("10000000-0000-4000-8000-000000000011")
+	agentID := util.MustParseUUID("30000000-0000-4000-8000-000000000011")
+	runtimeID := util.MustParseUUID("40000000-0000-4000-8000-000000000011")
+	installation := claimFeishuInstallation(util.MustParseUUID("50000000-0000-4000-8000-000000000011"), workspaceID, agentID, 1_700_000_000_000_000_011)
+	store := &fakeClaimFeishuDocumentsStore{installations: map[string]lark.Installation{util.UUIDToString(agentID): installation}}
+	h := newFeishuDocumentsClaimHandler(store)
+	agent := db.Agent{ID: agentID, WorkspaceID: workspaceID, RuntimeID: runtimeID}
+
+	for _, source := range []string{"feishu-chat", "web-chat", "issue"} {
+		t.Run(source, func(t *testing.T) {
+			task := db.AgentTaskQueue{ID: util.MustParseUUID("20000000-0000-4000-8000-000000000011"), AgentID: agentID, RuntimeID: runtimeID}
+			response := AgentTaskResponse{}
+			h.mountAgentScopedFeishuDocuments(remoteMCPClaimRequest(), task, agent, &response)
+			if len(response.RemoteMCPConnections) != 1 || response.RemoteMCPConnections[0].InstallationID != util.UUIDToString(installation.ID) {
+				t.Fatalf("source %s connections=%+v", source, response.RemoteMCPConnections)
+			}
+			if len(response.ConnectedApps) != 1 || response.ConnectedApps[0].ToolkitSlug != "feishu-documents" {
+				t.Fatalf("source %s connected_apps=%+v", source, response.ConnectedApps)
+			}
+		})
+	}
+}
+
+func TestSharedRuntimeClaimsUseEachAgentsOwnInstallation(t *testing.T) {
+	workspaceID := util.MustParseUUID("10000000-0000-4000-8000-000000000021")
+	runtimeID := util.MustParseUUID("40000000-0000-4000-8000-000000000021")
+	pikachuID := util.MustParseUUID("30000000-0000-4000-8000-000000000021")
+	maimaiID := util.MustParseUUID("30000000-0000-4000-8000-000000000022")
+	pikachuInstallation := claimFeishuInstallation(util.MustParseUUID("50000000-0000-4000-8000-000000000021"), workspaceID, pikachuID, 1_700_000_000_000_000_021)
+	maimaiInstallation := claimFeishuInstallation(util.MustParseUUID("50000000-0000-4000-8000-000000000022"), workspaceID, maimaiID, 1_700_000_000_000_000_022)
+	store := &fakeClaimFeishuDocumentsStore{installations: map[string]lark.Installation{
+		util.UUIDToString(pikachuID): pikachuInstallation,
+		util.UUIDToString(maimaiID):  maimaiInstallation,
+	}}
+	h := newFeishuDocumentsClaimHandler(store)
+	connectionFor := func(agentID pgtype.UUID) remotemcp.Connection {
+		response := AgentTaskResponse{}
+		h.mountAgentScopedFeishuDocuments(remoteMCPClaimRequest(),
+			db.AgentTaskQueue{ID: util.MustParseUUID("20000000-0000-4000-8000-000000000021"), AgentID: agentID, RuntimeID: runtimeID},
+			db.Agent{ID: agentID, WorkspaceID: workspaceID, RuntimeID: runtimeID}, &response)
+		if len(response.RemoteMCPConnections) != 1 {
+			t.Fatalf("agent %s connections=%+v", util.UUIDToString(agentID), response.RemoteMCPConnections)
+		}
+		return response.RemoteMCPConnections[0]
+	}
+	if connectionFor(pikachuID).InstallationID == connectionFor(maimaiID).InstallationID {
+		t.Fatal("shared runtime reused one Agent's Feishu installation")
+	}
+}
+
+func TestClaimOmitsFeishuDocumentsWhenUnsupportedUnboundRevokedOrUnavailable(t *testing.T) {
+	workspaceID := util.MustParseUUID("10000000-0000-4000-8000-000000000031")
+	agentID := util.MustParseUUID("30000000-0000-4000-8000-000000000031")
+	runtimeID := util.MustParseUUID("40000000-0000-4000-8000-000000000031")
+	active := claimFeishuInstallation(util.MustParseUUID("50000000-0000-4000-8000-000000000031"), workspaceID, agentID, 1_700_000_000_000_000_031)
+	revoked := active
+	revoked.Status = "revoked"
+	tests := []struct {
+		name         string
+		request      *http.Request
+		installation *lark.Installation
+		err          error
+	}{
+		{name: "unsupported daemon", request: httptest.NewRequest(http.MethodPost, "/claim", nil), installation: &active},
+		{name: "unbound", request: remoteMCPClaimRequest()},
+		{name: "revoked", request: remoteMCPClaimRequest(), installation: &revoked},
+		{name: "store unavailable", request: remoteMCPClaimRequest(), err: errors.New("database unavailable")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			installations := map[string]lark.Installation{}
+			if tc.installation != nil {
+				installations[util.UUIDToString(agentID)] = *tc.installation
+			}
+			store := &fakeClaimFeishuDocumentsStore{installations: installations, err: tc.err}
+			h := newFeishuDocumentsClaimHandler(store)
+			response := AgentTaskResponse{}
+			h.mountAgentScopedFeishuDocuments(tc.request,
+				db.AgentTaskQueue{ID: util.MustParseUUID("20000000-0000-4000-8000-000000000031"), AgentID: agentID, RuntimeID: runtimeID},
+				db.Agent{ID: agentID, WorkspaceID: workspaceID, RuntimeID: runtimeID}, &response)
+			if len(response.RemoteMCPConnections) != 0 || len(response.ConnectedApps) != 0 {
+				t.Fatalf("mounted revoked or unavailable documents: response=%+v", response)
+			}
+			if tc.name == "unsupported daemon" && store.calls != 0 {
+				t.Fatalf("unsupported daemon caused %d installation lookups", store.calls)
+			}
+		})
 	}
 }

--- a/server/internal/handler/feishu_documents_mcp.go
+++ b/server/internal/handler/feishu_documents_mcp.go
@@ -1,0 +1,575 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/integrations/lark"
+	"github.com/multica-ai/multica/server/internal/middleware"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/remotemcp"
+)
+
+const feishuDocumentsContributionPrefix = "builtin:feishu-documents:"
+
+const feishuDocumentsCallTimeout = 30 * time.Second
+
+var (
+	errFeishuDocumentsCapabilityDenied = errors.New("feishu documents capability denied")
+	errFeishuDocumentsUnavailable      = errors.New("feishu documents capability unavailable")
+)
+
+// FeishuDocumentsConnection builds the fixed, task-scoped built-in MCP connection.
+func FeishuDocumentsConnection(publicURL, taskID string, installation lark.Installation) (remotemcp.Connection, error) {
+	base, err := url.Parse(strings.TrimRight(publicURL, "/"))
+	if err != nil || base.Scheme != "https" || base.Hostname() == "" || base.User != nil || base.RawQuery != "" || base.Fragment != "" {
+		return remotemcp.Connection{}, errors.New("feishu documents: public URL must be an absolute HTTPS origin")
+	}
+	if taskID == "" || !installation.ID.Valid || !installation.UpdatedAt.Valid {
+		return remotemcp.Connection{}, errors.New("feishu documents: task and installation revision are required")
+	}
+	revision := installation.UpdatedAt.Time.UnixNano()
+	if revision <= 0 {
+		return remotemcp.Connection{}, errors.New("feishu documents: invalid installation revision")
+	}
+	installationID := util.UUIDToString(installation.ID)
+	contributionID := feishuDocumentsContributionPrefix + installationID + ":" + strconv.FormatInt(revision, 10)
+	tools, err := feishuDocumentTools()
+	if err != nil {
+		return remotemcp.Connection{}, err
+	}
+	toolSetDigest, err := remotemcp.ToolSetDigest(tools)
+	if err != nil {
+		return remotemcp.Connection{}, err
+	}
+	endpoint := strings.TrimRight(publicURL, "/") + "/api/daemon/tasks/" + url.PathEscape(taskID) +
+		"/feishu-documents/" + url.PathEscape(contributionID) + "/mcp"
+	return remotemcp.Connection{
+		InstallationID:       installationID,
+		ContributionID:       contributionID,
+		ContributionKey:      "feishu-documents",
+		ConfigID:             installationID,
+		ConfigRevision:       revision,
+		Endpoint:             endpoint,
+		Transport:            "streamable-http",
+		ProtocolVersions:     remotemcp.SupportedProtocolVersions(),
+		EndpointAllowedHosts: []string{strings.ToLower(base.Hostname())},
+		CredentialHeader:     "Authorization",
+		ApprovedTools:        tools,
+		ToolSchemaDigest:     toolSetDigest,
+		FailurePolicy:        "optional",
+	}, nil
+}
+
+func parseFeishuDocumentsContribution(raw string) (pgtype.UUID, int64, bool) {
+	trimmed, ok := strings.CutPrefix(raw, feishuDocumentsContributionPrefix)
+	if !ok {
+		return pgtype.UUID{}, 0, false
+	}
+	installationID, revisionRaw, ok := strings.Cut(trimmed, ":")
+	if !ok || installationID == "" || revisionRaw == "" || strings.Contains(revisionRaw, ":") {
+		return pgtype.UUID{}, 0, false
+	}
+	var parsedID pgtype.UUID
+	if err := parsedID.Scan(installationID); err != nil || !parsedID.Valid {
+		return pgtype.UUID{}, 0, false
+	}
+	revision, err := strconv.ParseInt(revisionRaw, 10, 64)
+	if err != nil || revision <= 0 {
+		return pgtype.UUID{}, 0, false
+	}
+	return parsedID, revision, true
+}
+
+func feishuDocumentTools() ([]remotemcp.Tool, error) {
+	definitions := []struct {
+		name        string
+		description string
+		properties  map[string]any
+		required    []string
+		risk        string
+	}{
+		{
+			name:        "feishu_docs_fetch",
+			description: "Read a bounded Feishu document scope as the Agent's connected bot. The bot must already have document access; use fresh block IDs before structural edits.",
+			properties: map[string]any{
+				"document_url":   documentURLSchema(),
+				"scope":          map[string]any{"type": "string", "enum": []string{"full", "outline", "section", "keyword", "range"}},
+				"keyword":        map[string]any{"type": "string", "maxLength": lark.DocumentMaxPatternBytes},
+				"start_block_id": blockIDSchema(),
+				"end_block_id":   blockIDSchema(),
+			},
+			required: []string{"document_url"}, risk: "read",
+		},
+		{
+			name:        "feishu_docs_append",
+			description: "Append bounded text with the connected Feishu bot after a fresh read, then verify. Large edits require preview and confirmation; uncertain writes must not be retried blindly.",
+			properties:  map[string]any{"document_url": documentURLSchema(), "content": contentSchema(), "confirmed": booleanSchema()},
+			required:    []string{"document_url", "content"}, risk: "write",
+		},
+		{
+			name:        "feishu_docs_replace_text",
+			description: "Replace exactly one short text match with the connected Feishu bot after a fresh read. Zero or multiple matches fail; verify after writing and never blindly retry an uncertain result.",
+			properties:  map[string]any{"document_url": documentURLSchema(), "pattern": patternSchema(), "content": contentSchema(), "confirmed": booleanSchema()},
+			required:    []string{"document_url", "pattern", "content"}, risk: "write",
+		},
+		{
+			name:        "feishu_docs_insert_after",
+			description: "Insert bounded ordinary content after a freshly-read block using the connected Feishu bot. Complex unsupported resources are rejected; verify after writing.",
+			properties:  map[string]any{"document_url": documentURLSchema(), "block_id": blockIDSchema(), "content": contentSchema(), "confirmed": booleanSchema()},
+			required:    []string{"document_url", "block_id", "content"}, risk: "write",
+		},
+		{
+			name:        "feishu_docs_replace_block",
+			description: "Replace one block or a small continuous range with the connected Feishu bot after a fresh read. Range and large edits require preview and confirmation; unsupported resources are rejected.",
+			properties:  map[string]any{"document_url": documentURLSchema(), "block_id": blockIDSchema(), "start_block_id": blockIDSchema(), "end_block_id": blockIDSchema(), "content": contentSchema(), "confirmed": booleanSchema()},
+			required:    []string{"document_url", "content"}, risk: "write",
+		},
+		{
+			name:        "feishu_docs_delete_block",
+			description: "Delete one block or a small continuous range with the connected Feishu bot only after preview and explicit confirmation. Read fresh IDs first and verify after writing.",
+			properties:  map[string]any{"document_url": documentURLSchema(), "block_id": blockIDSchema(), "start_block_id": blockIDSchema(), "end_block_id": blockIDSchema(), "confirmed": booleanSchema()},
+			required:    []string{"document_url", "confirmed"}, risk: "write",
+		},
+	}
+	tools := make([]remotemcp.Tool, 0, len(definitions))
+	for _, definition := range definitions {
+		schema, err := json.Marshal(map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties":           definition.properties,
+			"required":             definition.required,
+		})
+		if err != nil {
+			return nil, err
+		}
+		tools = append(tools, remotemcp.Tool{
+			Name: definition.name, Description: definition.description,
+			InputSchema: schema, SchemaDigest: remotemcp.DigestBytes(schema), Risk: definition.risk,
+		})
+	}
+	return tools, nil
+}
+
+func documentURLSchema() map[string]any {
+	return map[string]any{"type": "string", "format": "uri", "description": "Explicit Feishu /docx/ or /wiki/ HTTPS URL."}
+}
+
+func blockIDSchema() map[string]any {
+	return map[string]any{"type": "string", "maxLength": 128}
+}
+
+func patternSchema() map[string]any {
+	return map[string]any{"type": "string", "maxLength": lark.DocumentMaxPatternBytes}
+}
+
+func contentSchema() map[string]any {
+	return map[string]any{"type": "string", "maxLength": lark.DocumentMaxContentBytes}
+}
+
+func booleanSchema() map[string]any {
+	return map[string]any{"type": "boolean"}
+}
+
+type feishuDocumentExecutor interface {
+	Execute(context.Context, lark.DocumentTaskScope, lark.DocumentOperation, lark.DocumentToolInput) (lark.DocumentToolResult, *lark.DocumentToolError)
+}
+
+type feishuDocumentsScopeLoader func(context.Context, *http.Request, string, string) (feishuDocumentsScope, error)
+
+type feishuDocumentsScope struct {
+	Task         db.AgentTaskQueue
+	Runtime      db.AgentRuntime
+	Agent        db.Agent
+	Installation lark.Installation
+	WorkspaceID  pgtype.UUID
+	DaemonID     string
+}
+
+func (scope feishuDocumentsScope) documentTaskScope() lark.DocumentTaskScope {
+	return lark.DocumentTaskScope{
+		TaskID:               scope.Task.ID,
+		WorkspaceID:          scope.WorkspaceID,
+		AgentID:              scope.Agent.ID,
+		RuntimeID:            scope.Runtime.ID,
+		DaemonID:             scope.DaemonID,
+		InstallationID:       scope.Installation.ID,
+		InstallationRevision: scope.Installation.UpdatedAt.Time.UnixNano(),
+	}
+}
+
+func validateFeishuDocumentsScope(scope feishuDocumentsScope, installationID pgtype.UUID, revision int64) bool {
+	if !scope.Task.ID.Valid || !scope.Task.AgentID.Valid || !scope.Task.RuntimeID.Valid ||
+		(scope.Task.Status != "dispatched" && scope.Task.Status != "running") ||
+		!scope.WorkspaceID.Valid || scope.DaemonID == "" {
+		return false
+	}
+	if !scope.Runtime.ID.Valid || scope.Runtime.ID != scope.Task.RuntimeID ||
+		scope.Runtime.WorkspaceID != scope.WorkspaceID || !scope.Runtime.DaemonID.Valid ||
+		scope.Runtime.DaemonID.String != scope.DaemonID {
+		return false
+	}
+	if !scope.Agent.ID.Valid || scope.Agent.ID != scope.Task.AgentID ||
+		scope.Agent.WorkspaceID != scope.WorkspaceID || scope.Agent.RuntimeID != scope.Task.RuntimeID ||
+		scope.Agent.ArchivedAt.Valid {
+		return false
+	}
+	return installationID.Valid && revision > 0 && scope.Installation.ID == installationID &&
+		scope.Installation.WorkspaceID == scope.WorkspaceID && scope.Installation.AgentID == scope.Agent.ID &&
+		scope.Installation.Status == "active" && scope.Installation.UpdatedAt.Valid &&
+		scope.Installation.UpdatedAt.Time.UnixNano() == revision
+}
+
+func (h *Handler) loadFeishuDocumentsScope(ctx context.Context, r *http.Request, taskID, contributionID string) (feishuDocumentsScope, error) {
+	if h.Queries == nil || h.TaskService == nil {
+		return feishuDocumentsScope{}, errFeishuDocumentsUnavailable
+	}
+	taskUUID, err := util.ParseUUID(taskID)
+	if err != nil {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	_, _, ok := parseFeishuDocumentsContribution(contributionID)
+	if !ok {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	task, err := h.Queries.GetAgentTask(ctx, taskUUID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+		}
+		return feishuDocumentsScope{}, errFeishuDocumentsUnavailable
+	}
+	if task.ID != taskUUID || !task.AgentID.Valid || !task.RuntimeID.Valid ||
+		(task.Status != "dispatched" && task.Status != "running") {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	workspaceID, err := util.ParseUUID(h.TaskService.ResolveTaskWorkspaceID(ctx, task))
+	if err != nil {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	daemonID := middleware.DaemonIDFromContext(r.Context())
+	if middleware.DaemonWorkspaceIDFromContext(r.Context()) != util.UUIDToString(workspaceID) || daemonID == "" {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	runtime, err := h.Queries.GetAgentRuntime(ctx, task.RuntimeID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+		}
+		return feishuDocumentsScope{}, errFeishuDocumentsUnavailable
+	}
+	if runtime.ID != task.RuntimeID || runtime.WorkspaceID != workspaceID || !runtime.DaemonID.Valid ||
+		runtime.DaemonID.String != daemonID {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	agent, err := h.Queries.GetAgent(ctx, task.AgentID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+		}
+		return feishuDocumentsScope{}, errFeishuDocumentsUnavailable
+	}
+	if agent.ID != task.AgentID || agent.WorkspaceID != workspaceID || agent.RuntimeID != task.RuntimeID ||
+		agent.ArchivedAt.Valid {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	installation, err := lark.NewChannelStore(h.Queries).GetActiveLarkInstallationForAgent(ctx, workspaceID, task.AgentID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+		}
+		return feishuDocumentsScope{}, errFeishuDocumentsUnavailable
+	}
+	return feishuDocumentsScope{
+		Task: task, Runtime: runtime, Agent: agent, Installation: installation,
+		WorkspaceID: workspaceID, DaemonID: daemonID,
+	}, nil
+}
+
+func (h *Handler) authorizeFeishuDocumentsRequest(r *http.Request) (feishuDocumentsScope, error) {
+	if middleware.DaemonAuthPathFromContext(r.Context()) != middleware.DaemonAuthPathDaemonToken {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	taskID, err := util.ParseUUID(chi.URLParam(r, "id"))
+	if err != nil {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	installationID, revision, ok := parseFeishuDocumentsContribution(chi.URLParam(r, "contributionId"))
+	if !ok {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	loader := h.feishuDocumentsScopeLoader
+	if loader == nil {
+		loader = h.loadFeishuDocumentsScope
+	}
+	scope, err := loader(r.Context(), r, chi.URLParam(r, "id"), chi.URLParam(r, "contributionId"))
+	if err != nil {
+		return feishuDocumentsScope{}, err
+	}
+	if scope.Task.ID != taskID || middleware.DaemonWorkspaceIDFromContext(r.Context()) != util.UUIDToString(scope.WorkspaceID) ||
+		!validateFeishuDocumentsScope(scope, installationID, revision) {
+		return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+	}
+	return scope, nil
+}
+
+func writeFeishuDocumentsAccessError(w http.ResponseWriter, err error) {
+	if errors.Is(err, errFeishuDocumentsUnavailable) {
+		writeErrorCode(w, http.StatusServiceUnavailable, "capability_unavailable", "document capability is temporarily unavailable")
+		return
+	}
+	writeErrorCode(w, http.StatusForbidden, "capability_denied", "document capability denied")
+}
+
+// ResolveRemoteMCPCredential returns the same short-lived task daemon token
+// that authenticated this request. The broker uses it to call the built-in MCP
+// endpoint; no Feishu installation credential crosses the daemon boundary.
+func (h *Handler) ResolveRemoteMCPCredential(w http.ResponseWriter, r *http.Request) {
+	if _, err := h.authorizeFeishuDocumentsRequest(r); err != nil {
+		writeFeishuDocumentsAccessError(w, err)
+		return
+	}
+	authorization := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authorization, "Bearer mdt_") || strings.TrimSpace(authorization) != authorization {
+		writeFeishuDocumentsAccessError(w, errFeishuDocumentsCapabilityDenied)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{
+		"credential_header": "Authorization",
+		"credential":        authorization,
+	})
+}
+
+type feishuDocumentsRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+func strictJSONDecode(raw []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func strictJSONParams(raw json.RawMessage, target any) error {
+	if len(raw) == 0 {
+		raw = json.RawMessage(`{}`)
+	}
+	return strictJSONDecode(raw, target)
+}
+
+func hasRPCID(id json.RawMessage) bool {
+	return len(id) > 0 && string(id) != "null"
+}
+
+// ServeFeishuDocumentsMCP exposes only the six schema-pinned document tools to
+// the daemon that currently owns this exact running task.
+func (h *Handler) ServeFeishuDocumentsMCP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	scope, err := h.authorizeFeishuDocumentsRequest(r)
+	if err != nil {
+		writeFeishuDocumentsAccessError(w, err)
+		return
+	}
+	if h.LarkDocuments == nil {
+		writeErrorCode(w, http.StatusServiceUnavailable, "capability_unavailable", "document capability is temporarily unavailable")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), feishuDocumentsCallTimeout)
+	defer cancel()
+	r = r.WithContext(ctx)
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, lark.DocumentMaxRequestBytes))
+	if err != nil {
+		writeFeishuDocumentsRPCError(w, nil, -32600, "request is not valid JSON-RPC")
+		return
+	}
+	var request feishuDocumentsRPCRequest
+	if err := strictJSONDecode(raw, &request); err != nil || request.JSONRPC != "2.0" || request.Method == "" {
+		writeFeishuDocumentsRPCError(w, request.ID, -32600, "request is not valid JSON-RPC")
+		return
+	}
+
+	switch request.Method {
+	case "initialize":
+		h.serveFeishuDocumentsInitialize(w, request)
+	case "notifications/initialized":
+		if hasRPCID(request.ID) || strictJSONParams(request.Params, &struct{}{}) != nil {
+			writeFeishuDocumentsRPCError(w, request.ID, -32602, "invalid initialization notification")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	case "tools/list":
+		if !hasRPCID(request.ID) || strictJSONParams(request.Params, &struct{}{}) != nil {
+			writeFeishuDocumentsRPCError(w, request.ID, -32602, "invalid tools list request")
+			return
+		}
+		tools, toolErr := feishuDocumentTools()
+		if toolErr != nil {
+			writeFeishuDocumentsRPCError(w, request.ID, -32603, "document tools are unavailable")
+			return
+		}
+		descriptors := make([]map[string]any, 0, len(tools))
+		for _, tool := range tools {
+			descriptors = append(descriptors, map[string]any{
+				"name": tool.Name, "description": tool.Description, "inputSchema": tool.InputSchema,
+			})
+		}
+		writeFeishuDocumentsRPCResult(w, request.ID, map[string]any{"tools": descriptors})
+	case "tools/call":
+		h.serveFeishuDocumentsToolCall(w, r, scope, request)
+	default:
+		writeFeishuDocumentsRPCError(w, request.ID, -32601, "only Feishu document tools are available")
+	}
+}
+
+func (h *Handler) serveFeishuDocumentsInitialize(w http.ResponseWriter, request feishuDocumentsRPCRequest) {
+	if !hasRPCID(request.ID) {
+		writeFeishuDocumentsRPCError(w, request.ID, -32602, "invalid initialize request")
+		return
+	}
+	var params struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		Capabilities    any    `json:"capabilities"`
+		ClientInfo      struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"clientInfo"`
+	}
+	if strictJSONParams(request.Params, &params) != nil || !containsFeishuDocumentsString(remotemcp.SupportedProtocolVersions(), params.ProtocolVersion) {
+		writeFeishuDocumentsRPCError(w, request.ID, -32602, "unsupported MCP protocol version")
+		return
+	}
+	writeFeishuDocumentsRPCResult(w, request.ID, map[string]any{
+		"protocolVersion": params.ProtocolVersion,
+		"capabilities":    map[string]any{"tools": map[string]any{}},
+		"serverInfo":      map[string]string{"name": "feishu-documents", "version": "1"},
+	})
+}
+
+func containsFeishuDocumentsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *Handler) serveFeishuDocumentsToolCall(w http.ResponseWriter, r *http.Request, scope feishuDocumentsScope, request feishuDocumentsRPCRequest) {
+	if !hasRPCID(request.ID) {
+		writeFeishuDocumentsRPCError(w, request.ID, -32602, "invalid tool call parameters")
+		return
+	}
+	var params struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if strictJSONParams(request.Params, &params) != nil {
+		writeFeishuDocumentsRPCError(w, request.ID, -32602, "invalid tool call parameters")
+		return
+	}
+	operation := lark.DocumentOperation(params.Name)
+	input, err := strictFeishuDocumentToolInput(operation, params.Arguments)
+	if err != nil {
+		writeFeishuDocumentsRPCError(w, request.ID, -32602, "invalid document tool arguments")
+		return
+	}
+	validated, validationErr := lark.ValidateDocumentToolInput(operation, input)
+	if validationErr != nil {
+		writeFeishuDocumentsToolResult(w, request.ID, operation, lark.DocumentToolResult{}, validationErr)
+		return
+	}
+	result, toolErr := h.LarkDocuments.Execute(r.Context(), scope.documentTaskScope(), operation, validated.Input)
+	writeFeishuDocumentsToolResult(w, request.ID, operation, result, toolErr)
+}
+
+func strictFeishuDocumentToolInput(operation lark.DocumentOperation, raw json.RawMessage) (lark.DocumentToolInput, error) {
+	allowed := map[lark.DocumentOperation]map[string]bool{
+		lark.DocumentOperationFetch:        {"document_url": true, "scope": true, "keyword": true, "start_block_id": true, "end_block_id": true},
+		lark.DocumentOperationAppend:       {"document_url": true, "content": true, "confirmed": true},
+		lark.DocumentOperationReplaceText:  {"document_url": true, "pattern": true, "content": true, "confirmed": true},
+		lark.DocumentOperationInsertAfter:  {"document_url": true, "block_id": true, "content": true, "confirmed": true},
+		lark.DocumentOperationReplaceBlock: {"document_url": true, "block_id": true, "start_block_id": true, "end_block_id": true, "content": true, "confirmed": true},
+		lark.DocumentOperationDeleteBlock:  {"document_url": true, "block_id": true, "start_block_id": true, "end_block_id": true, "confirmed": true},
+	}[operation]
+	if allowed == nil || len(raw) == 0 {
+		return lark.DocumentToolInput{}, errors.New("unsupported document tool")
+	}
+	var fields map[string]json.RawMessage
+	if err := strictJSONDecode(raw, &fields); err != nil || fields == nil {
+		return lark.DocumentToolInput{}, errors.New("invalid document tool arguments")
+	}
+	for field := range fields {
+		if !allowed[field] {
+			return lark.DocumentToolInput{}, errors.New("document tool field is not allowed")
+		}
+	}
+	var input lark.DocumentToolInput
+	if err := strictJSONDecode(raw, &input); err != nil {
+		return lark.DocumentToolInput{}, err
+	}
+	return input, nil
+}
+
+func writeFeishuDocumentsToolResult(w http.ResponseWriter, id json.RawMessage, operation lark.DocumentOperation, result lark.DocumentToolResult, toolErr *lark.DocumentToolError) {
+	payload := map[string]any{"ok": toolErr == nil, "operation": operation}
+	rpcResult := map[string]any{}
+	if toolErr != nil {
+		payload["error"] = toolErr
+		rpcResult["isError"] = true
+	} else {
+		payload["result"] = result
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		writeFeishuDocumentsRPCError(w, id, -32603, "document result is unavailable")
+		return
+	}
+	rpcResult["content"] = []map[string]string{{"type": "text", "text": string(encoded)}}
+	writeFeishuDocumentsRPCResult(w, id, rpcResult)
+}
+
+func writeFeishuDocumentsRPCResult(w http.ResponseWriter, id json.RawMessage, result any) {
+	if len(id) == 0 {
+		id = json.RawMessage("null")
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+func writeFeishuDocumentsRPCError(w http.ResponseWriter, id json.RawMessage, code int, message string) {
+	if len(id) == 0 {
+		id = json.RawMessage("null")
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"jsonrpc": "2.0", "id": id,
+		"error": map[string]any{"code": code, "message": message},
+	})
+}

--- a/server/internal/handler/feishu_documents_mcp.go
+++ b/server/internal/handler/feishu_documents_mcp.go
@@ -35,7 +35,8 @@ var (
 // FeishuDocumentsConnection builds the fixed, task-scoped built-in MCP connection.
 func FeishuDocumentsConnection(publicURL, taskID string, installation lark.Installation) (remotemcp.Connection, error) {
 	base, err := url.Parse(strings.TrimRight(publicURL, "/"))
-	if err != nil || base.Scheme != "https" || base.Hostname() == "" || base.User != nil || base.RawQuery != "" || base.Fragment != "" {
+	if err != nil || base.Scheme != "https" || base.Hostname() == "" || base.User != nil ||
+		base.Path != "" || base.RawQuery != "" || base.Fragment != "" {
 		return remotemcp.Connection{}, errors.New("feishu documents: public URL must be an absolute HTTPS origin")
 	}
 	if taskID == "" || !installation.ID.Valid || !installation.UpdatedAt.Valid {

--- a/server/internal/handler/feishu_documents_mcp_test.go
+++ b/server/internal/handler/feishu_documents_mcp_test.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -13,6 +15,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/integrations/lark"
@@ -80,6 +83,25 @@ func TestFeishuDocumentsConnectionPinsExactlySixTools(t *testing.T) {
 	}
 }
 
+func TestFeishuDocumentsConnectionRequiresHTTPSOrigin(t *testing.T) {
+	installation := lark.Installation{
+		ID:        util.MustParseUUID("30000000-0000-4000-8000-000000000001"),
+		UpdatedAt: pgtype.Timestamptz{Time: time.Unix(1_700_000_000, 123), Valid: true},
+	}
+	for _, publicURL := range []string{
+		"http://agents.example.com",
+		"https://user@agents.example.com",
+		"https://agents.example.com/base",
+		"https://agents.example.com?region=cn",
+		"https://agents.example.com#fragment",
+	} {
+		_, err := FeishuDocumentsConnection(publicURL, "task-id", installation)
+		if err == nil {
+			t.Fatalf("accepted non-origin public URL %q", publicURL)
+		}
+	}
+}
+
 func TestParseFeishuDocumentsContributionRejectsMalformedValues(t *testing.T) {
 	for _, raw := range []string{
 		"",
@@ -135,8 +157,9 @@ func TestValidateFeishuDocumentsScopeRejectsCrossIdentityAndStaleCapabilities(t 
 	}
 
 	tests := map[string]func(*feishuDocumentsScope){
-		"wrong daemon": func(s *feishuDocumentsScope) { s.DaemonID = "daemon-b" },
-		"ended task":   func(s *feishuDocumentsScope) { s.Task.Status = "completed" },
+		"wrong daemon":   func(s *feishuDocumentsScope) { s.DaemonID = "daemon-b" },
+		"ended task":     func(s *feishuDocumentsScope) { s.Task.Status = "completed" },
+		"cancelled task": func(s *feishuDocumentsScope) { s.Task.Status = "cancelled" },
 		"different task runtime": func(s *feishuDocumentsScope) {
 			s.Task.RuntimeID = util.MustParseUUID("40000000-0000-4000-8000-000000000002")
 		},
@@ -312,5 +335,187 @@ func TestResolveRemoteMCPCredentialReturnsOnlyExistingTaskToken(t *testing.T) {
 		if strings.Contains(recorder.Body.String(), secret) {
 			t.Fatalf("credential response leaked %q", secret)
 		}
+	}
+}
+
+type mutableFeishuDocumentStore struct {
+	installations map[string]lark.Installation
+}
+
+func (s *mutableFeishuDocumentStore) GetActiveLarkInstallationForAgent(_ context.Context, workspaceID, agentID pgtype.UUID) (lark.Installation, error) {
+	installation, ok := s.installations[util.UUIDToString(agentID)]
+	if !ok || installation.WorkspaceID != workspaceID || installation.Status != "active" {
+		return lark.Installation{}, pgx.ErrNoRows
+	}
+	return installation, nil
+}
+
+type mappedFeishuDocumentCredentials struct {
+	secrets map[string]string
+}
+
+func (c mappedFeishuDocumentCredentials) DecryptAppSecret(installation lark.Installation) (string, error) {
+	secret, ok := c.secrets[util.UUIDToString(installation.ID)]
+	if !ok {
+		return "", io.EOF
+	}
+	return secret, nil
+}
+
+type recordingFeishuDocumentClient struct {
+	credentials []lark.InstallationCredentials
+}
+
+func (c *recordingFeishuDocumentClient) FetchDocument(_ context.Context, credentials lark.InstallationCredentials, _ lark.DocumentFetchParams) (lark.DocumentSnapshot, error) {
+	c.credentials = append(c.credentials, credentials)
+	return lark.DocumentSnapshot{RevisionID: int64(len(c.credentials)), Content: "bounded content"}, nil
+}
+
+func (c *recordingFeishuDocumentClient) UpdateDocument(_ context.Context, credentials lark.InstallationCredentials, _ lark.DocumentUpdateParams) (lark.DocumentUpdateResult, error) {
+	c.credentials = append(c.credentials, credentials)
+	return lark.DocumentUpdateResult{RevisionID: int64(len(c.credentials))}, nil
+}
+
+type feishuDocumentSecurityFixture struct {
+	handler       *Handler
+	store         *mutableFeishuDocumentStore
+	client        *recordingFeishuDocumentClient
+	tasks         map[string]db.AgentTaskQueue
+	agents        map[string]db.Agent
+	workspaceID   pgtype.UUID
+	runtimeID     pgtype.UUID
+	pikachuTaskID pgtype.UUID
+	maimaiTaskID  pgtype.UUID
+}
+
+func newFeishuDocumentSecurityFixture() *feishuDocumentSecurityFixture {
+	workspaceID := util.MustParseUUID("10000000-0000-4000-8000-000000000101")
+	runtimeID := util.MustParseUUID("40000000-0000-4000-8000-000000000101")
+	pikachuID := util.MustParseUUID("30000000-0000-4000-8000-000000000101")
+	maimaiID := util.MustParseUUID("30000000-0000-4000-8000-000000000102")
+	pikachuTaskID := util.MustParseUUID("20000000-0000-4000-8000-000000000101")
+	maimaiTaskID := util.MustParseUUID("20000000-0000-4000-8000-000000000102")
+	pikachuInstallation := lark.Installation{
+		ID: util.MustParseUUID("50000000-0000-4000-8000-000000000101"), WorkspaceID: workspaceID, AgentID: pikachuID,
+		AppID: "cli_pikachu", Status: "active", Region: string(lark.RegionFeishu),
+		UpdatedAt: pgtype.Timestamptz{Time: time.Unix(0, 1_700_000_000_000_000_101), Valid: true},
+	}
+	maimaiInstallation := lark.Installation{
+		ID: util.MustParseUUID("50000000-0000-4000-8000-000000000102"), WorkspaceID: workspaceID, AgentID: maimaiID,
+		AppID: "cli_maimai", Status: "active", Region: string(lark.RegionFeishu),
+		UpdatedAt: pgtype.Timestamptz{Time: time.Unix(0, 1_700_000_000_000_000_102), Valid: true},
+	}
+	store := &mutableFeishuDocumentStore{installations: map[string]lark.Installation{
+		util.UUIDToString(pikachuID): pikachuInstallation,
+		util.UUIDToString(maimaiID):  maimaiInstallation,
+	}}
+	client := &recordingFeishuDocumentClient{}
+	service := lark.NewDocumentService(store, mappedFeishuDocumentCredentials{secrets: map[string]string{
+		util.UUIDToString(pikachuInstallation.ID): "pikachu-secret",
+		util.UUIDToString(maimaiInstallation.ID):  "maimai-secret",
+	}}, client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	fixture := &feishuDocumentSecurityFixture{
+		store: store, client: client, workspaceID: workspaceID, runtimeID: runtimeID,
+		pikachuTaskID: pikachuTaskID, maimaiTaskID: maimaiTaskID,
+		tasks: map[string]db.AgentTaskQueue{
+			util.UUIDToString(pikachuTaskID): {ID: pikachuTaskID, AgentID: pikachuID, RuntimeID: runtimeID, Status: "running"},
+			util.UUIDToString(maimaiTaskID):  {ID: maimaiTaskID, AgentID: maimaiID, RuntimeID: runtimeID, Status: "running"},
+		},
+		agents: map[string]db.Agent{
+			util.UUIDToString(pikachuID): {ID: pikachuID, WorkspaceID: workspaceID, RuntimeID: runtimeID},
+			util.UUIDToString(maimaiID):  {ID: maimaiID, WorkspaceID: workspaceID, RuntimeID: runtimeID},
+		},
+	}
+	fixture.handler = &Handler{LarkDocuments: service}
+	fixture.handler.feishuDocumentsScopeLoader = func(_ context.Context, _ *http.Request, taskID, _ string) (feishuDocumentsScope, error) {
+		task, ok := fixture.tasks[taskID]
+		if !ok {
+			return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+		}
+		agent := fixture.agents[util.UUIDToString(task.AgentID)]
+		installation, err := fixture.store.GetActiveLarkInstallationForAgent(context.Background(), fixture.workspaceID, task.AgentID)
+		if err != nil {
+			return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+		}
+		return feishuDocumentsScope{
+			Task: task,
+			Runtime: db.AgentRuntime{
+				ID: fixture.runtimeID, WorkspaceID: fixture.workspaceID,
+				DaemonID: pgtype.Text{String: "daemon-shared", Valid: true},
+			},
+			Agent: agent, Installation: installation,
+			WorkspaceID: fixture.workspaceID, DaemonID: "daemon-shared",
+		}, nil
+	}
+	return fixture
+}
+
+func (f *feishuDocumentSecurityFixture) contribution(t *testing.T, agentID pgtype.UUID) string {
+	t.Helper()
+	installation := f.store.installations[util.UUIDToString(agentID)]
+	connection, err := FeishuDocumentsConnection("https://agents.example.com", "task", installation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return connection.ContributionID
+}
+
+func (f *feishuDocumentSecurityFixture) callFetch(taskID pgtype.UUID, contribution string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"feishu_docs_fetch","arguments":{"document_url":"https://example.feishu.cn/docx/AbCdEfGh1234"}}}`))
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("id", util.UUIDToString(taskID))
+	routeContext.URLParams.Add("contributionId", contribution)
+	ctx := context.WithValue(request.Context(), chi.RouteCtxKey, routeContext)
+	ctx = middleware.WithDaemonContext(ctx, util.UUIDToString(f.workspaceID), "daemon-shared")
+	request = request.WithContext(ctx)
+	request.Header.Set("Authorization", "Bearer mdt_security_fixture")
+	recorder := httptest.NewRecorder()
+	f.handler.ServeFeishuDocumentsMCP(recorder, request)
+	return recorder
+}
+
+func TestFeishuDocumentsEndToEndKeepsBotIdentityAndRevocationLive(t *testing.T) {
+	fixture := newFeishuDocumentSecurityFixture()
+	pikachuAgentID := fixture.tasks[util.UUIDToString(fixture.pikachuTaskID)].AgentID
+	maimaiAgentID := fixture.tasks[util.UUIDToString(fixture.maimaiTaskID)].AgentID
+	pikachuContribution := fixture.contribution(t, pikachuAgentID)
+	maimaiContribution := fixture.contribution(t, maimaiAgentID)
+
+	for _, call := range []struct {
+		task         pgtype.UUID
+		contribution string
+	}{
+		{fixture.pikachuTaskID, pikachuContribution},
+		{fixture.maimaiTaskID, maimaiContribution},
+	} {
+		response := fixture.callFetch(call.task, call.contribution)
+		if response.Code != http.StatusOK || strings.Contains(response.Body.String(), "secret") {
+			t.Fatalf("valid call failed or leaked a secret: status=%d body=%s", response.Code, response.Body.String())
+		}
+	}
+	if len(fixture.client.credentials) != 2 ||
+		fixture.client.credentials[0].AppID != "cli_pikachu" || fixture.client.credentials[0].AppSecret != "pikachu-secret" ||
+		fixture.client.credentials[1].AppID != "cli_maimai" || fixture.client.credentials[1].AppSecret != "maimai-secret" {
+		t.Fatalf("document credentials crossed Agent identity: %+v", fixture.client.credentials)
+	}
+
+	swapped := fixture.callFetch(fixture.pikachuTaskID, maimaiContribution)
+	if swapped.Code != http.StatusForbidden || !strings.Contains(swapped.Body.String(), "capability_denied") {
+		t.Fatalf("swapped contribution was not refused: status=%d body=%s", swapped.Code, swapped.Body.String())
+	}
+	pikachuInstallation := fixture.store.installations[util.UUIDToString(pikachuAgentID)]
+	pikachuInstallation.UpdatedAt.Time = pikachuInstallation.UpdatedAt.Time.Add(time.Nanosecond)
+	fixture.store.installations[util.UUIDToString(pikachuAgentID)] = pikachuInstallation
+	stale := fixture.callFetch(fixture.pikachuTaskID, pikachuContribution)
+	if stale.Code != http.StatusForbidden || !strings.Contains(stale.Body.String(), "capability_denied") {
+		t.Fatalf("changed installation revision was not live-revoked: status=%d body=%s", stale.Code, stale.Body.String())
+	}
+	maimaiTask := fixture.tasks[util.UUIDToString(fixture.maimaiTaskID)]
+	maimaiTask.Status = "completed"
+	fixture.tasks[util.UUIDToString(fixture.maimaiTaskID)] = maimaiTask
+	ended := fixture.callFetch(fixture.maimaiTaskID, maimaiContribution)
+	if ended.Code != http.StatusForbidden || !strings.Contains(ended.Body.String(), "capability_denied") {
+		t.Fatalf("completed task retained document capability: status=%d body=%s", ended.Code, ended.Body.String())
 	}
 }

--- a/server/internal/handler/feishu_documents_mcp_test.go
+++ b/server/internal/handler/feishu_documents_mcp_test.go
@@ -1,0 +1,316 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/integrations/lark"
+	"github.com/multica-ai/multica/server/internal/middleware"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/remotemcp"
+)
+
+func TestFeishuDocumentsConnectionPinsExactlySixTools(t *testing.T) {
+	updatedAt := time.Unix(1_700_000_000, 123)
+	installation := lark.Installation{
+		ID:        util.MustParseUUID("30000000-0000-4000-8000-000000000001"),
+		UpdatedAt: pgtype.Timestamptz{Time: updatedAt, Valid: true},
+	}
+	connection, err := FeishuDocumentsConnection("https://agents.example.com", "task-id", installation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNames := []string{
+		"feishu_docs_append",
+		"feishu_docs_delete_block",
+		"feishu_docs_fetch",
+		"feishu_docs_insert_after",
+		"feishu_docs_replace_block",
+		"feishu_docs_replace_text",
+	}
+	gotNames := make([]string, 0, len(connection.ApprovedTools))
+	for _, tool := range connection.ApprovedTools {
+		gotNames = append(gotNames, tool.Name)
+		if tool.SchemaDigest != remotemcp.DigestBytes(tool.InputSchema) {
+			t.Fatalf("schema for %s is not pinned", tool.Name)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+			t.Fatalf("schema %s: %v", tool.Name, err)
+		}
+		if schema["additionalProperties"] != false {
+			t.Fatalf("schema %s permits additional properties", tool.Name)
+		}
+		if !strings.Contains(strings.ToLower(tool.Description), "bot") {
+			t.Fatalf("description %s does not state bot identity", tool.Name)
+		}
+	}
+	sort.Strings(gotNames)
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("tools = %v, want %v", gotNames, wantNames)
+	}
+	wantContribution := "builtin:feishu-documents:" + util.UUIDToString(installation.ID) + ":" + strconv.FormatInt(updatedAt.UnixNano(), 10)
+	if connection.ContributionID != wantContribution || connection.ContributionKey != "feishu-documents" {
+		t.Fatalf("contribution = %q key=%q", connection.ContributionID, connection.ContributionKey)
+	}
+	if connection.Endpoint != "https://agents.example.com/api/daemon/tasks/task-id/feishu-documents/"+wantContribution+"/mcp" {
+		t.Fatalf("endpoint = %q", connection.Endpoint)
+	}
+	if connection.CredentialHeader != "Authorization" || !reflect.DeepEqual(connection.EndpointAllowedHosts, []string{"agents.example.com"}) {
+		t.Fatalf("credential/hosts = %q/%v", connection.CredentialHeader, connection.EndpointAllowedHosts)
+	}
+	wantDigest, err := remotemcp.ToolSetDigest(connection.ApprovedTools)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if connection.ToolSchemaDigest != wantDigest {
+		t.Fatalf("tool set digest = %q, want %q", connection.ToolSchemaDigest, wantDigest)
+	}
+}
+
+func TestParseFeishuDocumentsContributionRejectsMalformedValues(t *testing.T) {
+	for _, raw := range []string{
+		"",
+		"plugin:30000000-0000-4000-8000-000000000001:1",
+		"builtin:feishu-documents:bad:1",
+		"builtin:feishu-documents:30000000-0000-4000-8000-000000000001:0",
+		"builtin:feishu-documents:30000000-0000-4000-8000-000000000001:1:extra",
+	} {
+		if _, _, ok := parseFeishuDocumentsContribution(raw); ok {
+			t.Fatalf("accepted malformed contribution %q", raw)
+		}
+	}
+}
+
+var (
+	feishuDocumentsTestWorkspaceID    = util.MustParseUUID("10000000-0000-4000-8000-000000000001")
+	feishuDocumentsTestTaskID         = util.MustParseUUID("20000000-0000-4000-8000-000000000001")
+	feishuDocumentsTestAgentID        = util.MustParseUUID("30000000-0000-4000-8000-000000000001")
+	feishuDocumentsTestRuntimeID      = util.MustParseUUID("40000000-0000-4000-8000-000000000001")
+	feishuDocumentsTestInstallationID = util.MustParseUUID("50000000-0000-4000-8000-000000000001")
+)
+
+const feishuDocumentsTestRevision int64 = 1_700_000_000_000_000_123
+
+func validFeishuDocumentsScopeFixture() feishuDocumentsScope {
+	return feishuDocumentsScope{
+		Task: db.AgentTaskQueue{
+			ID: feishuDocumentsTestTaskID, AgentID: feishuDocumentsTestAgentID,
+			RuntimeID: feishuDocumentsTestRuntimeID, Status: "running",
+		},
+		Runtime: db.AgentRuntime{
+			ID: feishuDocumentsTestRuntimeID, WorkspaceID: feishuDocumentsTestWorkspaceID,
+			DaemonID: pgtype.Text{String: "daemon-a", Valid: true},
+		},
+		Agent: db.Agent{
+			ID: feishuDocumentsTestAgentID, WorkspaceID: feishuDocumentsTestWorkspaceID,
+			RuntimeID: feishuDocumentsTestRuntimeID,
+		},
+		Installation: lark.Installation{
+			ID: feishuDocumentsTestInstallationID, WorkspaceID: feishuDocumentsTestWorkspaceID,
+			AgentID: feishuDocumentsTestAgentID, Status: "active",
+			UpdatedAt: pgtype.Timestamptz{Time: time.Unix(0, feishuDocumentsTestRevision), Valid: true},
+		},
+		WorkspaceID: feishuDocumentsTestWorkspaceID,
+		DaemonID:    "daemon-a",
+	}
+}
+
+func TestValidateFeishuDocumentsScopeRejectsCrossIdentityAndStaleCapabilities(t *testing.T) {
+	valid := validFeishuDocumentsScopeFixture()
+	if !validateFeishuDocumentsScope(valid, feishuDocumentsTestInstallationID, feishuDocumentsTestRevision) {
+		t.Fatal("valid task capability was rejected")
+	}
+
+	tests := map[string]func(*feishuDocumentsScope){
+		"wrong daemon": func(s *feishuDocumentsScope) { s.DaemonID = "daemon-b" },
+		"ended task":   func(s *feishuDocumentsScope) { s.Task.Status = "completed" },
+		"different task runtime": func(s *feishuDocumentsScope) {
+			s.Task.RuntimeID = util.MustParseUUID("40000000-0000-4000-8000-000000000002")
+		},
+		"different runtime daemon": func(s *feishuDocumentsScope) { s.Runtime.DaemonID.String = "daemon-b" },
+		"different runtime workspace": func(s *feishuDocumentsScope) {
+			s.Runtime.WorkspaceID = util.MustParseUUID("10000000-0000-4000-8000-000000000002")
+		},
+		"rebound agent": func(s *feishuDocumentsScope) {
+			s.Agent.RuntimeID = util.MustParseUUID("40000000-0000-4000-8000-000000000002")
+		},
+		"archived agent": func(s *feishuDocumentsScope) { s.Agent.ArchivedAt.Valid = true },
+		"other agent installation": func(s *feishuDocumentsScope) {
+			s.Installation.AgentID = util.MustParseUUID("30000000-0000-4000-8000-000000000002")
+		},
+		"revoked installation": func(s *feishuDocumentsScope) { s.Installation.Status = "revoked" },
+		"changed revision": func(s *feishuDocumentsScope) {
+			s.Installation.UpdatedAt.Time = s.Installation.UpdatedAt.Time.Add(time.Nanosecond)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			scope := valid
+			mutate(&scope)
+			if validateFeishuDocumentsScope(scope, feishuDocumentsTestInstallationID, feishuDocumentsTestRevision) {
+				t.Fatal("stale or cross-identity capability was accepted")
+			}
+		})
+	}
+}
+
+type fakeFeishuDocumentExecutor struct {
+	called    int
+	operation lark.DocumentOperation
+	input     lark.DocumentToolInput
+	result    lark.DocumentToolResult
+	toolErr   *lark.DocumentToolError
+}
+
+func (f *fakeFeishuDocumentExecutor) Execute(_ context.Context, _ lark.DocumentTaskScope, operation lark.DocumentOperation, input lark.DocumentToolInput) (lark.DocumentToolResult, *lark.DocumentToolError) {
+	f.called++
+	f.operation = operation
+	f.input = input
+	return f.result, f.toolErr
+}
+
+func feishuDocumentsHandlerRequest(method, body, authPath string) *http.Request {
+	request := httptest.NewRequest(method, "/mcp", strings.NewReader(body))
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("id", util.UUIDToString(feishuDocumentsTestTaskID))
+	routeContext.URLParams.Add("contributionId", feishuDocumentsContributionPrefix+util.UUIDToString(feishuDocumentsTestInstallationID)+":"+strconv.FormatInt(feishuDocumentsTestRevision, 10))
+	ctx := context.WithValue(request.Context(), chi.RouteCtxKey, routeContext)
+	if authPath == middleware.DaemonAuthPathDaemonToken {
+		ctx = middleware.WithDaemonContext(ctx, util.UUIDToString(feishuDocumentsTestWorkspaceID), "daemon-a")
+	}
+	request = request.WithContext(ctx)
+	request.Header.Set("Authorization", "Bearer mdt_task_capability")
+	return request
+}
+
+func newFeishuDocumentsTestHandler(executor feishuDocumentExecutor) *Handler {
+	return &Handler{
+		LarkDocuments: executor,
+		feishuDocumentsScopeLoader: func(context.Context, *http.Request, string, string) (feishuDocumentsScope, error) {
+			return validFeishuDocumentsScopeFixture(), nil
+		},
+	}
+}
+
+func decodeFeishuDocumentsRPC(t *testing.T, recorder *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var response map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response %q: %v", recorder.Body.String(), err)
+	}
+	return response
+}
+
+func TestFeishuDocumentsMCPAcceptsInitializeListAndPinnedCall(t *testing.T) {
+	executor := &fakeFeishuDocumentExecutor{result: lark.DocumentToolResult{RevisionID: 12, Content: "hello", Verified: true}}
+	h := newFeishuDocumentsTestHandler(executor)
+
+	requests := []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"feishu_docs_fetch","arguments":{"document_url":"https://example.feishu.cn/docx/AbCdEfGh1234"}}}`,
+	}
+	for _, body := range requests {
+		recorder := httptest.NewRecorder()
+		h.ServeFeishuDocumentsMCP(recorder, feishuDocumentsHandlerRequest(http.MethodPost, body, middleware.DaemonAuthPathDaemonToken))
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("request %s: status=%d body=%s", body, recorder.Code, recorder.Body.String())
+		}
+		if strings.Contains(body, "notifications/initialized") {
+			continue
+		}
+		response := decodeFeishuDocumentsRPC(t, recorder)
+		if response["error"] != nil {
+			t.Fatalf("request %s: response=%v", body, response)
+		}
+	}
+	if executor.called != 1 || executor.operation != lark.DocumentOperationFetch || executor.input.DocumentURL == "" {
+		t.Fatalf("executor called=%d operation=%q input=%+v", executor.called, executor.operation, executor.input)
+	}
+}
+
+func TestFeishuDocumentsMCPStrictlyRejectsUnknownMethodsToolsAndFields(t *testing.T) {
+	executor := &fakeFeishuDocumentExecutor{}
+	h := newFeishuDocumentsTestHandler(executor)
+	requests := []string{
+		`{"jsonrpc":"2.0","id":1,"method":"resources/list"}`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"not_allowed","arguments":{}}}`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"feishu_docs_fetch","arguments":{"document_url":"https://example.feishu.cn/docx/AbCdEfGh1234","content":"must not pass"}}}`,
+		`[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","extra":true}`,
+	}
+	for _, body := range requests {
+		recorder := httptest.NewRecorder()
+		h.ServeFeishuDocumentsMCP(recorder, feishuDocumentsHandlerRequest(http.MethodPost, body, middleware.DaemonAuthPathDaemonToken))
+		response := decodeFeishuDocumentsRPC(t, recorder)
+		if response["error"] == nil {
+			t.Fatalf("request %s was accepted: %s", body, recorder.Body.String())
+		}
+	}
+	if executor.called != 0 {
+		t.Fatalf("executor was called %d times for rejected requests", executor.called)
+	}
+}
+
+func TestFeishuDocumentsMCPRejectsNonDaemonAuthAndCapabilityFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		authPath string
+		loader   feishuDocumentsScopeLoader
+	}{
+		{name: "human token", authPath: middleware.DaemonAuthPathPAT},
+		{name: "stale capability", authPath: middleware.DaemonAuthPathDaemonToken, loader: func(context.Context, *http.Request, string, string) (feishuDocumentsScope, error) {
+			return feishuDocumentsScope{}, errFeishuDocumentsCapabilityDenied
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newFeishuDocumentsTestHandler(&fakeFeishuDocumentExecutor{})
+			if tc.loader != nil {
+				h.feishuDocumentsScopeLoader = tc.loader
+			}
+			recorder := httptest.NewRecorder()
+			h.ServeFeishuDocumentsMCP(recorder, feishuDocumentsHandlerRequest(http.MethodPost, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, tc.authPath))
+			if recorder.Code != http.StatusForbidden || !strings.Contains(recorder.Body.String(), "capability_denied") {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestResolveRemoteMCPCredentialReturnsOnlyExistingTaskToken(t *testing.T) {
+	h := newFeishuDocumentsTestHandler(&fakeFeishuDocumentExecutor{})
+	recorder := httptest.NewRecorder()
+	h.ResolveRemoteMCPCredential(recorder, feishuDocumentsHandlerRequest(http.MethodGet, "", middleware.DaemonAuthPathDaemonToken))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		CredentialHeader string `json:"credential_header"`
+		Credential       string `json:"credential"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.CredentialHeader != "Authorization" || response.Credential != "Bearer mdt_task_capability" {
+		t.Fatalf("response=%+v", response)
+	}
+	for _, secret := range []string{"pikachu-app-secret", "pikachu-app-id"} {
+		if strings.Contains(recorder.Body.String(), secret) {
+			t.Fatalf("credential response leaked %q", secret)
+		}
+	}
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -276,6 +276,13 @@ type Handler struct {
 	// UI consults IsConfigured() to decide whether to surface install
 	// entry points.
 	LarkAPIClient lark.APIClient
+	// LarkDocuments executes the fixed Agent-scoped document MCP tools. It is
+	// wired with the same encrypted installation store and regional HTTP client
+	// as messaging, and remains nil when the Lark master key is unset.
+	LarkDocuments feishuDocumentExecutor
+	// Test seam for the capability resolver. Production always leaves this nil
+	// and performs fresh task/runtime/Agent/installation reads on every call.
+	feishuDocumentsScopeLoader feishuDocumentsScopeLoader
 	// Composio integration (MUL-3720). Nil when COMPOSIO_API_KEY is unset;
 	// the composio HTTP handlers return 503 in that case. Wired in
 	// cmd/server/router.go after handler.New.

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -280,6 +280,10 @@ type Handler struct {
 	// wired with the same encrypted installation store and regional HTTP client
 	// as messaging, and remains nil when the Lark master key is unset.
 	LarkDocuments feishuDocumentExecutor
+	// LarkDocumentInstallations resolves the active installation for the exact
+	// fresh Agent during claim assembly. The narrow interface also makes lookup
+	// failure and cross-Agent behavior independently testable.
+	LarkDocumentInstallations lark.DocumentInstallationStore
 	// Test seam for the capability resolver. Production always leaves this nil
 	// and performs fresh task/runtime/Agent/installation reads on every call.
 	feishuDocumentsScopeLoader feishuDocumentsScopeLoader

--- a/server/internal/integrations/lark/channel_store.go
+++ b/server/internal/integrations/lark/channel_store.go
@@ -99,6 +99,20 @@ func (s *ChannelStore) GetLarkInstallationInWorkspace(ctx context.Context, arg G
 	return installationFromRow(row)
 }
 
+// GetActiveLarkInstallationForAgent resolves only the active Feishu installation
+// owned by the exact workspace and Agent pair.
+func (s *ChannelStore) GetActiveLarkInstallationForAgent(ctx context.Context, workspaceID, agentID pgtype.UUID) (Installation, error) {
+	row, err := s.Queries.GetActiveChannelInstallationForAgent(ctx, db.GetActiveChannelInstallationForAgentParams{
+		WorkspaceID: workspaceID,
+		AgentID:     agentID,
+		ChannelType: channelTypeFeishu,
+	})
+	if err != nil {
+		return Installation{}, err
+	}
+	return installationFromRow(row)
+}
+
 func (s *ChannelStore) ListLarkInstallationsByWorkspace(ctx context.Context, workspaceID pgtype.UUID) ([]Installation, error) {
 	rows, err := s.Queries.ListChannelInstallationsByWorkspace(ctx, db.ListChannelInstallationsByWorkspaceParams{
 		WorkspaceID: workspaceID,

--- a/server/internal/integrations/lark/channel_store_scope_test.go
+++ b/server/internal/integrations/lark/channel_store_scope_test.go
@@ -58,18 +58,20 @@ func TestChannelStore_ScopesToFeishu(t *testing.T) {
 	// why the test cleans up explicitly, by deterministic key, before and
 	// after (a killed prior run must not leave colliding rows behind).
 	const (
-		feishuApp     = "cli_scope_feishu"
-		slackApp      = "cli_scope_slack"
-		wsID          = "5c09e000-0000-4000-8000-000000000001"
-		agentID       = "5c09e000-0000-4000-8000-000000000002"
-		chatSessionID = "5c09e000-0000-4000-8000-000000000003"
-		taskID        = "5c09e000-0000-4000-8000-000000000004"
-		installerID   = "5c09e000-0000-4000-8000-000000000005"
+		feishuApp      = "cli_scope_feishu"
+		otherFeishuApp = "cli_scope_feishu_other"
+		slackApp       = "cli_scope_slack"
+		wsID           = "5c09e000-0000-4000-8000-000000000001"
+		agentID        = "5c09e000-0000-4000-8000-000000000002"
+		otherAgentID   = "5c09e000-0000-4000-8000-000000000006"
+		chatSessionID  = "5c09e000-0000-4000-8000-000000000003"
+		taskID         = "5c09e000-0000-4000-8000-000000000004"
+		installerID    = "5c09e000-0000-4000-8000-000000000005"
 	)
 	clean := func() {
 		_, _ = pool.Exec(context.Background(),
 			`DELETE FROM channel_installation WHERE config->>'app_id' = ANY($1)`,
-			[]string{feishuApp, slackApp})
+			[]string{feishuApp, otherFeishuApp, slackApp})
 		_, _ = pool.Exec(context.Background(),
 			`DELETE FROM channel_chat_session_binding WHERE chat_session_id = $1`, chatSessionID)
 		_, _ = pool.Exec(context.Background(),
@@ -78,19 +80,20 @@ func TestChannelStore_ScopesToFeishu(t *testing.T) {
 	clean()
 	t.Cleanup(clean)
 
-	insertInstallation := func(channelType, app string) pgtype.UUID {
+	insertInstallation := func(channelType, app, ownerAgentID string) pgtype.UUID {
 		var id string
 		if err := pool.QueryRow(ctx, `
 INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, installer_user_id)
 VALUES ($1, $2, $3, jsonb_build_object('app_id', $4::text), $5)
 RETURNING id
-`, wsID, agentID, channelType, app, installerID).Scan(&id); err != nil {
+`, wsID, ownerAgentID, channelType, app, installerID).Scan(&id); err != nil {
 			t.Fatalf("insert %s installation: %v", channelType, err)
 		}
 		return util.MustParseUUID(id)
 	}
-	feishuID := insertInstallation("feishu", feishuApp)
-	slackID := insertInstallation("slack", slackApp)
+	feishuID := insertInstallation("feishu", feishuApp, agentID)
+	otherFeishuID := insertInstallation("feishu", otherFeishuApp, otherAgentID)
+	slackID := insertInstallation("slack", slackApp, agentID)
 
 	// A non-Feishu binding/card sharing this test's chat_session and task.
 	if _, err := pool.Exec(ctx, `
@@ -125,18 +128,28 @@ VALUES ($1, $2, 'slack', 'oc_scope_slack', 'om_scope_slack', 'pending')
 	if _, err := store.GetLarkInstallationInWorkspace(ctx, GetInstallationInWorkspaceParams{ID: slackID, WorkspaceID: wsUUID}); !errors.Is(err, pgx.ErrNoRows) {
 		t.Fatalf("GetLarkInstallationInWorkspace(slack): err=%v, want pgx.ErrNoRows (scoped out)", err)
 	}
+	gotForAgent, err := store.GetActiveLarkInstallationForAgent(ctx, wsUUID, util.MustParseUUID(agentID))
+	if err != nil || gotForAgent.ID != feishuID {
+		t.Fatalf("GetActiveLarkInstallationForAgent(primary): id=%v err=%v, want %v", gotForAgent.ID, err, feishuID)
+	}
+	gotForOtherAgent, err := store.GetActiveLarkInstallationForAgent(ctx, wsUUID, util.MustParseUUID(otherAgentID))
+	if err != nil || gotForOtherAgent.ID != otherFeishuID {
+		t.Fatalf("GetActiveLarkInstallationForAgent(other): id=%v err=%v, want %v", gotForOtherAgent.ID, err, otherFeishuID)
+	}
 
 	// list-by-workspace: only the Feishu installation in this workspace
 	byWs, err := store.ListLarkInstallationsByWorkspace(ctx, wsUUID)
 	if err != nil {
 		t.Fatalf("ListLarkInstallationsByWorkspace: %v", err)
 	}
-	if len(byWs) != 1 || byWs[0].AppID != feishuApp {
-		apps := make([]string, len(byWs))
-		for i, r := range byWs {
-			apps[i] = r.AppID
-		}
-		t.Fatalf("ListLarkInstallationsByWorkspace: got apps=%v, want exactly [%s]", apps, feishuApp)
+	apps := make([]string, len(byWs))
+	seenApps := make(map[string]bool, len(byWs))
+	for i, row := range byWs {
+		apps[i] = row.AppID
+		seenApps[row.AppID] = true
+	}
+	if len(byWs) != 2 || !seenApps[feishuApp] || !seenApps[otherFeishuApp] {
+		t.Fatalf("ListLarkInstallationsByWorkspace: got apps=%v, want two Feishu installations", apps)
 	}
 
 	// (ListActiveLarkInstallations channel-type + live workspace/agent scoping

--- a/server/internal/integrations/lark/document_client.go
+++ b/server/internal/integrations/lark/document_client.go
@@ -1,0 +1,317 @@
+package lark
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const documentRequestTimeout = 30 * time.Second
+
+// DocumentAPIClient is the bounded Docs AI surface used by the document service.
+type DocumentAPIClient interface {
+	FetchDocument(context.Context, InstallationCredentials, DocumentFetchParams) (DocumentSnapshot, error)
+	UpdateDocument(context.Context, InstallationCredentials, DocumentUpdateParams) (DocumentUpdateResult, error)
+}
+
+// OpenPlatformClient combines the existing messaging API with Docs AI.
+type OpenPlatformClient interface {
+	APIClient
+	DocumentAPIClient
+}
+
+// DocumentFetchParams selects one bounded Docs AI read.
+type DocumentFetchParams struct {
+	Token        string
+	Format       string
+	Scope        DocumentFetchScope
+	Keyword      string
+	StartBlockID string
+	EndBlockID   string
+}
+
+// DocumentSnapshot is the document state needed for guarded edits.
+type DocumentSnapshot struct {
+	RevisionID int64
+	Content    string
+	BlockIDs   []string
+}
+
+// DocumentUpdateParams describes one fixed Docs AI update command.
+type DocumentUpdateParams struct {
+	Token        string
+	Format       string
+	Command      string
+	Content      string
+	Pattern      string
+	BlockID      string
+	StartBlockID string
+	EndBlockID   string
+	RevisionID   int64
+}
+
+// DocumentUpdateResult identifies the committed document revision.
+type DocumentUpdateResult struct {
+	RevisionID int64
+}
+
+type documentAPIEnvelope struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		Result   string `json:"result"`
+		Document struct {
+			RevisionID int64  `json:"revision_id"`
+			Content    string `json:"content"`
+		} `json:"document"`
+	} `json:"data"`
+}
+
+func (c *httpAPIClient) FetchDocument(ctx context.Context, creds InstallationCredentials, p DocumentFetchParams) (DocumentSnapshot, error) {
+	body, err := documentFetchBody(p)
+	if err != nil {
+		return DocumentSnapshot{}, err
+	}
+	path := "/open-apis/docs_ai/v1/documents/" + url.PathEscape(p.Token) + "/fetch"
+	ctx, cancel := context.WithTimeout(ctx, documentRequestTimeout)
+	defer cancel()
+
+	var resp documentAPIEnvelope
+	for attempt := 0; attempt < 2; attempt++ {
+		resp = documentAPIEnvelope{}
+		token, tokenErr := c.tenantAccessToken(ctx, creds)
+		if tokenErr != nil {
+			return DocumentSnapshot{}, fmt.Errorf("lark document fetch: %w", tokenErr)
+		}
+		err = c.doDocumentJSON(ctx, creds, http.MethodPost, path, token, body, &resp)
+		code := larkErrorCode(err)
+		if err == nil {
+			code = resp.Code
+		}
+		if !isTokenError(code) || attempt == 1 {
+			break
+		}
+		c.invalidateToken(creds.AppID)
+	}
+	if err != nil {
+		return DocumentSnapshot{}, fmt.Errorf("lark document fetch: %w", err)
+	}
+	if resp.Code != 0 {
+		return DocumentSnapshot{}, &APIError{Op: "fetch document", Code: resp.Code}
+	}
+	return DocumentSnapshot{
+		RevisionID: resp.Data.Document.RevisionID,
+		Content:    resp.Data.Document.Content,
+		BlockIDs:   documentBlockIDs(resp.Data.Document.Content),
+	}, nil
+}
+
+func (c *httpAPIClient) UpdateDocument(ctx context.Context, creds InstallationCredentials, p DocumentUpdateParams) (DocumentUpdateResult, error) {
+	body, err := documentUpdateBody(p)
+	if err != nil {
+		return DocumentUpdateResult{}, err
+	}
+	path := "/open-apis/docs_ai/v1/documents/" + url.PathEscape(p.Token)
+	ctx, cancel := context.WithTimeout(ctx, documentRequestTimeout)
+	defer cancel()
+
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return DocumentUpdateResult{}, fmt.Errorf("lark document update: %w", err)
+	}
+	var resp documentAPIEnvelope
+	err = c.doDocumentJSON(ctx, creds, http.MethodPut, path, token, body, &resp)
+	code := larkErrorCode(err)
+	if err == nil {
+		code = resp.Code
+	}
+	if isTokenError(code) {
+		c.invalidateToken(creds.AppID)
+	}
+	if err != nil {
+		return DocumentUpdateResult{}, fmt.Errorf("lark document update: %w", err)
+	}
+	if resp.Code != 0 {
+		return DocumentUpdateResult{}, &APIError{Op: "update document", Code: resp.Code}
+	}
+	if resp.Data.Result != "success" {
+		return DocumentUpdateResult{}, &documentOperationError{partial: resp.Data.Result == "partial_success"}
+	}
+	return DocumentUpdateResult{RevisionID: resp.Data.Document.RevisionID}, nil
+}
+
+func documentFetchBody(p DocumentFetchParams) (map[string]any, error) {
+	if p.Token == "" {
+		return nil, errors.New("lark document fetch: missing token")
+	}
+	if p.Format == "" {
+		p.Format = "xml"
+	}
+	if p.Format != "xml" && p.Format != "markdown" {
+		return nil, errors.New("lark document fetch: unsupported format")
+	}
+	body := map[string]any{
+		"format": p.Format,
+		"export_option": map[string]any{
+			"export_block_id": p.Format == "xml",
+		},
+	}
+	scope := p.Scope
+	if scope == "" {
+		scope = DocumentFetchScopeFull
+	}
+	var readOption map[string]any
+	switch scope {
+	case DocumentFetchScopeFull:
+	case DocumentFetchScopeOutline:
+		readOption = map[string]any{"read_mode": "outline"}
+	case DocumentFetchScopeSection:
+		if p.StartBlockID == "" {
+			return nil, errors.New("lark document fetch: section requires a start block")
+		}
+		readOption = map[string]any{"read_mode": "section", "start_block_id": p.StartBlockID}
+	case DocumentFetchScopeKeyword:
+		if p.Keyword == "" {
+			return nil, errors.New("lark document fetch: keyword is required")
+		}
+		readOption = map[string]any{"read_mode": "keyword", "keyword": p.Keyword}
+	case DocumentFetchScopeRange:
+		if p.StartBlockID == "" || p.EndBlockID == "" {
+			return nil, errors.New("lark document fetch: range requires start and end blocks")
+		}
+		readOption = map[string]any{"read_mode": "range", "start_block_id": p.StartBlockID, "end_block_id": p.EndBlockID}
+	default:
+		return nil, errors.New("lark document fetch: unsupported scope")
+	}
+	if readOption != nil {
+		body["read_option"] = readOption
+	}
+	return body, nil
+}
+
+func documentUpdateBody(p DocumentUpdateParams) (map[string]any, error) {
+	if p.Token == "" {
+		return nil, errors.New("lark document update: missing token")
+	}
+	if p.Format == "" {
+		p.Format = "xml"
+	}
+	if p.Format != "xml" && p.Format != "markdown" {
+		return nil, errors.New("lark document update: unsupported format")
+	}
+	command := p.Command
+	blockID := p.BlockID
+	if command == "append" {
+		command = "block_insert_after"
+		blockID = "-1"
+	}
+	switch command {
+	case "str_replace", "block_insert_after", "block_replace", "block_delete":
+	default:
+		return nil, errors.New("lark document update: unsupported command")
+	}
+	body := map[string]any{"format": p.Format, "command": command}
+	for key, value := range map[string]string{
+		"content": p.Content, "pattern": p.Pattern, "block_id": blockID,
+		"start_block_id": p.StartBlockID, "end_block_id": p.EndBlockID,
+	} {
+		if value != "" {
+			body[key] = value
+		}
+	}
+	if p.RevisionID > 0 {
+		body["revision_id"] = p.RevisionID
+	}
+	return body, nil
+}
+
+func (c *httpAPIClient) doDocumentJSON(ctx context.Context, creds InstallationCredentials, method, path, token string, body, out any) error {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return errors.New("lark document request: encode failed")
+	}
+	if len(encoded) > DocumentMaxRequestBytes {
+		return errors.New("lark document request: request too large")
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.resolveBaseURL(creds)+path, bytes.NewReader(encoded))
+	if err != nil {
+		return errors.New("lark document request: create failed")
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := c.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return &documentTransportError{cause: err}
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, DocumentMaxResponseBytes+1))
+	if err != nil {
+		return errors.New("lark document response: read failed")
+	}
+	if len(raw) > DocumentMaxResponseBytes {
+		return errors.New("lark document response: response too large")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		code, _ := parseLarkErrorBody(raw)
+		return &larkAPIStatusError{StatusCode: resp.StatusCode, Code: code}
+	}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return errors.New("lark document response: decode failed")
+		}
+	}
+	return nil
+}
+
+type documentTransportError struct {
+	cause error
+}
+
+func (e *documentTransportError) Error() string { return "lark document request: transport failed" }
+func (e *documentTransportError) Unwrap() error { return e.cause }
+
+// documentOperationError represents a failed or partial Docs AI write. The
+// upstream response is intentionally omitted because it can contain document
+// content; callers must treat partial writes as uncertain and verify by reading.
+type documentOperationError struct {
+	partial bool
+}
+
+func (e *documentOperationError) Error() string {
+	return "lark document update: operation did not fully succeed"
+}
+
+func documentBlockIDs(content string) []string {
+	decoder := xml.NewDecoder(strings.NewReader("<root>" + content + "</root>"))
+	seen := make(map[string]struct{})
+	var ids []string
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			break
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		for _, attr := range start.Attr {
+			if attr.Name.Local != "block-id" && attr.Name.Local != "block_id" {
+				continue
+			}
+			if _, exists := seen[attr.Value]; exists || attr.Value == "" {
+				continue
+			}
+			seen[attr.Value] = struct{}{}
+			ids = append(ids, attr.Value)
+		}
+	}
+	return ids
+}

--- a/server/internal/integrations/lark/document_client_test.go
+++ b/server/internal/integrations/lark/document_client_test.go
@@ -1,0 +1,236 @@
+package lark
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestHTTPDocumentClientUsesDocsAIEndpoints(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok_docs", 7200)
+	fake.mux.HandleFunc("/open-apis/docs_ai/v1/documents/doc-token/fetch", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("fetch method = %s, want POST", r.Method)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		want := map[string]any{
+			"format":        "xml",
+			"export_option": map[string]any{"export_block_id": true},
+			"read_option": map[string]any{
+				"read_mode":      "section",
+				"start_block_id": "block-a",
+			},
+		}
+		if !reflect.DeepEqual(body, want) {
+			t.Fatalf("fetch body = %#v, want %#v", body, want)
+		}
+		writeJSON(w, map[string]any{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]any{"document": map[string]any{
+				"revision_id": 12,
+				"content":     `<h1 block-id="block-a">Heading</h1>`,
+			}},
+		})
+	})
+	fake.mux.HandleFunc("/open-apis/docs_ai/v1/documents/doc-token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("update method = %s, want PUT", r.Method)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		want := map[string]any{
+			"format":      "xml",
+			"command":     "block_insert_after",
+			"block_id":    "-1",
+			"content":     "hello",
+			"revision_id": float64(12),
+		}
+		if !reflect.DeepEqual(body, want) {
+			t.Fatalf("update body = %#v, want %#v", body, want)
+		}
+		writeJSON(w, map[string]any{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]any{"document": map[string]any{"revision_id": 13}, "result": "success"},
+		})
+	})
+
+	client := NewHTTPAPIClient(HTTPClientConfig{BaseURL: fake.URL()})
+	snapshot, err := client.FetchDocument(context.Background(), testCreds(), DocumentFetchParams{
+		Token:        "doc-token",
+		Format:       "xml",
+		Scope:        DocumentFetchScopeSection,
+		StartBlockID: "block-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.RevisionID != 12 || snapshot.Content == "" || !reflect.DeepEqual(snapshot.BlockIDs, []string{"block-a"}) {
+		t.Fatalf("snapshot = %+v", snapshot)
+	}
+	updated, err := client.UpdateDocument(context.Background(), testCreds(), DocumentUpdateParams{
+		Token:      "doc-token",
+		Format:     "xml",
+		Command:    "append",
+		Content:    "hello",
+		RevisionID: 12,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.RevisionID != 13 {
+		t.Fatalf("revision = %d, want 13", updated.RevisionID)
+	}
+}
+
+func TestHTTPDocumentClientDoesNotRetryUpdateTimeout(t *testing.T) {
+	var updateCalls atomic.Int32
+	transport := documentRoundTripper(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal" {
+			return documentJSONResponse(http.StatusOK, `{"code":0,"msg":"ok","tenant_access_token":"tok","expire":7200}`), nil
+		}
+		updateCalls.Add(1)
+		return nil, context.DeadlineExceeded
+	})
+	client := NewHTTPAPIClient(HTTPClientConfig{HTTPClient: &http.Client{Transport: transport}})
+	_, err := client.UpdateDocument(context.Background(), testCreds(), DocumentUpdateParams{Token: "doc-token", Format: "xml", Command: "append", Content: "hello"})
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want deadline exceeded", err)
+	}
+	if got := updateCalls.Load(); got != 1 {
+		t.Fatalf("update calls = %d, want 1", got)
+	}
+}
+
+func TestHTTPDocumentClientHonorsInstallationRegion(t *testing.T) {
+	for _, tc := range []struct {
+		region   Region
+		wantHost string
+	}{{RegionFeishu, "open.feishu.cn"}, {RegionLark, "open.larksuite.com"}} {
+		t.Run(string(tc.region), func(t *testing.T) {
+			var documentHost string
+			transport := documentRoundTripper(func(r *http.Request) (*http.Response, error) {
+				if r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal" {
+					return documentJSONResponse(http.StatusOK, `{"code":0,"msg":"ok","tenant_access_token":"tok","expire":7200}`), nil
+				}
+				documentHost = r.URL.Host
+				return documentJSONResponse(http.StatusOK, `{"code":0,"msg":"ok","data":{"document":{"revision_id":1,"content":"ok"}}}`), nil
+			})
+			client := NewHTTPAPIClient(HTTPClientConfig{HTTPClient: &http.Client{Transport: transport}})
+			creds := testCreds()
+			creds.Region = tc.region
+			if _, err := client.FetchDocument(context.Background(), creds, DocumentFetchParams{Token: "doc-token", Format: "markdown"}); err != nil {
+				t.Fatal(err)
+			}
+			if documentHost != tc.wantHost {
+				t.Fatalf("host = %q, want %q", documentHost, tc.wantHost)
+			}
+		})
+	}
+}
+
+func TestHTTPDocumentClientRefreshesRejectedTenantTokenOnce(t *testing.T) {
+	var tokenCalls atomic.Int32
+	var documentCalls atomic.Int32
+	transport := documentRoundTripper(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal" {
+			n := tokenCalls.Add(1)
+			return documentJSONResponse(http.StatusOK, `{"code":0,"msg":"ok","tenant_access_token":"tok`+string(rune('0'+n))+`","expire":7200}`), nil
+		}
+		if documentCalls.Add(1) == 1 {
+			return documentJSONResponse(http.StatusBadRequest, `{"code":99991663,"msg":"invalid token"}`), nil
+		}
+		return documentJSONResponse(http.StatusOK, `{"code":0,"msg":"ok","data":{"document":{"revision_id":1,"content":"ok"}}}`), nil
+	})
+	client := NewHTTPAPIClient(HTTPClientConfig{HTTPClient: &http.Client{Transport: transport}})
+	if _, err := client.FetchDocument(context.Background(), testCreds(), DocumentFetchParams{Token: "doc-token", Format: "xml"}); err != nil {
+		t.Fatal(err)
+	}
+	if tokenCalls.Load() != 2 || documentCalls.Load() != 2 {
+		t.Fatalf("token calls = %d, document calls = %d", tokenCalls.Load(), documentCalls.Load())
+	}
+}
+
+func TestHTTPDocumentClientDoesNotReplayUpdateAfterTokenRejection(t *testing.T) {
+	var updateCalls atomic.Int32
+	transport := documentRoundTripper(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal" {
+			return documentJSONResponse(http.StatusOK, `{"code":0,"msg":"ok","tenant_access_token":"tok","expire":7200}`), nil
+		}
+		updateCalls.Add(1)
+		return documentJSONResponse(http.StatusBadRequest, `{"code":99991663,"msg":"invalid token"}`), nil
+	})
+	client := NewHTTPAPIClient(HTTPClientConfig{HTTPClient: &http.Client{Transport: transport}})
+	_, err := client.UpdateDocument(context.Background(), testCreds(), DocumentUpdateParams{Token: "doc-token", Format: "xml", Command: "append", Content: "hello"})
+	if err == nil {
+		t.Fatal("update unexpectedly succeeded")
+	}
+	if got := updateCalls.Load(); got != 1 {
+		t.Fatalf("update calls = %d, want 1", got)
+	}
+}
+
+func TestHTTPDocumentClientRejectsPartialUpdateResult(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok", 7200)
+	fake.mux.HandleFunc("/open-apis/docs_ai/v1/documents/doc-token", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]any{"document": map[string]any{"revision_id": 13}, "result": "partial_success"},
+		})
+	})
+	client := NewHTTPAPIClient(HTTPClientConfig{BaseURL: fake.URL()})
+	_, err := client.UpdateDocument(context.Background(), testCreds(), DocumentUpdateParams{Token: "doc-token", Format: "xml", Command: "append", Content: "hello"})
+	if err == nil {
+		t.Fatal("partial update result was reported as success")
+	}
+}
+
+func TestHTTPDocumentClientRejectsOversizedResponse(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok", 7200)
+	fake.mux.HandleFunc("/open-apis/docs_ai/v1/documents/doc-token/fetch", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, strings.Repeat("x", DocumentMaxResponseBytes+1))
+	})
+	client := NewHTTPAPIClient(HTTPClientConfig{BaseURL: fake.URL()})
+	if _, err := client.FetchDocument(context.Background(), testCreds(), DocumentFetchParams{Token: "doc-token", Format: "xml"}); err == nil {
+		t.Fatal("accepted oversized response")
+	}
+}
+
+func TestHTTPDocumentClientErrorExcludesResponseBody(t *testing.T) {
+	const sentinel = "SENSITIVE-UPSTREAM-BODY"
+	fake := newLarkFake(t)
+	fake.stubToken("tok", 7200)
+	fake.mux.HandleFunc("/open-apis/docs_ai/v1/documents/doc-token/fetch", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, sentinel)
+	})
+	client := NewHTTPAPIClient(HTTPClientConfig{BaseURL: fake.URL()})
+	_, err := client.FetchDocument(context.Background(), testCreds(), DocumentFetchParams{Token: "doc-token", Format: "xml"})
+	if err == nil || strings.Contains(err.Error(), sentinel) {
+		t.Fatalf("unsafe error = %v", err)
+	}
+}
+
+type documentRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f documentRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func documentJSONResponse(status int, body string) *http.Response {
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body))}
+}

--- a/server/internal/integrations/lark/document_protocol.go
+++ b/server/internal/integrations/lark/document_protocol.go
@@ -1,0 +1,272 @@
+package lark
+
+import (
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	DocumentMaxRequestBytes  = 256 << 10
+	DocumentMaxContentBytes  = 32 << 10
+	DocumentMaxPatternBytes  = 2 << 10
+	DocumentMaxBlocks        = 20
+	DocumentConfirmBytes     = 8 << 10
+	DocumentConfirmBlocks    = 5
+	DocumentMaxResponseBytes = 4 << 20
+)
+
+type DocumentKind string
+
+const (
+	DocumentKindDocx DocumentKind = "docx"
+	DocumentKindWiki DocumentKind = "wiki"
+)
+
+type DocumentRef struct {
+	Token string
+	Kind  DocumentKind
+}
+
+type DocumentOperation string
+
+const (
+	DocumentOperationFetch        DocumentOperation = "feishu_docs_fetch"
+	DocumentOperationAppend       DocumentOperation = "feishu_docs_append"
+	DocumentOperationReplaceText  DocumentOperation = "feishu_docs_replace_text"
+	DocumentOperationInsertAfter  DocumentOperation = "feishu_docs_insert_after"
+	DocumentOperationReplaceBlock DocumentOperation = "feishu_docs_replace_block"
+	DocumentOperationDeleteBlock  DocumentOperation = "feishu_docs_delete_block"
+)
+
+type DocumentFetchScope string
+
+const (
+	DocumentFetchScopeFull    DocumentFetchScope = "full"
+	DocumentFetchScopeOutline DocumentFetchScope = "outline"
+	DocumentFetchScopeSection DocumentFetchScope = "section"
+	DocumentFetchScopeKeyword DocumentFetchScope = "keyword"
+	DocumentFetchScopeRange   DocumentFetchScope = "range"
+)
+
+type DocumentToolInput struct {
+	DocumentURL  string             `json:"document_url"`
+	Scope        DocumentFetchScope `json:"scope,omitempty"`
+	Keyword      string             `json:"keyword,omitempty"`
+	BlockID      string             `json:"block_id,omitempty"`
+	StartBlockID string             `json:"start_block_id,omitempty"`
+	EndBlockID   string             `json:"end_block_id,omitempty"`
+	Pattern      string             `json:"pattern,omitempty"`
+	Content      string             `json:"content,omitempty"`
+	RevisionID   int64              `json:"revision_id,omitempty"`
+	Confirmed    bool               `json:"confirmed,omitempty"`
+}
+
+type ValidatedDocumentRequest struct {
+	Operation DocumentOperation
+	Document  DocumentRef
+	Input     DocumentToolInput
+}
+
+type DocumentErrorCode string
+
+const (
+	DocumentErrorNotConnected        DocumentErrorCode = "not_connected"
+	DocumentErrorCapabilityDenied    DocumentErrorCode = "capability_denied"
+	DocumentErrorPermissionDenied    DocumentErrorCode = "permission_denied"
+	DocumentErrorInvalidRequest      DocumentErrorCode = "invalid_request"
+	DocumentErrorNotFound            DocumentErrorCode = "not_found"
+	DocumentErrorConflict            DocumentErrorCode = "conflict"
+	DocumentErrorUnsupportedContent  DocumentErrorCode = "unsupported_content"
+	DocumentErrorTimeoutUncertain    DocumentErrorCode = "timeout_uncertain"
+	DocumentErrorUpstreamUnavailable DocumentErrorCode = "upstream_unavailable"
+)
+
+type DocumentToolError struct {
+	Code      DocumentErrorCode `json:"code"`
+	Message   string            `json:"message"`
+	Uncertain bool              `json:"uncertain,omitempty"`
+}
+
+func (e *DocumentToolError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return string(e.Code) + ": " + e.Message
+}
+
+var (
+	documentPathPattern    = regexp.MustCompile(`^/(docx|wiki)/([A-Za-z0-9_-]{8,128})$`)
+	documentBlockIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
+)
+
+func ParseFeishuDocumentURL(raw string) (DocumentRef, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || parsed.Opaque != "" ||
+		parsed.User != nil || parsed.Port() != "" || parsed.Fragment != "" {
+		return DocumentRef{}, invalidDocumentRequest("document_url must be a supported Feishu document URL")
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" || net.ParseIP(host) != nil || !isFeishuDocumentHost(host) {
+		return DocumentRef{}, invalidDocumentRequest("document_url must use a supported Feishu document host")
+	}
+	match := documentPathPattern.FindStringSubmatch(parsed.EscapedPath())
+	if len(match) != 3 {
+		return DocumentRef{}, invalidDocumentRequest("document_url must identify one docx or wiki document")
+	}
+	return DocumentRef{Kind: DocumentKind(match[1]), Token: match[2]}, nil
+}
+
+func isFeishuDocumentHost(host string) bool {
+	for _, suffix := range []string{"feishu.cn", "larksuite.com", "larkoffice.com"} {
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func ValidateDocumentToolInput(operation DocumentOperation, input DocumentToolInput) (ValidatedDocumentRequest, *DocumentToolError) {
+	ref, err := ParseFeishuDocumentURL(input.DocumentURL)
+	if err != nil {
+		return ValidatedDocumentRequest{}, invalidDocumentRequest("document_url is invalid")
+	}
+	if input.RevisionID < 0 || !validDocumentStrings(input) {
+		return ValidatedDocumentRequest{}, invalidDocumentRequest("document input is invalid")
+	}
+	if len(input.Content) > DocumentMaxContentBytes || len(input.Pattern) > DocumentMaxPatternBytes ||
+		len(input.Keyword) > DocumentMaxPatternBytes {
+		return ValidatedDocumentRequest{}, invalidDocumentRequest("document input exceeds a fixed limit")
+	}
+	if input.Content != "" && len(input.Content) > DocumentConfirmBytes && !input.Confirmed {
+		return ValidatedDocumentRequest{}, invalidDocumentRequest("confirmed is required for this edit")
+	}
+	if !validOptionalBlockID(input.BlockID) || !validOptionalBlockID(input.StartBlockID) ||
+		!validOptionalBlockID(input.EndBlockID) {
+		return ValidatedDocumentRequest{}, invalidDocumentRequest("block identifier is invalid")
+	}
+
+	normalized := input
+	var validationErr *DocumentToolError
+	switch operation {
+	case DocumentOperationFetch:
+		validationErr = validateFetchInput(&normalized)
+	case DocumentOperationAppend:
+		validationErr = validateAppendInput(normalized)
+	case DocumentOperationReplaceText:
+		validationErr = validateReplaceTextInput(normalized)
+	case DocumentOperationInsertAfter:
+		validationErr = validateInsertAfterInput(normalized)
+	case DocumentOperationReplaceBlock:
+		validationErr = validateReplaceBlockInput(normalized)
+	case DocumentOperationDeleteBlock:
+		validationErr = validateDeleteBlockInput(normalized)
+	default:
+		validationErr = invalidDocumentRequest("document operation is unsupported")
+	}
+	if validationErr != nil {
+		return ValidatedDocumentRequest{}, validationErr
+	}
+	return ValidatedDocumentRequest{Operation: operation, Document: ref, Input: normalized}, nil
+}
+
+func validDocumentStrings(input DocumentToolInput) bool {
+	for _, value := range []string{
+		input.DocumentURL, string(input.Scope), input.Keyword, input.BlockID,
+		input.StartBlockID, input.EndBlockID, input.Pattern, input.Content,
+	} {
+		if !utf8.ValidString(value) || strings.ContainsRune(value, '\x00') {
+			return false
+		}
+	}
+	return true
+}
+
+func validOptionalBlockID(value string) bool {
+	return value == "" || documentBlockIDPattern.MatchString(value)
+}
+
+func validateFetchInput(input *DocumentToolInput) *DocumentToolError {
+	if input.Scope == "" {
+		input.Scope = DocumentFetchScopeFull
+	}
+	if input.Content != "" || input.Pattern != "" || input.BlockID != "" ||
+		input.RevisionID != 0 || input.Confirmed {
+		return invalidDocumentRequest("fetch contains edit-only fields")
+	}
+	switch input.Scope {
+	case DocumentFetchScopeFull, DocumentFetchScopeOutline:
+		if input.Keyword != "" || input.StartBlockID != "" || input.EndBlockID != "" {
+			return invalidDocumentRequest("fetch scope fields do not match")
+		}
+	case DocumentFetchScopeSection:
+		if input.Keyword != "" || input.StartBlockID == "" || input.EndBlockID != "" {
+			return invalidDocumentRequest("section fetch requires only a start block")
+		}
+	case DocumentFetchScopeKeyword:
+		if strings.TrimSpace(input.Keyword) == "" || input.StartBlockID != "" || input.EndBlockID != "" {
+			return invalidDocumentRequest("keyword fetch requires only keyword")
+		}
+	case DocumentFetchScopeRange:
+		if input.Keyword != "" || input.StartBlockID == "" || input.EndBlockID == "" {
+			return invalidDocumentRequest("range fetch requires start and end blocks")
+		}
+	default:
+		return invalidDocumentRequest("fetch scope is unsupported")
+	}
+	return nil
+}
+
+func validateAppendInput(input DocumentToolInput) *DocumentToolError {
+	if strings.TrimSpace(input.Content) == "" || input.Scope != "" || input.Keyword != "" ||
+		input.Pattern != "" || input.BlockID != "" || input.StartBlockID != "" || input.EndBlockID != "" {
+		return invalidDocumentRequest("append fields do not match")
+	}
+	return nil
+}
+
+func validateReplaceTextInput(input DocumentToolInput) *DocumentToolError {
+	if input.Pattern == "" || input.Content == "" || input.Scope != "" || input.Keyword != "" ||
+		input.BlockID != "" || input.StartBlockID != "" || input.EndBlockID != "" {
+		return invalidDocumentRequest("replace_text fields do not match")
+	}
+	return nil
+}
+
+func validateInsertAfterInput(input DocumentToolInput) *DocumentToolError {
+	if input.BlockID == "" || strings.TrimSpace(input.Content) == "" || input.Scope != "" ||
+		input.Keyword != "" || input.Pattern != "" || input.StartBlockID != "" || input.EndBlockID != "" {
+		return invalidDocumentRequest("insert_after fields do not match")
+	}
+	return nil
+}
+
+func validateReplaceBlockInput(input DocumentToolInput) *DocumentToolError {
+	hasBlock := input.BlockID != ""
+	hasRange := input.StartBlockID != "" && input.EndBlockID != ""
+	if hasBlock == hasRange || strings.TrimSpace(input.Content) == "" || input.Scope != "" ||
+		input.Keyword != "" || input.Pattern != "" ||
+		(input.StartBlockID == "") != (input.EndBlockID == "") {
+		return invalidDocumentRequest("replace_block fields do not match")
+	}
+	if hasRange && !input.Confirmed {
+		return invalidDocumentRequest("confirmed is required for a block range")
+	}
+	return nil
+}
+
+func validateDeleteBlockInput(input DocumentToolInput) *DocumentToolError {
+	hasBlock := input.BlockID != ""
+	hasRange := input.StartBlockID != "" && input.EndBlockID != ""
+	if hasBlock == hasRange || !input.Confirmed || input.Scope != "" || input.Keyword != "" ||
+		input.Pattern != "" || input.Content != "" || (input.StartBlockID == "") != (input.EndBlockID == "") {
+		return invalidDocumentRequest("delete_block fields do not match or confirmation is missing")
+	}
+	return nil
+}
+
+func invalidDocumentRequest(message string) *DocumentToolError {
+	return &DocumentToolError{Code: DocumentErrorInvalidRequest, Message: message}
+}

--- a/server/internal/integrations/lark/document_protocol_test.go
+++ b/server/internal/integrations/lark/document_protocol_test.go
@@ -1,0 +1,130 @@
+package lark
+
+import (
+	"strings"
+	"testing"
+)
+
+const testDocumentURL = "https://acme.feishu.cn/docx/AbcdefghijkLMNop"
+
+func TestParseFeishuDocumentURLAcceptsSupportedCloudsAndKinds(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantKind  DocumentKind
+		wantToken string
+	}{
+		{name: "mainland docx", raw: "https://acme.feishu.cn/docx/AbcdefghijkLMNop", wantKind: DocumentKindDocx, wantToken: "AbcdefghijkLMNop"},
+		{name: "international wiki with harmless share query", raw: "https://acme.larksuite.com/wiki/WikidefghijkLMNop?from=from_copylink", wantKind: DocumentKindWiki, wantToken: "WikidefghijkLMNop"},
+		{name: "legacy international host", raw: "https://acme.larkoffice.com/docx/Legacy2345678901", wantKind: DocumentKindDocx, wantToken: "Legacy2345678901"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseFeishuDocumentURL(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseFeishuDocumentURL() error = %v", err)
+			}
+			if got.Kind != tt.wantKind || got.Token != tt.wantToken {
+				t.Fatalf("ParseFeishuDocumentURL() = %+v, want kind=%q token=%q", got, tt.wantKind, tt.wantToken)
+			}
+		})
+	}
+}
+
+func TestParseFeishuDocumentURLRejectsIdentityAndEndpointConfusion(t *testing.T) {
+	tests := []string{
+		"AbcdefghijkLMNop",
+		"http://acme.feishu.cn/docx/AbcdefghijkLMNop",
+		"https://evilfeishu.cn/docx/AbcdefghijkLMNop",
+		"https://feishu.cn.evil.example/docx/AbcdefghijkLMNop",
+		"https://127.0.0.1/docx/AbcdefghijkLMNop",
+		"https://user@acme.feishu.cn/docx/AbcdefghijkLMNop",
+		"https://acme.feishu.cn:8443/docx/AbcdefghijkLMNop",
+		"https://acme.feishu.cn/docx/AbcdefghijkLMNop#fragment",
+		"https://acme.feishu.cn/drive/AbcdefghijkLMNop",
+		"https://acme.feishu.cn/docx/short",
+		"https://acme.feishu.cn/docx/AbcdefghijkLMNop/children",
+	}
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ParseFeishuDocumentURL(raw); err == nil {
+				t.Fatalf("ParseFeishuDocumentURL(%q) unexpectedly succeeded", raw)
+			}
+		})
+	}
+}
+
+func TestValidateDocumentToolInputAppliesOperationContracts(t *testing.T) {
+	tests := []struct {
+		name string
+		op   DocumentOperation
+		in   DocumentToolInput
+	}{
+		{name: "fetch defaults to full", op: DocumentOperationFetch, in: DocumentToolInput{DocumentURL: testDocumentURL}},
+		{name: "fetch section", op: DocumentOperationFetch, in: DocumentToolInput{DocumentURL: testDocumentURL, Scope: DocumentFetchScopeSection, StartBlockID: "section-heading"}},
+		{name: "fetch keyword", op: DocumentOperationFetch, in: DocumentToolInput{DocumentURL: testDocumentURL, Scope: DocumentFetchScopeKeyword, Keyword: "quarterly result"}},
+		{name: "append small text", op: DocumentOperationAppend, in: DocumentToolInput{DocumentURL: testDocumentURL, Content: "status update"}},
+		{name: "replace unique text request", op: DocumentOperationReplaceText, in: DocumentToolInput{DocumentURL: testDocumentURL, Pattern: "old", Content: "new"}},
+		{name: "insert after block", op: DocumentOperationInsertAfter, in: DocumentToolInput{DocumentURL: testDocumentURL, BlockID: "doxcn_target-1", Content: "new paragraph"}},
+		{name: "replace one block", op: DocumentOperationReplaceBlock, in: DocumentToolInput{DocumentURL: testDocumentURL, BlockID: "doxcn_target-1", Content: "replacement"}},
+		{name: "delete confirmed block", op: DocumentOperationDeleteBlock, in: DocumentToolInput{DocumentURL: testDocumentURL, BlockID: "doxcn_target-1", Confirmed: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, toolErr := ValidateDocumentToolInput(tt.op, tt.in)
+			if toolErr != nil {
+				t.Fatalf("ValidateDocumentToolInput() error = %v", toolErr)
+			}
+			if got.Operation != tt.op || got.Document.Token != "AbcdefghijkLMNop" {
+				t.Fatalf("ValidateDocumentToolInput() = %+v", got)
+			}
+			if tt.name == "fetch defaults to full" && got.Input.Scope != DocumentFetchScopeFull {
+				t.Fatalf("default scope = %q, want %q", got.Input.Scope, DocumentFetchScopeFull)
+			}
+		})
+	}
+}
+
+func TestValidateDocumentToolInputRejectsUnsafeShapesAndBounds(t *testing.T) {
+	tests := []struct {
+		name string
+		op   DocumentOperation
+		in   DocumentToolInput
+	}{
+		{"unknown operation", DocumentOperation("overwrite"), DocumentToolInput{DocumentURL: testDocumentURL}},
+		{"section without anchor", DocumentOperationFetch, DocumentToolInput{DocumentURL: testDocumentURL, Scope: DocumentFetchScopeSection}},
+		{"keyword scope without keyword", DocumentOperationFetch, DocumentToolInput{DocumentURL: testDocumentURL, Scope: DocumentFetchScopeKeyword}},
+		{"range without end", DocumentOperationFetch, DocumentToolInput{DocumentURL: testDocumentURL, Scope: DocumentFetchScopeRange, StartBlockID: "start"}},
+		{"append without content", DocumentOperationAppend, DocumentToolInput{DocumentURL: testDocumentURL}},
+		{"pattern too large", DocumentOperationReplaceText, DocumentToolInput{DocumentURL: testDocumentURL, Pattern: strings.Repeat("x", DocumentMaxPatternBytes+1), Content: "new"}},
+		{"content too large", DocumentOperationAppend, DocumentToolInput{DocumentURL: testDocumentURL, Content: strings.Repeat("x", DocumentMaxContentBytes+1), Confirmed: true}},
+		{"large edit without confirmation", DocumentOperationAppend, DocumentToolInput{DocumentURL: testDocumentURL, Content: strings.Repeat("x", DocumentConfirmBytes+1)}},
+		{"delete without confirmation", DocumentOperationDeleteBlock, DocumentToolInput{DocumentURL: testDocumentURL, BlockID: "target"}},
+		{"multi block replace without confirmation", DocumentOperationReplaceBlock, DocumentToolInput{DocumentURL: testDocumentURL, StartBlockID: "start", EndBlockID: "end", Content: "replacement"}},
+		{"block id with slash", DocumentOperationInsertAfter, DocumentToolInput{DocumentURL: testDocumentURL, BlockID: "../target", Content: "new"}},
+		{"negative revision", DocumentOperationAppend, DocumentToolInput{DocumentURL: testDocumentURL, Content: "new", RevisionID: -1}},
+		{"nul content", DocumentOperationAppend, DocumentToolInput{DocumentURL: testDocumentURL, Content: "before\x00after"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, toolErr := ValidateDocumentToolInput(tt.op, tt.in)
+			if toolErr == nil || toolErr.Code != DocumentErrorInvalidRequest {
+				t.Fatalf("ValidateDocumentToolInput() error = %+v, want invalid_request", toolErr)
+			}
+		})
+	}
+}
+
+func TestDocumentValidationErrorsDoNotEchoRejectedValues(t *testing.T) {
+	const sentinel = "SECRET-REJECTED-VALUE"
+	_, toolErr := ValidateDocumentToolInput(
+		DocumentOperationAppend,
+		DocumentToolInput{DocumentURL: "https://evil.example/docx/" + sentinel, Content: sentinel},
+	)
+	if toolErr == nil {
+		t.Fatal("ValidateDocumentToolInput() unexpectedly succeeded")
+	}
+	if strings.Contains(toolErr.Error(), sentinel) {
+		t.Fatalf("validation error leaked rejected input: %v", toolErr)
+	}
+}

--- a/server/internal/integrations/lark/document_service.go
+++ b/server/internal/integrations/lark/document_service.go
@@ -1,0 +1,339 @@
+package lark
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/util"
+)
+
+// DocumentInstallationStore resolves the active Feishu installation for an Agent.
+type DocumentInstallationStore interface {
+	GetActiveLarkInstallationForAgent(context.Context, pgtype.UUID, pgtype.UUID) (Installation, error)
+}
+
+// DocumentTaskScope is trusted task capability state supplied by the MCP handler.
+type DocumentTaskScope struct {
+	TaskID               pgtype.UUID
+	WorkspaceID          pgtype.UUID
+	AgentID              pgtype.UUID
+	RuntimeID            pgtype.UUID
+	DaemonID             string
+	InstallationID       pgtype.UUID
+	InstallationRevision int64
+}
+
+// DocumentToolResult contains only bounded document output and verification state.
+type DocumentToolResult struct {
+	RevisionID int64    `json:"revision_id"`
+	Content    string   `json:"content,omitempty"`
+	BlockIDs   []string `json:"block_ids,omitempty"`
+	Changed    bool     `json:"changed,omitempty"`
+	Verified   bool     `json:"verified,omitempty"`
+}
+
+// DocumentService performs guarded document operations using one Agent installation.
+type DocumentService struct {
+	store       DocumentInstallationStore
+	credentials CredentialsResolver
+	client      DocumentAPIClient
+	logger      *slog.Logger
+	now         func() time.Time
+}
+
+// NewDocumentService constructs the Agent-scoped document orchestrator.
+func NewDocumentService(store DocumentInstallationStore, credentials CredentialsResolver, client DocumentAPIClient, logger *slog.Logger) *DocumentService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &DocumentService{store: store, credentials: credentials, client: client, logger: logger, now: time.Now}
+}
+
+// Execute validates the fixed protocol, rechecks the pinned installation, and
+// performs one read or one guarded write followed by verification.
+func (s *DocumentService) Execute(ctx context.Context, scope DocumentTaskScope, operation DocumentOperation, input DocumentToolInput) (result DocumentToolResult, toolErr *DocumentToolError) {
+	started := s.now()
+	fingerprint := "invalid"
+	defer func() {
+		resultClass := "success"
+		if toolErr != nil {
+			resultClass = string(toolErr.Code)
+		}
+		s.logger.Info("feishu document operation",
+			"operation", string(operation),
+			"result_class", resultClass,
+			"duration_ms", s.now().Sub(started).Milliseconds(),
+			"document_fingerprint", fingerprint,
+			"task_id", util.UUIDToString(scope.TaskID),
+			"installation_id", util.UUIDToString(scope.InstallationID),
+		)
+	}()
+
+	request, validationErr := ValidateDocumentToolInput(operation, input)
+	if validationErr != nil {
+		return DocumentToolResult{}, validationErr
+	}
+	fingerprint = documentFingerprint(request.Document.Token)
+	if !validDocumentTaskScope(scope) {
+		return DocumentToolResult{}, documentCapabilityDenied()
+	}
+
+	installation, err := s.store.GetActiveLarkInstallationForAgent(ctx, scope.WorkspaceID, scope.AgentID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return DocumentToolResult{}, &DocumentToolError{Code: DocumentErrorNotConnected, Message: "This Agent has no active Feishu bot connection."}
+		}
+		return DocumentToolResult{}, documentUpstreamUnavailable()
+	}
+	if !installationMatchesDocumentScope(installation, scope) {
+		return DocumentToolResult{}, documentCapabilityDenied()
+	}
+	secret, err := s.credentials.DecryptAppSecret(installation)
+	if err != nil || secret == "" || installation.AppID == "" {
+		return DocumentToolResult{}, documentUpstreamUnavailable()
+	}
+	credentials := InstallationCredentials{
+		AppID:     installation.AppID,
+		AppSecret: secret,
+		TenantKey: installation.TenantKey.String,
+		Region:    RegionOrDefault(installation.Region),
+	}
+
+	if operation == DocumentOperationFetch {
+		snapshot, fetchErr := s.client.FetchDocument(ctx, credentials, fetchParamsForRequest(request))
+		if fetchErr != nil {
+			return DocumentToolResult{}, normalizeDocumentServiceError(fetchErr, false)
+		}
+		return documentResultFromSnapshot(snapshot, false, true), nil
+	}
+	return s.executeWrite(ctx, credentials, request)
+}
+
+func (s *DocumentService) executeWrite(ctx context.Context, credentials InstallationCredentials, request ValidatedDocumentRequest) (DocumentToolResult, *DocumentToolError) {
+	preParams := guardedWriteFetchParams(request)
+	before, err := s.client.FetchDocument(ctx, credentials, preParams)
+	if err != nil {
+		return DocumentToolResult{}, normalizeDocumentServiceError(err, false)
+	}
+	if before.RevisionID <= 0 {
+		return DocumentToolResult{}, &DocumentToolError{Code: DocumentErrorConflict, Message: "The current document revision is unavailable; read it again before writing."}
+	}
+	if request.Operation == DocumentOperationReplaceText && strings.Count(before.Content, request.Input.Pattern) != 1 {
+		return DocumentToolResult{}, &DocumentToolError{Code: DocumentErrorConflict, Message: "The replacement target is not unique in the current document."}
+	}
+	if targetErr := validateDocumentWriteTargets(request, before); targetErr != nil {
+		return DocumentToolResult{}, targetErr
+	}
+
+	updateParams := updateParamsForRequest(request, before.RevisionID)
+	updated, updateErr := s.client.UpdateDocument(ctx, credentials, updateParams)
+	if updateErr != nil && !ambiguousDocumentWriteError(updateErr) {
+		return DocumentToolResult{}, normalizeDocumentServiceError(updateErr, true)
+	}
+	after, verifyErr := s.client.FetchDocument(ctx, credentials, preParams)
+	if verifyErr != nil {
+		return DocumentToolResult{}, &DocumentToolError{Code: DocumentErrorTimeoutUncertain, Message: "The write may have completed, but its result could not be verified.", Uncertain: true}
+	}
+	if updateErr != nil {
+		if writeAppearsApplied(request, before, after) {
+			return documentResultFromSnapshot(after, true, true), nil
+		}
+		return DocumentToolResult{}, &DocumentToolError{Code: DocumentErrorTimeoutUncertain, Message: "The write result is uncertain; read the target again before any retry.", Uncertain: true}
+	}
+	if after.RevisionID == 0 {
+		after.RevisionID = updated.RevisionID
+	}
+	return documentResultFromSnapshot(after, true, true), nil
+}
+
+func validDocumentTaskScope(scope DocumentTaskScope) bool {
+	return scope.TaskID.Valid && scope.WorkspaceID.Valid && scope.AgentID.Valid && scope.RuntimeID.Valid &&
+		scope.InstallationID.Valid && scope.DaemonID != "" && scope.InstallationRevision > 0
+}
+
+func installationMatchesDocumentScope(installation Installation, scope DocumentTaskScope) bool {
+	if installation.ID != scope.InstallationID || installation.WorkspaceID != scope.WorkspaceID || installation.AgentID != scope.AgentID ||
+		installation.Status != "active" || !installation.UpdatedAt.Valid || installation.UpdatedAt.Time.UnixNano() != scope.InstallationRevision {
+		return false
+	}
+	switch Region(installation.Region) {
+	case "", RegionFeishu, RegionLark:
+		return true
+	default:
+		return false
+	}
+}
+
+func fetchParamsForRequest(request ValidatedDocumentRequest) DocumentFetchParams {
+	format := "xml"
+	if request.Input.Scope == DocumentFetchScopeFull {
+		format = "markdown"
+	}
+	return DocumentFetchParams{
+		Token:        request.Document.Token,
+		Format:       format,
+		Scope:        request.Input.Scope,
+		Keyword:      request.Input.Keyword,
+		StartBlockID: request.Input.StartBlockID,
+		EndBlockID:   request.Input.EndBlockID,
+	}
+}
+
+func guardedWriteFetchParams(request ValidatedDocumentRequest) DocumentFetchParams {
+	params := DocumentFetchParams{Token: request.Document.Token, Format: "markdown", Scope: DocumentFetchScopeFull}
+	switch request.Operation {
+	case DocumentOperationInsertAfter, DocumentOperationReplaceBlock, DocumentOperationDeleteBlock:
+		params.Format = "xml"
+		params.Scope = DocumentFetchScopeRange
+		if request.Input.BlockID != "" {
+			params.StartBlockID = request.Input.BlockID
+			params.EndBlockID = request.Input.BlockID
+		} else {
+			params.StartBlockID = request.Input.StartBlockID
+			params.EndBlockID = request.Input.EndBlockID
+		}
+	}
+	return params
+}
+
+func updateParamsForRequest(request ValidatedDocumentRequest, revisionID int64) DocumentUpdateParams {
+	command := map[DocumentOperation]string{
+		DocumentOperationAppend:       "append",
+		DocumentOperationReplaceText:  "str_replace",
+		DocumentOperationInsertAfter:  "block_insert_after",
+		DocumentOperationReplaceBlock: "block_replace",
+		DocumentOperationDeleteBlock:  "block_delete",
+	}[request.Operation]
+	format := "xml"
+	if request.Operation == DocumentOperationAppend {
+		format = "markdown"
+	}
+	return DocumentUpdateParams{
+		Token:        request.Document.Token,
+		Format:       format,
+		Command:      command,
+		Content:      request.Input.Content,
+		Pattern:      request.Input.Pattern,
+		BlockID:      request.Input.BlockID,
+		StartBlockID: request.Input.StartBlockID,
+		EndBlockID:   request.Input.EndBlockID,
+		RevisionID:   revisionID,
+	}
+}
+
+func validateDocumentWriteTargets(request ValidatedDocumentRequest, snapshot DocumentSnapshot) *DocumentToolError {
+	if request.Operation != DocumentOperationInsertAfter && request.Operation != DocumentOperationReplaceBlock && request.Operation != DocumentOperationDeleteBlock {
+		return nil
+	}
+	if len(snapshot.BlockIDs) > DocumentMaxBlocks {
+		return &DocumentToolError{Code: DocumentErrorInvalidRequest, Message: "The selected block range exceeds the fixed limit."}
+	}
+	want := []string{request.Input.BlockID}
+	if request.Input.BlockID == "" {
+		want = []string{request.Input.StartBlockID, request.Input.EndBlockID}
+	}
+	for _, id := range want {
+		if !containsDocumentBlock(snapshot.BlockIDs, id) {
+			return &DocumentToolError{Code: DocumentErrorNotFound, Message: "A selected document block was not found in the fresh read."}
+		}
+	}
+	return nil
+}
+
+func containsDocumentBlock(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func writeAppearsApplied(request ValidatedDocumentRequest, before, after DocumentSnapshot) bool {
+	switch request.Operation {
+	case DocumentOperationAppend:
+		return !strings.Contains(before.Content, request.Input.Content) && strings.Contains(after.Content, request.Input.Content)
+	case DocumentOperationReplaceText:
+		return strings.Count(after.Content, request.Input.Pattern) == 0 && strings.Contains(after.Content, request.Input.Content)
+	case DocumentOperationDeleteBlock:
+		if request.Input.BlockID != "" {
+			return containsDocumentBlock(before.BlockIDs, request.Input.BlockID) && !containsDocumentBlock(after.BlockIDs, request.Input.BlockID)
+		}
+	}
+	return false
+}
+
+func ambiguousDocumentWriteError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var transportErr *documentTransportError
+	if errors.As(err, &transportErr) {
+		return true
+	}
+	var statusErr *larkAPIStatusError
+	if errors.As(err, &statusErr) && statusErr.StatusCode >= http.StatusInternalServerError {
+		return true
+	}
+	var operationErr *documentOperationError
+	return errors.As(err, &operationErr)
+}
+
+func normalizeDocumentServiceError(err error, write bool) *DocumentToolError {
+	if write && ambiguousDocumentWriteError(err) {
+		return &DocumentToolError{Code: DocumentErrorTimeoutUncertain, Message: "The write result is uncertain; read the target again before any retry.", Uncertain: true}
+	}
+	var statusErr *larkAPIStatusError
+	if errors.As(err, &statusErr) {
+		switch statusErr.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return documentPermissionDenied()
+		case http.StatusNotFound:
+			return &DocumentToolError{Code: DocumentErrorNotFound, Message: "The document or selected block was not found."}
+		case http.StatusConflict:
+			return &DocumentToolError{Code: DocumentErrorConflict, Message: "The document changed; read it again before retrying."}
+		}
+	}
+	switch larkErrorCode(err) {
+	case 99991672, 1770003:
+		return documentPermissionDenied()
+	case 1770002, 1061004, 1061044:
+		return &DocumentToolError{Code: DocumentErrorNotFound, Message: "The document or selected block was not found."}
+	}
+	return documentUpstreamUnavailable()
+}
+
+func documentPermissionDenied() *DocumentToolError {
+	return &DocumentToolError{Code: DocumentErrorPermissionDenied, Message: "The current Feishu bot cannot access this document. Grant that bot the required document permission and retry."}
+}
+
+func documentCapabilityDenied() *DocumentToolError {
+	return &DocumentToolError{Code: DocumentErrorCapabilityDenied, Message: "This task's Feishu document capability is no longer valid."}
+}
+
+func documentUpstreamUnavailable() *DocumentToolError {
+	return &DocumentToolError{Code: DocumentErrorUpstreamUnavailable, Message: "The Feishu document service is temporarily unavailable."}
+}
+
+func documentResultFromSnapshot(snapshot DocumentSnapshot, changed, verified bool) DocumentToolResult {
+	return DocumentToolResult{RevisionID: snapshot.RevisionID, Content: snapshot.Content, BlockIDs: snapshot.BlockIDs, Changed: changed, Verified: verified}
+}
+
+func documentFingerprint(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return fmt.Sprintf("%x", sum[:6])
+}
+
+func formatDocumentRevision(revision int64) string {
+	return strconv.FormatInt(revision, 10)
+}

--- a/server/internal/integrations/lark/document_service_test.go
+++ b/server/internal/integrations/lark/document_service_test.go
@@ -1,0 +1,247 @@
+package lark
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+var (
+	documentTestWorkspaceID  = mustDocumentUUID("10000000-0000-4000-8000-000000000001")
+	documentTestAgentID      = mustDocumentUUID("10000000-0000-4000-8000-000000000002")
+	documentTestRuntimeID    = mustDocumentUUID("10000000-0000-4000-8000-000000000003")
+	documentTestTaskID       = mustDocumentUUID("10000000-0000-4000-8000-000000000004")
+	documentTestInstallID    = mustDocumentUUID("10000000-0000-4000-8000-000000000005")
+	documentTestInstalledAt  = time.Unix(1_700_000_000, 123)
+	documentTestInstallation = Installation{
+		ID:          documentTestInstallID,
+		WorkspaceID: documentTestWorkspaceID,
+		AgentID:     documentTestAgentID,
+		AppID:       "cli_pikachu",
+		Status:      "active",
+		Region:      string(RegionFeishu),
+		UpdatedAt:   pgtype.Timestamptz{Time: documentTestInstalledAt, Valid: true},
+	}
+	documentTestScope = DocumentTaskScope{
+		TaskID:               documentTestTaskID,
+		WorkspaceID:          documentTestWorkspaceID,
+		AgentID:              documentTestAgentID,
+		RuntimeID:            documentTestRuntimeID,
+		DaemonID:             "daemon-a",
+		InstallationID:       documentTestInstallID,
+		InstallationRevision: documentTestInstalledAt.UnixNano(),
+	}
+)
+
+func TestDocumentServiceUsesScopedInstallationCredentials(t *testing.T) {
+	client := &fakeDocumentClient{fetches: []DocumentSnapshot{{RevisionID: 7, Content: "hello"}}}
+	service := NewDocumentService(
+		&fakeDocumentInstallStore{installation: documentTestInstallation},
+		fakeDocumentCredentials{secret: "pikachu-secret"},
+		client,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	result, toolErr := service.Execute(context.Background(), documentTestScope, DocumentOperationFetch, DocumentToolInput{DocumentURL: testDocumentURL})
+	if toolErr != nil {
+		t.Fatal(toolErr)
+	}
+	if result.Content != "hello" || client.lastCredentials.AppID != "cli_pikachu" || client.lastCredentials.AppSecret != "pikachu-secret" {
+		t.Fatalf("result=%+v credentials=%+v", result, client.lastCredentials)
+	}
+}
+
+func TestDocumentServiceRejectsStaleInstallationCapability(t *testing.T) {
+	for _, mutate := range []func(*DocumentTaskScope){
+		func(scope *DocumentTaskScope) {
+			scope.InstallationID = mustDocumentUUID("20000000-0000-4000-8000-000000000005")
+		},
+		func(scope *DocumentTaskScope) { scope.InstallationRevision++ },
+		func(scope *DocumentTaskScope) {
+			scope.AgentID = mustDocumentUUID("20000000-0000-4000-8000-000000000002")
+		},
+	} {
+		scope := documentTestScope
+		mutate(&scope)
+		client := &fakeDocumentClient{}
+		_, toolErr := newTestDocumentService(client).Execute(context.Background(), scope, DocumentOperationFetch, DocumentToolInput{DocumentURL: testDocumentURL})
+		if toolErr == nil || toolErr.Code != DocumentErrorCapabilityDenied || client.fetchCalls != 0 {
+			t.Fatalf("error=%+v fetches=%d", toolErr, client.fetchCalls)
+		}
+	}
+}
+
+func TestDocumentServiceReplaceTextRequiresOneMatch(t *testing.T) {
+	for _, content := range []string{"no match", "old and old"} {
+		client := &fakeDocumentClient{fetches: []DocumentSnapshot{{RevisionID: 7, Content: content}}}
+		_, toolErr := newTestDocumentService(client).Execute(context.Background(), documentTestScope, DocumentOperationReplaceText, DocumentToolInput{
+			DocumentURL: testDocumentURL,
+			Pattern:     "old",
+			Content:     "new",
+		})
+		if toolErr == nil || toolErr.Code != DocumentErrorConflict || len(client.updates) != 0 {
+			t.Fatalf("content=%q error=%+v updates=%d", content, toolErr, len(client.updates))
+		}
+	}
+}
+
+func TestDocumentServiceWriteTimeoutReadsBeforeAnyRetry(t *testing.T) {
+	client := &fakeDocumentClient{
+		fetches:   []DocumentSnapshot{{RevisionID: 7, Content: "before"}, {RevisionID: 8, Content: "after"}},
+		updateErr: context.DeadlineExceeded,
+	}
+	_, toolErr := newTestDocumentService(client).Execute(context.Background(), documentTestScope, DocumentOperationAppend, DocumentToolInput{
+		DocumentURL: testDocumentURL,
+		Content:     "marker",
+	})
+	if toolErr == nil || toolErr.Code != DocumentErrorTimeoutUncertain || len(client.updates) != 1 || client.fetchCalls != 2 {
+		t.Fatalf("error=%+v updates=%d fetches=%d", toolErr, len(client.updates), client.fetchCalls)
+	}
+}
+
+func TestDocumentServiceRefusesUnversionedWrite(t *testing.T) {
+	client := &fakeDocumentClient{fetches: []DocumentSnapshot{{RevisionID: 0, Content: "before"}}}
+	_, toolErr := newTestDocumentService(client).Execute(context.Background(), documentTestScope, DocumentOperationAppend, DocumentToolInput{
+		DocumentURL: testDocumentURL,
+		Content:     "marker",
+	})
+	if toolErr == nil || toolErr.Code != DocumentErrorConflict || len(client.updates) != 0 {
+		t.Fatalf("error=%+v updates=%d", toolErr, len(client.updates))
+	}
+}
+
+func TestDocumentServiceStructuralWriteFetchesBeforeAndAfter(t *testing.T) {
+	client := &fakeDocumentClient{fetches: []DocumentSnapshot{
+		{RevisionID: 7, BlockIDs: []string{"block-a"}},
+		{RevisionID: 8, BlockIDs: []string{"block-a"}},
+	}}
+	_, toolErr := newTestDocumentService(client).Execute(context.Background(), documentTestScope, DocumentOperationReplaceBlock, DocumentToolInput{
+		DocumentURL: testDocumentURL,
+		BlockID:     "block-a",
+		Content:     "new",
+	})
+	if toolErr != nil || !reflect.DeepEqual(client.calls, []string{"fetch", "update:7", "fetch"}) {
+		t.Fatalf("error=%+v calls=%v", toolErr, client.calls)
+	}
+}
+
+func TestDocumentServiceAuditContainsNoSensitiveMaterial(t *testing.T) {
+	var logs bytes.Buffer
+	installation := documentTestInstallation
+	installation.AppID = "SENSITIVE-APP-ID"
+	installation.AppSecretEncrypted = []byte("SENSITIVE-CIPHERTEXT")
+	client := &fakeDocumentClient{fetches: []DocumentSnapshot{{RevisionID: 7, Content: "SENSITIVE-DOCUMENT-CONTENT"}}}
+	service := NewDocumentService(
+		&fakeDocumentInstallStore{installation: installation},
+		fakeDocumentCredentials{secret: "SENSITIVE-APP-SECRET"},
+		client,
+		slog.New(slog.NewTextHandler(&logs, nil)),
+	)
+	_, toolErr := service.Execute(context.Background(), documentTestScope, DocumentOperationFetch, DocumentToolInput{DocumentURL: testDocumentURL})
+	if toolErr != nil {
+		t.Fatal(toolErr)
+	}
+	client.fetchErrs = []error{nil, errors.New("SENSITIVE-UPSTREAM-BODY")}
+	_, toolErr = service.Execute(context.Background(), documentTestScope, DocumentOperationFetch, DocumentToolInput{DocumentURL: testDocumentURL})
+	if toolErr == nil || toolErr.Code != DocumentErrorUpstreamUnavailable {
+		t.Fatalf("error=%+v", toolErr)
+	}
+	for _, secret := range []string{testDocumentURL, "AbcdefghijkLMNop", "SENSITIVE-DOCUMENT-CONTENT", "SENSITIVE-APP-ID", "SENSITIVE-CIPHERTEXT", "SENSITIVE-APP-SECRET", "SENSITIVE-UPSTREAM-BODY"} {
+		if strings.Contains(logs.String(), secret) {
+			t.Fatalf("logs leaked %q: %s", secret, logs.String())
+		}
+	}
+	for _, field := range []string{"operation=", "result_class=", "duration_ms=", "document_fingerprint="} {
+		if !strings.Contains(logs.String(), field) {
+			t.Fatalf("missing %s in %s", field, logs.String())
+		}
+	}
+}
+
+func newTestDocumentService(client *fakeDocumentClient) *DocumentService {
+	return NewDocumentService(
+		&fakeDocumentInstallStore{installation: documentTestInstallation},
+		fakeDocumentCredentials{secret: "pikachu-secret"},
+		client,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+}
+
+type fakeDocumentInstallStore struct {
+	installation Installation
+	err          error
+}
+
+func (s *fakeDocumentInstallStore) GetActiveLarkInstallationForAgent(_ context.Context, _, _ pgtype.UUID) (Installation, error) {
+	return s.installation, s.err
+}
+
+type fakeDocumentCredentials struct {
+	secret string
+	err    error
+}
+
+func (c fakeDocumentCredentials) DecryptAppSecret(Installation) (string, error) {
+	return c.secret, c.err
+}
+
+type fakeDocumentClient struct {
+	lastCredentials InstallationCredentials
+	fetches         []DocumentSnapshot
+	fetchErrs       []error
+	fetchCalls      int
+	updates         []DocumentUpdateParams
+	updateResult    DocumentUpdateResult
+	updateErr       error
+	calls           []string
+}
+
+func (c *fakeDocumentClient) FetchDocument(_ context.Context, creds InstallationCredentials, _ DocumentFetchParams) (DocumentSnapshot, error) {
+	c.lastCredentials = creds
+	c.fetchCalls++
+	c.calls = append(c.calls, "fetch")
+	index := c.fetchCalls - 1
+	if index < len(c.fetchErrs) && c.fetchErrs[index] != nil {
+		return DocumentSnapshot{}, c.fetchErrs[index]
+	}
+	if index < len(c.fetches) {
+		return c.fetches[index], nil
+	}
+	return DocumentSnapshot{}, nil
+}
+
+func (c *fakeDocumentClient) UpdateDocument(_ context.Context, creds InstallationCredentials, p DocumentUpdateParams) (DocumentUpdateResult, error) {
+	c.lastCredentials = creds
+	c.updates = append(c.updates, p)
+	c.calls = append(c.calls, "update:"+formatDocumentRevision(p.RevisionID))
+	return c.updateResult, c.updateErr
+}
+
+func mustDocumentUUID(value string) pgtype.UUID {
+	var id pgtype.UUID
+	if err := id.Scan(value); err != nil {
+		panic(err)
+	}
+	return id
+}
+
+func TestDocumentServiceNormalizesNotConnected(t *testing.T) {
+	service := NewDocumentService(
+		&fakeDocumentInstallStore{err: pgx.ErrNoRows},
+		fakeDocumentCredentials{},
+		&fakeDocumentClient{},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	_, toolErr := service.Execute(context.Background(), documentTestScope, DocumentOperationFetch, DocumentToolInput{DocumentURL: testDocumentURL})
+	if toolErr == nil || toolErr.Code != DocumentErrorNotConnected {
+		t.Fatalf("error=%+v", toolErr)
+	}
+}

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -162,7 +162,7 @@ func (c HTTPClientConfig) withDefaults() HTTPClientConfig {
 // each call's InstallationCredentials parameter; tokens are cached
 // keyed by app_id so a single Multica server reuses Lark's
 // tenant_access_token across calls to the same app.
-func NewHTTPAPIClient(cfg HTTPClientConfig) APIClient {
+func NewHTTPAPIClient(cfg HTTPClientConfig) OpenPlatformClient {
 	cfg = cfg.withDefaults()
 	return &httpAPIClient{cfg: cfg, tokens: make(map[string]*cachedToken)}
 }

--- a/server/internal/runtimeapps/connected_app.go
+++ b/server/internal/runtimeapps/connected_app.go
@@ -30,6 +30,8 @@ func DisplayNameForToolkitSlug(slug string) string {
 		return ""
 	}
 	switch slug {
+	case "feishu-documents":
+		return "Feishu Documents"
 	case "github":
 		return "GitHub"
 	case "gmail":

--- a/server/pkg/db/generated/channel.sql.go
+++ b/server/pkg/db/generated/channel.sql.go
@@ -1178,6 +1178,41 @@ func (q *Queries) FindReusableChannelUserBinding(ctx context.Context, arg FindRe
 	return i, err
 }
 
+const getActiveChannelInstallationForAgent = `-- name: GetActiveChannelInstallationForAgent :one
+SELECT id, workspace_id, agent_id, channel_type, config, status, ws_lease_token, ws_lease_expires_at, installer_user_id, installed_at, created_at, updated_at FROM channel_installation
+WHERE workspace_id = $1
+  AND agent_id = $2
+  AND channel_type = $3
+  AND status = 'active'
+LIMIT 1
+`
+
+type GetActiveChannelInstallationForAgentParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	AgentID     pgtype.UUID `json:"agent_id"`
+	ChannelType string      `json:"channel_type"`
+}
+
+func (q *Queries) GetActiveChannelInstallationForAgent(ctx context.Context, arg GetActiveChannelInstallationForAgentParams) (ChannelInstallation, error) {
+	row := q.db.QueryRow(ctx, getActiveChannelInstallationForAgent, arg.WorkspaceID, arg.AgentID, arg.ChannelType)
+	var i ChannelInstallation
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.AgentID,
+		&i.ChannelType,
+		&i.Config,
+		&i.Status,
+		&i.WsLeaseToken,
+		&i.WsLeaseExpiresAt,
+		&i.InstallerUserID,
+		&i.InstalledAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getChannelChatContextGeneration = `-- name: GetChannelChatContextGeneration :one
 SELECT chat_session_id, revision, history_start_message_id, history_end_message_id, history_boundary_pending, pending_fresh, initiator_user_id, created_at FROM channel_chat_context_generation
 WHERE chat_session_id = $1

--- a/server/pkg/db/queries/channel.sql
+++ b/server/pkg/db/queries/channel.sql
@@ -85,6 +85,14 @@ WHERE id = sqlc.arg('id')
   AND workspace_id = sqlc.arg('workspace_id')
   AND channel_type = sqlc.arg('channel_type');
 
+-- name: GetActiveChannelInstallationForAgent :one
+SELECT * FROM channel_installation
+WHERE workspace_id = sqlc.arg('workspace_id')
+  AND agent_id = sqlc.arg('agent_id')
+  AND channel_type = sqlc.arg('channel_type')
+  AND status = 'active'
+LIMIT 1;
+
 -- name: GetChannelInstallationByAppID :one
 -- Inbound routing. The platform event carries only the channel's app
 -- identifier (Feishu app_id); the dispatcher's installation resolver routes


### PR DESCRIPTION
## Summary

- expose six bounded Feishu document operations through a task-scoped built-in MCP endpoint
- bind every capability to the exact workspace, Agent, runtime, daemon, installation, and installation revision
- automatically mount the tools for all task sources when the Agent has an active Feishu bot connection
- keep Feishu application credentials on the backend and use the bot document ACL as the authorization boundary

## Safety

- accept only explicit Feishu or Lark document URLs and fixed tool schemas
- require fresh reads, unique text replacement, bounded content and block ranges, and confirmation for destructive or large edits
- revalidate task and installation state on every call so disconnects and reconnects revoke stale capabilities
- avoid blind retries when a write result is uncertain

## Verification

- go test ./... -count=1 -p=1
- go build ./...
- go vet -tags agentintegration ./...
- sqlc v1.31.1 generate with a clean worktree afterward