### PR TITLE
MUL-7275: fix(skills): normalize Windows archive entry paths

### DIFF
--- a/server/internal/handler/skill_import_archive.go
+++ b/server/internal/handler/skill_import_archive.go
@@ -105,6 +105,7 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 	// primary content — keeping every accepted entry zip-slip-safe.
 	var skillMd *zip.File
 	rootPrefix := ""
+	skillMdEntries := make(map[string]string)
 	for _, f := range zr.File {
 		if f.FileInfo().IsDir() {
 			continue
@@ -113,9 +114,13 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 		if !strings.EqualFold(path.Base(clean), skillpkg.ContentFilename) {
 			continue
 		}
-		if !validateFilePath(clean) {
+		if !validateArchiveFilePath(clean) {
 			continue
 		}
+		if previous, exists := skillMdEntries[clean]; exists {
+			return nil, fmt.Errorf("archive entries %q and %q resolve to the same path %q", previous, f.Name, clean)
+		}
+		skillMdEntries[clean] = f.Name
 		prefix := archiveEntryPrefix(clean)
 		if skillMd == nil || len(prefix) < len(rootPrefix) {
 			skillMd = f
@@ -145,6 +150,7 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 		content:     content,
 	}
 
+	seenFiles := make(map[string]string)
 	for _, f := range zr.File {
 		if f.FileInfo().IsDir() {
 			continue
@@ -168,9 +174,13 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 			continue
 		}
 		// zip-slip / absolute-path guard.
-		if !validateFilePath(rel) {
+		if !validateArchiveFilePath(rel) {
 			continue
 		}
+		if previous, exists := seenFiles[rel]; exists {
+			return nil, fmt.Errorf("archive entries %q and %q resolve to the same path %q", previous, f.Name, rel)
+		}
+		seenFiles[rel] = f.Name
 		fileContent, ferr := readZipFile(f, maxImportFileSize)
 		if ferr != nil {
 			// An oversize or unreadable individual asset is skipped rather than
@@ -196,6 +206,24 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 // absolute and traversal entries cannot bypass the zip-slip guards.
 func cleanArchiveEntryName(name string) string {
 	return path.Clean(strings.ReplaceAll(name, "\\", "/"))
+}
+
+// validateArchiveFilePath extends the existing import validation with portable
+// archive constraints. Windows drive syntax is not recognized by filepath.IsAbs
+// on a Unix server, and NUL bytes would be removed before persistence. Neither
+// can safely be passed to the daemon as a bundle path.
+func validateArchiveFilePath(p string) bool {
+	if strings.ContainsRune(p, '\x00') {
+		return false
+	}
+	if len(p) >= 2 && isASCIIAlpha(p[0]) && p[1] == ':' {
+		return false
+	}
+	return validateFilePath(p)
+}
+
+func isASCIIAlpha(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
 }
 
 // archiveEntryPrefix returns the directory prefix (with trailing slash) of a

--- a/server/internal/handler/skill_import_archive.go
+++ b/server/internal/handler/skill_import_archive.go
@@ -107,7 +107,8 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 	rootPrefix := ""
 	skillMdEntries := make(map[string]string)
 	for _, f := range zr.File {
-		if f.FileInfo().IsDir() {
+		// Compress-Archive directory markers may have no directory attributes.
+		if f.FileInfo().IsDir() || strings.HasSuffix(f.Name, `\`) {
 			continue
 		}
 		clean := cleanArchiveEntryName(f.Name)
@@ -152,7 +153,8 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 
 	seenFiles := make(map[string]string)
 	for _, f := range zr.File {
-		if f.FileInfo().IsDir() {
+		// Compress-Archive directory markers may have no directory attributes.
+		if f.FileInfo().IsDir() || strings.HasSuffix(f.Name, `\`) {
 			continue
 		}
 		clean := cleanArchiveEntryName(f.Name)

--- a/server/internal/handler/skill_import_archive.go
+++ b/server/internal/handler/skill_import_archive.go
@@ -109,7 +109,7 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 		if f.FileInfo().IsDir() {
 			continue
 		}
-		clean := path.Clean(f.Name)
+		clean := cleanArchiveEntryName(f.Name)
 		if !strings.EqualFold(path.Base(clean), skillpkg.ContentFilename) {
 			continue
 		}
@@ -149,7 +149,7 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 		if f.FileInfo().IsDir() {
 			continue
 		}
-		clean := path.Clean(f.Name)
+		clean := cleanArchiveEntryName(f.Name)
 		// Only files under the resolved skill root belong to this skill.
 		if rootPrefix != "" && !strings.HasPrefix(clean, rootPrefix) {
 			continue
@@ -188,6 +188,14 @@ func parseSkillArchive(data []byte, filename string) (*importedSkill, error) {
 		return imported.files[i].path < imported.files[j].path
 	})
 	return imported, nil
+}
+
+// cleanArchiveEntryName canonicalizes the non-standard backslash separators
+// emitted by Windows PowerShell's Compress-Archive before applying ZIP path
+// semantics. Validation still runs on the cleaned result, so backslash-based
+// absolute and traversal entries cannot bypass the zip-slip guards.
+func cleanArchiveEntryName(name string) string {
+	return path.Clean(strings.ReplaceAll(name, "\\", "/"))
 }
 
 // archiveEntryPrefix returns the directory prefix (with trailing slash) of a

--- a/server/internal/handler/skill_import_archive_directory_markers_test.go
+++ b/server/internal/handler/skill_import_archive_directory_markers_test.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+)
+
+func TestParseSkillArchive_SkipsWindowsDirectoryMarkers(t *testing.T) {
+	for _, prefix := range []string{"", `review-helper\`} {
+		t.Run(prefix, func(t *testing.T) {
+			var buf bytes.Buffer
+			zw := zip.NewWriter(&buf)
+			for name, content := range map[string]string{
+				prefix + "SKILL.md":                   "---\nname: review-helper\n---\n# Review",
+				prefix + `references\`:                "",
+				prefix + `references\guides\setup.md`: "setup guide",
+				prefix + `assets\`:                    "",
+				`SKILL.md\`:                           "",
+			} {
+				w, err := zw.Create(name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := w.Write([]byte(content)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := zw.Close(); err != nil {
+				t.Fatal(err)
+			}
+			zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, f := range zr.File {
+				if f.FileInfo().IsDir() {
+					t.Fatalf("fixture unexpectedly has directory attributes: %q", f.Name)
+				}
+			}
+			imported, err := parseSkillArchive(buf.Bytes(), "review-helper.zip")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if imported.content != "---\nname: review-helper\n---\n# Review" {
+				t.Fatalf("wrong primary content: %q", imported.content)
+			}
+			if len(imported.files) != 1 || imported.files[0].path != "references/guides/setup.md" || imported.files[0].content != "setup guide" {
+				t.Fatalf("expected only the nested supporting file, got %#v", imported.files)
+			}
+		})
+	}
+}

--- a/server/internal/handler/skill_import_archive_test.go
+++ b/server/internal/handler/skill_import_archive_test.go
@@ -181,6 +181,11 @@ func TestParseSkillArchive_RejectsUnsafeSkillMdPath(t *testing.T) {
 		"/abs/SKILL.md",
 		`..\escape\SKILL.md`,
 		`\abs\SKILL.md`,
+		`C:\abs\SKILL.md`,
+		`C:relative\SKILL.md`,
+		`.\C:\abs\SKILL.md`,
+		`\\server\share\SKILL.md`,
+		"unsafe\x00/SKILL.md",
 	} {
 		data := buildTestZip(t, map[string]string{name: testSkillMd})
 		if _, err := parseSkillArchive(data, "x.skill"); err == nil {
@@ -211,17 +216,58 @@ func TestParseSkillArchive_DropsTraversalAndJunk(t *testing.T) {
 
 func TestParseSkillArchive_DropsUnsafeWindowsSupportingPaths(t *testing.T) {
 	data := buildTestZip(t, map[string]string{
-		"SKILL.md":       testSkillMd,
-		`..\escape.txt`:  "outside",
-		`\absolute.txt`:  "absolute",
-		`safe\nested.md`: "keep",
+		"SKILL.md":             testSkillMd,
+		`..\escape.txt`:        "outside",
+		`\absolute.txt`:        "absolute",
+		`C:\absolute.txt`:      "drive absolute",
+		`C:drive-relative.txt`: "drive relative",
+		`\\server\share.txt`:   "unc",
+		"unsafe\x00/file.txt":  "nul",
+		`safe\nested/file.md`:  "keep",
 	})
 	imported, err := parseSkillArchive(data, "s.skill")
 	if err != nil {
 		t.Fatalf("parseSkillArchive: %v", err)
 	}
-	if got := filePaths(imported); len(got) != 1 || got[0] != "safe/nested.md" {
-		t.Fatalf("files = %v, want only [safe/nested.md]", got)
+	if got := filePaths(imported); len(got) != 1 || got[0] != "safe/nested/file.md" {
+		t.Fatalf("files = %v, want only [safe/nested/file.md]", got)
+	}
+}
+
+func TestParseSkillArchive_DropsDrivePathAfterWrapperRemoval(t *testing.T) {
+	data := buildTestZip(t, map[string]string{
+		`s\SKILL.md`:        testSkillMd,
+		`s\C:\absolute.txt`: "drive absolute",
+		`s\C:relative.txt`:  "drive relative",
+		`s\safe.txt`:        "keep",
+	})
+	imported, err := parseSkillArchive(data, "s.skill")
+	if err != nil {
+		t.Fatalf("parseSkillArchive: %v", err)
+	}
+	if got := filePaths(imported); len(got) != 1 || got[0] != "safe.txt" {
+		t.Fatalf("files = %v, want only [safe.txt]", got)
+	}
+}
+
+func TestParseSkillArchive_RejectsCanonicalSkillMdCollision(t *testing.T) {
+	data := buildTestZip(t, map[string]string{
+		"SKILL.md":   testSkillMd,
+		`.\SKILL.md`: testSkillMd,
+	})
+	if _, err := parseSkillArchive(data, "s.skill"); err == nil || !strings.Contains(err.Error(), "same path") {
+		t.Fatalf("error = %v, want canonical path collision", err)
+	}
+}
+
+func TestParseSkillArchive_RejectsCanonicalSupportingFileCollision(t *testing.T) {
+	data := buildTestZip(t, map[string]string{
+		"SKILL.md":           testSkillMd,
+		`agents\openai.yaml`: "windows",
+		"agents/openai.yaml": "slash",
+	})
+	if _, err := parseSkillArchive(data, "s.skill"); err == nil || !strings.Contains(err.Error(), "same path") {
+		t.Fatalf("error = %v, want canonical path collision", err)
 	}
 }
 

--- a/server/internal/handler/skill_import_archive_test.go
+++ b/server/internal/handler/skill_import_archive_test.go
@@ -119,6 +119,45 @@ func TestParseSkillArchive_RootLayout(t *testing.T) {
 	}
 }
 
+func TestParseSkillArchive_NormalizesWindowsEntrySeparators(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		entries  map[string]string
+		wantPath string
+	}{
+		{
+			name: "root layout",
+			entries: map[string]string{
+				"SKILL.md":           testSkillMd,
+				`agents\openai.yaml`: "model: openai",
+			},
+			wantPath: "agents/openai.yaml",
+		},
+		{
+			name: "wrapper layout",
+			entries: map[string]string{
+				`review-helper\SKILL.md`:           testSkillMd,
+				`review-helper\agents\openai.yaml`: "model: openai",
+			},
+			wantPath: "agents/openai.yaml",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data := buildTestZip(t, tc.entries)
+			imported, err := parseSkillArchive(data, "review-helper.zip")
+			if err != nil {
+				t.Fatalf("parseSkillArchive: %v", err)
+			}
+			if got := filePaths(imported); len(got) != 1 || got[0] != tc.wantPath {
+				t.Fatalf("files = %v, want [%s]", got, tc.wantPath)
+			}
+			if strings.Contains(imported.files[0].path, `\`) {
+				t.Fatalf("stored path %q still contains a backslash", imported.files[0].path)
+			}
+		})
+	}
+}
+
 func TestParseSkillArchive_NoSkillMd(t *testing.T) {
 	data := buildTestZip(t, map[string]string{
 		"my-skill/notes.md": "hello",
@@ -137,7 +176,12 @@ func TestParseSkillArchive_InvalidZip(t *testing.T) {
 func TestParseSkillArchive_RejectsUnsafeSkillMdPath(t *testing.T) {
 	// A SKILL.md whose only candidate path is absolute or traversal must not be
 	// accepted as the primary content; the archive is treated as having none.
-	for _, name := range []string{"../escape/SKILL.md", "/abs/SKILL.md"} {
+	for _, name := range []string{
+		"../escape/SKILL.md",
+		"/abs/SKILL.md",
+		`..\escape\SKILL.md`,
+		`\abs\SKILL.md`,
+	} {
 		data := buildTestZip(t, map[string]string{name: testSkillMd})
 		if _, err := parseSkillArchive(data, "x.skill"); err == nil {
 			t.Errorf("expected rejection for unsafe SKILL.md path %q", name)
@@ -162,6 +206,22 @@ func TestParseSkillArchive_DropsTraversalAndJunk(t *testing.T) {
 	got := filePaths(imported)
 	if len(got) != 1 || got[0] != "keep.md" {
 		t.Fatalf("files = %v, want only [keep.md]", got)
+	}
+}
+
+func TestParseSkillArchive_DropsUnsafeWindowsSupportingPaths(t *testing.T) {
+	data := buildTestZip(t, map[string]string{
+		"SKILL.md":       testSkillMd,
+		`..\escape.txt`:  "outside",
+		`\absolute.txt`:  "absolute",
+		`safe\nested.md`: "keep",
+	})
+	imported, err := parseSkillArchive(data, "s.skill")
+	if err != nil {
+		t.Fatalf("parseSkillArchive: %v", err)
+	}
+	if got := filePaths(imported); len(got) != 1 || got[0] != "safe/nested.md" {
+		t.Fatalf("files = %v, want only [safe/nested.md]", got)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Windows PowerShell 5.1 can produce ZIP entries with backslash separators even though the ZIP format specifies forward slashes. The archive importer previously passed those raw names to `path.Clean`, which treats backslashes as ordinary characters on the server. Root-layout archives therefore persisted daemon-invalid supporting-file paths, while wrapper-layout archives could fail to find their existing `SKILL.md`.

Both passes through `parseSkillArchive` now translate archive-entry backslashes to `/` before applying `path.Clean`. The existing validation remains after cleaning, so traversal and absolute paths encoded with either separator are still rejected; the daemon's strict bundle validator is unchanged.

## Related Issue

Fixes #8292

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Normalize non-standard Windows separators before cleaning ZIP entry names in both archive parsing loops.
- Add regressions for root and wrapper archive layouts with backslash entry names.
- Add regressions proving backslash-encoded traversal and absolute paths remain excluded.
- Skip trailing-backslash directory markers, including entries without directory attributes produced by PowerShell `Compress-Archive`, in both parsing passes.
- Reject the entire import when entries resolve to the same path. This replaces nondeterministic duplicate-file selection with a clear error.
- Drop drive-prefixed and NUL-containing paths before persistence so imported paths remain compatible with the daemon.

## How to Test

1. All `TestParseSkillArchive` tests — passed, including root/wrapper Windows directory markers without directory attributes, nested supporting files, path collisions and unsafe paths. The pure parser suite used a Go overlay to bypass the package’s database-only `TestMain`; archives were synthesized locally with `zip.Writer.Create`, not generated on a Windows machine.
2. `go vet ./internal/handler` — passed.
3. `go build ./internal/handler` — passed.
4. `gofmt` and `git diff --check` — passed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable; backend-only)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented interface changed)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
I used Codex to trace both archive parsing passes and the daemon/import path contract, compare the archive-upload scope with the related runtime-local and direct-authoring fixes, implement normalization at the archive trust boundary, and add focused regression coverage for Windows layouts and path-safety cases.

## Screenshots (optional)

Not applicable; backend-only change.