### PR TITLE
MUL-6967 perf(inbox): ship a 200-character preview of comment notifications in the lists

### DIFF
--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -53,6 +53,62 @@ func inboxToResponse(i db.InboxItem) InboxItemResponse {
 	}
 }
 
+// inboxListBodyPreviewLimit caps, in characters, the body a comment
+// notification carries in the inbox LIST responses. The ellipsis counts
+// toward it.
+//
+// A comment notification stores the full comment it was raised for, and the
+// list shipped that verbatim — a several-thousand-character agent reply went
+// over the wire, through JSON parsing and into the client cache, only for
+// every client to render it as a single truncated line. 200 leaves ample room
+// for that one line at any width or script, while bounding what each row can
+// cost.
+const inboxListBodyPreviewLimit = 200
+
+// inboxListBody returns the body a notification carries in the inbox list:
+// comment notifications on an issue get a bounded preview, everything else is
+// returned as stored. The database keeps the full text.
+//
+// Scoped to exactly the rows whose full body no client ever reads from the
+// list. Opening an issue-backed notification renders the issue itself, and the
+// comment it points at is found through `details.comment_id`, which is left
+// intact — on every client already installed, so none needs to change. Other
+// notification types are NOT shortened: issue-less notifications render their
+// body in the detail pane straight from the list cache, and Quick Create
+// failures refill the composer from `details` — cutting those would lose
+// content, not just bytes.
+//
+// Truncation is by code point, so a multi-byte character is never split into
+// invalid UTF-8. A grapheme cluster (an emoji sequence, a letter with a
+// combining mark) can still be cut at the boundary; that lands ~200 characters
+// in, far past the single line any client shows.
+//
+// One pass that stops at the limit, rather than counting or converting the
+// whole string: the work per row stays bounded by the preview, not by however
+// long the comment happens to be.
+func inboxListBody(notifType string, issueID pgtype.UUID, body pgtype.Text) *string {
+	full := textToPtr(body)
+	if full == nil || notifType != "new_comment" || !issueID.Valid {
+		return full
+	}
+	// `range` yields the byte offset where each character starts. `cut` ends
+	// up where the ellipsis goes: after limit-1 characters.
+	cut, seen := 0, 0
+	for offset := range *full {
+		if seen == inboxListBodyPreviewLimit-1 {
+			cut = offset
+		}
+		if seen++; seen > inboxListBodyPreviewLimit {
+			preview := (*full)[:cut] + "…"
+			return &preview
+		}
+	}
+	return full
+}
+
+// inboxRowToResponse maps a LIST row — the main inbox and, through
+// archivedInboxRowToResponse, the archived view. Single-item responses go
+// through inboxToResponse and keep the full body.
 func inboxRowToResponse(r db.ListInboxItemsRow) InboxItemResponse {
 	return InboxItemResponse{
 		ID:            uuidToString(r.ID),
@@ -63,7 +119,7 @@ func inboxRowToResponse(r db.ListInboxItemsRow) InboxItemResponse {
 		Severity:      r.Severity,
 		IssueID:       uuidToPtr(r.IssueID),
 		Title:         r.Title,
-		Body:          textToPtr(r.Body),
+		Body:          inboxListBody(r.Type, r.IssueID, r.Body),
 		Read:          r.Read,
 		Archived:      r.Archived,
 		CreatedAt:     timestampToString(r.CreatedAt),

--- a/server/internal/handler/inbox_test.go
+++ b/server/internal/handler/inbox_test.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/testutil"
 )
@@ -209,4 +211,155 @@ func TestArchiveCompletedInboxExpandsCustomTerminalStatuses(t *testing.T) {
 		"SELECT count(*) FROM inbox_item WHERE issue_id = $1 AND archived = true", openIssueID); got != 0 {
 		t.Fatalf("archived rows for open issue = %d, want 0", got)
 	}
+}
+
+func TestInboxListBodyPreview(t *testing.T) {
+	issue := pgtype.UUID{Bytes: uuid.New(), Valid: true}
+	text := func(s string) pgtype.Text { return pgtype.Text{String: s, Valid: true} }
+	long := strings.Repeat("a", 5000)
+	// Every CJK character is three bytes in UTF-8: a byte-based cut would land
+	// mid-character and produce invalid UTF-8.
+	longCJK := strings.Repeat("评论内容", 500)
+
+	cases := []struct {
+		name      string
+		notifType string
+		issueID   pgtype.UUID
+		body      pgtype.Text
+		want      *string
+	}{
+		{"null body stays null", "new_comment", issue, pgtype.Text{}, nil},
+		{"short comment is untouched", "new_comment", issue, text("looks good"), ptr("looks good")},
+		{"exactly at the limit is untouched", "new_comment", issue,
+			text(strings.Repeat("a", inboxListBodyPreviewLimit)),
+			ptr(strings.Repeat("a", inboxListBodyPreviewLimit))},
+		{"one past the limit is cut, ellipsis included", "new_comment", issue,
+			text(strings.Repeat("a", inboxListBodyPreviewLimit+1)),
+			ptr(strings.Repeat("a", inboxListBodyPreviewLimit-1) + "…")},
+		{"long comment is cut to the limit", "new_comment", issue, text(long),
+			ptr(strings.Repeat("a", inboxListBodyPreviewLimit-1) + "…")},
+		// Issue-less notifications render their body in the detail pane from
+		// the list cache, so shortening them would lose content.
+		{"comment without an issue keeps its full body", "new_comment", pgtype.UUID{}, text(long), ptr(long)},
+		// Other types are out of scope even when issue-backed: their body is
+		// not merely a preview of something the issue page shows.
+		{"other types keep their full body", "task_failed", issue, text(long), ptr(long)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := inboxListBody(tc.notifType, tc.issueID, tc.body)
+			switch {
+			case tc.want == nil && got != nil:
+				t.Fatalf("body = %q, want nil", *got)
+			case tc.want != nil && got == nil:
+				t.Fatalf("body = nil, want %d characters", utf8.RuneCountInString(*tc.want))
+			case tc.want != nil && *got != *tc.want:
+				t.Fatalf("body = %d characters %q…, want %d characters",
+					utf8.RuneCountInString(*got), truncateForLog(*got),
+					utf8.RuneCountInString(*tc.want))
+			}
+		})
+	}
+
+	t.Run("multi-byte text is cut on a character boundary", func(t *testing.T) {
+		got := inboxListBody("new_comment", issue, text(longCJK))
+		if got == nil {
+			t.Fatal("body = nil")
+		}
+		if !utf8.ValidString(*got) {
+			t.Fatalf("preview is not valid UTF-8: %q", truncateForLog(*got))
+		}
+		if n := utf8.RuneCountInString(*got); n != inboxListBodyPreviewLimit {
+			t.Fatalf("preview = %d characters, want %d", n, inboxListBodyPreviewLimit)
+		}
+		if !strings.HasSuffix(*got, "…") {
+			t.Fatalf("preview does not end with an ellipsis: %q", truncateForLog(*got))
+		}
+	})
+}
+
+// Both inbox lists ship the preview, the stored row keeps the whole comment,
+// and a notification that needs its full body still gets it.
+func TestInboxListsShipCommentPreviewNotFullComment(t *testing.T) {
+	workspaceID := dbfx.Workspace(t, "Inbox body preview", "inbox-preview-"+uuid.NewString())
+	dbfx.Member(t, workspaceID, testUserID, "owner")
+	activeIssue := dbfx.Issue(t, "Active comment issue", testutil.Cols{"workspace_id": workspaceID})
+	archivedIssue := dbfx.Issue(t, "Archived comment issue", testutil.Cols{"workspace_id": workspaceID})
+	fullComment := strings.Repeat("A long agent reply. ", 300)
+	issueLessBody := strings.Repeat("An issue-less notice. ", 300)
+
+	insert := func(cols testutil.Cols) {
+		base := testutil.Cols{
+			"workspace_id":   workspaceID,
+			"recipient_type": "member",
+			"recipient_id":   testUserID,
+			"severity":       "info",
+			"title":          "Notification",
+		}
+		for k, v := range cols {
+			base[k] = v
+		}
+		dbfx.Insert(t, "inbox_item", base)
+	}
+	insert(testutil.Cols{"type": "new_comment", "issue_id": activeIssue, "body": fullComment})
+	insert(testutil.Cols{"type": "new_comment", "issue_id": archivedIssue, "body": fullComment, "archived": true})
+	insert(testutil.Cols{"type": "autopilot_paused", "body": issueLessBody})
+
+	wantPreview := string([]rune(fullComment)[:inboxListBodyPreviewLimit-1]) + "…"
+	bodyOf := func(items []InboxItemResponse, issueID string) string {
+		t.Helper()
+		for _, item := range items {
+			if item.IssueID != nil && *item.IssueID == issueID {
+				if item.Body == nil {
+					t.Fatalf("item for issue %s has no body", issueID)
+				}
+				return *item.Body
+			}
+		}
+		t.Fatalf("no item for issue %s in %d items", issueID, len(items))
+		return ""
+	}
+
+	var active []InboxItemResponse
+	testutil.Call(t, inboxWorkspaceHandler(testHandler.ListInbox),
+		inboxRequest(http.MethodGet, "/api/inbox", workspaceID)).
+		Want(http.StatusOK).
+		JSON(&active)
+	if got := bodyOf(active, activeIssue); got != wantPreview {
+		t.Errorf("main list body = %d characters, want the %d-character preview",
+			utf8.RuneCountInString(got), inboxListBodyPreviewLimit)
+	}
+	var issueLess *string
+	for _, item := range active {
+		if item.IssueID == nil {
+			issueLess = item.Body
+		}
+	}
+	if issueLess == nil || *issueLess != issueLessBody {
+		t.Errorf("issue-less notification lost its full body (its detail pane renders it)")
+	}
+
+	var archived []InboxItemResponse
+	testutil.Call(t, inboxWorkspaceHandler(testHandler.ListArchivedInbox),
+		inboxRequest(http.MethodGet, "/api/inbox/archived", workspaceID)).
+		Want(http.StatusOK).
+		JSON(&archived)
+	if got := bodyOf(archived, archivedIssue); got != wantPreview {
+		t.Errorf("archived list body = %d characters, want the %d-character preview",
+			utf8.RuneCountInString(got), inboxListBodyPreviewLimit)
+	}
+
+	// Only the response is shortened; the stored comment is whole.
+	if got := dbfx.Count(t,
+		`SELECT count(*) FROM inbox_item WHERE workspace_id = $1 AND type = 'new_comment' AND body = $2`,
+		workspaceID, fullComment); got != 2 {
+		t.Errorf("stored full comments = %d, want 2", got)
+	}
+}
+
+func truncateForLog(s string) string {
+	if r := []rune(s); len(r) > 40 {
+		return string(r[:40])
+	}
+	return s
 }


### PR DESCRIPTION
## Problem

A comment notification stores the **full comment** it was raised for, and both inbox list endpoints (`GET /api/inbox`, `GET /api/inbox/archived`) returned it verbatim. `notification_listeners.go` copies `commentContent` straight into the row, one copy per subscriber.

So a several-thousand-character agent reply travelled over the wire, through JSON parsing, and into the client cache — for every subscriber — only for every client to render it as **a single CSS-truncated line**.

## Change

The two list responses cap the `body` of a **`new_comment` notification that has an issue** at **200 characters, ellipsis included**.

- The database keeps the full text; only the list response is shortened.
- `details.comment_id` is untouched.
- Single-item responses (mark read / unread / archive / unarchive) are unchanged.
- Server-only. No new field, no type change, no new endpoint or parameter.

## Why this scope is safe — including for installed clients

I checked every consumer of `body` on every client rather than relying on the design notes:

| Where | What it does with a `new_comment` body |
| --- | --- |
| Web/desktop list row — `inbox-detail-label.tsx:111` | one line |
| Web/desktop detail pane — `inbox-page.tsx` | issue-backed rows render `<IssueDetail>`; the `body` branch is only reached for issue-less rows |
| Mobile list row — `detail-label.tsx:135` | `singleLine(item.body)` |
| Mobile `inbox/[id]` screen | autopilot notices only; issue-backed rows open the issue |
| Filters / search | none read `body` |

So a `new_comment` body is only ever a one-line label, and the full comment is reached through the issue and `comment_id`. That is true of builds **already installed**, which is why none of them needs to change.

**Deliberately not shortened:**

- **Issue-less notifications** render their body in the detail pane straight from the list cache.
- **Other types** (for example `task_failed`, which also stores comment text) aren't simply previews of something on the issue page.
- **`details`** — Quick Create failures refill the composer from `details.original_prompt`.

Trimming those needs a single-item read first, which does not exist yet.

`mentioned` notifications store no body at all, so `new_comment` is the only type carrying a full comment copy into the list.

## Implementation notes

- **Unicode-safe.** Truncation walks code points, so a multi-byte character is never split into invalid UTF-8 — covered with a CJK case. A grapheme cluster (emoji sequence, combining mark) can still be cut at the boundary, but that lands ~200 characters in, far past the single line any client shows.
- **Bounded work.** One pass that stops at the limit, instead of counting or converting the whole string, so per-row cost is bounded by the preview rather than by the comment's length. The obvious `[]rune(body)` version would allocate 4 bytes per character of the *full* comment, per row, per request — on the endpoint this PR is meant to lighten.

## Expected effect

Sampled from **264 comments** on this workspace's 40 most recent issues (lengths only):

- **Half exceed 200 characters.** Median is 203, p75 is 1,459, p90 is 3,277, and the longest is 12,251.
- Capping cuts that comment text by **86%**.

A list of `new_comment` rows built from those same comments:

| | before | after | |
| --- | --- | --- | --- |
| raw JSON | 648.6 KiB | 233.7 KiB | **64% smaller** (2,516 → 907 B/row) |
| gzipped | 245.2 KiB | 75.2 KiB | **69% smaller** |

An individual inbox's overall saving depends on how much of it is comment notifications. Status changes, assignments and the like carry short or empty bodies and are unaffected. This is an estimate from the sample, not a measurement of a real inbox response.

## Tests

- `TestInboxListBodyPreview` — table test of the rule: null body, short, **exactly 200** (untouched), **201** (cut, ellipsis counted), very long, **multi-byte cut stays valid UTF-8 and exactly 200 characters**, issue-less `new_comment` keeps its full body, other types keep theirs.
- `TestInboxListsShipCommentPreviewNotFullComment` — end to end through **both** list handlers against a real database: the main and archived lists ship the preview, an issue-less notification keeps its full body, and **the stored row still holds the whole comment**. Confirmed failing with the mapper reverted (both lists returned all 6,000 characters) and passing with the change.

Verification: `go test ./internal/handler/ ./cmd/server/` pass on an isolated worktree database, and `go vet` and `gofmt` are clean. No frontend change.

## Not in this PR

- The `inbox:new` WebSocket payload still carries the full body. Clients use it only for the OS notification banner and then refetch the list, so it's out of this scope — but it's the same copy, pushed to every subscriber.
- Grouping, filtering and pagination on the server remain the larger follow-up.

Refs MUL-6967.
