### PR TITLE
MUL-7267: fix(autopilot): backfill legacy trigger creators from the autopilot creator

### DIFF
--- a/server/internal/attribution/attribution.go
+++ b/server/internal/attribution/attribution.go
@@ -52,17 +52,18 @@ const (
 	// comment.source_task_id (a special case of delegation, MUL-4302 §3.3).
 	SourceCommentSource Source = "comment_source"
 	// SourceTriggerOwner — an autopilot schedule/webhook trigger enqueued the run;
-	// the human is the member who CREATED that specific trigger (set up the schedule
-	// / registered the webhook). Preferred over rule_owner: a run belongs to whoever
-	// armed the trigger that fired it, not to whoever last published the rule
-	// (MUL-4302; Bohan's refinement). Since MUL-6951 that human is the ORIGINATOR as
-	// well as the accountable — arming a trigger authorizes the run the same way
-	// clicking "run now" does — so this label marks HOW the human was resolved, not a
-	// weaker grant. The label is what still distinguishes an autonomous fire from a
-	// manual one in the audit trail.
+	// the human is that trigger's persisted created_by principal: the member who
+	// created it, or for a legacy trigger a principal inferred by backfill (see
+	// service.ResolveAutopilotTriggerPrincipal). Preferred over rule_owner: a run
+	// belongs to whoever armed the trigger that fired it, not to whoever last
+	// published the rule (MUL-4302; Bohan's refinement). Since MUL-6951 that human
+	// is the ORIGINATOR as well as the accountable — arming a trigger authorizes the
+	// run the same way clicking "run now" does — so this label marks HOW the human
+	// was resolved, not a weaker grant. The label is what still distinguishes an
+	// autonomous fire from a manual one in the audit trail.
 	SourceTriggerOwner Source = "trigger_owner"
-	// SourceRuleOwner — an autopilot trigger enqueued the run but records no
-	// provable creator (a trigger predating per-trigger creators); the ACCOUNTABLE
+	// SourceRuleOwner — an autopilot trigger enqueued the run but has no created_by
+	// principal (a legacy trigger that no backfill could fill); the ACCOUNTABLE
 	// human degrades to the publisher of the rule's active version (MUL-4302 §3.4),
 	// while authorization carries none. Precise for audit, deliberately powerless.
 	SourceRuleOwner Source = "rule_owner"
@@ -156,8 +157,8 @@ const (
 //     run), the two may diverge — owner_fallback names the agent owner, and
 //     rule_owner the rule publisher, as the accountable human while authorization
 //     correctly carries none. trigger_owner is NOT such a case since MUL-6951: an
-//     armed autopilot carries its trigger creator's authorization, so both columns
-//     hold that human.
+//     armed autopilot carries the authorization of its trigger's created_by
+//     principal, so both columns hold that human.
 //
 // The remaining fields are audit metadata written into the Phase 1 provenance
 // columns. Construct a Result through ClassifyComment / ClassifyDirect /
@@ -207,7 +208,7 @@ type CommentFacts struct {
 
 	// ParentAccountable is the source task's accountable_user_id (MUL-4302 §3.2).
 	// It lets an autopilot-rooted chain — where the parent has NO authorizing human
-	// (ParentOriginator NULL) but IS accountable to someone (trigger creator / rule
+	// (ParentOriginator NULL) but IS accountable to someone (trigger principal / rule
 	// publisher) — copy that responsible human down the delegation, instead of
 	// dropping the chain root to unattributed. Loaded by the caller alongside
 	// ParentOriginator; invalid when the parent has no accountable human either.
@@ -242,7 +243,7 @@ func ClassifyComment(f CommentFacts, agentAuthoredSource Source) Result {
 			r.Source = agentAuthoredSource
 		} else if f.ParentAccountable.Valid {
 			// The parent had no authorizing human (autopilot-rooted chain:
-			// originator NULL, accountable = trigger creator / rule publisher) but
+			// originator NULL, accountable = trigger principal / rule publisher) but
 			// IS accountable to someone. Copy that accountable down so the
 			// responsibility chain root stays stable at any depth (MUL-4302 §3.2);
 			// originator stays NULL so authorization is unchanged and a fail-closed
@@ -325,7 +326,7 @@ func ClassifyDirect(f DirectFacts) Result {
 			r.Source = SourceDelegation
 		} else if f.OriginAccountable.Valid {
 			// Autopilot-rooted origin task: no authorizing human, but accountable
-			// to the trigger creator / rule publisher. Copy accountable down so the
+			// to the trigger principal / rule publisher. Copy accountable down so the
 			// chain root stays stable; originator stays NULL (MUL-4302 §3.2).
 			r.AccountableUserID = f.OriginAccountable
 			r.Source = SourceDelegation
@@ -369,7 +370,7 @@ func Unattributed(evidenceKind EvidenceKind, evidenceRefID pgtype.UUID) Result {
 }
 
 // RuleOwner builds attribution for an autopilot-triggered run whose firing
-// trigger records no provable creator (MUL-4302 §3.4) — the coarser fallback
+// trigger has no created_by principal (MUL-4302 §3.4) — the coarser fallback
 // behind TriggerOwner. publisherUserID, the member who published the active rule
 // version, becomes the AUDIT-accountable human only; UserID (the originator, the
 // authorization value) stays NULL.
@@ -402,13 +403,14 @@ func RuleOwner(publisherUserID, ruleVersionID pgtype.UUID, evidenceKind Evidence
 }
 
 // TriggerOwner builds attribution for an autopilot schedule/webhook run keyed to
-// the firing trigger's CREATOR (MUL-4302; MUL-6951). It sets UserID — the ORIGINATOR — so the run carries
-// that human's authorization context, exactly as a manual "run now" by the same
-// person would (MUL-6951; Bohan's call). finalizeAttribution mirrors it onto the
-// accountable side, satisfying the originator == accountable invariant migration
-// 190/197 enforces. Evidence is caller-supplied (autopilot_run for run_only, the
-// issue for create_issue). An invalid creator degrades to unattributed so callers
-// that lost the creator fall back to rule_owner rather than fabricating a human.
+// the firing trigger's created_by principal (MUL-4302; MUL-6951). It sets UserID —
+// the ORIGINATOR — so the run carries that human's authorization context, exactly
+// as a manual "run now" by the same person would (MUL-6951; Bohan's call).
+// finalizeAttribution mirrors it onto the accountable side, satisfying the
+// originator == accountable invariant migration 190/197 enforces. Evidence is
+// caller-supplied (autopilot_run for run_only, the issue for create_issue). An
+// invalid principal degrades to unattributed so callers without one fall back to
+// rule_owner rather than fabricating a human.
 //
 // WHY the originator and not accountable-only (MUL-6951): arming a trigger IS the
 // authorization — the same act as clicking "run now", just deferred. Withholding
@@ -420,9 +422,11 @@ func RuleOwner(publisherUserID, ruleVersionID pgtype.UUID, evidenceKind Evidence
 // and lets those borrow paths be deleted.
 //
 // The caller (service.ResolveAutopilotTriggerPrincipal) resolves that human from
-// the trigger's IMMUTABLE created_by, never published_by: published_by transfers
-// on a substantive edit, so using it would let a collaborator editing a cron
-// expression silently move whose rights the automation runs with. The same
+// the trigger's created_by — never rewritten by an edit, and for a legacy trigger a
+// backfilled inference rather than proof of its creator — never from published_by:
+// published_by transfers on a substantive edit, so using it would let a
+// collaborator editing a cron expression silently move whose rights the
+// automation runs with. The same
 // resolver feeds dispatch admission, so one run can never be admitted as one human
 // and executed as another.
 func TriggerOwner(creatorUserID pgtype.UUID, evidenceKind EvidenceKind, evidenceRefID pgtype.UUID) Result {

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -1222,7 +1222,7 @@ func (h *Handler) UpdateAutopilot(w http.ResponseWriter, r *http.Request) {
 	// changed what the rule does. Cosmetic edits (title / description / template)
 	// write no version (MUL-4302 §3.4). Since MUL-6951 the rule publisher is an
 	// AUDIT value only — it is the coarse fallback a run degrades to when its
-	// trigger records no creator, and such a run carries no authorization.
+	// trigger has no created_by principal, and such a run carries no authorization.
 	if autopilotRuleSubstantiveChange(prev, autopilot) {
 		if err := h.recordAutopilotRuleVersion(r.Context(), qtx, autopilot, "member", actor.UserID); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to update autopilot")
@@ -1232,7 +1232,7 @@ func (h *Handler) UpdateAutopilot(w http.ResponseWriter, r *http.Request) {
 		// responsibility for each one transfers to this editor. A trigger-scoped edit
 		// re-stamps only its own row (see UpdateAutopilotTrigger). Since MUL-6951 this
 		// moves published_by alone: the runs each trigger fires keep acting as, and
-		// stay accountable to, that trigger's immutable created_by.
+		// stay accountable to, that trigger's created_by, which no edit rewrites.
 		if err := qtx.SetAutopilotTriggerPublishersByAutopilot(r.Context(), db.SetAutopilotTriggerPublishersByAutopilotParams{
 			AutopilotID:     autopilot.ID,
 			PublishedByType: pgtype.Text{String: "member", Valid: true},

--- a/server/internal/handler/autopilot_trigger_creator_backfill_test.go
+++ b/server/internal/handler/autopilot_trigger_creator_backfill_test.go
@@ -1,0 +1,144 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+// Migration 467 fills a legacy trigger's missing creator from its autopilot's
+// creator, so schedule/webhook dispatch has a principal again instead of
+// skipping every run (#8284).
+//
+// The shipped SQL runs twice inside a transaction that is rolled back: the
+// UPDATE is table-wide, and committing it would rewrite the NULL-creator
+// triggers that other packages' tests build concurrently in the same database.
+func TestMigration467BackfillsTriggerCreatorFromAutopilot(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	otherMemberID := dbfx.User(t, "Backfill Other Member", "mul7267-member@multica.test")
+	dbfx.Member(t, testWorkspaceID, otherMemberID, "member")
+	departedID := dbfx.User(t, "Backfill Departed Member", "mul7267-departed@multica.test")
+	agentID := dbfx.Agent(t, "Backfill Agent", handlerTestRuntimeID(t))
+
+	autopilot := func(creatorID string) string {
+		return dbfx.Insert(t, "autopilot", testutil.Cols{
+			"workspace_id":    testWorkspaceID,
+			"title":           "Trigger creator backfill",
+			"assignee_type":   "agent",
+			"assignee_id":     agentID,
+			"status":          "active",
+			"execution_mode":  "run_only",
+			"created_by_type": "member",
+			"created_by_id":   creatorID,
+		})
+	}
+	scheduleTrigger := func(autopilotID string, createdByType, createdByID any) string {
+		return dbfx.Insert(t, "autopilot_trigger", testutil.Cols{
+			"autopilot_id":    autopilotID,
+			"kind":            "schedule",
+			"enabled":         true,
+			"cron_expression": "0 9 * * *",
+			"created_by_type": createdByType,
+			"created_by_id":   createdByID,
+		})
+	}
+
+	liveAutopilotID := autopilot(testUserID)
+	token, err := generateWebhookToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The #8284 shape: created before published_by existed and never edited, so
+	// migration 449 had nothing to backfill created_by from.
+	legacyWebhookID := dbfx.Insert(t, "autopilot_trigger", testutil.Cols{
+		"autopilot_id":  liveAutopilotID,
+		"kind":          "webhook",
+		"enabled":       true,
+		"webhook_token": token,
+	})
+	agentCreatedID := scheduleTrigger(liveAutopilotID, "agent", agentID)
+	memberCreatedID := scheduleTrigger(liveAutopilotID, "member", otherMemberID)
+	departedCreatorID := scheduleTrigger(autopilot(departedID), nil, nil)
+
+	w := postWebhook(t, token, map[string]any{"ref": "refs/heads/main"}, map[string]string{"X-GitHub-Event": "push"})
+	var before map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &before); err != nil {
+		t.Fatalf("decode pre-backfill response: %v", err)
+	}
+	if before["status"] != "skipped" {
+		t.Fatalf("pre-backfill webhook = %v, want skipped: the legacy trigger has no principal yet", before)
+	}
+
+	migration, err := os.ReadFile("../../migrations/467_autopilot_trigger_creator_from_autopilot.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+	for range 2 {
+		if _, err := tx.Exec(ctx, string(migration)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	creatorOf := func(triggerID string) (createdByType, createdByID *string) {
+		t.Helper()
+		if err := tx.QueryRow(ctx,
+			`SELECT created_by_type, created_by_id::text FROM autopilot_trigger WHERE id = $1`, triggerID,
+		).Scan(&createdByType, &createdByID); err != nil {
+			t.Fatal(err)
+		}
+		return createdByType, createdByID
+	}
+	for _, tc := range []struct {
+		name, triggerID string
+		wantType        *string
+		wantID          *string
+	}{
+		{"no creator takes the autopilot creator", legacyWebhookID, ptr("member"), ptr(testUserID)},
+		{"agent creator takes the autopilot creator", agentCreatedID, ptr("member"), ptr(testUserID)},
+		{"member creator is never rewritten", memberCreatedID, ptr("member"), ptr(otherMemberID)},
+		{"departed autopilot creator is not written in", departedCreatorID, nil, nil},
+	} {
+		gotType, gotID := creatorOf(tc.triggerID)
+		if orNULL(gotType) != orNULL(tc.wantType) || orNULL(gotID) != orNULL(tc.wantID) {
+			t.Errorf("%s: created_by = %s/%s, want %s/%s",
+				tc.name, orNULL(gotType), orNULL(gotID), orNULL(tc.wantType), orNULL(tc.wantID))
+		}
+	}
+	filledType, filledID := creatorOf(legacyWebhookID)
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit the value the migration computed for this trigger alone: the next
+	// delivery must run instead of being skipped.
+	dbfx.Exec(t, `UPDATE autopilot_trigger SET created_by_type = $2, created_by_id = $3 WHERE id = $1`,
+		legacyWebhookID, filledType, filledID)
+	w = postWebhook(t, token, map[string]any{"ref": "refs/heads/main"}, map[string]string{"X-GitHub-Event": "push"})
+	delivery := processQueuedWebhookDelivery(t, requireAcceptedWebhookResponse(t, w))
+	run, err := testHandler.Queries.GetAutopilotRun(ctx, delivery.AutopilotRunID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if run.Status != "running" || !run.TaskID.Valid {
+		t.Fatalf("post-backfill run status=%s task=%v failure=%q, want running with a task",
+			run.Status, run.TaskID.Valid, run.FailureReason.String)
+	}
+}
+
+func orNULL(s *string) string {
+	if s == nil {
+		return "NULL"
+	}
+	return *s
+}

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -124,9 +124,11 @@ func (s *AutopilotService) DispatchAutopilot(
 	payload []byte,
 ) (*db.AutopilotRun, error) {
 	// No member actor on this entry point (schedule / webhook / api, or a manual
-	// trigger without a resolved member): the run acts as the trigger's creator
-	// (trigger_owner), degrading to the audit-only rule_owner when no creator is
-	// recoverable — in which case it carries no authorization at all (MUL-6951).
+	// trigger without a resolved member): the run acts as the trigger's persisted
+	// created_by principal (trigger_owner; legacy semantics in
+	// ResolveAutopilotTriggerPrincipal), degrading to the audit-only rule_owner when
+	// the trigger has none — in which case it carries no authorization at all
+	// (MUL-6951).
 	// These callers don't surface a per-run reason code to a human, so it is
 	// dropped.
 	// webhookDeliveryID is invalid here — durable webhook deliveries admit through
@@ -136,8 +138,8 @@ func (s *AutopilotService) DispatchAutopilot(
 }
 
 // DispatchAutopilotManual is the "run now" entry point for a manual trigger.
-// Scheduled / webhook / api dispatch acts as the firing trigger's creator
-// (MUL-6951); a manual trigger is a direct human action by the human who ORDERED
+// Scheduled / webhook / api dispatch acts as the firing trigger's created_by
+// principal (MUL-6951); a manual trigger is a direct human action by the human who ORDERED
 // it instead, so it need not consult the trigger at all: the run is attributed
 // direct_human to actorUserID, which becomes BOTH its originator (authorization)
 // and accountable human (MUL-4302 §4), across both execution modes.
@@ -201,8 +203,8 @@ func (s *AutopilotService) AdmitAutopilotWebhookDelivery(
 	}
 
 	// Webhook admission has no member actor → the automation principal is this
-	// trigger's creator (MUL-6951); the per-run reason code is not surfaced to a
-	// human here, so it is dropped.
+	// trigger's created_by (MUL-6951; see ResolveAutopilotTriggerPrincipal); the
+	// per-run reason code is not surfaced to a human here, so it is dropped.
 	if reason, _, skip := s.shouldSkipDispatch(ctx, autopilot, pgtype.UUID{}, triggerID); skip {
 		run, err := s.recordSkippedRun(
 			ctx,
@@ -475,8 +477,8 @@ func (s *AutopilotService) DispatchAutopilotForPlan(
 		return nil, fmt.Errorf("dispatch for plan: lookup existing run: %w", err)
 	}
 
-	// Scheduled dispatch has no member actor → it acts as the trigger's creator
-	// (trigger_owner, MUL-6951), and has no human surface for a per-run reason
+	// Scheduled dispatch has no member actor → it acts as the trigger's created_by
+	// principal (trigger_owner, MUL-6951), and has no human surface for a per-run reason
 	// code, so it is dropped. No webhook delivery on the scheduled-plan path.
 	key := "schedule:" + util.UUIDToString(triggerID) + ":" + plannedAt.UTC().Format(time.RFC3339Nano)
 	run, _, err := s.dispatchAutopilot(ctx, autopilot, triggerID, source, payload, plannedTS, pgtype.UUID{}, pgtype.UUID{}, key)
@@ -807,13 +809,13 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 	// actor-carrying entry points so attribution resolves direct_human to the
 	// triggering member (originator == accountable == actor, MUL-4302 §4). Schedule /
 	// webhook dispatch has no actor and takes the plain entry points, where the
-	// autopilot-origin issue resolves to the trigger's creator (MUL-6951). The
-	// *ByActor variants are the actor-carrying enqueue methods.
+	// autopilot-origin issue resolves to the trigger's created_by principal
+	// (MUL-6951). The *ByActor variants are the actor-carrying enqueue methods.
 	if ap.AssigneeType == "squad" {
 		// Fail-closed invocation gate: verify the admission principal (manual
-		// clicker, else creator — see autopilotAdmitInvoke) may still invoke the
-		// leader. Catches configs that predate the save-time gate, and configs
-		// that no longer pass (MUL-3963 / MUL-4525).
+		// clicker, else the trigger's created_by — see autopilotAdmitInvoke) may
+		// still invoke the leader. Catches configs that predate the save-time
+		// gate, and configs that no longer pass (MUL-3963 / MUL-4525).
 		if !s.autopilotAdmitInvoke(ctx, ap, leader, actorUserID, run.TriggerID) {
 			return fmt.Errorf("not allowed to invoke private squad leader")
 		}
@@ -970,7 +972,7 @@ func (s *AutopilotService) dispatchRunOnly(ctx context.Context, ap db.Autopilot,
 	}
 
 	// Fail-closed invocation gate for squad autopilots (admission principal =
-	// manual clicker, else creator — see autopilotAdmitInvoke).
+	// manual clicker, else the trigger's created_by — see autopilotAdmitInvoke).
 	if ap.AssigneeType == "squad" && !s.autopilotAdmitInvoke(ctx, ap, agent, actorUserID, run.TriggerID) {
 		return &errDispatchSkipped{reason: formatAdmissionReason(ap, "not allowed to invoke private squad leader"), code: dispatch.ReasonInvocationNotAllowed}
 	}
@@ -1360,8 +1362,9 @@ func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopil
 	// resolved by the handler (requireAutopilotTriggerInvoker) — not the
 	// autopilot creator's, so admission and attribution credit the same human and
 	// never fork. Automation (schedule / webhook, actorUserID invalid) preserves
-	// that same property by resolving the trigger's creator, which is also the
-	// human the run will act as (MUL-6951). Admins do NOT bypass a private agent
+	// that same property by resolving the trigger's created_by principal
+	// (ResolveAutopilotTriggerPrincipal), which is also the human the run will act
+	// as (MUL-6951). Admins do NOT bypass a private agent
 	// they do not own, and no branch admits a principal-less dispatch. For squad
 	// autopilots the gate runs against the resolved leader.
 	if !s.autopilotAdmitInvoke(ctx, ap, agent, actorUserID, triggerID) {
@@ -1871,8 +1874,10 @@ func (s *AutopilotService) getIssuePrefix(workspaceID pgtype.UUID) string {
 // invoke the target agent (MUL-4525). A MANUAL "run now" (actorUserID valid) is
 // a direct human action gated by the CURRENT clicker's access, so admission and
 // attribution credit the same member. Automation (schedule / webhook / api,
-// actorUserID invalid) resolves the trigger's creator — the same human the run
-// itself will act as (MUL-6951). Both branches fail closed and never grant an admin bypass.
+// actorUserID invalid) resolves the trigger's created_by principal — the same
+// human the run itself will act as (MUL-6951; legacy semantics in
+// ResolveAutopilotTriggerPrincipal). Both branches fail closed and never grant an
+// admin bypass.
 func (s *AutopilotService) autopilotAdmitInvoke(ctx context.Context, ap db.Autopilot, agent db.Agent, actorUserID, triggerID pgtype.UUID) bool {
 	if actorUserID.Valid {
 		return s.canMemberInvokeAgent(ctx, agent, actorUserID, ap.WorkspaceID)

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -978,10 +978,11 @@ func (s *AutopilotService) dispatchRunOnly(ctx context.Context, ap db.Autopilot,
 	// Attribution splits on the trigger only to pick WHICH human and which source
 	// label; both branches now produce a real originator. A MANUAL trigger is a
 	// direct human action: the triggering member is direct_human (MUL-4302 §4). A
-	// schedule / webhook trigger resolves the firing trigger's immutable CREATOR —
-	// trigger_owner, from run.TriggerID (MUL-4302; MUL-6951) — degrading to the rule
-	// version publisher (rule_owner, audit-only) when no creator is recoverable, then
-	// to unattributed. An edit of the trigger does NOT move this: published_by
+	// schedule / webhook trigger resolves the firing trigger's created_by principal —
+	// trigger_owner, from run.TriggerID (MUL-4302; MUL-6951; for a legacy trigger a
+	// backfilled inference, see ResolveAutopilotTriggerPrincipal) — degrading to the
+	// rule version publisher (rule_owner, audit-only) when it has none, then to
+	// unattributed. An edit of the trigger does NOT move this: published_by
 	// transfers, created_by does not. Since MUL-6951 that human is the originator
 	// too, so an armed autopilot runs with its creator's authorization instead of
 	// borrowing narrowly-scoped capabilities per surface; the source label is what

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -659,8 +659,9 @@ func triggerOwnerAttribution(ctx context.Context, q *db.Queries, triggerID, work
 //     cannot select the principal. The membership check below is not a substitute:
 //     it proves the resolved human is in the workspace passed in, which a member of
 //     two workspaces satisfies even when the trigger came from the other one;
-//   - created_by names a member — a legacy trigger predating the column (and with
-//     no published_by to backfill from) resolves nobody rather than a guess;
+//   - created_by names a member — a legacy trigger predating the column that had
+//     neither a published_by (migration 449) nor a still-member autopilot creator
+//     (migration 467) to backfill from resolves nobody rather than a guess;
 //   - that member is STILL in the autopilot's workspace, re-checked on every
 //     dispatch, so removing someone actually revokes what their triggers can do.
 func ResolveAutopilotTriggerPrincipal(ctx context.Context, q *db.Queries, triggerID, autopilotID, workspaceID pgtype.UUID) pgtype.UUID {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -612,23 +612,24 @@ func ruleOwnerAttribution(ctx context.Context, q *db.Queries, workspaceID, autop
 }
 
 // triggerOwnerAttribution resolves an autopilot schedule/webhook run to the firing
-// trigger's CREATOR (MUL-4302; MUL-6951). triggerID is the autopilot_run's
-// trigger_id.
+// trigger's dispatch principal, created_by (MUL-4302; MUL-6951) — see
+// ResolveAutopilotTriggerPrincipal for what that column does and does not prove.
+// triggerID is the autopilot_run's trigger_id.
 //
-// The creator is immutable — a substantive edit re-stamps published_by, not
-// created_by, so it cannot re-authorize the automation as the editor (MUL-6951,
-// Bohan's ruling). Because the DB invariant forces accountable == originator once
-// the originator is set, BOTH columns on the task name the creator; the editor's
-// responsibility for the config lives on autopilot_trigger.published_by.
+// No edit rewrites created_by — a substantive edit re-stamps published_by — so it
+// cannot re-authorize the automation as the editor (MUL-6951, Bohan's ruling).
+// Because the DB invariant forces accountable == originator once the originator is
+// set, BOTH columns on the task name that principal; the editor's responsibility
+// for the config lives on autopilot_trigger.published_by.
 //
-// A trigger with no recoverable creator degrades to ruleOwnerAttribution, which is
+// A trigger with no principal degrades to ruleOwnerAttribution, which is
 // audit-only — the run then carries no originator and the invoke gate fails closed.
 // Never errors: attribution must not fail an enqueue.
 func triggerOwnerAttribution(ctx context.Context, q *db.Queries, triggerID, workspaceID, autopilotID pgtype.UUID, evidenceKind attribution.EvidenceKind, evidenceRefID pgtype.UUID) attribution.Result {
 	if principal := ResolveAutopilotTriggerPrincipal(ctx, q, triggerID, autopilotID, workspaceID); principal.Valid {
 		return attribution.TriggerOwner(principal, evidenceKind, evidenceRefID)
 	}
-	// No provable principal: degrade to the rule publisher, which is AUDIT-ONLY.
+	// No principal: degrade to the rule publisher, which is AUDIT-ONLY.
 	// rule_owner must never become an authorization identity — it is a guess at
 	// "who probably owns this rule", and promoting it would hand a legacy trigger
 	// somebody's invoke rights without that person ever arming anything. The run
@@ -637,8 +638,9 @@ func triggerOwnerAttribution(ctx context.Context, q *db.Queries, triggerID, work
 }
 
 // ResolveAutopilotTriggerPrincipal returns the human a schedule/webhook dispatch
-// ACTS AS, or an invalid UUID when none can be proven — in which case every
-// caller must fail closed rather than substitute a different human.
+// ACTS AS — the trigger's created_by — or an invalid UUID when there is none, in
+// which case every caller must fail closed rather than substitute a different
+// human.
 //
 // This is the single source of that answer (MUL-6951). Admission
 // (autopilotAdmitInvoke), the originator stamped on the task, and every run
@@ -646,11 +648,19 @@ func triggerOwnerAttribution(ctx context.Context, q *db.Queries, triggerID, work
 // person A and then run with person B's rights — a combination neither of them
 // could produce by hand, and the exact fork Elon's review found.
 //
-// The principal is the trigger's IMMUTABLE created_by, not published_by:
-// published_by transfers to whoever last substantively edits the trigger, so
-// using it would let a collaborator adjusting a cron expression silently hand the
-// automation their own rights (MUL-6951, Bohan's ruling: the run always acts as
-// the trigger's creator).
+// The principal is the trigger's created_by, not published_by: published_by
+// transfers to whoever last substantively edits the trigger, so using it would let
+// a collaborator adjusting a cron expression silently hand the automation their
+// own rights (MUL-6951, Bohan's ruling: the run always acts as the trigger's
+// creator).
+//
+// What created_by records depends on the trigger's age. For a trigger created
+// since MUL-6951 it is the member who created it, written at creation. For a legacy
+// trigger it is a principal inferred once by backfill and frozen — the last
+// publisher (migration 449), else the autopilot's creator (migration 467) — so it
+// is NOT proof of who created that trigger; treat it only as the dispatch
+// principal. Nothing here infers a principal at dispatch time, and no edit
+// rewrites it.
 //
 // Three conditions, all required, all fail-closed:
 //
@@ -659,9 +669,8 @@ func triggerOwnerAttribution(ctx context.Context, q *db.Queries, triggerID, work
 //     cannot select the principal. The membership check below is not a substitute:
 //     it proves the resolved human is in the workspace passed in, which a member of
 //     two workspaces satisfies even when the trigger came from the other one;
-//   - created_by names a member — a legacy trigger predating the column that had
-//     neither a published_by (migration 449) nor a still-member autopilot creator
-//     (migration 467) to backfill from resolves nobody rather than a guess;
+//   - created_by names a member — a legacy trigger that neither backfill could
+//     fill resolves nobody;
 //   - that member is STILL in the autopilot's workspace, re-checked on every
 //     dispatch, so removing someone actually revokes what their triggers can do.
 func ResolveAutopilotTriggerPrincipal(ctx context.Context, q *db.Queries, triggerID, autopilotID, workspaceID pgtype.UUID) pgtype.UUID {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -541,9 +541,10 @@ func (s *TaskService) attributionForIssueTask(ctx context.Context, issue db.Issu
 		}
 	}
 	// Autopilot-origin issues (origin_id is the autopilot id) from a schedule /
-	// webhook trigger attribute to the firing trigger's CREATOR — trigger_owner
-	// (MUL-4302; MUL-6951) — degrading to the audit-only rule publisher when no
-	// creator is recoverable. That human is the originator as well as the
+	// webhook trigger attribute to the firing trigger's persisted created_by
+	// principal — trigger_owner (MUL-4302; MUL-6951; legacy semantics in
+	// ResolveAutopilotTriggerPrincipal) — degrading to the audit-only rule publisher
+	// when the trigger has none. That human is the originator as well as the
 	// accountable, so a create_issue-mode run carries the same authorization a
 	// manual "run now" by that member would; an edit of the trigger does not move
 	// it. Resolved the same way
@@ -587,8 +588,9 @@ func (s *TaskService) attributionForIssueTask(ctx context.Context, issue db.Issu
 // from its active (latest) rule version snapshot (MUL-4302 §3.4). Shared by both
 // autopilot execution modes — run_only dispatch and the create_issue enqueue path —
 // so they attribute identically. originator stays NULL: an autopilot DOES carry a
-// human's authority since MUL-6951, but it comes from the trigger's creator, and
-// this is the fallback for when that creator cannot be proven. Only the
+// human's authority since MUL-6951, but it comes from the trigger's created_by
+// principal (see ResolveAutopilotTriggerPrincipal), and this is the fallback for a
+// trigger that has none. Only the
 // audit-accountable side is set, to the version's member publisher. A missing version (autopilot published before this feature, or
 // none yet) or a non-member/absent publisher degrades to unattributed rather than
 // fabricating a human. Never returns an error: attribution must not fail an

--- a/server/migrations/467_autopilot_trigger_creator_from_autopilot.down.sql
+++ b/server/migrations/467_autopilot_trigger_creator_from_autopilot.down.sql
@@ -1,5 +1,8 @@
 -- The backfill is irreversible: a filled row is indistinguishable from a trigger
 -- its creator made, and clearing it would stop that trigger again. Restore only
--- migration 449's column comment.
+-- migration 449's column comments, verbatim.
 COMMENT ON COLUMN autopilot_trigger.created_by_type IS
     'Actor type of the trigger''s immutable creator: member | agent. Only ''member'' yields a run principal. NULL for triggers created before MUL-6951 that had no published_by to backfill from.';
+
+COMMENT ON COLUMN autopilot_trigger.created_by_id IS
+    'The member a schedule/webhook run fires AS: dispatch admission, the task''s originator/accountable, and every delegated run all resolve to this one human (MUL-6951). Written once at creation and never re-stamped, so editing the trigger cannot re-authorize its runs as the editor. NULL means no provable principal and the dispatch fails closed. No FK; workspace membership is re-validated on every dispatch.';

--- a/server/migrations/467_autopilot_trigger_creator_from_autopilot.down.sql
+++ b/server/migrations/467_autopilot_trigger_creator_from_autopilot.down.sql
@@ -1,0 +1,5 @@
+-- The backfill is irreversible: a filled row is indistinguishable from a trigger
+-- its creator made, and clearing it would stop that trigger again. Restore only
+-- migration 449's column comment.
+COMMENT ON COLUMN autopilot_trigger.created_by_type IS
+    'Actor type of the trigger''s immutable creator: member | agent. Only ''member'' yields a run principal. NULL for triggers created before MUL-6951 that had no published_by to backfill from.';

--- a/server/migrations/467_autopilot_trigger_creator_from_autopilot.up.sql
+++ b/server/migrations/467_autopilot_trigger_creator_from_autopilot.up.sql
@@ -1,0 +1,50 @@
+-- MUL-7267: give legacy autopilot triggers the creator migration 449 could not
+-- recover.
+--
+-- Migration 449 backfilled autopilot_trigger.created_by from published_by and
+-- left the row NULL when there was no published_by either: every trigger created
+-- before migration 189 that nobody substantively edited since. A schedule/webhook
+-- dispatch acts as the trigger's creator and fails closed without one (MUL-6951),
+-- so since that upgrade each such trigger has produced only skipped runs — the
+-- webhook delivery still reads "dispatched" and the schedule still advances, but
+-- nothing executes (#8284).
+--
+-- This fills those rows from the AUTOPILOT's creator, reversing 449's "leave them
+-- empty" choice:
+--   - it is the principal automatic dispatch was admitted as before MUL-6951
+--     (canCreatorInvokeAgent), so no trigger gains an authorization its runs did
+--     not already pass before the upgrade;
+--   - before migration 189 an autopilot and its triggers were normally created
+--     together, in one dialog, by one member, so for most rows this recovers the
+--     historical creator rather than guessing one;
+--   - NULL has no in-product recovery that keeps the trigger: an edit re-stamps
+--     published_by only, so the user must delete and re-create the trigger, which
+--     also changes a webhook's URL for every external sender.
+--
+-- Only rows without a member creator are touched. An existing member creator is
+-- never rewritten, so an edit still cannot move who a trigger acts as. The
+-- autopilot creator must be a member of the autopilot's workspace now; a departed
+-- creator is not written in to regain rights if they are re-invited later, and
+-- such rows keep failing closed. Dispatch still re-validates membership and invoke
+-- access on every run: this changes no gate, it only supplies the principal those
+-- gates evaluate.
+--
+-- autopilot_trigger holds one row per configured trigger (bounded by autopilot
+-- count), so this runs as a single statement, like 449. Re-running it is a no-op.
+UPDATE autopilot_trigger t
+SET created_by_type = 'member',
+    created_by_id = a.created_by_id
+FROM autopilot a
+WHERE a.id = t.autopilot_id
+  AND (t.created_by_id IS NULL OR t.created_by_type IS DISTINCT FROM 'member')
+  AND a.created_by_type = 'member'
+  AND a.created_by_id IS NOT NULL
+  AND EXISTS (
+      SELECT 1
+      FROM member m
+      WHERE m.user_id = a.created_by_id
+        AND m.workspace_id = a.workspace_id
+  );
+
+COMMENT ON COLUMN autopilot_trigger.created_by_type IS
+    'Actor type of the trigger''s immutable creator: member | agent. Only ''member'' yields a run principal. Legacy triggers were backfilled from published_by (migration 449), then from the autopilot''s creator (migration 467); NULL only when neither was a usable member.';

--- a/server/migrations/467_autopilot_trigger_creator_from_autopilot.up.sql
+++ b/server/migrations/467_autopilot_trigger_creator_from_autopilot.up.sql
@@ -1,33 +1,42 @@
--- MUL-7267: give legacy autopilot triggers the creator migration 449 could not
--- recover.
+-- MUL-7267: give legacy autopilot triggers the dispatch principal migration 449
+-- could not recover.
 --
 -- Migration 449 backfilled autopilot_trigger.created_by from published_by and
 -- left the row NULL when there was no published_by either: every trigger created
 -- before migration 189 that nobody substantively edited since. A schedule/webhook
--- dispatch acts as the trigger's creator and fails closed without one (MUL-6951),
--- so since that upgrade each such trigger has produced only skipped runs — the
--- webhook delivery still reads "dispatched" and the schedule still advances, but
--- nothing executes (#8284).
+-- dispatch acts as created_by and fails closed without one (MUL-6951), so since
+-- that upgrade each such trigger has produced only skipped runs — the webhook
+-- delivery still reads "dispatched" and the schedule still advances, but nothing
+-- executes (#8284).
 --
 -- This fills those rows from the AUTOPILOT's creator, reversing 449's "leave them
--- empty" choice:
---   - it is the principal automatic dispatch was admitted as before MUL-6951
---     (canCreatorInvokeAgent), so no trigger gains an authorization its runs did
---     not already pass before the upgrade;
---   - before migration 189 an autopilot and its triggers were normally created
---     together, in one dialog, by one member, so for most rows this recovers the
---     historical creator rather than guessing one;
---   - NULL has no in-product recovery that keeps the trigger: an edit re-stamps
---     published_by only, so the user must delete and re-create the trigger, which
---     also changes a webhook's URL for every external sender.
+-- empty" choice. The value is a best-effort INFERENCE frozen here, not a record of
+-- who created the trigger: before migration 189 an autopilot and its triggers were
+-- normally created together, in one dialog, by one member, so for most rows it is
+-- the historical creator — but a trigger another member added later through the
+-- edit dialog gets the autopilot's creator instead.
 --
--- Only rows without a member creator are touched. An existing member creator is
--- never rewritten, so an edit still cannot move who a trigger acts as. The
--- autopilot creator must be a member of the autopilot's workspace now; a departed
--- creator is not written in to regain rights if they are re-invited later, and
--- such rows keep failing closed. Dispatch still re-validates membership and invoke
--- access on every run: this changes no gate, it only supplies the principal those
--- gates evaluate.
+-- This IS a widening, accepted as the same compatibility tradeoff 449 made. The
+-- member chosen is the one automatic dispatch was ADMITTED as before MUL-6951
+-- (canCreatorInvokeAgent), so admission decides as it did before that upgrade.
+-- Execution does not: a pre-MUL-6951 automatic run carried no originator, only
+-- narrowly-scoped borrow paths, whereas a run of a filled trigger acts as the
+-- autopilot's creator with that member's own rights, and every run delegated from
+-- it inherits that principal. The alternative, NULL, has no in-product recovery
+-- that keeps the trigger: an edit re-stamps published_by only, so the user must
+-- delete and re-create it, which also changes a webhook's URL for every external
+-- sender.
+--
+-- Only rows without a member principal are touched. An existing member is never
+-- rewritten, so an edit still cannot move who a trigger acts as. The autopilot
+-- creator must be a member of the autopilot's workspace now; a departed creator is
+-- not written in to regain rights if they are re-invited later, and such rows keep
+-- failing closed. Dispatch still re-validates membership and invoke access on
+-- every run.
+--
+-- Rollback cannot take this back: from the next schedule or webhook fire the
+-- trigger runs as the filled member, and neither an application rollback nor the
+-- down migration clears the value.
 --
 -- autopilot_trigger holds one row per configured trigger (bounded by autopilot
 -- count), so this runs as a single statement, like 449. Re-running it is a no-op.
@@ -46,5 +55,11 @@ WHERE a.id = t.autopilot_id
         AND m.workspace_id = a.workspace_id
   );
 
+-- 449's comments describe created_by as the creator, written once at creation.
+-- That now holds only for triggers created since MUL-6951, and the text is
+-- generated into pkg/db/generated/models.go, so correct it here.
 COMMENT ON COLUMN autopilot_trigger.created_by_type IS
-    'Actor type of the trigger''s immutable creator: member | agent. Only ''member'' yields a run principal. Legacy triggers were backfilled from published_by (migration 449), then from the autopilot''s creator (migration 467); NULL only when neither was a usable member.';
+    'Actor type of created_by_id: member | agent. Only ''member'' yields a run principal. NULL only for a legacy trigger that neither backfill (migrations 449, 467) could fill.';
+
+COMMENT ON COLUMN autopilot_trigger.created_by_id IS
+    'The member a schedule/webhook run fires AS: dispatch admission, the task''s originator/accountable, and every delegated run all resolve to this one human (MUL-6951). For a trigger created since MUL-6951 it is the creator, written at creation. For a legacy trigger it is a best-effort principal inferred once by backfill and frozen (the last publisher, migration 449, else the autopilot''s creator, migration 467), not proof of who created it. Ordinary edits never rewrite it, so editing the trigger cannot re-authorize its runs as the editor. NULL means no principal and the dispatch fails closed. No FK; workspace membership is re-validated on every dispatch.';

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -314,9 +314,9 @@ type AutopilotTrigger struct {
 	PublishedByType pgtype.Text `json:"published_by_type"`
 	// The member/agent currently responsible for this trigger's effective config (creator, then last substantive editor). CONFIG audit only: since MUL-6951 the runs this trigger fires act as, and are accountable to, created_by_id instead, so an edit recorded here never moves a run's authority. No FK, app-layer integrity (MUL-4302).
 	PublishedByID pgtype.UUID `json:"published_by_id"`
-	// Actor type of the trigger's immutable creator: member | agent. Only 'member' yields a run principal. Legacy triggers were backfilled from published_by (migration 449), then from the autopilot's creator (migration 467); NULL only when neither was a usable member.
+	// Actor type of created_by_id: member | agent. Only 'member' yields a run principal. NULL only for a legacy trigger that neither backfill (migrations 449, 467) could fill.
 	CreatedByType pgtype.Text `json:"created_by_type"`
-	// The member a schedule/webhook run fires AS: dispatch admission, the task's originator/accountable, and every delegated run all resolve to this one human (MUL-6951). Written once at creation and never re-stamped, so editing the trigger cannot re-authorize its runs as the editor. NULL means no provable principal and the dispatch fails closed. No FK; workspace membership is re-validated on every dispatch.
+	// The member a schedule/webhook run fires AS: dispatch admission, the task's originator/accountable, and every delegated run all resolve to this one human (MUL-6951). For a trigger created since MUL-6951 it is the creator, written at creation. For a legacy trigger it is a best-effort principal inferred once by backfill and frozen (the last publisher, migration 449, else the autopilot's creator, migration 467), not proof of who created it. Ordinary edits never rewrite it, so editing the trigger cannot re-authorize its runs as the editor. NULL means no principal and the dispatch fails closed. No FK; workspace membership is re-validated on every dispatch.
 	CreatedByID pgtype.UUID `json:"created_by_id"`
 }
 

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -314,7 +314,7 @@ type AutopilotTrigger struct {
 	PublishedByType pgtype.Text `json:"published_by_type"`
 	// The member/agent currently responsible for this trigger's effective config (creator, then last substantive editor). CONFIG audit only: since MUL-6951 the runs this trigger fires act as, and are accountable to, created_by_id instead, so an edit recorded here never moves a run's authority. No FK, app-layer integrity (MUL-4302).
 	PublishedByID pgtype.UUID `json:"published_by_id"`
-	// Actor type of the trigger's immutable creator: member | agent. Only 'member' yields a run principal. NULL for triggers created before MUL-6951 that had no published_by to backfill from.
+	// Actor type of the trigger's immutable creator: member | agent. Only 'member' yields a run principal. Legacy triggers were backfilled from published_by (migration 449), then from the autopilot's creator (migration 467); NULL only when neither was a usable member.
 	CreatedByType pgtype.Text `json:"created_by_type"`
 	// The member a schedule/webhook run fires AS: dispatch admission, the task's originator/accountable, and every delegated run all resolve to this one human (MUL-6951). Written once at creation and never re-stamped, so editing the trigger cannot re-authorize its runs as the editor. NULL means no provable principal and the dispatch fails closed. No FK; workspace membership is re-validated on every dispatch.
 	CreatedByID pgtype.UUID `json:"created_by_id"`


### PR DESCRIPTION
## Summary

Since v0.4.39, schedule and webhook Autopilot runs act as the trigger's `created_by` and fail closed when there isn't one. Migration 449 filled `created_by` from `published_by`. Triggers created before `published_by` existed (migration 189, v0.4.2) and never edited afterwards had nothing to fill from, so they were left NULL.

Every run of those triggers is now recorded as `skipped` with `this trigger's owner lacks access to the private assignee agent, or the trigger records no owner`. From the user's side:

- webhook deliveries still show as dispatched;
- schedules still advance;
- the skipped runs are collapsed in Run history;
- manual "Run now" still works, because it uses the clicker's permissions.

Nothing in the product can repair such a trigger: editing it re-stamps `published_by` only, so the only way out is to delete and re-create it, which also changes a webhook's URL.

This PR adds migration 467, which fills the missing principal from the **autopilot's creator**.

- **It is an inference, not a record.** Before migration 189, an autopilot and its triggers were normally created together, in one dialog, by one member, so for most rows this is the actual creator. A trigger another member added later through the edit dialog gets the autopilot's creator instead.
- **It is an accepted permission widening, like 449.** Admission is unchanged from before v0.4.39: that is the member automatic dispatch was admitted as then (`canCreatorInvokeAgent`). Execution is not: a pre-v0.4.39 automatic run carried no originator, while a filled trigger now runs, and delegates, as the autopilot's creator with that member's own rights.

Scope of the backfill:

- Only rows without a member principal are touched: `created_by` is NULL or its type isn't `member`. An existing member principal is never rewritten, so editing a trigger still cannot change whose permissions it runs with.
- The autopilot creator must still be a member of the workspace. A departed creator is not written in (they would get the rights back if re-invited later), and those rows keep failing closed.
- Dispatch is unchanged: membership and invoke access are still checked on every run.
- The migration is a single idempotent `UPDATE` over `autopilot_trigger` (one row per configured trigger), like 449.
- It is irreversible: from the next fire the trigger runs as the filled member, and neither an application rollback nor the down migration clears the value. The down migration restores only 449's column comments.

Comment changes:

- 467 overrides both `created_by_*` column comments, regenerated into `models.go`. For triggers created since v0.4.39 `created_by` is the creator, written at creation. For legacy triggers it is a best-effort principal inferred by backfill (449, then 467), not proof of who created them.
- `ResolveAutopilotTriggerPrincipal` and the admission, dispatch and attribution call-site comments (`service/autopilot.go`, `service/task.go`, `attribution/attribution.go`) now say the same. They refer to the trigger's `created_by` principal rather than "the trigger's creator".

Refs #8284

## Testing

- New `TestMigration467BackfillsTriggerCreatorFromAutopilot`:
  - Builds a legacy webhook trigger and confirms a GitHub `push` delivery is skipped.
  - Runs the shipped migration SQL twice inside a transaction that is rolled back, so the table-wide `UPDATE` can't touch other packages' fixtures, and asserts four cases:
    - no creator → autopilot creator;
    - agent-typed creator → autopilot creator;
    - existing member unchanged;
    - departed autopilot creator → still NULL.
  - Commits the computed principal for the legacy trigger and confirms the next delivery produces a `running` run with a task.
  - With the migration replaced by a no-op, the test fails on those assertions.
- `go run ./cmd/migrate up` on a fresh local database applies 467. Running the down and then the up SQL again switches both column comments back and forth, and the re-run `UPDATE` is a no-op.
- `go test ./internal/handler ./internal/service ./cmd/migrate -count=1` passes locally.
- `go vet ./internal/handler ./internal/service ./pkg/db/generated` and `git diff --check` are clean.

