### PR TITLE
fix(issues): preserve parent stage handoffs alongside pending runs

### DIFF
--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -705,10 +705,12 @@ func sanitizeMentionLabel(name string) string {
 //     parent silently stalled in in_progress (MUL-3969). The squad path now
 //     mirrors the agent path (MUL-2808): always dispatch, bounded only by
 //     idempotency.
-//   - Idempotency: HasPendingTaskForIssueAndAgent dedupes rapid-fire enqueues
-//     for the same parent (e.g. two children finishing back-to-back). It also
-//     bounds any re-trigger, since a leader waking on the parent does not by
-//     itself push a child back into a terminal transition.
+//   - Idempotency is scoped to the system comment's thread, matching the
+//     pending-task unique index. An unrelated assignment or comment run has
+//     not received this signal and must not suppress its wake. Distinct
+//     notifications queue independently but still execute serially for the
+//     same (parent, agent). A leader waking on the parent does not by itself
+//     push a child back into a terminal transition.
 //   - Readiness: archived agents / missing runtimes are silently skipped
 //     so a closed-out agent does not surface as a phantom assignee.
 func (h *Handler) dispatchParentAssigneeTrigger(ctx context.Context, parent db.Issue, systemComment db.Comment) {
@@ -727,16 +729,15 @@ func (h *Handler) dispatchParentAssigneeTrigger(ctx context.Context, parent db.I
 // triggerChildDoneAgent enqueues a mention-style task for the parent's
 // agent assignee.
 //
-// There is intentionally NO same-agent self-trigger guard here, unlike the
-// squad path. Waking the parent agent when one of its children finishes is a
-// serial sub-task handoff between two DIFFERENT issues, which the platform
+// There is intentionally NO same-agent self-trigger guard here. Waking the
+// parent agent when one of its children finishes is a serial sub-task handoff
+// between two DIFFERENT issues, which the platform
 // loop model treats as legitimate ("not a loop and must fire" — see
 // isAgentRunningOnIssue); only re-entering the SAME issue is a loop. A lone
 // agent that decomposes its parent into sub-issues it owns itself has no
 // other wake path, so the old "child owner == parent agent" guard silently
-// stranded those parents (MUL-2808). Runaway re-triggering is prevented by
-// the HasPendingTaskForIssueAndAgent dedup below, exactly as the @mention
-// self-trigger path relies on it (see computeMentionedAgentCommentTriggers).
+// stranded those parents (MUL-2808). Pending re-dispatch of the same system
+// comment is deduplicated below; unrelated pending work cannot cover it.
 func (h *Handler) triggerChildDoneAgent(ctx context.Context, parent db.Issue, triggerCommentID pgtype.UUID) {
 	agent, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
 		ID:          parent.AssigneeID,
@@ -746,9 +747,10 @@ func (h *Handler) triggerChildDoneAgent(ctx context.Context, parent db.Issue, tr
 		return
 	}
 
-	hasPending, err := h.Queries.HasPendingTaskForIssueAndAgent(ctx, db.HasPendingTaskForIssueAndAgentParams{
-		IssueID: parent.ID,
-		AgentID: parent.AssigneeID,
+	hasPending, err := h.Queries.HasPendingTaskForIssueAndAgentInThread(ctx, db.HasPendingTaskForIssueAndAgentInThreadParams{
+		IssueID:         parent.ID,
+		AgentID:         parent.AssigneeID,
+		ThreadCommentID: triggerCommentID,
 		// Key dedup on the reviewed head (TEN-356).
 		HeadSha: h.TaskService.ResolveIssueReviewSHAParam(ctx, parent.ID),
 	})
@@ -787,8 +789,8 @@ func (h *Handler) triggerChildDoneAgent(ctx context.Context, parent db.Issue, tr
 //     child-done follow one path; if invocation permission is ever reintroduced
 //     it must be added to BOTH paths together.
 //
-// Re-triggering is bounded by the HasPendingTaskForIssueAndAgent idempotency
-// check below, exactly as the agent path relies on it.
+// Pending re-dispatch is deduplicated within the system comment's thread,
+// exactly as on the agent path.
 func (h *Handler) triggerChildDoneSquad(ctx context.Context, parent db.Issue, triggerCommentID pgtype.UUID) {
 	squad, err := h.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
 		ID:          parent.AssigneeID,
@@ -803,9 +805,10 @@ func (h *Handler) triggerChildDoneSquad(ctx context.Context, parent db.Issue, tr
 		return
 	}
 
-	hasPending, err := h.Queries.HasPendingTaskForIssueAndAgent(ctx, db.HasPendingTaskForIssueAndAgentParams{
-		IssueID: parent.ID,
-		AgentID: squad.LeaderID,
+	hasPending, err := h.Queries.HasPendingTaskForIssueAndAgentInThread(ctx, db.HasPendingTaskForIssueAndAgentInThreadParams{
+		IssueID:         parent.ID,
+		AgentID:         squad.LeaderID,
+		ThreadCommentID: triggerCommentID,
 		// Key dedup on the reviewed head (TEN-356).
 		HeadSha: h.TaskService.ResolveIssueReviewSHAParam(ctx, parent.ID),
 	})

--- a/server/internal/handler/issue_child_done_pending_test.go
+++ b/server/internal/handler/issue_child_done_pending_test.go
@@ -1,0 +1,172 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// Drive status update -> claim -> start -> complete -> next claim. A visible
+// system comment alone is not evidence that the parent agent received it.
+func TestChildDoneHandoffSurvivesUnrelatedPendingTask(t *testing.T) {
+	for _, owner := range []string{"agent", "squad"} {
+		for _, state := range []string{"queued", "dispatched"} {
+			for _, source := range []string{"assignment", "other thread"} {
+				t.Run(owner+"/"+state+"/"+source, func(t *testing.T) {
+					ctx := context.Background()
+					runtimeID := dbfx.Runtime(t, "Parent handoff runtime")
+					agentID := dbfx.Agent(t, "Parent coordinator", runtimeID, testutil.Cols{"max_concurrent_tasks": 3})
+					assigneeID := agentID
+					if owner == "squad" {
+						assigneeID = dbfx.Squad(t, "Parent squad", agentID)
+					}
+					parentID := dbfx.Issue(t, "Parent awaiting stage completion", testutil.Cols{
+						"status": "in_progress", "assignee_type": owner, "assignee_id": assigneeID,
+					})
+					childID := dbfx.Issue(t, "Last stage 1 child", testutil.Cols{
+						"status": "in_progress", "parent_issue_id": parentID, "stage": 1,
+					})
+					nextChildID := dbfx.Issue(t, "Parked stage 2 child", testutil.Cols{
+						"status": "backlog", "parent_issue_id": parentID, "stage": 2,
+					})
+					cols := testutil.Cols{"runtime_id": runtimeID, "issue_id": parentID, "priority": 5}
+					if source == "other thread" {
+						cols["trigger_comment_id"] = dbfx.Comment(t, parentID, "An independent request")
+					}
+					pendingID := dbfx.Task(t, agentID, cols)
+					claim := func() *AgentTaskResponse {
+						req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil, testWorkspaceID, "parent-handoff-test")
+						req = withURLParam(req, "runtimeId", runtimeID)
+						var response struct {
+							Task *AgentTaskResponse `json:"task"`
+						}
+						testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK).JSON(&response)
+						return response.Task
+					}
+					var initial *AgentTaskResponse
+					if state == "dispatched" {
+						initial = claim()
+					}
+
+					// The child status handler must record AND deliver the new stage
+					// signal even though a different run already occupies the parent.
+					req := withURLParam(newRequest(http.MethodPut, "/api/issues/"+childID, map[string]any{"status": "done"}), "id", childID)
+					testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
+					var signalID, signalContent string
+					dbfx.QueryRow(t, `SELECT id, content FROM comment WHERE issue_id = $1 AND type = 'system'`, parentID).Scan(&signalID, &signalContent)
+					if !strings.Contains(signalContent, "Stage 2 is next") {
+						t.Fatalf("missing next-stage instruction: %s", signalContent)
+					}
+					parent, err := testHandler.Queries.GetIssue(ctx, parseUUID(parentID))
+					if err != nil {
+						t.Fatal(err)
+					}
+					// A repeated dispatch while the signal's own run is queued must
+					// not duplicate it. Repeat again after claim below.
+					testHandler.dispatchParentAssigneeTrigger(ctx, parent, db.Comment{ID: parseUUID(signalID)})
+					if state == "queued" {
+						initial = claim()
+					}
+					if initial == nil || initial.ID != pendingID {
+						t.Fatal("expected to claim the pre-existing higher-priority run")
+					}
+					if slices.Contains(initial.DeliveredCommentIDs, signalID) {
+						t.Fatal("unrelated run unexpectedly acknowledged the new system thread")
+					}
+
+					if _, err := testHandler.TaskService.StartTask(ctx, parseUUID(pendingID)); err != nil {
+						t.Fatal(err)
+					}
+					if parallel := claim(); parallel != nil {
+						t.Fatal("parent handoff must remain serialized even with spare agent capacity")
+					}
+					complete := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+pendingID+"/complete", map[string]any{"output": "Prior request finished"}, testWorkspaceID, "parent-handoff-test")
+					complete = withURLParam(complete, "taskId", pendingID)
+					testutil.Call(t, testHandler.CompleteTask, complete).Want(http.StatusOK)
+
+					followup := claim()
+					if followup == nil {
+						t.Fatal("stage completion comment persisted, but no parent run received it after the pending run finished")
+					}
+					if followup.ID == pendingID || followup.TriggerCommentContent != signalContent || !slices.Contains(followup.DeliveredCommentIDs, signalID) {
+						t.Fatal("parent follow-up did not deliver the stage completion instruction")
+					}
+					if followup.IsLeaderTask != (owner == "squad") {
+						t.Fatalf("leader role = %t for %s parent", followup.IsLeaderTask, owner)
+					}
+					stored, err := testHandler.Queries.GetAgentTask(ctx, parseUUID(followup.ID))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if owner == "squad" && stored.SquadID != parseUUID(assigneeID) {
+						t.Fatal("handoff lost squad provenance")
+					}
+					var nextStatus string
+					dbfx.QueryRow(t, `SELECT status FROM issue WHERE id = $1`, nextChildID).Scan(&nextStatus)
+					if nextStatus != "backlog" {
+						t.Fatal("notification must not automatically promote the next stage")
+					}
+
+					// Re-dispatching the SAME signal must still deduplicate while its
+					// run is pending, including after the daemon has claimed it.
+					testHandler.dispatchParentAssigneeTrigger(ctx, parent, db.Comment{ID: parseUUID(signalID)})
+					var signalTasks int
+					dbfx.QueryRow(t, `SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND trigger_comment_id = $2`, parentID, signalID).Scan(&signalTasks)
+					if signalTasks != 1 {
+						t.Fatalf("same stage signal created %d runs", signalTasks)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestBatchChildDoneQueuesLatestHandoffAlongsideEarlierStage(t *testing.T) {
+	runtimeID := dbfx.Runtime(t, "Batch parent handoff runtime")
+	agentID := dbfx.Agent(t, "Batch parent coordinator", runtimeID)
+	parentID := dbfx.Issue(t, "Parent with an earlier stage wake", testutil.Cols{
+		"status": "in_progress", "assignee_type": "agent", "assignee_id": agentID,
+	})
+	children := make([]string, 3)
+	for i := range children {
+		children[i] = dbfx.Issue(t, "Stage child", testutil.Cols{
+			"status": "in_progress", "parent_issue_id": parentID, "stage": i + 1,
+		})
+	}
+
+	req := withURLParam(newRequest(http.MethodPut, "/api/issues/"+children[0], map[string]any{"status": "done"}), "id", children[0])
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
+	var earlierSignal string
+	dbfx.QueryRow(t, `SELECT trigger_comment_id FROM agent_task_queue WHERE issue_id = $1`, parentID).Scan(&earlierSignal)
+
+	// A batch closing later stages still emits one final-state notification.
+	// Its instruction must not be swallowed by the earlier stage's queued run.
+	req = newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
+		"issue_ids": []string{children[2], children[1]}, "updates": map[string]any{"status": "done"},
+	})
+	var result struct {
+		Updated int `json:"updated"`
+	}
+	testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusOK).JSON(&result)
+	if result.Updated != 2 {
+		t.Fatalf("batch updated %d children, want 2", result.Updated)
+	}
+	var latestSignal, latestContent string
+	dbfx.QueryRow(t, `SELECT id, content FROM comment WHERE issue_id = $1 AND type = 'system' AND id <> $2`, parentID, earlierSignal).Scan(&latestSignal, &latestContent)
+	if !strings.Contains(latestContent, "Stage 3 of this issue is complete") || !strings.Contains(latestContent, "together in a batch update") {
+		t.Fatalf("batch handoff did not describe the final stage: %s", latestContent)
+	}
+	var queuedSignals []string
+	dbfx.QueryRow(t, `SELECT array_agg(trigger_comment_id::text) FROM agent_task_queue WHERE issue_id = $1 AND status = 'queued'`, parentID).Scan(&queuedSignals)
+	slices.Sort(queuedSignals)
+	want := []string{earlierSignal, latestSignal}
+	slices.Sort(want)
+	if !slices.Equal(queuedSignals, want) {
+		t.Fatalf("queued signal ids = %v, want both stage handoffs %v", queuedSignals, want)
+	}
+}

--- a/server/internal/service/builtin_skills/multica-platform/references/issues.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/issues.md
@@ -351,6 +351,12 @@ A completion that does not close a stage is silent (no comment, no wake). A
 sibling set with **no** stages is one implicit stage, so the parent is woken
 once when the *last* sub-issue finishes — not on every child.
 
+Each stage-completion system comment has its own conversation thread. An
+unrelated pending run on the parent does not absorb or suppress that signal:
+the notification queues its own run, still serialized with other runs for the
+same parent and agent. Re-dispatch of the same notification is deduplicated
+while its run is queued or dispatched.
+
 Advancement is agent-driven: the server only detects the closed barrier and
 wakes the parent assignee, who then decides whether to promote the next stage's
 `backlog` sub-issues to `todo`.


### PR DESCRIPTION
## What does this PR do?

A parent agent can lose a stage-completion handoff when it already has a queued or dispatched run. The system comment is saved, but the issue-wide pending check suppresses its enqueue. The existing run never receives the new comment, and completing it does not replay this system notification, so the parent can stall.

Both agent and squad-leader handoffs now use the existing thread-scoped pending query, keyed by the system comment. An assignment run or another comment thread cannot suppress the new signal. Re-dispatch of the same notification still deduplicates while its run is pending; execution remains serialized per parent issue and agent.

## Changes Made

- Change the two parent-assignee pending checks to `HasPendingTaskForIssueAndAgentInThread`, retaining the reviewed-head predicate and existing readiness/attribution behavior.
- Add PostgreSQL-backed regressions that drive child status update, parent claim/start/completion, and the next claim. Verify both the delivered instruction and its receipt, squad provenance, same-notification dedup, serialization with spare agent capacity, and a parked next stage.
- Cover a batch closing later stages while an earlier stage's notification is still queued, and document the notification/thread behavior in the built-in issue reference.

## Validation

- Before the fix, all eight agent/squad × queued/dispatched × assignment/other-thread cases reproduce the same failure: the stage comment persists, but no subsequent parent run receives it.
- After the fix, the regression matrix and existing child/stage/batch tests pass with `go test -race ./internal/handler` using the repository's agent CLI guard and an isolated PostgreSQL 17 / pgvector database.
- `go vet ./internal/handler` and `git diff --check` pass.
- The full handler suite has two clock-sensitive failures: `TestClaimTasksByRuntime_ClaimPollHintSchedulesNextDeferredTask` and `TestReportTaskMessagesFallsBackWholeBatchForClockSkew`. Both reproduce with the untouched main implementation through a Go source overlay; the Docker database clock is approximately 70–80 ms ahead of the host. The same baseline run also reproduces the eight missing-handoff cases and the later-stage batch regression.
- The entire handler suite passes with only those two baseline failures excluded via `-skip` (55.1 s).

## Risks and scope

**Draft: concurrent stage completion needs a notification-generation fix before this is ready to merge.**

A deterministic PostgreSQL-backed probe has now confirmed the previously stated duplicate-notification risk. Two independent child status requests can both commit `done` before either reads their shared stage. Releasing the first request through notification/enqueue, then releasing the second, produces two different system comments for the same stage. On main `b36906e6d`, the issue-wide pending check leaves one parent run. With this PR's handler, both comments queue runs; both can be claimed, started, and completed serially with their own delivery receipts. The PR result reproduced three times under the race detector. These investigation probes are local follow-up work and are not included in this PR's current diff.

The thread-scoped change still fixes independently meaningful stage handoffs being discarded. Restoring the issue-wide check would reintroduce that loss. A follow-up must deduplicate the same logical barrier at notification generation, while defining how reopening children or changing the stage layout creates a new event. Until that is addressed, this patch can cause extra parent executions for one stage.

This patch also does not add durable replay for failures between a committed child status change, system-comment creation, and parent-run enqueue. Its current diff has no schema or API changes.

## AI Disclosure

**AI tool used:** Codex

**Approach:** Reproduced the missing handoff against current main with real PostgreSQL and handler/claim calls, then applied the existing thread queue contract to the two remaining parent-handoff checks. No real agent CLI was invoked.

