### PR TITLE
MUL-7250: fix(server): suppress no-op issue metadata writes

### DIFF
--- a/server/internal/handler/issue_last_activity_test.go
+++ b/server/internal/handler/issue_last_activity_test.go
@@ -70,7 +70,7 @@ func TestIssueActivityTimestampIsMonotonic(t *testing.T) {
 	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET last_activity_at = $2 WHERE id = $1`, created.ID, future); err != nil {
 		t.Fatalf("seed future last_activity_at: %v", err)
 	}
-	updated, err := testHandler.Queries.SetIssueMetadataKey(context.Background(), db.SetIssueMetadataKeyParams{
+	_, err := testHandler.Queries.SetIssueMetadataKey(context.Background(), db.SetIssueMetadataKeyParams{
 		Key:         "activity_test",
 		Value:       []byte(`"changed"`),
 		ID:          parseUUID(created.ID),
@@ -79,8 +79,12 @@ func TestIssueActivityTimestampIsMonotonic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetIssueMetadataKey: %v", err)
 	}
-	if !updated.LastActivityAt.Valid || !updated.LastActivityAt.Time.Equal(future) {
-		t.Fatalf("activity timestamp regressed: got=%v want=%s", updated.LastActivityAt, future)
+	var updatedActivity time.Time
+	if err := testPool.QueryRow(context.Background(), `SELECT last_activity_at FROM issue WHERE id = $1`, created.ID).Scan(&updatedActivity); err != nil {
+		t.Fatalf("read updated last_activity_at: %v", err)
+	}
+	if !updatedActivity.Equal(future) {
+		t.Fatalf("activity timestamp regressed: got=%v want=%s", updatedActivity, future)
 	}
 }
 

--- a/server/internal/handler/issue_metadata.go
+++ b/server/internal/handler/issue_metadata.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"sync/atomic"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
@@ -33,6 +35,8 @@ const (
 )
 
 var issueMetadataKeyRE = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.-]{0,63}$`)
+
+var issueMetadataMutationLogSequence atomic.Uint64
 
 // SetIssueMetadataKeyRequest carries the JSON value to write under the key
 // named in the URL. Value is a RawMessage so we can preserve numeric vs.
@@ -81,6 +85,24 @@ func validateIssueMetadataValue(raw json.RawMessage) error {
 // describing an issue agree on what an unset bag looks like on the wire.
 func parseIssueMetadata(raw []byte) map[string]any {
 	return util.JSONObjectOrEmpty(raw)
+}
+
+func (h *Handler) recordIssueMetadataMutation(r *http.Request, op, result, issueID, key string, duration time.Duration) {
+	h.Metrics.RecordIssueMetadataMutation(op, result, duration)
+	// Keep issue IDs and metadata keys out of metric labels. A one-percent
+	// process-local sample retains request-level correlation without turning a
+	// hot metadata endpoint into an equally hot high-cardinality log stream.
+	if !slog.Default().Enabled(r.Context(), slog.LevelDebug) || issueMetadataMutationLogSequence.Add(1)%100 != 1 {
+		return
+	}
+	slog.Debug("issue metadata mutation", append(logger.RequestAttrs(r),
+		"source", "api",
+		"operation", op,
+		"result", result,
+		"issue_id", issueID,
+		"key", key,
+		"db_duration_ms", duration.Milliseconds(),
+	)...)
 }
 
 // parseMetadataFilterParam reads the `metadata` query parameter (a JSON
@@ -168,13 +190,39 @@ func (h *Handler) SetIssueMetadataKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	queryStarted := time.Now()
 	updated, err := h.Queries.SetIssueMetadataKey(r.Context(), db.SetIssueMetadataKeyParams{
 		ID:          issue.ID,
 		WorkspaceID: issue.WorkspaceID,
 		Key:         key,
 		Value:       []byte(req.Value),
 	})
+	queryDuration := time.Since(queryStarted)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			current, getErr := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+				ID:          issue.ID,
+				WorkspaceID: issue.WorkspaceID,
+			})
+			if errors.Is(getErr, pgx.ErrNoRows) {
+				h.recordIssueMetadataMutation(r, "set", "not_found", issueID, key, queryDuration)
+				writeError(w, http.StatusNotFound, "issue not found")
+				return
+			}
+			if getErr != nil {
+				h.recordIssueMetadataMutation(r, "set", "error", issueID, key, queryDuration)
+				slog.Warn("GetIssueInWorkspace after metadata set no-op failed", append(logger.RequestAttrs(r), "error", getErr, "issue_id", issueID, "key", key)...)
+				writeError(w, http.StatusInternalServerError, "failed to load issue metadata")
+				return
+			}
+			h.recordIssueMetadataMutation(r, "set", "noop", issueID, key, queryDuration)
+			writeJSON(w, http.StatusOK, map[string]any{
+				"metadata":       parseIssueMetadata(current.Metadata),
+				"issue_revision": current.Revision,
+			})
+			return
+		}
+		h.recordIssueMetadataMutation(r, "set", "error", issueID, key, queryDuration)
 		if isCheckViolation(err) {
 			writeError(w, http.StatusBadRequest, "metadata exceeds the 8KB size limit")
 			return
@@ -183,6 +231,7 @@ func (h *Handler) SetIssueMetadataKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to set metadata key")
 		return
 	}
+	h.recordIssueMetadataMutation(r, "set", "changed", issueID, key, queryDuration)
 
 	workspaceID := uuidToString(updated.WorkspaceID)
 	actorType, actorID := h.resolveActor(r, userID, workspaceID)
@@ -212,20 +261,43 @@ func (h *Handler) DeleteIssueMetadataKey(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	queryStarted := time.Now()
 	updated, err := h.Queries.DeleteIssueMetadataKey(r.Context(), db.DeleteIssueMetadataKeyParams{
 		ID:          issue.ID,
 		WorkspaceID: issue.WorkspaceID,
 		Key:         key,
 	})
+	queryDuration := time.Since(queryStarted)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			writeError(w, http.StatusNotFound, "issue not found")
+			current, getErr := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+				ID:          issue.ID,
+				WorkspaceID: issue.WorkspaceID,
+			})
+			if errors.Is(getErr, pgx.ErrNoRows) {
+				h.recordIssueMetadataMutation(r, "delete", "not_found", issueID, key, queryDuration)
+				writeError(w, http.StatusNotFound, "issue not found")
+				return
+			}
+			if getErr != nil {
+				h.recordIssueMetadataMutation(r, "delete", "error", issueID, key, queryDuration)
+				slog.Warn("GetIssueInWorkspace after metadata delete no-op failed", append(logger.RequestAttrs(r), "error", getErr, "issue_id", issueID, "key", key)...)
+				writeError(w, http.StatusInternalServerError, "failed to load issue metadata")
+				return
+			}
+			h.recordIssueMetadataMutation(r, "delete", "noop", issueID, key, queryDuration)
+			writeJSON(w, http.StatusOK, map[string]any{
+				"metadata":       parseIssueMetadata(current.Metadata),
+				"issue_revision": current.Revision,
+			})
 			return
 		}
+		h.recordIssueMetadataMutation(r, "delete", "error", issueID, key, queryDuration)
 		slog.Warn("DeleteIssueMetadataKey failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID, "key", key)...)
 		writeError(w, http.StatusInternalServerError, "failed to delete metadata key")
 		return
 	}
+	h.recordIssueMetadataMutation(r, "delete", "changed", issueID, key, queryDuration)
 
 	workspaceID := uuidToString(updated.WorkspaceID)
 	actorType, actorID := h.resolveActor(r, userID, workspaceID)

--- a/server/internal/handler/issue_metadata.go
+++ b/server/internal/handler/issue_metadata.go
@@ -200,10 +200,12 @@ func (h *Handler) SetIssueMetadataKey(w http.ResponseWriter, r *http.Request) {
 	queryDuration := time.Since(queryStarted)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			current, getErr := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+			fallbackStarted := time.Now()
+			current, getErr := h.Queries.GetIssueMetadataInWorkspace(r.Context(), db.GetIssueMetadataInWorkspaceParams{
 				ID:          issue.ID,
 				WorkspaceID: issue.WorkspaceID,
 			})
+			queryDuration += time.Since(fallbackStarted)
 			if errors.Is(getErr, pgx.ErrNoRows) {
 				h.recordIssueMetadataMutation(r, "set", "not_found", issueID, key, queryDuration)
 				writeError(w, http.StatusNotFound, "issue not found")
@@ -211,7 +213,7 @@ func (h *Handler) SetIssueMetadataKey(w http.ResponseWriter, r *http.Request) {
 			}
 			if getErr != nil {
 				h.recordIssueMetadataMutation(r, "set", "error", issueID, key, queryDuration)
-				slog.Warn("GetIssueInWorkspace after metadata set no-op failed", append(logger.RequestAttrs(r), "error", getErr, "issue_id", issueID, "key", key)...)
+				slog.Warn("GetIssueMetadataInWorkspace after metadata set no-op failed", append(logger.RequestAttrs(r), "error", getErr, "issue_id", issueID, "key", key)...)
 				writeError(w, http.StatusInternalServerError, "failed to load issue metadata")
 				return
 			}
@@ -270,10 +272,12 @@ func (h *Handler) DeleteIssueMetadataKey(w http.ResponseWriter, r *http.Request)
 	queryDuration := time.Since(queryStarted)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			current, getErr := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+			fallbackStarted := time.Now()
+			current, getErr := h.Queries.GetIssueMetadataInWorkspace(r.Context(), db.GetIssueMetadataInWorkspaceParams{
 				ID:          issue.ID,
 				WorkspaceID: issue.WorkspaceID,
 			})
+			queryDuration += time.Since(fallbackStarted)
 			if errors.Is(getErr, pgx.ErrNoRows) {
 				h.recordIssueMetadataMutation(r, "delete", "not_found", issueID, key, queryDuration)
 				writeError(w, http.StatusNotFound, "issue not found")
@@ -281,7 +285,7 @@ func (h *Handler) DeleteIssueMetadataKey(w http.ResponseWriter, r *http.Request)
 			}
 			if getErr != nil {
 				h.recordIssueMetadataMutation(r, "delete", "error", issueID, key, queryDuration)
-				slog.Warn("GetIssueInWorkspace after metadata delete no-op failed", append(logger.RequestAttrs(r), "error", getErr, "issue_id", issueID, "key", key)...)
+				slog.Warn("GetIssueMetadataInWorkspace after metadata delete no-op failed", append(logger.RequestAttrs(r), "error", getErr, "issue_id", issueID, "key", key)...)
 				writeError(w, http.StatusInternalServerError, "failed to load issue metadata")
 				return
 			}

--- a/server/internal/handler/issue_metadata_noop_test.go
+++ b/server/internal/handler/issue_metadata_noop_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -326,11 +327,11 @@ func TestIssueMetadataMutationIsWorkspaceScoped(t *testing.T) {
 		Key:         "state",
 		Value:       []byte(`"ready"`),
 	})
-	if err != pgx.ErrNoRows {
+	if !errors.Is(err, pgx.ErrNoRows) {
 		t.Fatalf("cross-workspace set error = %v, want pgx.ErrNoRows", err)
 	}
 	state := readMetadataRowState(t, foreignIssueID)
-	if string(state.metadata) != "{}" {
+	if state.metadata != "{}" {
 		t.Fatalf("cross-workspace set mutated metadata: %s", state.metadata)
 	}
 }

--- a/server/internal/handler/issue_metadata_noop_test.go
+++ b/server/internal/handler/issue_metadata_noop_test.go
@@ -2,16 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -68,171 +63,37 @@ func handlerWithMetadataEventCounter(counter *atomic.Int64) *Handler {
 }
 
 func TestIssueMetadataNoopPreservesRowAndSuppressesEvents(t *testing.T) {
-	issueID := dbfx.Issue(t, "metadata no-op row preservation")
-	var eventCount atomic.Int64
-	h := handlerWithMetadataEventCounter(&eventCount)
-
-	var changed metadataMutationResponse
-	testutil.Call(t, h.SetIssueMetadataKey,
-		mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "ready"}),
-	).Want(http.StatusOK).JSON(&changed)
-	if got := eventCount.Load(); got != 1 {
-		t.Fatalf("events after changed set = %d, want 1", got)
-	}
-	afterSet := readMetadataRowState(t, issueID)
-
-	var duplicateSet metadataMutationResponse
-	testutil.Call(t, h.SetIssueMetadataKey,
-		mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "ready"}),
-	).Want(http.StatusOK).JSON(&duplicateSet)
-	if duplicateSet.IssueRevision != changed.IssueRevision || duplicateSet.Metadata["state"] != "ready" {
-		t.Fatalf("duplicate set response = %+v, want committed metadata/revision %+v", duplicateSet, changed)
-	}
-	if got := readMetadataRowState(t, issueID); got != afterSet {
-		t.Fatalf("duplicate set changed row state:\n before=%+v\n after=%+v", afterSet, got)
-	}
-	if got := eventCount.Load(); got != 1 {
-		t.Fatalf("events after duplicate set = %d, want 1", got)
-	}
-
-	var missingDelete metadataMutationResponse
-	testutil.Call(t, h.DeleteIssueMetadataKey,
-		mutationRequest(http.MethodDelete, issueID, "missing", nil),
-	).Want(http.StatusOK).JSON(&missingDelete)
-	if missingDelete.IssueRevision != changed.IssueRevision || missingDelete.Metadata["state"] != "ready" {
-		t.Fatalf("missing-key delete response = %+v, want current state", missingDelete)
-	}
-	if got := readMetadataRowState(t, issueID); got != afterSet {
-		t.Fatalf("missing-key delete changed row state:\n before=%+v\n after=%+v", afterSet, got)
-	}
-	if got := eventCount.Load(); got != 1 {
-		t.Fatalf("events after missing-key delete = %d, want 1", got)
-	}
-
-	var changedDelete metadataMutationResponse
-	testutil.Call(t, h.DeleteIssueMetadataKey,
-		mutationRequest(http.MethodDelete, issueID, "state", nil),
-	).Want(http.StatusOK).JSON(&changedDelete)
-	if _, ok := changedDelete.Metadata["state"]; ok {
-		t.Fatalf("changed delete retained state key: %+v", changedDelete.Metadata)
-	}
-	if changedDelete.IssueRevision != changed.IssueRevision+1 {
-		t.Fatalf("changed delete revision = %d, want %d", changedDelete.IssueRevision, changed.IssueRevision+1)
-	}
-	afterDelete := readMetadataRowState(t, issueID)
-
-	testutil.Call(t, h.DeleteIssueMetadataKey,
-		mutationRequest(http.MethodDelete, issueID, "state", nil),
-	).Want(http.StatusOK)
-	if got := readMetadataRowState(t, issueID); got != afterDelete {
-		t.Fatalf("duplicate delete changed row state:\n before=%+v\n after=%+v", afterDelete, got)
-	}
-	if got := eventCount.Load(); got != 2 {
-		t.Fatalf("events after changed and duplicate delete = %d, want 2", got)
-	}
-}
-
-func TestIssueMetadataConcurrentIdenticalSetsMutateAndPublishOnce(t *testing.T) {
-	issueID := dbfx.Issue(t, "metadata concurrent identical sets")
+	issueID := dbfx.Issue(t, "metadata no-op row preservation", testutil.Cols{
+		"metadata":         testutil.Raw(`'{"state":"ready"}'::jsonb`),
+		"revision":         7,
+		"last_activity_at": testutil.Raw("now() - interval '1 minute'"),
+	})
 	before := readMetadataRowState(t, issueID)
 	var eventCount atomic.Int64
 	h := handlerWithMetadataEventCounter(&eventCount)
 
-	const workers = 20
-	start := make(chan struct{})
-	results := make(chan metadataMutationResponse, workers)
-	errs := make(chan string, workers)
-	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			<-start
-			resp := testutil.Call(t, h.SetIssueMetadataKey,
-				mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "ready"}),
-			)
-			if resp.Code != http.StatusOK {
-				errs <- fmt.Sprintf("status=%d body=%s", resp.Code, resp.Body.String())
-				return
-			}
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		request *http.Request
+	}{
+		{"set same value", h.SetIssueMetadataKey, mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "ready"})},
+		{"delete missing key", h.DeleteIssueMetadataKey, mutationRequest(http.MethodDelete, issueID, "missing", nil)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			var body metadataMutationResponse
-			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
-				errs <- fmt.Sprintf("decode: %v", err)
-				return
+			testutil.Call(t, tc.handler, tc.request).Want(http.StatusOK).JSON(&body)
+			if body.IssueRevision != before.revision || body.Metadata["state"] != "ready" {
+				t.Fatalf("response = %+v, want current metadata at revision %d", body, before.revision)
 			}
-			results <- body
-		}()
-	}
-	close(start)
-	wg.Wait()
-	close(results)
-	close(errs)
-	for errText := range errs {
-		t.Error(errText)
-	}
-	for body := range results {
-		if body.IssueRevision != before.revision+1 || body.Metadata["state"] != "ready" {
-			t.Errorf("concurrent response = %+v, want revision %d and committed value", body, before.revision+1)
-		}
-	}
-
-	after := readMetadataRowState(t, issueID)
-	if after.revision != before.revision+1 {
-		t.Fatalf("revision after identical sets = %d, want %d", after.revision, before.revision+1)
-	}
-	if got := eventCount.Load(); got != 1 {
-		t.Fatalf("events after identical sets = %d, want 1", got)
-	}
-}
-
-func TestIssueMetadataConcurrentDistinctKeysArePreserved(t *testing.T) {
-	issueID := dbfx.Issue(t, "metadata concurrent distinct keys")
-	before := readMetadataRowState(t, issueID)
-	var eventCount atomic.Int64
-	h := handlerWithMetadataEventCounter(&eventCount)
-
-	const workers = 20
-	start := make(chan struct{})
-	errs := make(chan string, workers)
-	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
-		i := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			<-start
-			key := fmt.Sprintf("key_%02d", i)
-			resp := testutil.Call(t, h.SetIssueMetadataKey,
-				mutationRequest(http.MethodPut, issueID, key, map[string]any{"value": i}),
-			)
-			if resp.Code != http.StatusOK {
-				errs <- fmt.Sprintf("%s: status=%d body=%s", key, resp.Code, resp.Body.String())
+			if after := readMetadataRowState(t, issueID); after != before {
+				t.Fatalf("no-op changed row state:\n before=%+v\n after=%+v", before, after)
 			}
-		}()
+		})
 	}
-	close(start)
-	wg.Wait()
-	close(errs)
-	for errText := range errs {
-		t.Error(errText)
-	}
-
-	after := readMetadataRowState(t, issueID)
-	if after.revision != before.revision+workers {
-		t.Fatalf("revision after distinct sets = %d, want %d", after.revision, before.revision+workers)
-	}
-	var metadata map[string]any
-	if err := json.Unmarshal([]byte(after.metadata), &metadata); err != nil {
-		t.Fatalf("decode persisted metadata: %v", err)
-	}
-	for i := 0; i < workers; i++ {
-		key := fmt.Sprintf("key_%02d", i)
-		if got := metadata[key]; got != float64(i) {
-			t.Errorf("metadata[%q] = %v, want %d", key, got, i)
-		}
-	}
-	if got := eventCount.Load(); got != workers {
-		t.Fatalf("events after distinct sets = %d, want %d", got, workers)
+	if got := eventCount.Load(); got != 0 {
+		t.Fatalf("events after no-op mutations = %d, want 0", got)
 	}
 }
 
@@ -258,14 +119,13 @@ func TestIssueMetadataWaitingNoopReturnsCommittedSnapshot(t *testing.T) {
 	h := handlerWithMetadataEventCounter(&eventCount)
 	response := make(chan *testutil.Response, 1)
 	go func() {
-		req := mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "committed"})
-		response <- testutil.Call(t, h.SetIssueMetadataKey, req)
+		response <- testutil.Call(t, h.SetIssueMetadataKey,
+			mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "committed"}))
 	}()
-
 	if !waitForWaiterBlockedBy(t, holderPID, 10*time.Second) {
 		_ = holder.Rollback(context.Background())
 		<-response
-		t.Fatalf("metadata set did not reach a row-lock wait behind pid %d", holderPID)
+		t.Fatalf("metadata set did not wait behind pid %d", holderPID)
 	}
 	if err := holder.Commit(context.Background()); err != nil {
 		t.Fatalf("commit holder transaction: %v", err)
@@ -274,64 +134,9 @@ func TestIssueMetadataWaitingNoopReturnsCommittedSnapshot(t *testing.T) {
 	var body metadataMutationResponse
 	(<-response).Want(http.StatusOK).JSON(&body)
 	if body.IssueRevision != before.revision+1 || body.Metadata["state"] != "committed" {
-		t.Fatalf("waiting no-op response = %+v, want committed snapshot at revision %d", body, before.revision+1)
+		t.Fatalf("response = %+v, want committed snapshot at revision %d", body, before.revision+1)
 	}
 	if got := eventCount.Load(); got != 0 {
-		t.Fatalf("waiting no-op events = %d, want 0", got)
-	}
-}
-
-func TestIssueMetadataConcurrentDeleteReturnsNotFound(t *testing.T) {
-	issueID := dbfx.Issue(t, "metadata concurrent issue delete")
-	holder, err := testPool.Begin(context.Background())
-	if err != nil {
-		t.Fatalf("begin holder transaction: %v", err)
-	}
-	defer holder.Rollback(context.Background())
-	holderPID := holderBackendPID(t, context.Background(), holder)
-	if _, err := holder.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID); err != nil {
-		t.Fatalf("delete issue in holder transaction: %v", err)
-	}
-
-	var eventCount atomic.Int64
-	h := handlerWithMetadataEventCounter(&eventCount)
-	response := make(chan *testutil.Response, 1)
-	go func() {
-		req := mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "ready"})
-		response <- testutil.Call(t, h.SetIssueMetadataKey, req)
-	}()
-
-	if !waitForWaiterBlockedBy(t, holderPID, 10*time.Second) {
-		_ = holder.Rollback(context.Background())
-		<-response
-		t.Fatalf("metadata set did not wait behind concurrent delete held by pid %d", holderPID)
-	}
-	if err := holder.Commit(context.Background()); err != nil {
-		t.Fatalf("commit issue delete: %v", err)
-	}
-	(<-response).Want(http.StatusNotFound)
-	if got := eventCount.Load(); got != 0 {
-		t.Fatalf("events after concurrent issue delete = %d, want 0", got)
-	}
-}
-
-func TestIssueMetadataMutationIsWorkspaceScoped(t *testing.T) {
-	foreignWorkspaceID := dbfx.Workspace(t, "metadata foreign workspace", "metadata-foreign-workspace")
-	foreignIssueID := dbfx.Issue(t, "metadata foreign issue", testutil.Cols{
-		"workspace_id": foreignWorkspaceID,
-	})
-
-	_, err := testHandler.Queries.SetIssueMetadataKey(context.Background(), db.SetIssueMetadataKeyParams{
-		ID:          parseUUID(foreignIssueID),
-		WorkspaceID: parseUUID(testWorkspaceID),
-		Key:         "state",
-		Value:       []byte(`"ready"`),
-	})
-	if !errors.Is(err, pgx.ErrNoRows) {
-		t.Fatalf("cross-workspace set error = %v, want pgx.ErrNoRows", err)
-	}
-	state := readMetadataRowState(t, foreignIssueID)
-	if state.metadata != "{}" {
-		t.Fatalf("cross-workspace set mutated metadata: %s", state.metadata)
+		t.Fatalf("events after waiting no-op = %d, want 0", got)
 	}
 }

--- a/server/internal/handler/issue_metadata_noop_test.go
+++ b/server/internal/handler/issue_metadata_noop_test.go
@@ -1,0 +1,336 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+type metadataMutationResponse struct {
+	Metadata      map[string]any `json:"metadata"`
+	IssueRevision int64          `json:"issue_revision"`
+}
+
+type metadataRowState struct {
+	ctid           string
+	xmin           string
+	metadata       string
+	revision       int64
+	updatedAt      string
+	lastActivityAt string
+}
+
+func readMetadataRowState(t *testing.T, issueID string) metadataRowState {
+	t.Helper()
+	var state metadataRowState
+	dbfx.QueryRow(t, `
+		SELECT ctid::text, xmin::text, metadata, revision,
+		       updated_at::text, COALESCE(last_activity_at::text, '<null>')
+		FROM issue WHERE id = $1
+	`, issueID).Scan(
+		&state.ctid,
+		&state.xmin,
+		&state.metadata,
+		&state.revision,
+		&state.updatedAt,
+		&state.lastActivityAt,
+	)
+	return state
+}
+
+func mutationRequest(method, issueID, key string, value any) *http.Request {
+	return testutil.WithURLParams(
+		newRequest(method, "/api/issues/"+issueID+"/metadata/"+key, value),
+		"id", issueID,
+		"key", key,
+	)
+}
+
+func handlerWithMetadataEventCounter(counter *atomic.Int64) *Handler {
+	h := *testHandler
+	h.Bus = events.New()
+	h.Bus.Subscribe(protocol.EventIssueMetadataChanged, func(events.Event) {
+		counter.Add(1)
+	})
+	return &h
+}
+
+func TestIssueMetadataNoopPreservesRowAndSuppressesEvents(t *testing.T) {
+	issueID := dbfx.Issue(t, "metadata no-op row preservation")
+	var eventCount atomic.Int64
+	h := handlerWithMetadataEventCounter(&eventCount)
+
+	var changed metadataMutationResponse
+	testutil.Call(t, h.SetIssueMetadataKey,
+		mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "ready"}),
+	).Want(http.StatusOK).JSON(&changed)
+	if got := eventCount.Load(); got != 1 {
+		t.Fatalf("events after changed set = %d, want 1", got)
+	}
+	afterSet := readMetadataRowState(t, issueID)
+
+	var duplicateSet metadataMutationResponse
+	testutil.Call(t, h.SetIssueMetadataKey,
+		mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "ready"}),
+	).Want(http.StatusOK).JSON(&duplicateSet)
+	if duplicateSet.IssueRevision != changed.IssueRevision || duplicateSet.Metadata["state"] != "ready" {
+		t.Fatalf("duplicate set response = %+v, want committed metadata/revision %+v", duplicateSet, changed)
+	}
+	if got := readMetadataRowState(t, issueID); got != afterSet {
+		t.Fatalf("duplicate set changed row state:\n before=%+v\n after=%+v", afterSet, got)
+	}
+	if got := eventCount.Load(); got != 1 {
+		t.Fatalf("events after duplicate set = %d, want 1", got)
+	}
+
+	var missingDelete metadataMutationResponse
+	testutil.Call(t, h.DeleteIssueMetadataKey,
+		mutationRequest(http.MethodDelete, issueID, "missing", nil),
+	).Want(http.StatusOK).JSON(&missingDelete)
+	if missingDelete.IssueRevision != changed.IssueRevision || missingDelete.Metadata["state"] != "ready" {
+		t.Fatalf("missing-key delete response = %+v, want current state", missingDelete)
+	}
+	if got := readMetadataRowState(t, issueID); got != afterSet {
+		t.Fatalf("missing-key delete changed row state:\n before=%+v\n after=%+v", afterSet, got)
+	}
+	if got := eventCount.Load(); got != 1 {
+		t.Fatalf("events after missing-key delete = %d, want 1", got)
+	}
+
+	var changedDelete metadataMutationResponse
+	testutil.Call(t, h.DeleteIssueMetadataKey,
+		mutationRequest(http.MethodDelete, issueID, "state", nil),
+	).Want(http.StatusOK).JSON(&changedDelete)
+	if _, ok := changedDelete.Metadata["state"]; ok {
+		t.Fatalf("changed delete retained state key: %+v", changedDelete.Metadata)
+	}
+	if changedDelete.IssueRevision != changed.IssueRevision+1 {
+		t.Fatalf("changed delete revision = %d, want %d", changedDelete.IssueRevision, changed.IssueRevision+1)
+	}
+	afterDelete := readMetadataRowState(t, issueID)
+
+	testutil.Call(t, h.DeleteIssueMetadataKey,
+		mutationRequest(http.MethodDelete, issueID, "state", nil),
+	).Want(http.StatusOK)
+	if got := readMetadataRowState(t, issueID); got != afterDelete {
+		t.Fatalf("duplicate delete changed row state:\n before=%+v\n after=%+v", afterDelete, got)
+	}
+	if got := eventCount.Load(); got != 2 {
+		t.Fatalf("events after changed and duplicate delete = %d, want 2", got)
+	}
+}
+
+func TestIssueMetadataConcurrentIdenticalSetsMutateAndPublishOnce(t *testing.T) {
+	issueID := dbfx.Issue(t, "metadata concurrent identical sets")
+	before := readMetadataRowState(t, issueID)
+	var eventCount atomic.Int64
+	h := handlerWithMetadataEventCounter(&eventCount)
+
+	const workers = 20
+	start := make(chan struct{})
+	results := make(chan metadataMutationResponse, workers)
+	errs := make(chan string, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			resp := testutil.Call(t, h.SetIssueMetadataKey,
+				mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "ready"}),
+			)
+			if resp.Code != http.StatusOK {
+				errs <- fmt.Sprintf("status=%d body=%s", resp.Code, resp.Body.String())
+				return
+			}
+			var body metadataMutationResponse
+			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+				errs <- fmt.Sprintf("decode: %v", err)
+				return
+			}
+			results <- body
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+	for errText := range errs {
+		t.Error(errText)
+	}
+	for body := range results {
+		if body.IssueRevision != before.revision+1 || body.Metadata["state"] != "ready" {
+			t.Errorf("concurrent response = %+v, want revision %d and committed value", body, before.revision+1)
+		}
+	}
+
+	after := readMetadataRowState(t, issueID)
+	if after.revision != before.revision+1 {
+		t.Fatalf("revision after identical sets = %d, want %d", after.revision, before.revision+1)
+	}
+	if got := eventCount.Load(); got != 1 {
+		t.Fatalf("events after identical sets = %d, want 1", got)
+	}
+}
+
+func TestIssueMetadataConcurrentDistinctKeysArePreserved(t *testing.T) {
+	issueID := dbfx.Issue(t, "metadata concurrent distinct keys")
+	before := readMetadataRowState(t, issueID)
+	var eventCount atomic.Int64
+	h := handlerWithMetadataEventCounter(&eventCount)
+
+	const workers = 20
+	start := make(chan struct{})
+	errs := make(chan string, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			key := fmt.Sprintf("key_%02d", i)
+			resp := testutil.Call(t, h.SetIssueMetadataKey,
+				mutationRequest(http.MethodPut, issueID, key, map[string]any{"value": i}),
+			)
+			if resp.Code != http.StatusOK {
+				errs <- fmt.Sprintf("%s: status=%d body=%s", key, resp.Code, resp.Body.String())
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for errText := range errs {
+		t.Error(errText)
+	}
+
+	after := readMetadataRowState(t, issueID)
+	if after.revision != before.revision+workers {
+		t.Fatalf("revision after distinct sets = %d, want %d", after.revision, before.revision+workers)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(after.metadata), &metadata); err != nil {
+		t.Fatalf("decode persisted metadata: %v", err)
+	}
+	for i := 0; i < workers; i++ {
+		key := fmt.Sprintf("key_%02d", i)
+		if got := metadata[key]; got != float64(i) {
+			t.Errorf("metadata[%q] = %v, want %d", key, got, i)
+		}
+	}
+	if got := eventCount.Load(); got != workers {
+		t.Fatalf("events after distinct sets = %d, want %d", got, workers)
+	}
+}
+
+func TestIssueMetadataWaitingNoopReturnsCommittedSnapshot(t *testing.T) {
+	issueID := dbfx.Issue(t, "metadata waiting no-op snapshot")
+	before := readMetadataRowState(t, issueID)
+	holder, err := testPool.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin holder transaction: %v", err)
+	}
+	defer holder.Rollback(context.Background())
+	holderPID := holderBackendPID(t, context.Background(), holder)
+	if _, err := db.New(holder).SetIssueMetadataKey(context.Background(), db.SetIssueMetadataKeyParams{
+		ID:          parseUUID(issueID),
+		WorkspaceID: parseUUID(testWorkspaceID),
+		Key:         "state",
+		Value:       []byte(`"committed"`),
+	}); err != nil {
+		t.Fatalf("set metadata in holder transaction: %v", err)
+	}
+
+	var eventCount atomic.Int64
+	h := handlerWithMetadataEventCounter(&eventCount)
+	response := make(chan *testutil.Response, 1)
+	go func() {
+		req := mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "committed"})
+		response <- testutil.Call(t, h.SetIssueMetadataKey, req)
+	}()
+
+	if !waitForWaiterBlockedBy(t, holderPID, 10*time.Second) {
+		_ = holder.Rollback(context.Background())
+		<-response
+		t.Fatalf("metadata set did not reach a row-lock wait behind pid %d", holderPID)
+	}
+	if err := holder.Commit(context.Background()); err != nil {
+		t.Fatalf("commit holder transaction: %v", err)
+	}
+
+	var body metadataMutationResponse
+	(<-response).Want(http.StatusOK).JSON(&body)
+	if body.IssueRevision != before.revision+1 || body.Metadata["state"] != "committed" {
+		t.Fatalf("waiting no-op response = %+v, want committed snapshot at revision %d", body, before.revision+1)
+	}
+	if got := eventCount.Load(); got != 0 {
+		t.Fatalf("waiting no-op events = %d, want 0", got)
+	}
+}
+
+func TestIssueMetadataConcurrentDeleteReturnsNotFound(t *testing.T) {
+	issueID := dbfx.Issue(t, "metadata concurrent issue delete")
+	holder, err := testPool.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin holder transaction: %v", err)
+	}
+	defer holder.Rollback(context.Background())
+	holderPID := holderBackendPID(t, context.Background(), holder)
+	if _, err := holder.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID); err != nil {
+		t.Fatalf("delete issue in holder transaction: %v", err)
+	}
+
+	var eventCount atomic.Int64
+	h := handlerWithMetadataEventCounter(&eventCount)
+	response := make(chan *testutil.Response, 1)
+	go func() {
+		req := mutationRequest(http.MethodPut, issueID, "state", map[string]any{"value": "ready"})
+		response <- testutil.Call(t, h.SetIssueMetadataKey, req)
+	}()
+
+	if !waitForWaiterBlockedBy(t, holderPID, 10*time.Second) {
+		_ = holder.Rollback(context.Background())
+		<-response
+		t.Fatalf("metadata set did not wait behind concurrent delete held by pid %d", holderPID)
+	}
+	if err := holder.Commit(context.Background()); err != nil {
+		t.Fatalf("commit issue delete: %v", err)
+	}
+	(<-response).Want(http.StatusNotFound)
+	if got := eventCount.Load(); got != 0 {
+		t.Fatalf("events after concurrent issue delete = %d, want 0", got)
+	}
+}
+
+func TestIssueMetadataMutationIsWorkspaceScoped(t *testing.T) {
+	foreignWorkspaceID := dbfx.Workspace(t, "metadata foreign workspace", "metadata-foreign-workspace")
+	foreignIssueID := dbfx.Issue(t, "metadata foreign issue", testutil.Cols{
+		"workspace_id": foreignWorkspaceID,
+	})
+
+	_, err := testHandler.Queries.SetIssueMetadataKey(context.Background(), db.SetIssueMetadataKeyParams{
+		ID:          parseUUID(foreignIssueID),
+		WorkspaceID: parseUUID(testWorkspaceID),
+		Key:         "state",
+		Value:       []byte(`"ready"`),
+	})
+	if err != pgx.ErrNoRows {
+		t.Fatalf("cross-workspace set error = %v, want pgx.ErrNoRows", err)
+	}
+	state := readMetadataRowState(t, foreignIssueID)
+	if string(state.metadata) != "{}" {
+		t.Fatalf("cross-workspace set mutated metadata: %s", state.metadata)
+	}
+}

--- a/server/internal/handler/issue_revision_test.go
+++ b/server/internal/handler/issue_revision_test.go
@@ -927,15 +927,21 @@ func TestAuxiliaryVisibleMutationsAdvanceOwnerRevisionExactlyOnce(t *testing.T) 
 	if err != nil || metadataIssue.Revision != 9 {
 		t.Fatalf("set metadata = (%+v, %v), want revision 9", metadataIssue, err)
 	}
-	metadataIssue, err = testHandler.Queries.SetIssueMetadataKey(ctx, metadataParams)
-	if err != nil || metadataIssue.Revision != 9 {
-		t.Fatalf("duplicate metadata set = (%+v, %v), want unchanged revision 9", metadataIssue, err)
+	_, err = testHandler.Queries.SetIssueMetadataKey(ctx, metadataParams)
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("duplicate metadata set error = %v, want pgx.ErrNoRows", err)
 	}
-	metadataIssue, err = testHandler.Queries.DeleteIssueMetadataKey(ctx, db.DeleteIssueMetadataKeyParams{
+	currentMetadataIssue, err := testHandler.Queries.GetIssueInWorkspace(ctx, db.GetIssueInWorkspaceParams{
+		ID: issueUUID, WorkspaceID: workspaceUUID,
+	})
+	if err != nil || currentMetadataIssue.Revision != 9 {
+		t.Fatalf("issue after duplicate metadata set = (%+v, %v), want revision 9", currentMetadataIssue, err)
+	}
+	deletedMetadataIssue, err := testHandler.Queries.DeleteIssueMetadataKey(ctx, db.DeleteIssueMetadataKeyParams{
 		Key: metadataParams.Key, ID: issueUUID, WorkspaceID: workspaceUUID,
 	})
-	if err != nil || metadataIssue.Revision != 10 {
-		t.Fatalf("delete metadata = (%+v, %v), want revision 10", metadataIssue, err)
+	if err != nil || deletedMetadataIssue.Revision != 10 {
+		t.Fatalf("delete metadata = (%+v, %v), want revision 10", deletedMetadataIssue, err)
 	}
 
 	propertyParams := db.SetIssuePropertyValueParams{

--- a/server/internal/metrics/business.go
+++ b/server/internal/metrics/business.go
@@ -295,7 +295,7 @@ func NewBusinessMetrics() *BusinessMetrics {
 		}, metricLabels("multica_issue_metadata_mutation_total")),
 		issueMetadataMutationDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "multica", Subsystem: "issue_metadata", Name: "mutation_duration_seconds",
-			Help: "Duration of issue metadata UPDATE queries by operation and bounded result.", Buckets: chatClaimResumeQueryDurationBuckets,
+			Help: "Duration of issue metadata database work by operation and bounded result, including fallback reads after conditional no-ops.", Buckets: chatClaimResumeQueryDurationBuckets,
 		}, metricLabels("multica_issue_metadata_mutation_duration_seconds")),
 		activeTasks: map[string]activeTaskLabels{},
 		events:      newBusinessEventMetrics(),
@@ -357,9 +357,10 @@ func (m *BusinessMetrics) Collectors() []prometheus.Collector {
 	}, m.events.collectors()...)
 }
 
-// RecordIssueMetadataMutation records the UPDATE query only. HTTP latency and
-// pool acquisition pressure are exposed by the existing HTTP and DB pool
-// collectors, while these labels distinguish useful writes from no-op load.
+// RecordIssueMetadataMutation records the UPDATE and, for a no-row result, its
+// fallback read. HTTP latency and pool acquisition pressure are exposed by the
+// existing HTTP and DB pool collectors, while these labels distinguish useful
+// writes from no-op load.
 func (m *BusinessMetrics) RecordIssueMetadataMutation(op, result string, duration time.Duration) {
 	if m == nil {
 		return

--- a/server/internal/metrics/business.go
+++ b/server/internal/metrics/business.go
@@ -79,7 +79,9 @@ type BusinessMetrics struct {
 	// the product-source attribution that neither query shape exposes on its
 	// own, including daemon heartbeats, browser polling, and readiness gates.
 	// See labels.go for the closed enum.
-	agentRuntimeLookup *prometheus.CounterVec
+	agentRuntimeLookup            *prometheus.CounterVec
+	issueMetadataMutation         *prometheus.CounterVec
+	issueMetadataMutationDuration *prometheus.HistogramVec
 
 	activeMu    sync.Mutex
 	activeTasks map[string]activeTaskLabels
@@ -287,6 +289,14 @@ func NewBusinessMetrics() *BusinessMetrics {
 			Namespace: "multica", Subsystem: "agent_runtime", Name: "lookup_total",
 			Help: "Total logical agent_runtime lookups by product source and outcome (one per requested id, not per SQL query).",
 		}, metricLabels("multica_agent_runtime_lookup_total")),
+		issueMetadataMutation: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "multica", Subsystem: "issue_metadata", Name: "mutation_total",
+			Help: "Total issue metadata mutation attempts by operation and bounded result.",
+		}, metricLabels("multica_issue_metadata_mutation_total")),
+		issueMetadataMutationDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "multica", Subsystem: "issue_metadata", Name: "mutation_duration_seconds",
+			Help: "Duration of issue metadata UPDATE queries by operation and bounded result.", Buckets: chatClaimResumeQueryDurationBuckets,
+		}, metricLabels("multica_issue_metadata_mutation_duration_seconds")),
 		activeTasks: map[string]activeTaskLabels{},
 		events:      newBusinessEventMetrics(),
 	}
@@ -342,7 +352,30 @@ func (m *BusinessMetrics) Collectors() []prometheus.Collector {
 		m.entitlementVersionRegression,
 		m.autopilotQuotaDecision,
 		m.agentRuntimeLookup,
+		m.issueMetadataMutation,
+		m.issueMetadataMutationDuration,
 	}, m.events.collectors()...)
+}
+
+// RecordIssueMetadataMutation records the UPDATE query only. HTTP latency and
+// pool acquisition pressure are exposed by the existing HTTP and DB pool
+// collectors, while these labels distinguish useful writes from no-op load.
+func (m *BusinessMetrics) RecordIssueMetadataMutation(op, result string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	switch op {
+	case "set", "delete":
+	default:
+		op = "other"
+	}
+	switch result {
+	case "changed", "noop", "not_found", "error":
+	default:
+		result = "error"
+	}
+	m.issueMetadataMutation.WithLabelValues(op, result).Inc()
+	m.issueMetadataMutationDuration.WithLabelValues(op, result).Observe(duration.Seconds())
 }
 
 func (m *BusinessMetrics) RecordEntitlementConfigError() {

--- a/server/internal/metrics/business_test.go
+++ b/server/internal/metrics/business_test.go
@@ -93,6 +93,27 @@ func TestBusinessMetricsChatClaimResumeObservations(t *testing.T) {
 	}
 }
 
+func TestBusinessMetricsIssueMetadataMutationObservations(t *testing.T) {
+	m := NewBusinessMetrics()
+
+	m.RecordIssueMetadataMutation("set", "changed", 20*time.Millisecond)
+	m.RecordIssueMetadataMutation("set", "noop", 10*time.Millisecond)
+	m.RecordIssueMetadataMutation("delete", "not_found", 5*time.Millisecond)
+
+	for _, labels := range [][]string{
+		{"set", "changed"},
+		{"set", "noop"},
+		{"delete", "not_found"},
+	} {
+		if got := testutil.ToFloat64(m.issueMetadataMutation.WithLabelValues(labels...)); got != 1 {
+			t.Errorf("issue metadata mutation %v = %v, want 1", labels, got)
+		}
+	}
+	if got := testutil.CollectAndCount(m.issueMetadataMutationDuration); got != 3 {
+		t.Fatalf("issue metadata duration series = %d, want 3", got)
+	}
+}
+
 func TestBusinessMetricsLLMPricingAndUnpricedTokens(t *testing.T) {
 	m := NewBusinessMetrics()
 
@@ -139,6 +160,7 @@ func TestBusinessMetricsRegistryExposesAllFamilies(t *testing.T) {
 	m.RecordChatClaimSessionFallbackHit()
 	m.ObserveChatClaimLastSessionQuery(0.01)
 	m.ObserveChatClaimRolloutMissingQuery(0.01)
+	m.RecordIssueMetadataMutation("set", "changed", 10*time.Millisecond)
 	m.RecordLLMUsage("issue", "local", "codex", "gpt-5.4", 1, 1, 1, 1, 0)
 	m.RecordLLMUsage("issue", "local", "custom-provider", "custom-model", 1, 0, 0, 0, 0)
 

--- a/server/internal/metrics/business_test.go
+++ b/server/internal/metrics/business_test.go
@@ -93,27 +93,6 @@ func TestBusinessMetricsChatClaimResumeObservations(t *testing.T) {
 	}
 }
 
-func TestBusinessMetricsIssueMetadataMutationObservations(t *testing.T) {
-	m := NewBusinessMetrics()
-
-	m.RecordIssueMetadataMutation("set", "changed", 20*time.Millisecond)
-	m.RecordIssueMetadataMutation("set", "noop", 10*time.Millisecond)
-	m.RecordIssueMetadataMutation("delete", "not_found", 5*time.Millisecond)
-
-	for _, labels := range [][]string{
-		{"set", "changed"},
-		{"set", "noop"},
-		{"delete", "not_found"},
-	} {
-		if got := testutil.ToFloat64(m.issueMetadataMutation.WithLabelValues(labels...)); got != 1 {
-			t.Errorf("issue metadata mutation %v = %v, want 1", labels, got)
-		}
-	}
-	if got := testutil.CollectAndCount(m.issueMetadataMutationDuration); got != 3 {
-		t.Fatalf("issue metadata duration series = %d, want 3", got)
-	}
-}
-
 func TestBusinessMetricsLLMPricingAndUnpricedTokens(t *testing.T) {
 	m := NewBusinessMetrics()
 

--- a/server/internal/metrics/labels.go
+++ b/server/internal/metrics/labels.go
@@ -62,6 +62,8 @@ var businessMetricLabels = map[string][]string{
 	"multica_runtime_sweeper_candidate_rows_total":     {labelStage},
 	"multica_runtime_sweeper_rows_changed_total":       {labelStage},
 	"multica_agent_runtime_lookup_total":               {labelSource, labelResult},
+	"multica_issue_metadata_mutation_total":            {labelOp, labelResult},
+	"multica_issue_metadata_mutation_duration_seconds": {labelOp, labelResult},
 
 	// PR3 funnel / community / commercial.
 	"multica_signup_total":                             {labelSignupSource},

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -415,15 +415,12 @@ func (q *Queries) DeleteIssue(ctx context.Context, arg DeleteIssueParams) error 
 const deleteIssueMetadataKey = `-- name: DeleteIssueMetadataKey :one
 UPDATE issue SET
     metadata = metadata - $1::text,
-    revision = revision + CASE WHEN metadata ? $1::text THEN 1 ELSE 0 END,
-    last_activity_at = CASE
-        WHEN metadata ? $1::text
-        THEN GREATEST(COALESCE(last_activity_at, updated_at), now())
-        ELSE last_activity_at
-    END,
+    revision = revision + 1,
+    last_activity_at = GREATEST(COALESCE(last_activity_at, updated_at), now()),
     updated_at = now()
 WHERE id = $2 AND workspace_id = $3
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage, properties, revision, last_activity_at
+  AND metadata ? $1::text
+RETURNING id, workspace_id, metadata, revision
 `
 
 type DeleteIssueMetadataKeyParams struct {
@@ -432,40 +429,23 @@ type DeleteIssueMetadataKeyParams struct {
 	WorkspaceID pgtype.UUID `json:"workspace_id"`
 }
 
+type DeleteIssueMetadataKeyRow struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	Metadata    []byte      `json:"metadata"`
+	Revision    int64       `json:"revision"`
+}
+
 // Atomically removes a single key from the issue's metadata JSONB.
-// Deleting a missing key is a no-op (still returns the row).
-func (q *Queries) DeleteIssueMetadataKey(ctx context.Context, arg DeleteIssueMetadataKeyParams) (Issue, error) {
+// Deleting a missing key is a no-op (returns no rows).
+func (q *Queries) DeleteIssueMetadataKey(ctx context.Context, arg DeleteIssueMetadataKeyParams) (DeleteIssueMetadataKeyRow, error) {
 	row := q.db.QueryRow(ctx, deleteIssueMetadataKey, arg.Key, arg.ID, arg.WorkspaceID)
-	var i Issue
+	var i DeleteIssueMetadataKeyRow
 	err := row.Scan(
 		&i.ID,
 		&i.WorkspaceID,
-		&i.Title,
-		&i.Description,
-		&i.Status,
-		&i.Priority,
-		&i.AssigneeType,
-		&i.AssigneeID,
-		&i.CreatorType,
-		&i.CreatorID,
-		&i.ParentIssueID,
-		&i.AcceptanceCriteria,
-		&i.ContextRefs,
-		&i.Position,
-		&i.DueDate,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.Number,
-		&i.ProjectID,
-		&i.OriginType,
-		&i.OriginID,
-		&i.FirstExecutedAt,
-		&i.StartDate,
 		&i.Metadata,
-		&i.Stage,
-		&i.Properties,
 		&i.Revision,
-		&i.LastActivityAt,
 	)
 	return i, err
 }
@@ -1625,15 +1605,12 @@ const setIssueMetadataKey = `-- name: SetIssueMetadataKey :one
 
 UPDATE issue SET
     metadata = jsonb_set(metadata, ARRAY[$1::text], $2::jsonb),
-    revision = revision + CASE WHEN metadata -> $1::text IS DISTINCT FROM $2::jsonb THEN 1 ELSE 0 END,
-    last_activity_at = CASE
-        WHEN metadata -> $1::text IS DISTINCT FROM $2::jsonb
-        THEN GREATEST(COALESCE(last_activity_at, updated_at), now())
-        ELSE last_activity_at
-    END,
+    revision = revision + 1,
+    last_activity_at = GREATEST(COALESCE(last_activity_at, updated_at), now()),
     updated_at = now()
 WHERE id = $3 AND workspace_id = $4
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage, properties, revision, last_activity_at
+  AND metadata -> $1::text IS DISTINCT FROM $2::jsonb
+RETURNING id, workspace_id, metadata, revision
 `
 
 type SetIssueMetadataKeyParams struct {
@@ -1643,47 +1620,30 @@ type SetIssueMetadataKeyParams struct {
 	WorkspaceID pgtype.UUID `json:"workspace_id"`
 }
 
+type SetIssueMetadataKeyRow struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	Metadata    []byte      `json:"metadata"`
+	Revision    int64       `json:"revision"`
+}
+
 // SearchIssues: moved to handler (dynamic SQL for multi-word search support).
 // Atomically sets a single key in the issue's metadata JSONB. The
 // workspace_id filter is the authorization gate — handler resolves the
 // issue first so this is also the tenant check.
-func (q *Queries) SetIssueMetadataKey(ctx context.Context, arg SetIssueMetadataKeyParams) (Issue, error) {
+func (q *Queries) SetIssueMetadataKey(ctx context.Context, arg SetIssueMetadataKeyParams) (SetIssueMetadataKeyRow, error) {
 	row := q.db.QueryRow(ctx, setIssueMetadataKey,
 		arg.Key,
 		arg.Value,
 		arg.ID,
 		arg.WorkspaceID,
 	)
-	var i Issue
+	var i SetIssueMetadataKeyRow
 	err := row.Scan(
 		&i.ID,
 		&i.WorkspaceID,
-		&i.Title,
-		&i.Description,
-		&i.Status,
-		&i.Priority,
-		&i.AssigneeType,
-		&i.AssigneeID,
-		&i.CreatorType,
-		&i.CreatorID,
-		&i.ParentIssueID,
-		&i.AcceptanceCriteria,
-		&i.ContextRefs,
-		&i.Position,
-		&i.DueDate,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.Number,
-		&i.ProjectID,
-		&i.OriginType,
-		&i.OriginID,
-		&i.FirstExecutedAt,
-		&i.StartDate,
 		&i.Metadata,
-		&i.Stage,
-		&i.Properties,
 		&i.Revision,
-		&i.LastActivityAt,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -860,6 +860,30 @@ func (q *Queries) GetIssueInWorkspace(ctx context.Context, arg GetIssueInWorkspa
 	return i, err
 }
 
+const getIssueMetadataInWorkspace = `-- name: GetIssueMetadataInWorkspace :one
+SELECT metadata, revision FROM issue
+WHERE id = $1 AND workspace_id = $2
+`
+
+type GetIssueMetadataInWorkspaceParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+type GetIssueMetadataInWorkspaceRow struct {
+	Metadata []byte `json:"metadata"`
+	Revision int64  `json:"revision"`
+}
+
+// Reloads the committed metadata snapshot after a conditional mutation
+// returns no rows, without fetching the rest of the issue payload.
+func (q *Queries) GetIssueMetadataInWorkspace(ctx context.Context, arg GetIssueMetadataInWorkspaceParams) (GetIssueMetadataInWorkspaceRow, error) {
+	row := q.db.QueryRow(ctx, getIssueMetadataInWorkspace, arg.ID, arg.WorkspaceID)
+	var i GetIssueMetadataInWorkspaceRow
+	err := row.Scan(&i.Metadata, &i.Revision)
+	return i, err
+}
+
 const listChildIssues = `-- name: ListChildIssues :many
 SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage, properties, revision, last_activity_at FROM issue
 WHERE parent_issue_id = $1
@@ -1630,7 +1654,9 @@ type SetIssueMetadataKeyRow struct {
 // SearchIssues: moved to handler (dynamic SQL for multi-word search support).
 // Atomically sets a single key in the issue's metadata JSONB. The
 // workspace_id filter is the authorization gate — handler resolves the
-// issue first so this is also the tenant check.
+// issue first so this is also the tenant check. A no-op, a missing issue, or
+// a workspace mismatch returns no rows; callers that must distinguish those
+// cases need a separate workspace-scoped read.
 func (q *Queries) SetIssueMetadataKey(ctx context.Context, arg SetIssueMetadataKeyParams) (SetIssueMetadataKeyRow, error) {
 	row := q.db.QueryRow(ctx, setIssueMetadataKey,
 		arg.Key,

--- a/server/pkg/db/generated/issue_property.sql.go
+++ b/server/pkg/db/generated/issue_property.sql.go
@@ -290,8 +290,9 @@ type SetIssuePropertyValueParams struct {
 	WorkspaceID pgtype.UUID `json:"workspace_id"`
 }
 
-// Single-key atomic write (mirror of SetIssueMetadataKey): concurrent writers
-// on different property keys never clobber each other.
+// Single-key atomic write: concurrent writers on different property keys
+// never clobber each other. Unlike SetIssueMetadataKey, a no-op still updates
+// and returns the issue row.
 func (q *Queries) SetIssuePropertyValue(ctx context.Context, arg SetIssuePropertyValueParams) (Issue, error) {
 	row := q.db.QueryRow(ctx, setIssuePropertyValue,
 		arg.Key,

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -81,6 +81,12 @@ WHERE workspace_id = sqlc.arg('workspace_id')
 SELECT * FROM issue
 WHERE id = $1 AND workspace_id = $2;
 
+-- name: GetIssueMetadataInWorkspace :one
+-- Reloads the committed metadata snapshot after a conditional mutation
+-- returns no rows, without fetching the rest of the issue payload.
+SELECT metadata, revision FROM issue
+WHERE id = $1 AND workspace_id = $2;
+
 -- name: LockIssueForChannelMediaBind :one
 -- Channel media resolves after /issue creation. Hold a key-share lock while
 -- the attachment row is written so a concurrent issue delete cannot land
@@ -561,7 +567,9 @@ GROUP BY parent_issue_id;
 -- name: SetIssueMetadataKey :one
 -- Atomically sets a single key in the issue's metadata JSONB. The
 -- workspace_id filter is the authorization gate — handler resolves the
--- issue first so this is also the tenant check.
+-- issue first so this is also the tenant check. A no-op, a missing issue, or
+-- a workspace mismatch returns no rows; callers that must distinguish those
+-- cases need a separate workspace-scoped read.
 UPDATE issue SET
     metadata = jsonb_set(metadata, ARRAY[sqlc.arg('key')::text], sqlc.arg('value')::jsonb),
     revision = revision + 1,

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -564,30 +564,24 @@ GROUP BY parent_issue_id;
 -- issue first so this is also the tenant check.
 UPDATE issue SET
     metadata = jsonb_set(metadata, ARRAY[sqlc.arg('key')::text], sqlc.arg('value')::jsonb),
-    revision = revision + CASE WHEN metadata -> sqlc.arg('key')::text IS DISTINCT FROM sqlc.arg('value')::jsonb THEN 1 ELSE 0 END,
-    last_activity_at = CASE
-        WHEN metadata -> sqlc.arg('key')::text IS DISTINCT FROM sqlc.arg('value')::jsonb
-        THEN GREATEST(COALESCE(last_activity_at, updated_at), now())
-        ELSE last_activity_at
-    END,
+    revision = revision + 1,
+    last_activity_at = GREATEST(COALESCE(last_activity_at, updated_at), now()),
     updated_at = now()
 WHERE id = sqlc.arg('id') AND workspace_id = sqlc.arg('workspace_id')
-RETURNING *;
+  AND metadata -> sqlc.arg('key')::text IS DISTINCT FROM sqlc.arg('value')::jsonb
+RETURNING id, workspace_id, metadata, revision;
 
 -- name: DeleteIssueMetadataKey :one
 -- Atomically removes a single key from the issue's metadata JSONB.
--- Deleting a missing key is a no-op (still returns the row).
+-- Deleting a missing key is a no-op (returns no rows).
 UPDATE issue SET
     metadata = metadata - sqlc.arg('key')::text,
-    revision = revision + CASE WHEN metadata ? sqlc.arg('key')::text THEN 1 ELSE 0 END,
-    last_activity_at = CASE
-        WHEN metadata ? sqlc.arg('key')::text
-        THEN GREATEST(COALESCE(last_activity_at, updated_at), now())
-        ELSE last_activity_at
-    END,
+    revision = revision + 1,
+    last_activity_at = GREATEST(COALESCE(last_activity_at, updated_at), now()),
     updated_at = now()
 WHERE id = sqlc.arg('id') AND workspace_id = sqlc.arg('workspace_id')
-RETURNING *;
+  AND metadata ? sqlc.arg('key')::text
+RETURNING id, workspace_id, metadata, revision;
 
 -- name: MarkIssueFirstExecuted :one
 -- Flips first_executed_at from NULL to now() atomically. Returns the row if

--- a/server/pkg/db/queries/issue_property.sql
+++ b/server/pkg/db/queries/issue_property.sql
@@ -48,8 +48,9 @@ WHERE id = $1 AND workspace_id = $2
 RETURNING *;
 
 -- name: SetIssuePropertyValue :one
--- Single-key atomic write (mirror of SetIssueMetadataKey): concurrent writers
--- on different property keys never clobber each other.
+-- Single-key atomic write: concurrent writers on different property keys
+-- never clobber each other. Unlike SetIssueMetadataKey, a no-op still updates
+-- and returns the issue row.
 UPDATE issue
 SET properties = jsonb_set(properties, ARRAY[sqlc.arg('key')::text], sqlc.arg('value')::jsonb, true),
     revision = revision + CASE WHEN properties -> sqlc.arg('key')::text IS DISTINCT FROM sqlc.arg('value')::jsonb THEN 1 ELSE 0 END,


### PR DESCRIPTION
## What does this PR do?

Suppresses physical PostgreSQL updates when an issue metadata set/delete would not change the JSONB document.

The existing `CASE` expressions kept `revision` and `last_activity_at` stable, but the statement still updated `updated_at`, created a new row version, acquired the hot issue-row lock, and caused the handler to publish a metadata-changed event. This PR moves the change predicates into `WHERE`, keeps the update atomic, and uses a separate narrow primary-database read of `metadata, revision` when sqlc returns `pgx.ErrNoRows`. That independent read preserves the current 200 response for a no-op, returns the committed metadata snapshot after a lock wait, and distinguishes a concurrently deleted issue as 404.

No schema migration or API response-shape change is required. A real metadata change on the same issue still serializes at the row level; this deliberately removes no-op write/event amplification rather than claiming to eliminate all lock waits.

## Related Issue

MUL-7250 (Multica workspace issue)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Add change predicates to set/delete metadata SQL and reduce `RETURNING` to the four fields the handlers use.
- Preserve 200 responses for no-ops via an independent, workspace-scoped `metadata, revision` primary read; publish realtime events only for actual mutations.
- Add bounded `operation`/`result` counters and database-duration histograms. No-op durations include both the conditional UPDATE and fallback read.
- Add a 1% debug-only request correlation sample without metadata values. Production rollout signals are the bounded metadata metrics plus the existing HTTP and DB pool metrics; the debug sample is not assumed to be enabled in production.
- Add two focused DB-backed regressions: set/delete no-ops preserve the row and suppress events, and a lock-waiting no-op returns the committed snapshot.

## How to Test

1. `cd server && go test -race ./internal/handler -run '^(TestIssueMetadataNoopPreservesRowAndSuppressesEvents|TestIssueMetadataWaitingNoopReturnsCommittedSnapshot)$' -count=1`
2. `cd server && go test ./internal/handler -run '^(TestIssueMetadata|TestIssueActivityTimestampIsMonotonic|TestIssueDecorationActivityOnlyAdvancesOnChange)' -count=1`
3. `cd server && go test ./internal/metrics -count=1 && go vet ./internal/handler ./internal/metrics ./pkg/db/generated`

All scoped tests and vet pass locally. I also attempted the complete handler package; the shared local database is behind `main` migrations and fails existing unrelated tests on missing columns such as `agent.conversation_starters`, `chat_session.explicitly_created_at`, and `attachment.source_context_id`. I did not migrate the shared database from this worktree. The independent review ran the complete handler package successfully against a freshly migrated temporary database.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run the scoped tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] This change does not affect the UI
- [x] No documentation update is required for this internal behavior fix
- [x] This change does not add a runtime, coding tool, or UI tab
- [x] This change does not touch Chinese product copy
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:** Investigated the reported PostgreSQL lock chain, reviewed the proposed no-op predicate and READ COMMITTED recheck behavior, implemented the SQL/handler/observability changes, and validated the concurrency semantics with focused DB-backed tests.

## Screenshots (optional)

Not applicable; server-only behavior change.
