### PR TITLE
test(server): reduce slow Go unit test waits

### DIFF
--- a/server/cmd/migrate/migrate_concurrent_test.go
+++ b/server/cmd/migrate/migrate_concurrent_test.go
@@ -328,7 +328,7 @@ func TestRunMigrationsConcurrentAlreadyApplied(t *testing.T) {
 // acquire. The expectation:
 //
 //   - While the side connection holds the lock, zero goroutines have
-//     completed (we observe via a small delay + count-check).
+//     completed (we observe a blocked contender in pg_locks).
 //   - The moment the side connection releases the lock, the goroutines
 //     start unblocking and finish in well under the test timeout.
 //
@@ -373,20 +373,44 @@ func TestRunMigrationsAdvisoryLockSerializes(t *testing.T) {
 		})
 	}
 
-	// Watchdog: while the side holder still has the lock, no
-	// runMigrations goroutine should have completed. We sample for a
-	// generous window (1 s) — much longer than the trivial migration
-	// set takes to apply on the unlocked path — to give a regressed
-	// implementation room to incorrectly succeed.
-	const observeWindow = 1 * time.Second
-	const observeStep = 50 * time.Millisecond
+	// Wait until PostgreSQL confirms that a contender is blocked on this exact
+	// advisory lock. This proves serialization directly without making the
+	// passing path pay a fixed observation delay.
+	const observeWindow = 2 * time.Second
+	const observeStep = 10 * time.Millisecond
 	deadline := time.Now().Add(observeWindow)
+	blocked := false
 	for time.Now().Before(deadline) {
 		if n := atomic.LoadInt64(&done); n != 0 {
 			t.Fatalf("advisory lock did not block: %d/%d goroutines finished while side connection held the lock for %s",
 				n, concurrentRunners, time.Since(startedAt))
 		}
+		if err := holder.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_locks AS held
+				JOIN pg_locks AS waiter
+				  ON waiter.locktype = held.locktype
+				 AND waiter.database IS NOT DISTINCT FROM held.database
+				 AND waiter.classid IS NOT DISTINCT FROM held.classid
+				 AND waiter.objid IS NOT DISTINCT FROM held.objid
+				 AND waiter.objsubid IS NOT DISTINCT FROM held.objsubid
+				 AND waiter.mode = held.mode
+				WHERE held.pid = pg_backend_pid()
+				  AND held.locktype = 'advisory'
+				  AND held.granted
+				  AND NOT waiter.granted
+			)
+		`).Scan(&blocked); err != nil {
+			t.Fatalf("observe advisory-lock waiter: %v", err)
+		}
+		if blocked {
+			break
+		}
 		time.Sleep(observeStep)
+	}
+	if !blocked {
+		t.Fatal("no runMigrations contender reached the held advisory lock")
 	}
 
 	// Release the side lock and wait for all goroutines to finish.

--- a/server/cmd/migrate/migrate_invalid_index_test.go
+++ b/server/cmd/migrate/migrate_invalid_index_test.go
@@ -299,7 +299,7 @@ func TestRunMigrationsRepairsInvalidConcurrentIndexDuringRollback(t *testing.T) 
 		blocker.Release()
 		t.Fatalf("acquire builder conn: %v", err)
 	}
-	if _, err := builder.Exec(ctx, "SET statement_timeout = '2s'"); err != nil {
+	if _, err := builder.Exec(ctx, "SET statement_timeout = '250ms'"); err != nil {
 		builder.Release()
 		blocker.Release()
 		t.Fatalf("set statement_timeout: %v", err)
@@ -436,14 +436,14 @@ func TestRunMigrationsRepairsInvalidTerminalCompletedAtIndex(t *testing.T) {
 	// SET must ride the same connection as the build, and must be its own
 	// protocol message — a multi-command string would put CREATE INDEX
 	// CONCURRENTLY in an implicit transaction, which PostgreSQL rejects.
-	if _, err := builder.Exec(ctx, "SET statement_timeout = '2s'"); err != nil {
+	if _, err := builder.Exec(ctx, "SET statement_timeout = '250ms'"); err != nil {
 		builder.Release()
 		blocker.Release()
 		t.Fatalf("set statement_timeout: %v", err)
 	}
 	_, buildErr := builder.Exec(ctx, createV2)
 	// Clear the timeout before the connection goes back to the pool; pgxpool
-	// does not reset session state, so leaving it set would arm a 2s fuse on
+	// does not reset session state, so leaving it set would arm a timeout on
 	// whichever later caller happens to draw this connection.
 	if _, err := builder.Exec(ctx, "SET statement_timeout = DEFAULT"); err != nil {
 		t.Logf("reset statement_timeout: %v", err)

--- a/server/cmd/migrate/migrate_mul5999_index_retry_test.go
+++ b/server/cmd/migrate/migrate_mul5999_index_retry_test.go
@@ -244,7 +244,7 @@ func TestRunMigrationsRepairsInvalidRuntimeIDIndex(t *testing.T) {
 		blocker.Release()
 		t.Fatalf("acquire builder conn: %v", err)
 	}
-	if _, err := builder.Exec(ctx, "SET statement_timeout = '2s'"); err != nil {
+	if _, err := builder.Exec(ctx, "SET statement_timeout = '250ms'"); err != nil {
 		builder.Release()
 		blocker.Release()
 		t.Fatalf("set statement_timeout: %v", err)

--- a/server/internal/analytics/client_test.go
+++ b/server/internal/analytics/client_test.go
@@ -68,13 +68,15 @@ func TestPostHogClient_Batching(t *testing.T) {
 }
 
 func TestPostHogClient_DropsWhenFull(t *testing.T) {
-	// Handler blocks so batches never flush — queue will fill up.
-	block := make(chan struct{})
+	// Hold the first request so the worker is observably busy before filling the
+	// queue. Releasing it during cleanup avoids paying the client's flush timeout.
+	started := make(chan struct{})
+	release := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-block
+		close(started)
+		<-release
 	}))
 	defer srv.Close()
-	defer close(block)
 
 	c := NewPostHogClient(PostHogConfig{
 		APIKey:     "test-key",
@@ -83,15 +85,22 @@ func TestPostHogClient_DropsWhenFull(t *testing.T) {
 		BatchSize:  1,
 		FlushEvery: time.Hour,
 	})
-	defer c.Close()
+	defer func() {
+		close(release)
+		c.Close()
+	}()
 
-	// First event may be consumed by the worker (which is now blocked in send).
-	// Next events will sit in the queue (cap=2) until it's full and then drop.
-	for i := 0; i < 20; i++ {
+	// The first event is consumed by the worker and blocks in the handler. Two
+	// more fill the queue, so the final capture must be dropped.
+	c.Capture(Event{Name: "spam", DistinctID: "u"})
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not start the first request")
+	}
+	for i := 0; i < 3; i++ {
 		c.Capture(Event{Name: "spam", DistinctID: "u"})
 	}
-	// Give the worker a chance to pick up at least one.
-	time.Sleep(50 * time.Millisecond)
 	if c.dropped.Load() == 0 {
 		t.Fatalf("expected some drops when queue saturated")
 	}
@@ -99,11 +108,11 @@ func TestPostHogClient_DropsWhenFull(t *testing.T) {
 
 func TestEmailDomain(t *testing.T) {
 	cases := map[string]string{
-		"a@example.com":       "example.com",
-		"user@Company.co.uk":  "company.co.uk",
-		"":                    "",
-		"no-at":               "",
-		"trailing@":           "",
+		"a@example.com":      "example.com",
+		"user@Company.co.uk": "company.co.uk",
+		"":                   "",
+		"no-at":              "",
+		"trailing@":          "",
 	}
 	for in, want := range cases {
 		if got := emailDomain(in); got != want {

--- a/server/internal/daemon/agent_version_refresh_test.go
+++ b/server/internal/daemon/agent_version_refresh_test.go
@@ -940,6 +940,7 @@ func TestRefreshAgentVersions_ObligationSurvivesAnIncompletePayload(t *testing.T
 // round's payload actually carries disagrees" would turn that into one
 // register call per workspace every few minutes for the life of the daemon.
 func TestRefreshAgentVersions_UnreachableProviderDoesNotStormTheServer(t *testing.T) {
+	stubProbeRetry(t, time.Millisecond, time.Second)
 	fx := newBatchFixture(t)
 	d := fx.daemon
 	d.cfg.Agents = map[string]AgentEntry{
@@ -995,6 +996,7 @@ func TestRefreshAgentVersions_UnreachableProviderDoesNotStormTheServer(t *testin
 // upgrade. Yielding to that would let one stuck CLI silently disable version
 // refresh for every healthy provider on the machine, forever.
 func TestRefreshAgentVersions_NotStarvedByAStuckProvider(t *testing.T) {
+	stubProbeRetry(t, time.Millisecond, time.Second)
 	fx := newVersionRefreshFixture(t)
 	d := fx.daemon
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -608,6 +608,9 @@ type Daemon struct {
 
 	runner             taskRunner    // executes agent tasks; set to d.runTask by New(), overridable in tests
 	cancelPollInterval time.Duration // how often handleTask polls for server-side cancellation; overridable in tests
+	// taskSlotWait is the brief semaphore wait before the capacity backoff.
+	// New sets the production default; tests shorten it to reach that branch.
+	taskSlotWait time.Duration
 	// envRootBusyWait is how long a task that is entitled to a prior env root
 	// waits for the previous run to let go of it before giving up and preparing
 	// a fresh one. New() sets it; the zero value means "do not wait", which is
@@ -665,6 +668,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		reregisterNextAttempt:     make(map[string]time.Time),
 		reregisterLastCompletedAt: make(map[string]time.Time),
 		cancelPollInterval:        5 * time.Second,
+		taskSlotWait:              taskSlotWaitTimeout,
 		envRootBusyWait:           15 * time.Second,
 		taskPrepareTimeout:        defaultTaskPrepareTimeout,
 		reconcile:                 newReconcileBroadcaster(),
@@ -5077,7 +5081,11 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 
 		// Acquire at least one slot (blocking briefly), then grab any other free
 		// slots so a single batch claim can fill them all.
-		slot, acquired, woke, err := waitForTaskSlot(pollerCtx, sem, wakeup, taskSlotWaitTimeout)
+		slotWait := d.taskSlotWait
+		if slotWait <= 0 {
+			slotWait = taskSlotWaitTimeout
+		}
+		slot, acquired, woke, err := waitForTaskSlot(pollerCtx, sem, wakeup, slotWait)
 		if err != nil {
 			return
 		}

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -3545,7 +3545,7 @@ func TestExecuteAndDrain_CodexInactivityReportsMCPToolResultTranscript(t *testin
 		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-drain","turn":{"id":"turn-drain"}}}'` + "\n" +
 		`echo '{"jsonrpc":"2.0","method":"item/started","params":{"threadId":"thr-drain","item":{"type":"mcpToolCall","id":"mcp-1","server":"plugin-exa-search","tool":"web_search_exa","arguments":{"query":"latest Multica news"},"status":"inProgress"}}}'` + "\n" +
 		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-drain","item":{"type":"mcpToolCall","id":"mcp-1","server":"plugin-exa-search","tool":"web_search_exa","arguments":{"query":"latest Multica news"},"status":"completed","durationMs":1627,"result":{"content":[{"type":"text","text":"private provider payload"}]}}}}'` + "\n" +
-		`sleep 5` + "\n"
+		`sleep 0.3` + "\n"
 	if err := os.WriteFile(fakePath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake codex: %v", err)
 	}

--- a/server/internal/daemon/execenv/gitroot_lock_test.go
+++ b/server/internal/daemon/execenv/gitroot_lock_test.go
@@ -100,6 +100,7 @@ func startLockHolder(t *testing.T, repo string) (release func()) {
 // the child still held the repository, which is the state that let two
 // prepares run `git stash create` on one index.
 func TestLockGitRootExcludesOtherProcesses(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	release := startLockHolder(t, repo)
 
@@ -137,6 +138,7 @@ func TestLockGitRootExcludesOtherProcesses(t *testing.T) {
 // git dir gives two resources bound to two linked worktrees two different
 // locks while they still race on that shared state.
 func TestGitRootLockPathIsRepoWide(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	path, err := gitRootLockPath(repo)
 	if err != nil {
@@ -212,6 +214,7 @@ func TestGitRootLockTimeoutDoesNotAdviseDeletingTheLock(t *testing.T) {
 // property, not for the retry that used to work around the absence of it
 // (#7434).
 func TestCaptureUserSnapshotIgnoresTheRepositoryIndexLock(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "edited by the user\n")
 	writeFile(t, filepath.Join(repo, "brand-new.txt"), "untracked\n")
@@ -242,6 +245,7 @@ func TestCaptureUserSnapshotIgnoresTheRepositoryIndexLock(t *testing.T) {
 // Every failure through runGitStdout used to arrive as "exit status 1": stderr
 // was captured by cmd.Output() and then dropped on the floor.
 func TestRunGitSurfacesStderrInTheError(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	_, err := runGitTrimmed(repo, "rev-parse", "--verify", "definitely-not-a-ref")
 	if err == nil {
@@ -256,6 +260,7 @@ func TestRunGitSurfacesStderrInTheError(t *testing.T) {
 // its own helper process. Both must get a worktree; before the cross-process
 // lock one of them routinely died in `git stash create`.
 func TestConcurrentIsolatedPreparesOnOneRepo(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work in progress\n")
 	writeFile(t, filepath.Join(repo, "untracked.txt"), "new file\n")

--- a/server/internal/daemon/execenv/isolation_unix_test.go
+++ b/server/internal/daemon/execenv/isolation_unix_test.go
@@ -38,7 +38,7 @@ func TestPrepareIsolated_PermanentFIFOBlockThenImmediateRetry(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 	defer cancel()
 
 	startedAt := time.Now()

--- a/server/internal/daemon/execenv/local_worktree_test.go
+++ b/server/internal/daemon/execenv/local_worktree_test.go
@@ -105,6 +105,7 @@ func prepareForTest(t *testing.T, localPath string) *LocalWorktree {
 // This is the property that makes worktree mode usable rather than confusing:
 // otherwise the agent silently reviews code the user hasn't got open.
 func TestPrepareLocalWorktreeReplaysUncommittedWork(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "edited by user\n")
 	writeFile(t, filepath.Join(repo, "brand-new.txt"), "untracked\n")
@@ -130,6 +131,7 @@ func TestPrepareLocalWorktreeReplaysUncommittedWork(t *testing.T) {
 // they may have a build running against it. `git stash create` writes a commit
 // object but must leave the index, the files, and the stash list alone.
 func TestPrepareLocalWorktreeLeavesUserTreeUntouched(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "edited by user\n")
 	writeFile(t, filepath.Join(repo, "brand-new.txt"), "untracked\n")
@@ -152,6 +154,7 @@ func TestPrepareLocalWorktreeLeavesUserTreeUntouched(t *testing.T) {
 // committed onto it before the worktree is removed, or `git worktree remove
 // --force` would delete the work with no way back.
 func TestFinalizeCommitsLeftoversAndKeepsBranch(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	wt := prepareForTest(t, repo)
 
@@ -185,6 +188,7 @@ func TestFinalizeCommitsLeftoversAndKeepsBranch(t *testing.T) {
 // such run would turn `git branch` into noise, so the branch is dropped and the
 // result reports no branch at all.
 func TestFinalizeDropsBranchWhenNothingChanged(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	wt := prepareForTest(t, repo)
 
@@ -206,6 +210,7 @@ func TestFinalizeDropsBranchWhenNothingChanged(t *testing.T) {
 // still counts as a no-op and leaves no branch — the user's WIP is already safe
 // in their own working tree, and a branch duplicating it is pure noise.
 func TestFinalizeDropsBranchWhenOnlyBaseWasDirty(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "edited by user\n")
 	writeFile(t, filepath.Join(repo, "scratch.txt"), "untracked scratch\n")
@@ -233,6 +238,7 @@ func TestFinalizeDropsBranchWhenOnlyBaseWasDirty(t *testing.T) {
 // user's WIP is the baseline commit, the agent's work sits on top. That is what
 // makes `git diff <baseline>..<branch>` a readable review of the agent alone.
 func TestFinalizeSeparatesUserBaselineFromAgentWork(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "edited by user\n")
 	wt := prepareForTest(t, repo)
@@ -257,6 +263,7 @@ func TestFinalizeSeparatesUserBaselineFromAgentWork(t *testing.T) {
 // A resource may point at a subdirectory of a repo. The worktree covers the
 // whole repo, but the agent has to land at the same depth the user chose.
 func TestPrepareLocalWorktreeSubdirectory(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "services/api/main.go"), "package main\n")
 	gitRun(t, repo, "add", ".")
@@ -282,6 +289,7 @@ func TestPrepareLocalWorktreeSubdirectory(t *testing.T) {
 // than silently running in-place, which would leave them wondering why their
 // tasks still queue one at a time.
 func TestPrepareLocalWorktreeRejectsNonGitDirectory(t *testing.T) {
+	t.Parallel()
 	_, err := PrepareLocalWorktree(LocalWorktreeParams{
 		LocalPath: t.TempDir(),
 		EnvRoot:   t.TempDir(),
@@ -299,6 +307,7 @@ func TestPrepareLocalWorktreeRejectsNonGitDirectory(t *testing.T) {
 // because "git worktree add failed" alone sends the user hunting in the wrong
 // place.
 func TestPrepareLocalWorktreeRejectsRepoWithoutCommits(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	gitRun(t, dir, "init", "-b", "main")
 
@@ -319,6 +328,7 @@ func TestPrepareLocalWorktreeRejectsRepoWithoutCommits(t *testing.T) {
 // both get a working checkout, with distinct branches, without corrupting git's
 // admin files.
 func TestPrepareLocalWorktreeConcurrentTasks(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	const tasks = 4
@@ -379,6 +389,7 @@ func TestPrepareLocalWorktreeConcurrentTasks(t *testing.T) {
 // sidecar-free branch is the user-visible contract — a diff full of
 // .agent_context/ scaffolding would make the mode unusable for review.
 func TestWorktreeModeDeliversBranchWithoutSidecars(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	// Start dirty, so the branch gets a baseline commit as well as the agent's
 	// own — a sidecar could otherwise hide in either one.
@@ -449,6 +460,7 @@ func TestWorktreeModeDeliversBranchWithoutSidecars(t *testing.T) {
 // deletes. The next task on the same repo must clean that up rather than
 // accumulating dead entries in the user's `git worktree list` forever.
 func TestPrepareLocalWorktreePrunesStaleRegistrations(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	orphanEnv := t.TempDir()
 	orphan, err := PrepareLocalWorktree(LocalWorktreeParams{
@@ -494,6 +506,7 @@ func finalizeOK(t *testing.T, wt *LocalWorktree) LocalWorktreeOutcome {
 // commit.gpgSign with no usable key is the realistic trigger: --no-verify does
 // not disable signing.
 func TestFinalizeKeepsWorktreeWhenCommitFails(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	wt := prepareForTest(t, repo)
 
@@ -530,6 +543,7 @@ func TestFinalizeKeepsWorktreeWhenCommitFails(t *testing.T) {
 // untracked files; copying them would hand this task another issue's brief and
 // commit it to the branch.
 func TestPrepareLocalWorktreeSkipsMulticaSidecars(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, ".agent_context", "issue_context.md"), "OTHER issue's brief\n")
 	writeFile(t, filepath.Join(repo, ".multica", "project", "resources.json"), "{}\n")
@@ -567,6 +581,7 @@ func TestPrepareLocalWorktreeSkipsMulticaSidecars(t *testing.T) {
 // replayed would have the agent review code the user never wrote and report on
 // it confidently. Refusing to start is the recoverable outcome.
 func TestPrepareLocalWorktreeFailsWhenUntrackedReplayIsTruncated(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	// One file over the copy budget is enough to prove the bound fails closed
 	// rather than under-copying; writing 2001 files would only be slower.
@@ -658,6 +673,7 @@ func TestPrepareWorktreeModeUsesPerIssueCodexSessionStore(t *testing.T) {
 // must therefore stop the commit AND keep the worktree, since the agent's work
 // is still in it.
 func TestFinalizeAbortRefusesToCommitAndKeepsWorktree(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	wt := prepareForTest(t, repo)
 
@@ -696,6 +712,7 @@ func TestFinalizeAbortRefusesToCommitAndKeepsWorktree(t *testing.T) {
 // The first reason is the one closest to the root cause, so later aborts must
 // not overwrite it.
 func TestAbortWithReasonKeepsFirstReason(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	wt := prepareForTest(t, repo)
 	t.Cleanup(func() { removeLocalWorktreeDir(repo, wt.Path, worktreeTestLogger()) })
@@ -717,6 +734,7 @@ func TestAbortWithReasonKeepsFirstReason(t *testing.T) {
 // ambiguous (link vs target, targets outside the repo), so the snapshot must
 // fail rather than hand the agent a tree with a file quietly missing.
 func TestPrepareLocalWorktreeFailsOnUntrackedSymlink(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	if err := os.Symlink(filepath.Join(repo, "tracked.txt"), filepath.Join(repo, "shortcut.txt")); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
@@ -744,6 +762,7 @@ func TestPrepareLocalWorktreeFailsOnUntrackedSymlink(t *testing.T) {
 // exists. Without it every such failure leaves a registration in the user's
 // repo and a branch no task ever ran in.
 func TestDiscardRemovesWorktreeAndBranch(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	wt := prepareForTest(t, repo)
 
@@ -805,6 +824,7 @@ const (
 // from HEAD, so the second turn stood in a tree that did not contain the first
 // turn's work and nothing said so (MUL-6881).
 func TestPrepareLocalWorktreeContinuesTheConversationBranch(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -859,6 +879,7 @@ func TestPrepareLocalWorktreeContinuesTheConversationBranch(t *testing.T) {
 // when the agent did what it was asked to do — so only what they changed since
 // is replayed.
 func TestPrepareLocalWorktreeReplaysOnlyTheUserEditsSinceTheLastTurn(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work in progress\n")
 
@@ -895,6 +916,7 @@ func TestPrepareLocalWorktreeReplaysOnlyTheUserEditsSinceTheLastTurn(t *testing.
 // both versions in it, because the only alternative that does not lose the
 // user's newer edit is having something read both sides and decide.
 func TestPrepareLocalWorktreeHandsConflictingUserEditsToTheAgent(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work in progress\n")
 
@@ -930,6 +952,7 @@ func TestPrepareLocalWorktreeHandsConflictingUserEditsToTheAgent(t *testing.T) {
 // conflict markers into the branch's content, and recording the snapshot would
 // tell every later turn the user's edit had landed.
 func TestFinalizeRefusesToDeliverAnUnresolvedMerge(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work in progress\n")
 
@@ -969,6 +992,7 @@ func TestFinalizeRefusesToDeliverAnUnresolvedMerge(t *testing.T) {
 // The A/B/C round trip: the user's conflicting edit survives until the agent
 // resolves it, and is not replayed again afterwards.
 func TestConflictResolvedByTheAgentIsDeliveredAndNotReplayedAgain(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "A\n")
 
@@ -1007,6 +1031,7 @@ func TestConflictResolvedByTheAgentIsDeliveredAndNotReplayedAgain(t *testing.T) 
 // A conflict the agent never resolved must stay pending: the user's edit is
 // still missing from the branch, so the next turn has to offer it again.
 func TestUnresolvedConflictIsReplayedOnTheNextTurn(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "A\n")
 
@@ -1048,6 +1073,7 @@ func finalizeAndDiscardForTest(t *testing.T, wt *LocalWorktree) {
 // to their own copy still have to reach the next turn — the snapshot has to
 // cover untracked content for that question to be answerable at all.
 func TestPrepareLocalWorktreeCarriesLaterUserEditsToOnceUntrackedFiles(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "scratch.txt"), "v1\n")
 	writeFile(t, filepath.Join(repo, "notes.txt"), "notes v1\n")
@@ -1078,6 +1104,7 @@ func TestPrepareLocalWorktreeCarriesLaterUserEditsToOnceUntrackedFiles(t *testin
 // Copying the user's older copy over it on the next turn would revert whatever
 // the agent did to it — silently, every turn.
 func TestPrepareLocalWorktreeKeepsAgentEditsToOnceUntrackedFiles(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "scratch.txt"), "user scratch\n")
 
@@ -1094,6 +1121,7 @@ func TestPrepareLocalWorktreeKeepsAgentEditsToOnceUntrackedFiles(t *testing.T) {
 // A turn that only reads must leave the conversation's branch alone: it holds
 // every turn before it, and the read-only cleanup would take those with it.
 func TestFinalizeKeepsTheConversationBranchAfterAReadOnlyTurn(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1116,6 +1144,7 @@ func TestFinalizeKeepsTheConversationBranchAfterAReadOnlyTurn(t *testing.T) {
 // Discard runs when preparation fails after the worktree exists. It may only
 // drop a branch this prepare created.
 func TestDiscardKeepsTheContinuedBranch(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1141,6 +1170,7 @@ func TestDiscardKeepsTheContinuedBranch(t *testing.T) {
 // baseline commit of its own, so there is a checkpoint to record before the
 // first turn has finished — see commitBaseline.
 func TestPrepareLocalWorktreeForksWhenTheConversationBranchIsBusy(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1171,6 +1201,7 @@ func TestPrepareLocalWorktreeForksWhenTheConversationBranchIsBusy(t *testing.T) 
 // Once the user merges the branch, its tip carries nothing HEAD does not.
 // Continuing from it would leave the next turn behind the user's own commits.
 func TestPrepareLocalWorktreeRestartsAMergedConversationBranch(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1203,6 +1234,7 @@ func TestPrepareLocalWorktreeRestartsAMergedConversationBranch(t *testing.T) {
 // A task with no conversation behind it — no issue, no chat session — has
 // nothing to continue and keeps the task-scoped branch.
 func TestPrepareLocalWorktreeKeepsTaskScopedBranchWithoutAConversation(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	wt := prepareForTest(t, repo)
 	if want := "agent/j/" + taskKey("11112222-3333-4444-5555-666677778888"); wt.Branch != want {
@@ -1214,6 +1246,7 @@ func TestPrepareLocalWorktreeKeepsTaskScopedBranchWithoutAConversation(t *testin
 }
 
 func TestLocalWorktreeConversation(t *testing.T) {
+	t.Parallel()
 	issueID := "01a056ac-0eda-797d-8ac2-b7d7a3935ae7"
 	chatID := "01a056ad-5b37-762a-a15f-390717f4dae1"
 	tests := []struct {
@@ -1242,6 +1275,7 @@ func TestLocalWorktreeConversation(t *testing.T) {
 // themselves, and appending to their branch — or reading their work as the
 // previous turn's — is the failure this guards.
 func TestPrepareLocalWorktreeRefusesToAdoptABranchItDoesNotOwn(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	// The user made this branch themselves, with content of their own.
@@ -1298,6 +1332,7 @@ func TestPrepareLocalWorktreeRefusesToAdoptABranchItDoesNotOwn(t *testing.T) {
 // Two workspaces can mint the same issue identifier, and two agents can share a
 // display name. Neither may end up on one branch.
 func TestPrepareLocalWorktreeSeparatesIdenticallyNamedConversations(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	mine := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1326,6 +1361,7 @@ func TestPrepareLocalWorktreeSeparatesIdenticallyNamedConversations(t *testing.T
 // pins their whole working tree as of some past turn against `git gc`, and
 // nothing else would ever come back for it.
 func TestPrepareLocalWorktreePrunesSnapshotsOfDeletedBranches(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work\n")
 
@@ -1372,6 +1408,7 @@ func TestPrepareLocalWorktreePrunesSnapshotsOfDeletedBranches(t *testing.T) {
 // The snapshot is the user's directory, not the daemon's view of it: a sidecar
 // left in their tree by a concurrent in_place task must never reach the branch.
 func TestCaptureUserSnapshotExcludesMulticaSidecars(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, ".agent_context", "brief.md"), "another task's brief\n")
 	writeFile(t, filepath.Join(repo, "sub", ".multica", "state.json"), "{}\n")
@@ -1396,6 +1433,7 @@ func TestCaptureUserSnapshotExcludesMulticaSidecars(t *testing.T) {
 // The record is what proves a branch is this conversation's: an owner AND the
 // tip it was written at.
 func TestBranchRecordRoundTrips(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	head := gitRun(t, repo, "rev-parse", "HEAD")
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work\n")
@@ -1439,6 +1477,7 @@ func TestBranchRecordRoundTrips(t *testing.T) {
 // the recorded owner — and there is no prepare in between for the orphan sweep
 // to notice the gap. Only the recorded checkpoint distinguishes them.
 func TestPrepareLocalWorktreeRefusesABranchDeletedAndRecreatedUnderTheSameName(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1479,6 +1518,7 @@ func TestPrepareLocalWorktreeRefusesABranchDeletedAndRecreatedUnderTheSameName(t
 // Same proof, other shape: the branch still exists but was force-moved onto
 // history that never carried this conversation's work.
 func TestPrepareLocalWorktreeRefusesABranchForceMovedOffItsRecord(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1510,6 +1550,7 @@ func TestPrepareLocalWorktreeRefusesABranchForceMovedOffItsRecord(t *testing.T) 
 // — the checkpoint is still in the history, so the conversation continues and
 // picks their commit up.
 func TestPrepareLocalWorktreeContinuesAfterTheUserCommitsOnTheBranch(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1540,6 +1581,7 @@ func TestPrepareLocalWorktreeContinuesAfterTheUserCommitsOnTheBranch(t *testing.
 // the task fails and the worktree is kept, rather than reporting success and
 // leaving a stale record behind to authorise the next turn.
 func TestFinalizeFailsWhenTheBranchRecordCannotBeWritten(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	wt := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1601,6 +1643,7 @@ func TestFinalizeFailsWhenTheBranchRecordCannotBeWritten(t *testing.T) {
 // says afterwards. A branch moved between the delivery and any later read is
 // therefore refused rather than silently continued.
 func TestBranchRecordPinsTheDeliveredCommitNotTheLiveRef(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1648,6 +1691,7 @@ func TestBranchRecordPinsTheDeliveredCommitNotTheLiveRef(t *testing.T) {
 // there look like this conversation's, so the turn refuses to record it and
 // keeps the worktree instead.
 func TestFinalizeRefusesToRecordADeliveryThatResetPastItsBaseline(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work in progress\n")
 	head := gitRun(t, repo, "rev-parse", "HEAD")
@@ -1704,6 +1748,7 @@ func TestFinalizeRefusesToRecordADeliveryThatResetPastItsBaseline(t *testing.T) 
 // different branch — delivered a commit this record has no business describing,
 // and the branch it names would not carry it.
 func TestFinalizeRefusesToRecordADeliveryFromOffTheBranch(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	head := gitRun(t, repo, "rev-parse", "HEAD")
 
@@ -1748,6 +1793,7 @@ func TestFinalizeRefusesToRecordADeliveryFromOffTheBranch(t *testing.T) {
 // the branch would sit exactly where the user's HEAD does, and nothing would
 // tell it apart from a branch they create there themselves.
 func TestPrepareLocalWorktreeAlwaysGivesANewBranchACommitOfItsOwn(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	head := gitRun(t, repo, "rev-parse", "HEAD")
 
@@ -1778,6 +1824,7 @@ func TestPrepareLocalWorktreeAlwaysGivesANewBranchACommitOfItsOwn(t *testing.T) 
 // edits, and recording them as delivered is how they disappear from every later
 // turn without anyone seeing it.
 func TestFinalizeRefusesWhenAFollowUpResetsPastTheUserEditsItReplayed(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 
 	first := prepareTurn(t, repo, "MUL-6881", turnOneTask)
@@ -1820,6 +1867,7 @@ func TestFinalizeRefusesWhenAFollowUpResetsPastTheUserEditsItReplayed(t *testing
 // that leaves no commit is indistinguishable from throwing the merge away, so
 // the record stays where it was and the edits come back next turn.
 func TestConflictResolvedWithoutACommitDoesNotAdvanceTheRecord(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work in progress\n")
 
@@ -1857,6 +1905,7 @@ func TestConflictResolvedWithoutACommitDoesNotAdvanceTheRecord(t *testing.T) {
 // nothing count as delivered, and the user's local edit then went missing from
 // the turn after.
 func TestConflictAfterAUserCommitOnTheBranchStillOffersTheEditAgain(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work in progress\n")
 
@@ -1915,6 +1964,7 @@ func TestConflictAfterAUserCommitOnTheBranchStillOffersTheEditAgain(t *testing.T
 // plumbing between them is covered too: which claim fields become the branch
 // name, and which become the identity the branch is recorded under.
 func TestPrepareTwoTurnsOfOneIssueThroughPrepare(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work in progress\n")
 	workspacesRoot := t.TempDir()
@@ -1979,6 +2029,7 @@ func TestPrepareTwoTurnsOfOneIssueThroughPrepare(t *testing.T) {
 // worktree it believed it owned nothing of. This test runs two turns across
 // that boundary, which is where the in-process tests above cannot look.
 func TestIsolatedPrepareCarriesTheStateFinalizeNeeds(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	writeFile(t, filepath.Join(repo, "tracked.txt"), "user work in progress\n")
 	workspacesRoot := t.TempDir()
@@ -2052,6 +2103,7 @@ func TestIsolatedPrepareCarriesTheStateFinalizeNeeds(t *testing.T) {
 // A read-only turn drops its branch — which the daemon could not do either
 // while createdBranch was being lost on the way back from the helper.
 func TestIsolatedPrepareKeepsTheReadOnlyBranchDrop(t *testing.T) {
+	t.Parallel()
 	repo := newTestRepo(t)
 	workspacesRoot := t.TempDir()
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/server/internal/daemon/execenv/openclaw_config_timeout_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_timeout_test.go
@@ -65,6 +65,7 @@ func TestResolveOpenclawCLITimeout(t *testing.T) {
 // The pre-existing context contract must survive alongside it: callers that
 // check errors.Is(err, context.DeadlineExceeded) keep working.
 func TestExecOpenclawCLITimeoutIsTypedSentinel(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("shell shim shape is covered by the windows-tagged tests")
 	}
@@ -117,6 +118,7 @@ func TestPrepareOpenclawConfigPropagatesTimeoutSentinel(t *testing.T) {
 // but it is not a slow CLI — labelling it as one would tell the user to raise
 // a deadline that was never involved.
 func TestExecOpenclawCLICancellationIsNotATimeout(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("shell shim shape is covered by the windows-tagged tests")
 	}
@@ -155,6 +157,7 @@ func TestExecOpenclawCLICancellationIsNotATimeout(t *testing.T) {
 // non-retryable reason — rather than doubling the time spent inside the outer
 // preparation budget to reach an identical conclusion.
 func TestOpenclawActiveConfigPathSpendsOneBudgetAcrossBothAttempts(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("shell shim shape is covered by the windows-tagged tests")
 	}
@@ -171,7 +174,7 @@ func TestOpenclawActiveConfigPathSpendsOneBudgetAcrossBothAttempts(t *testing.T)
 			"  'config file') printf '/tmp/openclaw.json\\n' ;;\n"+
 			"esac\n", "")
 
-	const budget = 1500 * time.Millisecond
+	const budget = 300 * time.Millisecond
 	start := time.Now()
 	_, _, err = openclawActiveConfigPath(shim, budget)
 	elapsed := time.Since(start)

--- a/server/internal/daemon/execenv/openclaw_process_tree_test.go
+++ b/server/internal/daemon/execenv/openclaw_process_tree_test.go
@@ -80,6 +80,7 @@ func helperGone(pid int, within time.Duration) bool {
 // makes openclawCLITimeout meaningful: the call must come back on the direct
 // child's exit, not on the helper's lifetime and not on the deadline.
 func TestExecOpenclawCLIReturnsDespitePipeHoldingHelper(t *testing.T) {
+	t.Parallel()
 	pidFile := filepath.Join(t.TempDir(), "helper.pid")
 	bin := writeHelperForkingOpenclaw(t, pidFile)
 
@@ -108,10 +109,11 @@ func TestExecOpenclawCLIReturnsDespitePipeHoldingHelper(t *testing.T) {
 // runs per task, and this is where the orphan `openclaw-config` processes came
 // from. It is also what the reverted cmd.WaitDelay backstop could not do.
 func TestExecOpenclawCLIReapsForkedHelper(t *testing.T) {
+	t.Parallel()
 	pidFile := filepath.Join(t.TempDir(), "helper.pid")
 	bin := writeHelperForkingOpenclaw(t, pidFile)
 
-	if _, err := execOpenclawCLI(context.Background(), bin, "config", "file"); err != nil {
+	if _, err := execOpenclawCLI(context.Background(), bin, "config", "get", "--json"); err != nil {
 		t.Fatalf("execOpenclawCLI: %v", err)
 	}
 
@@ -126,6 +128,7 @@ func TestExecOpenclawCLIReapsForkedHelper(t *testing.T) {
 // TestExecOpenclawCLIDoesNotSalvagePartialJSON pins that a `--json` subcommand
 // still streaming when the deadline arrives is an error, not a truncated success.
 func TestExecOpenclawCLIDoesNotSalvagePartialJSON(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "openclaw")
 	body := "#!/bin/sh\nprintf '{\"agents\":['\n" +
@@ -220,6 +223,7 @@ func TestOpenclawOutputCompleteRules(t *testing.T) {
 // TestOpenclawActiveConfigPathFailsClosedWhenConfigFileNeverExits for what it
 // does instead.
 func TestExecOpenclawCLIToleratesNonExitingCLI(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "openclaw")
 	body := "#!/bin/sh\n" +
@@ -293,6 +297,7 @@ func writeOpenclawConfigStub(t *testing.T, validateOut string, validateExit int,
 // hostile `config file` branch in the stub precisely so that a future change that
 // reinstates shape-based parsing as the primary path fails here.
 func TestOpenclawActiveConfigPathIgnoresAPathShapedWarning(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	realPath := filepath.Join(dir, "openclaw.json")
 	warnPath := filepath.Join(dir, "plugin-cache.json")
@@ -331,6 +336,7 @@ func TestOpenclawActiveConfigPathIgnoresAPathShapedWarning(t *testing.T) {
 // CLI whose `config validate --json` is unusable (too old, or a shape we do not
 // recognise) must still resolve through `config file`.
 func TestOpenclawActiveConfigPathFallsBackToConfigFile(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	realPath := filepath.Join(dir, "openclaw.json")
 	if err := os.WriteFile(realPath, []byte("{}\n"), 0o600); err != nil {
@@ -347,7 +353,9 @@ func TestOpenclawActiveConfigPathFallsBackToConfigFile(t *testing.T) {
 		{"validate omits the path field", "  printf '{\"valid\":true}\\n'\n", 0},
 		{"validate reports a relative path", "  printf '{\"valid\":false,\"path\":\"openclaw.json\"}\\n'\n", 1},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			bin := writeOpenclawConfigStub(t, tc.validateOut, tc.validateExit,
 				"  printf '%s\\n' '"+realPath+"'\n", "")
 			got, exists, err := openclawActiveConfigPath(bin, 30*time.Second)
@@ -370,6 +378,7 @@ func TestOpenclawActiveConfigPathFallsBackToConfigFile(t *testing.T) {
 // answer" would break the most common first-run path. Both payloads below are the
 // real shapes measured on OpenClaw 2026.7.1-2, with stderr empty in both.
 func TestOpenclawActiveConfigPathReadsThePathFromANonZeroExit(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	presentPath := filepath.Join(dir, "openclaw.json")
 	if err := os.WriteFile(presentPath, []byte("{}\n"), 0o600); err != nil {
@@ -409,7 +418,9 @@ func TestOpenclawActiveConfigPathReadsThePathFromANonZeroExit(t *testing.T) {
 			wantExists: true,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			exit := 1
 			if strings.Contains(tc.payload, `"valid":true`) {
 				exit = 0
@@ -442,6 +453,7 @@ func TestOpenclawActiveConfigPathReadsThePathFromANonZeroExit(t *testing.T) {
 // alternative was demonstrated to return a wrong path. The deadline is what makes
 // it bounded, and MULTICA_OPENCLAW_CLI_TIMEOUT (#7142) is what makes it tunable.
 func TestOpenclawActiveConfigPathFailsClosedWhenConfigFileNeverExits(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	realPath := filepath.Join(dir, "openclaw.json")
 	bin := writeOpenclawConfigStub(t,
@@ -450,13 +462,13 @@ func TestOpenclawActiveConfigPathFailsClosedWhenConfigFileNeverExits(t *testing.
 		"  sleep 300\n")
 
 	start := time.Now()
-	_, _, err := openclawActiveConfigPath(bin, 3*time.Second)
+	_, _, err := openclawActiveConfigPath(bin, 500*time.Millisecond)
 	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatal("a `config file` that never exits must fail closed, not have its " +
 			"stdout accepted on shape")
 	}
-	if elapsed > 20*time.Second {
+	if elapsed > 3*time.Second {
 		t.Errorf("took %v — the deadline did not bound the call", elapsed)
 	}
 }

--- a/server/internal/daemon/execenv/openclaw_shim_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_test.go
@@ -369,6 +369,7 @@ func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.
 // for an explicitly cancelled context, not just a deadline, so a caller can
 // distinguish "we gave up" from "the CLI failed" without parsing strings.
 func TestExecOpenclawCLICancellationIsWrapped(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("shell shim shape is covered by the windows-tagged tests")
 	}
@@ -425,6 +426,7 @@ func TestExecOpenclawCLIPrefersRealStderr(t *testing.T) {
 // but it must stay out of the error text because other config commands can
 // print resolved configuration and secrets there.
 func TestExecOpenclawCLIPreservesFailedStdoutWithoutLeakingIt(t *testing.T) {
+	t.Parallel()
 	const marker = "stdout-only-sensitive-marker"
 	shim := writeShim(t, t.TempDir(),
 		"#!/bin/sh\necho '"+marker+"'\nexit 1\n",
@@ -471,6 +473,7 @@ func TestExecOpenclawCLIMissingTempDoesNotChangeOutcome(t *testing.T) {
 // containing a space or non-ASCII characters must not break invocation or
 // mangle the captured output.
 func TestExecOpenclawCLIHandlesShimInPathWithSpacesAndUnicode(t *testing.T) {
+	t.Parallel()
 	for _, segment := range []string{"Program Files", "用户 開發", "café dir"} {
 		t.Run(segment, func(t *testing.T) {
 			dir := filepath.Join(t.TempDir(), segment)

--- a/server/internal/daemon/runtime_gone_test.go
+++ b/server/internal/daemon/runtime_gone_test.go
@@ -762,7 +762,7 @@ func TestHandleRuntimeGone_RecoveryContextStopsOnDaemonShutdown(t *testing.T) {
 			}
 			select {
 			case <-r.Context().Done():
-			case <-time.After(2 * time.Second):
+			case <-time.After(250 * time.Millisecond):
 			}
 			return
 		}

--- a/server/internal/daemon/runtime_isolation_test.go
+++ b/server/internal/daemon/runtime_isolation_test.go
@@ -252,12 +252,12 @@ func TestRunBatchPollerWakesAfterTaskExit(t *testing.T) {
 }
 
 // The max-concurrency=1 shape takes a different sleep branch: after the
-// two-second slot wait expires, the poller parks on the five-second capacity
+// slot wait expires, the poller parks on the five-second capacity
 // backoff. A returned semaphore slot alone does not wake that sleep, so the
 // explicit completion signal is required there too.
 func TestRunBatchPollerWakesFromCapacityBackoffAfterTaskExit(t *testing.T) {
 	t.Parallel()
-	testRunBatchPollerTaskExitWakeup(t, 1, taskSlotWaitTimeout+250*time.Millisecond)
+	testRunBatchPollerTaskExitWakeup(t, 1, 200*time.Millisecond)
 }
 
 func testRunBatchPollerTaskExitWakeup(t *testing.T, maxConcurrent int, releaseDelay time.Duration) {
@@ -301,6 +301,7 @@ func testRunBatchPollerTaskExitWakeup(t *testing.T, maxConcurrent int, releaseDe
 	d.workspaces["ws-1"] = &workspaceState{workspaceID: "ws-1", runtimeIDs: []string{"rt-1"}}
 	d.runtimeIndex["rt-1"] = Runtime{ID: "rt-1"}
 	d.cancelPollInterval = time.Hour
+	d.taskSlotWait = 50 * time.Millisecond
 	d.runner = taskRunnerFunc(func(ctx context.Context, task Task, provider string, slot int, log *slog.Logger) (TaskResult, error) {
 		switch task.ID {
 		case "t1":

--- a/server/internal/daemon/runtime_not_executable_test.go
+++ b/server/internal/daemon/runtime_not_executable_test.go
@@ -154,6 +154,7 @@ func TestConfirmNotExecutable_WindowStartsAtFirstSighting(t *testing.T) {
 // repair, without a daemon restart.
 func TestRefreshAgentVersions_TakesNotExecutableRuntimeOfflineAndBack(t *testing.T) {
 	stubConfirmWindow(t, 0)
+	stubProbeRetry(t, time.Millisecond, time.Second)
 	fx := newVersionRefreshFixture(t)
 	d := fx.daemon
 
@@ -235,6 +236,7 @@ func TestDetectBuiltinRuntimes_HealthyProbeClearsPendingVerdict(t *testing.T) {
 // (MUL-6164).
 func TestDeregisterRevivedRuntimes_ReattachesTheUnusableReason(t *testing.T) {
 	stubConfirmWindow(t, 0)
+	stubProbeRetry(t, time.Millisecond, time.Second)
 	// Stable ids before the first registration: the interleave only exists when
 	// the stale response names the same row the demotion took offline.
 	fx := newVersionRefreshFixtureWith(t, func(fx *batchFixture) { fx.enableStableRuntimeIDs() })

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1033,7 +1033,9 @@ type DaemonHeartbeatRequest struct {
 // cleanly un-run from the client side if the context expires mid-script. We
 // therefore only invoke PopPending after HasPending confirms there is work
 // to claim, so we never start a claim we might have to abort.
-const heartbeatHasPendingTimeout = 1 * time.Second
+// Kept as a variable so the slow-probe test can preserve this relationship
+// without paying the production timeout; production never reassigns it.
+var heartbeatHasPendingTimeout = 1 * time.Second
 
 // maxLocalSkillImportBatch is how many pending import requests the heartbeat
 // handler pops per cycle. Higher values let the daemon process more imports

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -991,6 +991,9 @@ func TestDaemonHeartbeat_SlowProbeDoesNotWedge(t *testing.T) {
 	}
 
 	runtimeID := createRuntimeLocalSkillTestRuntime(t, testUserID)
+	origProbeTimeout := heartbeatHasPendingTimeout
+	heartbeatHasPendingTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { heartbeatHasPendingTimeout = origProbeTimeout })
 
 	origList := testHandler.LocalSkillListStore
 	origImport := testHandler.LocalSkillImportStore
@@ -1013,8 +1016,8 @@ func TestDaemonHeartbeat_SlowProbeDoesNotWedge(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("DaemonHeartbeat with slow probes: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	// Two bounded probes at 1s each + a small fixed slack.
-	if elapsed > 3*time.Second {
+	// Two bounded probes plus a small fixed slack.
+	if elapsed > time.Second {
 		t.Fatalf("DaemonHeartbeat took %s; expected fast return despite slow probes", elapsed)
 	}
 }

--- a/server/internal/handler/issue_status_test.go
+++ b/server/internal/handler/issue_status_test.go
@@ -575,7 +575,7 @@ func archiveStatusVia(t *testing.T, entry db.IssueStatus) int {
 
 // holdExclusiveCatalogLock takes the archive side of the catalog lock and holds
 // it until the returned release func runs, so a test can pin one ordering.
-func holdExclusiveCatalogLock(t *testing.T) (release func()) {
+func holdExclusiveCatalogLock(t *testing.T) (holderPID int32, release func()) {
 	t.Helper()
 	ctx := context.Background()
 	tx, err := testPool.Begin(ctx)
@@ -587,14 +587,51 @@ func holdExclusiveCatalogLock(t *testing.T) (release func()) {
 		parseUUID(testWorkspaceID)); err != nil {
 		t.Fatalf("take exclusive lock: %v", err)
 	}
+	if err := tx.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&holderPID); err != nil {
+		t.Fatalf("read lock-holder pid: %v", err)
+	}
 	released := false
-	return func() {
+	return holderPID, func() {
 		if released {
 			return
 		}
 		released = true
 		tx.Rollback(ctx)
 	}
+}
+
+// waitForCatalogLockWaiter observes a contender waiting on the exact advisory
+// lock held by holderPID. It replaces fixed sleeps in race tests with the state
+// transition those sleeps were trying to approximate.
+func waitForCatalogLockWaiter(t *testing.T, ctx context.Context, holderPID int32) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		var waiting bool
+		if err := testPool.QueryRow(ctx, `
+SELECT EXISTS (
+    SELECT 1
+    FROM pg_locks AS held
+    JOIN pg_locks AS waiter
+      ON waiter.locktype = held.locktype
+     AND waiter.database IS NOT DISTINCT FROM held.database
+     AND waiter.classid IS NOT DISTINCT FROM held.classid
+     AND waiter.objid IS NOT DISTINCT FROM held.objid
+     AND waiter.objsubid IS NOT DISTINCT FROM held.objsubid
+    WHERE held.pid = $1
+      AND held.locktype = 'advisory'
+      AND held.granted
+      AND NOT waiter.granted
+)
+`, holderPID).Scan(&waiting); err != nil {
+			t.Fatalf("observe issue-status catalog-lock waiter: %v", err)
+		}
+		if waiting {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("writer never reached the held issue-status catalog lock")
 }
 
 // TestWritesRejectAnArchivedStatus covers the SEQUENTIAL case: the status is
@@ -724,7 +761,7 @@ func TestArchiveSucceedsAfterACommittedWrite(t *testing.T) {
 	// closed by luck.
 	t.Run("writer blocks while archive holds the exclusive lock", func(t *testing.T) {
 		createTestCustomStatus(t, "race_block", issuestatus.InProgress)
-		release := holdExclusiveCatalogLock(t)
+		holderPID, release := holdExclusiveCatalogLock(t)
 		defer release()
 
 		done := make(chan int, 1)
@@ -736,11 +773,11 @@ func TestArchiveSucceedsAfterACommittedWrite(t *testing.T) {
 			done <- rec.Code
 		}()
 
+		waitForCatalogLockWaiter(t, ctx, holderPID)
 		select {
 		case code := <-done:
 			t.Fatalf("write completed (%d) while the archive lock was held", code)
-		case <-time.After(400 * time.Millisecond):
-			// Blocked as required.
+		default:
 		}
 
 		release()
@@ -872,15 +909,19 @@ func TestArchiveCommitsInsideTheWriteRaceWindow(t *testing.T) {
 				parseUUID(testWorkspaceID)); err != nil {
 				t.Fatalf("take exclusive lock: %v", err)
 			}
+			var holderPID int32
+			if err := tx.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&holderPID); err != nil {
+				t.Fatalf("read lock-holder pid: %v", err)
+			}
 
 			done := make(chan int, 1)
 			go func() { done <- tc.write(t, tc.key, seedID) }()
 
+			waitForCatalogLockWaiter(t, ctx, holderPID)
 			select {
 			case code := <-done:
 				t.Fatalf("write completed (%d) before the archive released the lock", code)
-			case <-time.After(400 * time.Millisecond):
-				// Parked on the lock, as required.
+			default:
 			}
 
 			// Archive inside the held lock and commit: from the writer's point

--- a/server/internal/handler/plugin_hook_test.go
+++ b/server/internal/handler/plugin_hook_test.go
@@ -356,31 +356,32 @@ func TestEventDispatchRespectsTheFeatureFlagEndToEnd(t *testing.T) {
 		t.Fatalf("install: status=%d body=%s", install.Code, install.Body.String())
 	}
 
-	dispatch := func() {
+	dispatch := func() *service.PluginEventDispatcher {
 		dispatcher := service.NewPluginEventDispatcher(testHandler.PluginService)
-		defer dispatcher.Close()
 		dispatcher.Dispatch(plugincontract.EventIssueCreated, testWorkspaceID, map[string]any{})
-		// Long enough for a worker to pick the job up and complete the call.
-		time.Sleep(2 * time.Second)
+		return dispatcher
 	}
 
 	// Flag on: the endpoint is called.
 	testHandler.PluginService.FeatureFlags = testHandler.FeatureFlags
-	dispatch()
+	dispatcher := dispatch()
 	select {
 	case <-received:
-	default:
+	case <-time.After(2 * time.Second):
+		dispatcher.Close()
 		t.Fatal("with the flag on, an installed event hook was never called")
 	}
+	dispatcher.Close()
 
 	// Flag off: nothing leaves, even though the same installation is still
 	// enabled and still declares the hook.
 	withPluginsV1Flag(t, testHandler, false)
 	testHandler.PluginService.FeatureFlags = testHandler.FeatureFlags
-	dispatch()
+	dispatcher = dispatch()
+	defer dispatcher.Close()
 	select {
 	case <-received:
 		t.Fatal("with the flag off, an event hook still called out — the flag does not gate the outbound path")
-	default:
+	case <-time.After(300 * time.Millisecond):
 	}
 }

--- a/server/internal/handler/workspace_delete_fence_test.go
+++ b/server/internal/handler/workspace_delete_fence_test.go
@@ -89,7 +89,7 @@ func TestTaskWriteFence_BlocksOnWorkspaceLockAlone(t *testing.T) {
 			t.Fatalf("%s: begin: %v", name, err)
 		}
 		defer writer.Rollback(ctx)
-		if _, err := writer.Exec(ctx, "SET LOCAL lock_timeout = 750"); err != nil {
+		if _, err := writer.Exec(ctx, "SET LOCAL lock_timeout = 200"); err != nil {
 			t.Fatalf("%s: set lock_timeout: %v", name, err)
 		}
 		err = enqueueViaRealQuery(ctx, testHandler.Queries.WithTx(writer), agentID, runtimeID, issueID)
@@ -113,7 +113,7 @@ func TestTaskWriteFence_BlocksOnWorkspaceLockAlone(t *testing.T) {
 		t.Fatalf("begin reassign: %v", err)
 	}
 	defer reassign.Rollback(ctx)
-	if _, err := reassign.Exec(ctx, "SET LOCAL lock_timeout = 750"); err != nil {
+	if _, err := reassign.Exec(ctx, "SET LOCAL lock_timeout = 200"); err != nil {
 		t.Fatalf("reassign: set lock_timeout: %v", err)
 	}
 	_, err = testHandler.Queries.WithTx(reassign).ReassignTasksToRuntime(ctx, db.ReassignTasksToRuntimeParams{
@@ -131,7 +131,7 @@ func TestTaskWriteFence_BlocksOnWorkspaceLockAlone(t *testing.T) {
 		t.Fatalf("begin unrelated: %v", err)
 	}
 	defer unrelated.Rollback(ctx)
-	if _, err := unrelated.Exec(ctx, "SET LOCAL lock_timeout = 750"); err != nil {
+	if _, err := unrelated.Exec(ctx, "SET LOCAL lock_timeout = 200"); err != nil {
 		t.Fatalf("unrelated: set lock_timeout: %v", err)
 	}
 	if err := enqueueViaRealQuery(ctx, testHandler.Queries.WithTx(unrelated),
@@ -145,7 +145,7 @@ func TestTaskWriteFence_BlocksOnWorkspaceLockAlone(t *testing.T) {
 		t.Fatalf("begin status update: %v", err)
 	}
 	defer statusUpdate.Rollback(ctx)
-	if _, err := statusUpdate.Exec(ctx, "SET LOCAL lock_timeout = 750"); err != nil {
+	if _, err := statusUpdate.Exec(ctx, "SET LOCAL lock_timeout = 200"); err != nil {
 		t.Fatalf("status update: set lock_timeout: %v", err)
 	}
 	if _, err := statusUpdate.Exec(ctx,

--- a/server/internal/handler/workspace_delete_task_discovery_test.go
+++ b/server/internal/handler/workspace_delete_task_discovery_test.go
@@ -568,7 +568,7 @@ func TestDeleteWorkspaceTasks_FencesConcurrentEnqueueAndReassignment(t *testing.
 			t.Fatalf("%s: begin: %v", name, err)
 		}
 		defer other.Rollback(ctx)
-		if _, err := other.Exec(ctx, "SET LOCAL lock_timeout = 750"); err != nil {
+		if _, err := other.Exec(ctx, "SET LOCAL lock_timeout = 200"); err != nil {
 			t.Fatalf("%s: set lock_timeout: %v", name, err)
 		}
 		_, err = other.Exec(ctx, sql, args...)
@@ -603,7 +603,7 @@ UPDATE agent_task_queue SET runtime_id = $1 WHERE id = $2
 		t.Fatalf("begin unrelated tx: %v", err)
 	}
 	defer unrelated.Rollback(ctx)
-	if _, err := unrelated.Exec(ctx, "SET LOCAL lock_timeout = 750"); err != nil {
+	if _, err := unrelated.Exec(ctx, "SET LOCAL lock_timeout = 200"); err != nil {
 		t.Fatalf("unrelated: set lock_timeout: %v", err)
 	}
 	if _, err := unrelated.Exec(ctx, `

--- a/server/internal/integrations/wecom/ws_sender.go
+++ b/server/internal/integrations/wecom/ws_sender.go
@@ -67,9 +67,10 @@ type gorillaWSConn struct {
 // wsSender serializes writes to one WebSocket connection. Instantiated per
 // Connect() call and dropped when the connection ends.
 type wsSender struct {
-	conn wsConn
-	mu   sync.Mutex
-	log  *slog.Logger
+	conn       wsConn
+	mu         sync.Mutex
+	log        *slog.Logger
+	ackTimeout time.Duration
 
 	// replies holds the callers waiting on a server verdict, keyed by the
 	// req_id they wrote. Only the read loop delivers into these, which is why
@@ -89,13 +90,23 @@ func newWSSender(conn wsConn, log *slog.Logger) *wsSender {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &wsSender{conn: conn, log: log, replies: make(map[string]*replyWaiter)}
+	return &wsSender{
+		conn:       conn,
+		log:        log,
+		ackTimeout: newWSSenderAckTimeout,
+		replies:    make(map[string]*replyWaiter),
+	}
 }
 
 // ackTimeout caps the wait for a verdict. WeCom answers in a few hundred
 // milliseconds; past this we assume the ack was lost rather than the frame
 // refused, which matters because the two call for opposite responses.
 const ackTimeout = 5 * time.Second
+
+// newWSSenderAckTimeout is a constructor seam for package tests. Production
+// senders always inherit ackTimeout; tests shorten only the wait for a verdict
+// that their fake connection deliberately withholds.
+var newWSSenderAckTimeout = ackTimeout
 
 // errAckTimeout — the frame went out and no verdict came back. Distinct from a
 // refusal: the message may well have been delivered, so a caller retries at
@@ -206,7 +217,7 @@ func (s *wsSender) request(ctx context.Context, cmd string, body map[string]any)
 		return nil, err
 	}
 
-	timer := time.NewTimer(ackTimeout)
+	timer := time.NewTimer(s.ackTimeout)
 	defer timer.Stop()
 	select {
 	case res := <-w.ch:

--- a/server/internal/integrations/wecom/ws_sender_timeout_test.go
+++ b/server/internal/integrations/wecom/ws_sender_timeout_test.go
@@ -1,0 +1,7 @@
+package wecom
+
+import "time"
+
+func init() {
+	newWSSenderAckTimeout = 400 * time.Millisecond
+}

--- a/server/pkg/agent/claude_deadlock_test.go
+++ b/server/pkg/agent/claude_deadlock_test.go
@@ -35,6 +35,17 @@ func TestMain(m *testing.M) {
 	}
 	switch mode := os.Getenv("CLAUDE_FAKE_MODE"); mode {
 	case "":
+		// Preserve the production relationships while avoiding hundreds of
+		// milliseconds of intentional silence in every ACP fixture.
+		acpNotificationQuietTime = 100 * time.Millisecond
+		hermesNotificationQuietTime = 100 * time.Millisecond
+		grokNotificationQuietTime = 100 * time.Millisecond
+		zeroclawNotificationQuietTime = 100 * time.Millisecond
+		dimNotificationQuietTime = 100 * time.Millisecond
+		dimSessionLoadRetryDelay = 200 * time.Millisecond
+		collectDrainGrace = 750 * time.Millisecond
+		collectSettleGrace = 100 * time.Millisecond
+		probeWaitDelay = 500 * time.Millisecond
 		os.Exit(m.Run())
 	case "startup_stdout_burst":
 		runFakeClaudeStartupStdoutBurst()

--- a/server/pkg/agent/codex_cleanup_unix_test.go
+++ b/server/pkg/agent/codex_cleanup_unix_test.go
@@ -23,7 +23,7 @@ func TestCodexThreadStartTimeoutReapsDetachedStdioDescendant(t *testing.T) {
 		`read line`+"\n"+
 		`read line`+"\n"+
 		`sleep 30 >/dev/null 2>&1 & echo $! > "`+pidFile+`"`+"\n"+
-		`sleep 3.2`+"\n"+
+		`sleep 1.2`+"\n"+
 		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-late"}}}'`+"\n"+
 		`read line`+"\n")
 
@@ -32,7 +32,7 @@ func TestCodexThreadStartTimeoutReapsDetachedStdioDescendant(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	session, err := backend.Execute(context.Background(), "prompt", ExecOptions{Timeout: 8 * time.Second, HandshakeTimeout: 3 * time.Second})
+	session, err := backend.Execute(context.Background(), "prompt", ExecOptions{Timeout: 4 * time.Second, HandshakeTimeout: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestCodexInitializeTimeoutReapsDetachedStdioDescendant(t *testing.T) {
 	fakePath := writeFakeCodexAppServer(t, ""+
 		`read line`+"\n"+
 		`sleep 30 >/dev/null 2>&1 & echo $! > "`+pidFile+`"`+"\n"+
-		`sleep 3.2`+"\n"+
+		`sleep 1.2`+"\n"+
 		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
 		`read line`+"\n")
 
@@ -75,7 +75,7 @@ func TestCodexInitializeTimeoutReapsDetachedStdioDescendant(t *testing.T) {
 		t.Fatal(err)
 	}
 	backend := backendRaw.(*codexBackend)
-	session, err := backend.executeOnce(context.Background(), "prompt", ExecOptions{Timeout: 8 * time.Second, HandshakeTimeout: 3 * time.Second}, 1)
+	session, err := backend.executeOnce(context.Background(), "prompt", ExecOptions{Timeout: 4 * time.Second, HandshakeTimeout: time.Second}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestCodexInitializeTimeoutDoesNotPersistOpaqueEnv(t *testing.T) {
 	fakePath := writeFakeCodexAppServer(t, ""+
 		`read line`+"\n"+
 		`echo "$OPAQUE_AUTH_VALUE" >&2`+"\n"+
-		`sleep 3.2`+"\n"+
+		`sleep 1.2`+"\n"+
 		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n")
 
 	var logs strings.Builder
@@ -120,7 +120,7 @@ func TestCodexInitializeTimeoutDoesNotPersistOpaqueEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	backend := backendRaw.(*codexBackend)
-	session, err := backend.executeOnce(context.Background(), "prompt", ExecOptions{Timeout: 8 * time.Second, HandshakeTimeout: 3 * time.Second}, 1)
+	session, err := backend.executeOnce(context.Background(), "prompt", ExecOptions{Timeout: 4 * time.Second, HandshakeTimeout: time.Second}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -2474,7 +2474,7 @@ func TestCodexExecuteStartupRPCsHaveBoundedHandshakeTimeout(t *testing.T) {
 	// used to make initialize spuriously time out before the subtest reached
 	// the RPC it targets. Keep this comfortably above sh startup jitter yet
 	// below the 5s semantic timeout and the 10s executeFakeCodex ceiling.
-	const handshakeTimeout = 3 * time.Second
+	const handshakeTimeout = time.Second
 	tests := []struct {
 		name   string
 		method string
@@ -2543,10 +2543,10 @@ func TestCodexExecuteStartupRPCsHaveBoundedHandshakeTimeout(t *testing.T) {
 				}
 			}
 			// Proves the RPC was bounded rather than hanging to the 10s
-			// executeFakeCodex ceiling; the handshake fires at ~3s and
+			// executeFakeCodex ceiling; the handshake fires at ~1s and
 			// shutdown is fast (closing stdin EOFs the fake).
-			if elapsed > 8*time.Second {
-				t.Fatalf("handshake timeout took %s, expected < 8s", elapsed)
+			if elapsed > 4*time.Second {
+				t.Fatalf("handshake timeout took %s, expected < 4s", elapsed)
 			}
 		})
 	}
@@ -2629,7 +2629,7 @@ func TestCodexExecuteThreadStartTimeoutLifecycleIsFailClosed(t *testing.T) {
 		`read line`+"\n"+
 		`echo 'ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit' >&2`+"\n"+
 		`echo 'ERROR mcp_manager_init: transport error: channel closed' >&2`+"\n"+
-		`sleep 5`+"\n"+
+		`sleep 2`+"\n"+
 		// This response is deliberately later than the host timeout. Killing
 		// the process tree must prevent it from reaching turn/start.
 		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-late"}}}'`+"\n"+
@@ -2647,8 +2647,8 @@ func TestCodexExecuteThreadStartTimeoutLifecycleIsFailClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 	session, err := backend.Execute(context.Background(), "secret prompt must not be logged", ExecOptions{
-		Timeout:                   5 * time.Second,
-		HandshakeTimeout:          3 * time.Second,
+		Timeout:                   3 * time.Second,
+		HandshakeTimeout:          time.Second,
 		SemanticInactivityTimeout: time.Second,
 	})
 	if err != nil {
@@ -2715,7 +2715,7 @@ func TestCodexExecuteThreadResumeTimeoutUsesThreadBudgetAndLifecycle(t *testing.
 		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
 		`read line`+"\n"+
 		`read line`+"\n"+
-		`sleep 5`+"\n")
+		`sleep 2`+"\n")
 
 	var logs bytes.Buffer
 	backend, err := New("codex", Config{
@@ -2866,7 +2866,7 @@ func TestCodexExecuteConcurrentThreadStartTimeoutsRemainUnserialized(t *testing.
 		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
 		`read line`+"\n"+
 		`read line`+"\n"+
-		`sleep 5`+"\n")
+		`sleep 2`+"\n")
 
 	maxActiveCodexLaunchesObserved.Store(0)
 	results := make(chan Result, 2)
@@ -2878,8 +2878,8 @@ func TestCodexExecuteConcurrentThreadStartTimeoutsRemainUnserialized(t *testing.
 				return
 			}
 			session, err := backend.Execute(context.Background(), "prompt", ExecOptions{
-				Timeout:          5 * time.Second,
-				HandshakeTimeout: 3 * time.Second,
+				Timeout:          3 * time.Second,
+				HandshakeTimeout: time.Second,
 			})
 			if err != nil {
 				results <- Result{Status: "failed", Error: err.Error()}
@@ -2980,8 +2980,8 @@ func TestCodexExecuteInitializeRetrySafetyGates(t *testing.T) {
 			`count=0; test -f `+countPath+` && count=$(cat `+countPath+`)`+"\n"+
 			`count=$((count + 1)); echo "$count" > `+countPath+"\n"+
 			`read line`+"\n"+
-			`sleep 3.2`+"\n")
-		result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 8 * time.Second, HandshakeTimeout: 3 * time.Second})
+			`sleep 1.2`+"\n")
+		result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 4 * time.Second, HandshakeTimeout: time.Second})
 		if result.Status != "failed" || !strings.Contains(result.Error, CodexHandshakeTimeoutMarker) {
 			t.Fatalf("expected final initialize timeout, got status=%q error=%q", result.Status, result.Error)
 		}
@@ -2997,8 +2997,8 @@ func TestCodexExecuteInitializeRetrySafetyGates(t *testing.T) {
 			`echo x >> `+countPath+"\n"+
 			`read line`+"\n"+
 			`echo '{"jsonrpc":"2.0","method":"item/started","params":{"threadId":"unexpected","item":{"type":"commandExecution","id":"cmd-1","command":"true"}}}'`+"\n"+
-			`sleep 3.2`+"\n")
-		result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 8 * time.Second, HandshakeTimeout: 3 * time.Second})
+			`sleep 1.2`+"\n")
+		result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 4 * time.Second, HandshakeTimeout: time.Second})
 		if result.Status != "failed" {
 			t.Fatalf("expected failed, got %q", result.Status)
 		}
@@ -3015,8 +3015,8 @@ func TestCodexExecuteInitializeRetrySafetyGates(t *testing.T) {
 		fakePath := writeFakeCodexAppServer(t, ""+
 			`echo x >> `+countPath+"\n"+
 			`read line`+"\n"+
-			`sleep 3.2`+"\n")
-		result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 8 * time.Second, HandshakeTimeout: 3 * time.Second})
+			`sleep 1.2`+"\n")
+		result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 4 * time.Second, HandshakeTimeout: time.Second})
 		if !strings.Contains(result.Error, "retry suppressed: process cleanup/reap not confirmed") {
 			t.Fatalf("expected cleanup reason, got %q", result.Error)
 		}
@@ -3240,10 +3240,10 @@ func TestCodexExecuteTimesOutWhenTurnStopsAfterToolResult(t *testing.T) {
 		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-stale","turn":{"id":"turn-stale"}}}'`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"item/started","params":{"threadId":"thr-stale","item":{"type":"commandExecution","id":"cmd-1","command":"git status"}}}'`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-stale","item":{"type":"commandExecution","id":"cmd-1","aggregatedOutput":"clean"}}}'`+"\n"+
-		`sleep 5`+"\n")
+		`sleep 0.3`+"\n")
 
 	result := executeFakeCodex(t, fakePath, ExecOptions{
-		Timeout:                   5 * time.Second,
+		Timeout:                   time.Second,
 		SemanticInactivityTimeout: 100 * time.Millisecond,
 	})
 	if result.Status != "timeout" {
@@ -4071,7 +4071,7 @@ func TestCodexExecuteTimeoutWinsOverProcessExitDuringActiveTurn(t *testing.T) {
 		`read line`+"\n")
 
 	result := executeFakeCodex(t, fakePath, ExecOptions{
-		Timeout:                   5 * time.Second,
+		Timeout:                   time.Second,
 		SemanticInactivityTimeout: 30 * time.Second,
 	})
 	if result.Status != "timeout" {
@@ -4101,11 +4101,12 @@ func TestCodexExecuteFirstTurnRetryErrorDoesNotSatisfyProgress(t *testing.T) {
 		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-retry","turn":{"id":"turn-retry"}}}'`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"error","params":{"threadId":"thr-retry","error":{"message":"temporary reconnect"},"willRetry":true}}'`+"\n"+
-		`sleep 5`+"\n")
+		`sleep 0.7`+"\n")
 
 	result := executeFakeCodex(t, fakePath, ExecOptions{
-		Timeout:                   5 * time.Second,
-		SemanticInactivityTimeout: 200 * time.Millisecond,
+		Timeout:                    5 * time.Second,
+		SemanticInactivityTimeout:  2 * time.Second,
+		FirstTurnNoProgressTimeout: 500 * time.Millisecond,
 	})
 	if result.Status != "timeout" {
 		t.Fatalf("expected timeout, got status=%q error=%q", result.Status, result.Error)

--- a/server/pkg/agent/dim_test.go
+++ b/server/pkg/agent/dim_test.go
@@ -102,7 +102,7 @@ while IFS= read -r line; do
         # notification after a short delay — exercises the notification
         # quiescence drain (the late text must survive into Result.Output).
         printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":10,"outputTokens":20}}}\n' "$id"
-        sleep 0.1
+        sleep 0.05
         printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"%s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"late-answer"}}}}\n' "$DIM_SESSION_ID"
       else
         printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":10,"outputTokens":20}}}\n' "$id"

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -839,7 +839,9 @@ func waitForHermesNotificationQuiescence(ctx context.Context, activity <-chan st
 // before concluding an ACP agent has stopped emitting notifications. It is a
 // protocol-level heuristic rather than a per-backend trait, so backends that
 // have no reason to differ share it; the hard bound stays per-backend.
-const acpNotificationQuietTime = 250 * time.Millisecond
+// Package tests shorten it globally while keeping their late-output fixtures
+// inside the window; production never reassigns it.
+var acpNotificationQuietTime = 250 * time.Millisecond
 
 // waitForACPNotificationQuiescence gives the shared ACP stdout reader a
 // bounded chance to consume notifications a backend may emit just after its

--- a/server/pkg/agent/launch.go
+++ b/server/pkg/agent/launch.go
@@ -180,7 +180,9 @@ func runOwned(cmd *exec.Cmd, logger *slog.Logger) error {
 // descendants left open. It matches the bound detectCLIVersion already sets by
 // hand. The timer only starts once the child has exited or the context is
 // done, so a healthy probe never pays it.
-const probeWaitDelay = 2 * time.Second
+// Package tests shorten it while preserving the delayed-descendant ordering;
+// production never reassigns it.
+var probeWaitDelay = 2 * time.Second
 
 // outputOwned is cmd.Output() over an owned process tree. It matches the
 // stdlib's contract — stdout returned, a failed run's stderr attached to the

--- a/server/pkg/agent/qwenpaw_test.go
+++ b/server/pkg/agent/qwenpaw_test.go
@@ -268,7 +268,7 @@ func TestQwenpawUsesSessionLoad(t *testing.T) {
 // TestQwenpawTimeout tests that a context timeout during session/new
 // is reported as status=timeout. The fake script responds to
 // initialize immediately, then sleeps 30s on session/new so the
-// 5s context deadline expires during the session/new RPC.
+// 1s context deadline expires during the session/new RPC.
 func TestQwenpawTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -300,9 +300,9 @@ done`
 		t.Fatalf("New(qwenpaw) error: %v", err)
 	}
 
-	// Use a generous timeout so initialize always completes;
-	// the 30s sleep on session/new will trigger the timeout.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Initialization is immediate; the 30s sleep on session/new crosses this
+	// bounded test deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	session, err := b.Execute(ctx, "test prompt", ExecOptions{

--- a/server/pkg/agent/run_collect.go
+++ b/server/pkg/agent/run_collect.go
@@ -37,7 +37,9 @@ const (
 // collectDrainGrace expired waiting for one. What this cap cuts short is a
 // descendant that inherited the pipe and holds it open, whose trailing output is
 // not the answer. EOF short-circuits the wait, so the normal case pays nothing.
-const collectSettleGrace = 400 * time.Millisecond
+// Package tests shorten it together with their process fixtures; production
+// never reassigns it.
+var collectSettleGrace = 400 * time.Millisecond
 
 // collectDrainGrace bounds the wait for pipe EOF *after* the direct child has
 // exited, before the tree is reaped.
@@ -60,7 +62,9 @@ const collectSettleGrace = 400 * time.Millisecond
 // buffer there is nothing left to wait for, so the normal case — a CLI that
 // prints its answer and exits, with or without a lingering helper — pays
 // nothing.
-const collectDrainGrace = 2 * time.Second
+// Package tests shorten it together with their delayed-output fixtures;
+// production never reassigns it.
+var collectDrainGrace = 2 * time.Second
 
 // collectStdoutLimit caps the answer this package will accumulate, and
 // collectStderrTail caps the diagnostic sample kept from stderr.

--- a/server/pkg/agent/run_collect_lifecycle_test.go
+++ b/server/pkg/agent/run_collect_lifecycle_test.go
@@ -52,7 +52,7 @@ func writeWrapperExitingBeforeChild(t *testing.T, delay, answer string) string {
 // this function, and a caller cannot tell that answer from a CLI that legitimately
 // prints nothing.
 func TestDetectCLIVersionWaitsForAWrapperDescendant(t *testing.T) {
-	bin := writeWrapperExitingBeforeChild(t, "0.5", "fake-cli 1.2.3")
+	bin := writeWrapperExitingBeforeChild(t, "0.2", "fake-cli 1.2.3")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -133,7 +133,7 @@ func TestDetectCLIVersionDoesNotSalvageABannerAsTheVersion(t *testing.T) {
 // With a rule that is not yet satisfied at leader exit, it has to keep waiting —
 // bounded by collectDrainGrace — or it kills the process that owes the answer.
 func TestRunCollectQuietWaitsForAWrapperDescendant(t *testing.T) {
-	bin := writeWrapperExitingBeforeChild(t, "0.5", `{"ok":true}`)
+	bin := writeWrapperExitingBeforeChild(t, "0.2", `{"ok":true}`)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/server/pkg/agent/run_collect_quiet_test.go
+++ b/server/pkg/agent/run_collect_quiet_test.go
@@ -165,10 +165,10 @@ func TestRunCollectQuietWaitsForTheAnswerAfterAPrompt(t *testing.T) {
 // TestRunCollectQuietReportsLateNonZeroExit is the third regression the review
 // asked for. A CLI that prints a complete answer and then fails must be reported
 // as the failure it is, as long as it fails within the idle grace — which is
-// exactly what the grace is for. The stub exits at 150ms against a 400ms grace.
+// exactly what the grace is for. The stub exits at 50ms before the test grace.
 func TestRunCollectQuietReportsLateNonZeroExit(t *testing.T) {
 	cli := writeCLI(t, "#!/bin/sh\nprintf '%s\\n' '"+quietTestJSON+"'\n"+
-		"echo 'openclaw doctor found a problem' >&2\nsleep 0.15\nexit 5\n")
+		"echo 'openclaw doctor found a problem' >&2\nsleep 0.05\nexit 5\n")
 
 	out, stderr, quiet, err := RunCollectQuiet(context.Background(), nil, 0, JSONOutputComplete, cli)
 	if err == nil {

--- a/server/pkg/agent/run_collect_test.go
+++ b/server/pkg/agent/run_collect_test.go
@@ -350,15 +350,14 @@ func TestRunCollectLeavesNoGoroutines(t *testing.T) {
 	cli := writeForkingCLI(t, pidFile)
 
 	// Warm up so lazily-created runtime goroutines exist before the baseline.
-	if _, _, _, err := RunCollectQuiet(context.Background(), nil, 0, nil, cli); err != nil {
+	warmupCLI := writeCLI(t, "#!/bin/sh\nprintf '{}\\n'\n")
+	if _, _, _, err := RunCollectQuiet(context.Background(), nil, 0, nil, warmupCLI); err != nil {
 		t.Fatalf("warmup: %v", err)
 	}
 	before := runtime.NumGoroutine()
 
-	for i := 0; i < 2; i++ {
-		if _, _, _, err := RunCollectQuiet(context.Background(), nil, 0, nil, cli); err != nil {
-			t.Fatalf("run %d: %v", i, err)
-		}
+	if _, _, _, err := RunCollectQuiet(context.Background(), nil, 0, nil, cli); err != nil {
+		t.Fatalf("run: %v", err)
 	}
 	assertNoGoroutineGrowth(t, before)
 }

--- a/server/pkg/agent/zeroclaw_test.go
+++ b/server/pkg/agent/zeroclaw_test.go
@@ -725,7 +725,7 @@ func TestZeroclawSessionNewMissingAliasErrorIsActionable(t *testing.T) {
 
 // TestZeroclawTimeout tests that a context timeout during session/new is
 // reported as status=timeout. The fake script responds to initialize
-// immediately, then sleeps 30s on session/new so the 5s context deadline
+// immediately, then sleeps 30s on session/new so the 1s context deadline
 // expires during the session/new RPC.
 func TestZeroclawTimeout(t *testing.T) {
 	t.Parallel()
@@ -758,7 +758,7 @@ done`
 		t.Fatalf("New(zeroclaw) error: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	session, err := b.Execute(ctx, "test prompt", ExecOptions{


### PR DESCRIPTION
## Summary

- replace fixed sleeps in analytics, migration, daemon, and handler tests with observable request, lock, or lifecycle transitions
- shorten intentional timeout paths through test-only seams while retaining every production default and failure classification
- run isolated local-worktree and OpenClaw process fixtures in parallel, while keeping tests that mutate process-wide state serial
- keep the service package's database coverage unchanged after auditing it (no individual slow wait was safe to remove)

## Local timing

| Package | Before | After |
| --- | ---: | ---: |
| `cmd/migrate` | 11.33s | 3.46s |
| `internal/analytics` | 10.57s | 0.55s |
| `internal/daemon` | 43.23s | 21.95s |
| `internal/daemon/execenv` | 34.72s | 14.74s |
| `internal/handler` | 45.89s | 36.69s |
| `internal/integrations/wecom` | 32.60s | 9.71s |
| `internal/service` | 9.48s | unchanged |
| `pkg/agent` (`-p 2 -parallel 2`) | 249.25s | 205.03s |

## Validation

- `go vet ./cmd/migrate ./internal/analytics ./internal/daemon ./internal/daemon/execenv ./internal/handler ./internal/integrations/wecom ./internal/service ./pkg/agent`
- `go test -count=2 ./cmd/migrate ./internal/analytics ./internal/daemon/execenv ./internal/integrations/wecom ./internal/service`
- `go test -count=1 ./internal/daemon`
- `go test -count=1 -p 2 -parallel 2 ./pkg/agent`
- changed handler tests pass three consecutive runs; the rest of the package passes with `TestReportTaskMessagesFallsBackWholeBatchForClockSkew` skipped

The full handler run still fails that pre-existing clock-boundary assertion on this host because the database clock precedes the application clock by about 0.36ms. It is unrelated to these changes.

Closes MUL-7271.
