### PR TITLE
MUL-7266: OPE-969: authenticate Markdown attachment links

### DIFF
--- a/packages/views/rich-content/app-url-link-routing.test.tsx
+++ b/packages/views/rich-content/app-url-link-routing.test.tsx
@@ -12,8 +12,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Attachment } from "@multica/core/types";
 
 const APP_ORIGIN = "https://app.example";
+
+const { downloadAttachmentMock } = vi.hoisted(() => ({
+  downloadAttachmentMock: vi.fn(),
+}));
 
 vi.mock("../issues/hooks", () => ({
   useResolveIssueIdentifier: () => null,
@@ -45,6 +50,10 @@ vi.mock("../editor/link-hover-card", () => ({
   LinkHoverCard: () => null,
 }));
 
+vi.mock("../editor/use-download-attachment", () => ({
+  useDownloadAttachment: () => downloadAttachmentMock,
+}));
+
 vi.mock("mermaid", () => ({
   default: { initialize: vi.fn(), render: vi.fn() },
 }));
@@ -56,6 +65,7 @@ let openSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   navigatedPaths = [];
+  downloadAttachmentMock.mockReset();
   window.addEventListener("multica:navigate", captureNavigate);
   openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 });
@@ -70,13 +80,13 @@ function captureNavigate(e: Event) {
   if (path) navigatedPaths.push(path);
 }
 
-function renderContent(content: string) {
+function renderContent(content: string, attachments?: Attachment[]) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
   return render(
     <QueryClientProvider client={client}>
-      <RichContent content={content} />
+      <RichContent content={content} attachments={attachments} />
     </QueryClientProvider>,
   );
 }
@@ -117,6 +127,35 @@ describe("RichContent link routing", () => {
       "_blank",
       "noopener,noreferrer",
     );
+  });
+
+  it("downloads an associated attachment link instead of opening its protected API URL", () => {
+    const id = "11111111-2222-3333-4444-555555555555";
+    const download = `${APP_ORIGIN}/api/attachments/${id}/download`;
+    const attachment: Attachment = {
+      id,
+      workspace_id: "22222222-3333-4444-5555-666666666666",
+      issue_id: null,
+      comment_id: null,
+      chat_session_id: null,
+      chat_message_id: null,
+      uploader_type: "member",
+      uploader_id: "33333333-4444-5555-6666-777777777777",
+      filename: "report.pdf",
+      url: download,
+      download_url: download,
+      markdown_url: download,
+      content_type: "application/pdf",
+      size_bytes: 1,
+      created_at: "2026-09-11T00:00:00Z",
+    };
+    renderContent(`[report.pdf](${download})`, [attachment]);
+
+    screen.getByText("report.pdf").click();
+
+    expect(downloadAttachmentMock).toHaveBeenCalledWith(id);
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(navigatedPaths).toEqual([]);
   });
 
   it("keeps a same-origin /uploads file external — the backend serves it, not the router", () => {

--- a/packages/views/rich-content/rich-content.tsx
+++ b/packages/views/rich-content/rich-content.tsx
@@ -66,7 +66,10 @@ import {
 } from "../editor/utils/link-handler";
 import { preprocessMarkdown } from "../editor/utils/preprocess";
 import { highlightToHtml } from "../editor/utils/highlight-markdown";
-import { AttachmentDownloadProvider } from "../editor/attachment-download-context";
+import {
+  AttachmentDownloadProvider,
+  useAttachmentDownloadResolver,
+} from "../editor/attachment-download-context";
 import { Attachment as AttachmentRenderer } from "../editor/attachment";
 import { computeClosedFenceOffsets } from "./streaming-fence";
 import { remarkRepairCjkStrongTrailingWhitespace } from "./cjk-emphasis";
@@ -211,6 +214,9 @@ function RichLink({ href, children }: { href?: string; children?: ReactNode }) {
   // (web), modified clicks are left to the browser — the only way to get a
   // real background tab.
   const desktopTabs = !!useOptionalNavigation()?.openInNewTab;
+  const { resolveAttachmentId, openByUrl: openAttachmentByUrl } =
+    useAttachmentDownloadResolver();
+  const attachmentId = href ? resolveAttachmentId(href) : undefined;
 
   if (href?.startsWith("slash://skill/")) {
     return <span className="slash-command">{children}</span>;
@@ -250,12 +256,22 @@ function RichLink({ href, children }: { href?: string; children?: ReactNode }) {
           e.preventDefault();
           return;
         }
+        if (attachmentId) {
+          e.preventDefault();
+          openAttachmentByUrl(href);
+          return;
+        }
         if (!desktopTabs && (e.metaKey || e.ctrlKey || e.shiftKey)) return;
         e.preventDefault();
         openLink(href, slug, appOrigin, resolveClickIntent(e));
       }}
       onAuxClick={(e) => {
         if (e.button !== 1 || !href) return;
+        if (attachmentId) {
+          e.preventDefault();
+          openAttachmentByUrl(href);
+          return;
+        }
         // Web: native middle click on a real anchor already opens a
         // background tab. Desktop: the native window-open request dead-ends
         // (denied, then dropped by the http/https allowlist), so route it.


### PR DESCRIPTION
## Summary
- resolve ordinary Markdown links against the surrounding attachment records
- route matched links through the existing click-time attachment downloader instead of opening the bearer-protected API URL
- keep unrelated API and external links on their existing routing path

## Verification
- `pnpm -C packages/views test rich-content/app-url-link-routing.test.tsx editor/use-download-attachment.test.tsx` — 22 passed
- `pnpm -C packages/views typecheck` — passed
- changed-file ESLint — passed
- `pnpm lint` — passed with existing warnings
- `pnpm build` — passed
- `pnpm test` — 5018 passed, 16 unrelated `@multica/views` failures/timeouts
- `go test ./...` — unrelated CLI context failures caused by the daemon task marker
- `make test` — blocked before tests because Podman cannot resolve the unqualified `pgvector/pgvector:pg17` image

Root cause: `RichLink` bypassed `AttachmentDownloadProvider`, so a normal click navigated directly to `/api/attachments/{id}/download` without the bearer token.