### PR TITLE
MUL-7280: ci(backend): cache race builds per commit and shard pkg/agent onto its own runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
               - 'docker-compose.selfhost.yml'
               - 'docker-compose.selfhost.build.yml'
               - 'Makefile'
-            # Everything the backend jobs (backend-tests,
+            # Everything the backend jobs (backend-tests, backend-agent-tests,
             # go-vulnerability-scan, windows-execenv) read, which is NOT the
             # same thing as server/**: four Go tests reach out of the module
             # to pin a contract against a file the other side owns, across
@@ -495,6 +495,32 @@ jobs:
             exit 1
           fi
 
+  # The Go caches are handled explicitly here rather than through setup-go's
+  # `cache: true`. setup-go keys its entry on go.sum alone and shares that key
+  # with every Linux job in this workflow, so whichever job finished first,
+  # go-vulnerability-scan in under a minute, saved a ~95 MB entry holding
+  # little beyond module downloads; this job then "hit" that key on every run
+  # and never saved its own. The result was a from-scratch race-instrumented
+  # compile of the whole module on every backend run, measured at roughly
+  # half of the job's ~8 minutes (MUL-7280).
+  #
+  # Two entries now. The module cache is keyed by go.sum: immutable, saved on
+  # a miss, never grows. The build cache is keyed by commit SHA with a prefix
+  # fallback, so each run starts from the newest entry and recompiles only
+  # what its change touched. Only pushes to main publish a build-cache entry;
+  # PR runs restore and leave, which keeps storage churn at one entry per
+  # merge, the same shape as the turbo caches above. The key carries the
+  # resolved Go version because `check-latest` floats across patch releases.
+  #
+  # Every compile below runs in race mode so build, vet and test share one set
+  # of objects. A plain `go build` fed nothing to the -race test binaries and
+  # was pure duplicate work; nothing in server/ carries a `race` build tag, so
+  # both modes accept exactly the same code.
+  #
+  # `GOFLAGS=-count=1` because a rolling cache would otherwise let `go test`
+  # replay cached results. Migrations are read from disk at run time rather
+  # than embedded, so a schema change is invisible to a test binary's hash and
+  # a cached "ok" from an untouched package could mask a real failure.
   backend-tests:
     needs: changes
     runs-on: ubuntu-latest
@@ -534,12 +560,14 @@ jobs:
       # realtime relay + request stores); the tests talk to this Redis
       # directly so they run alongside the Postgres-backed suite.
       REDIS_TEST_URL: redis://localhost:6379/1
+      GOFLAGS: -count=1
     steps:
       - name: Checkout
         if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/checkout@v6
 
       - name: Setup Go
+        id: go
         if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/setup-go@v5
         with:
@@ -547,7 +575,23 @@ jobs:
           # CI follows the newest 1.26 patch available to setup-go.
           go-version: "1.26.x"
           check-latest: true
-          cache-dependency-path: server/go.sum
+          cache: false
+
+      - name: Restore Go module cache
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        uses: actions/cache@v6
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('server/go.sum') }}
+
+      - name: Restore Go build cache
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/go-build
+          key: go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-${{ github.sha }}
+          restore-keys: |
+            go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-
 
       - name: Setup Helm
         if: ${{ needs.changes.outputs.backend == 'true' }}
@@ -567,7 +611,7 @@ jobs:
 
       - name: Build
         if: ${{ needs.changes.outputs.backend == 'true' }}
-        run: cd server && go build ./...
+        run: cd server && go build -race ./...
 
       # The `agentintegration` files execute real agent CLIs, so no CI job runs
       # them. Nothing compiled them either, which let them rot silently: a
@@ -577,7 +621,7 @@ jobs:
       # cheapest gate that keeps them honest without needing an agent CLI.
       - name: Vet tag-gated agent integration tests
         if: ${{ needs.changes.outputs.backend == 'true' }}
-        run: cd server && go vet -tags agentintegration ./...
+        run: cd server && go vet -race -tags agentintegration ./...
 
       - name: Run migrations
         if: ${{ needs.changes.outputs.backend == 'true' }}
@@ -589,7 +633,68 @@ jobs:
 
       - name: Test
         if: ${{ needs.changes.outputs.backend == 'true' }}
-        run: bash scripts/test-go.sh --race
+        # pkg/agent runs on its own runner: backend-agent-tests below.
+        run: bash scripts/test-go.sh --race --only regular
+
+      # Publishes from main only; see the job comment. `!cancelled()` so a red
+      # main still refreshes the objects for the next run, and the Setup Go
+      # outcome so a run that never reached Go does not save an empty entry
+      # under a half-formed key.
+      - name: Save Go build cache
+        if: ${{ !cancelled() && github.event_name == 'push' && steps.go.outcome == 'success' }}
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/go-build
+          key: go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-${{ github.sha }}
+
+  # pkg/agent used to run as the tail of backend-tests: ~2m20s for a single
+  # package, throttled to -parallel 2 because its subprocess-backed tests carry
+  # hard deadlines and starve when a race build competes for the runner (see
+  # scripts/test-go.sh). Those tests are timer-bound rather than CPU-bound, so
+  # the throttle stays and the package simply gets its own runner; it reads no
+  # database, so no service containers either. Same trade as the frontend
+  # split: more runner-minutes, less wall clock. The build cache is restored
+  # but never saved here: backend-tests owns publishing, and this job's only
+  # unique output is the pkg/agent test binary, which is cheap to relink.
+  backend-agent-tests:
+    needs: changes
+    runs-on: ubuntu-latest
+    env:
+      # Same policy as backend-tests: CI always executes the tests it reports.
+      GOFLAGS: -count=1
+    steps:
+      - name: Checkout
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        id: go
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+          check-latest: true
+          cache: false
+
+      - name: Restore Go module cache
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        uses: actions/cache@v6
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('server/go.sum') }}
+
+      - name: Restore Go build cache
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/go-build
+          key: go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-${{ github.sha }}
+          restore-keys: |
+            go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-
+
+      - name: Test agent package
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        run: bash scripts/test-go.sh --race --only agent
 
   # Keep the live vulnerability database from hiding build and test results.
   # The aggregate backend job below still treats both jobs as one merge gate.
@@ -619,20 +724,22 @@ jobs:
   # Preserve the existing required-check name while allowing tests, generated
   # SQL verification, and the vulnerability scan to run independently.
   backend:
-    needs: [backend-tests, sqlc-check, go-vulnerability-scan]
+    needs: [backend-tests, backend-agent-tests, sqlc-check, go-vulnerability-scan]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check backend job results
         env:
           TEST_RESULT: ${{ needs.backend-tests.result }}
+          AGENT_TEST_RESULT: ${{ needs.backend-agent-tests.result }}
           SQLC_RESULT: ${{ needs.sqlc-check.result }}
           VULNERABILITY_RESULT: ${{ needs.go-vulnerability-scan.result }}
         run: |
-          echo "backend-tests:        $TEST_RESULT"
-          echo "sqlc-check:           $SQLC_RESULT"
+          echo "backend-tests:         $TEST_RESULT"
+          echo "backend-agent-tests:   $AGENT_TEST_RESULT"
+          echo "sqlc-check:            $SQLC_RESULT"
           echo "go-vulnerability-scan: $VULNERABILITY_RESULT"
-          if [ "$TEST_RESULT" != "success" ] || [ "$SQLC_RESULT" != "success" ] || [ "$VULNERABILITY_RESULT" != "success" ]; then
+          if [ "$TEST_RESULT" != "success" ] || [ "$AGENT_TEST_RESULT" != "success" ] || [ "$SQLC_RESULT" != "success" ] || [ "$VULNERABILITY_RESULT" != "success" ]; then
             echo "::error::backend validation failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,7 +510,16 @@ jobs:
   # what its change touched. Only pushes to main publish a build-cache entry;
   # PR runs restore and leave, which keeps storage churn at one entry per
   # merge, the same shape as the turbo caches above. The key carries the
-  # resolved Go version because `check-latest` floats across patch releases.
+  # resolved Go version because `check-latest` floats across patch releases,
+  # and the runner image (ImageOS) because cached cgo and race objects are
+  # linked against that image's glibc: when ubuntu-latest moves to a new
+  # release, an entry built on the old one must not be restored. setup-go
+  # keys on ImageOS for the same reason (actions/setup-go#368).
+  #
+  # This job is the only writer of either entry. backend-agent-tests restores
+  # both, but it downloads just pkg/agent's slice of the module graph and
+  # finishes first, so letting it save would repeat the first-writer-wins
+  # problem above: an immutable go.sum key pinned to a partial module cache.
   #
   # Every compile below runs in race mode so build, vet and test share one set
   # of objects. A plain `go build` fed nothing to the -race test binaries and
@@ -584,14 +593,20 @@ jobs:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('server/go.sum') }}
 
+      # ImageOS is a runner environment variable, not a context value, so a
+      # shell step spells the build-cache key prefix once for restore and save.
+      - name: Resolve Go build cache key
+        id: gocache
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        run: echo "prefix=go-build-race-${{ runner.os }}-${{ runner.arch }}-$ImageOS-${{ steps.go.outputs.go-version }}-" >> "$GITHUB_OUTPUT"
+
       - name: Restore Go build cache
         if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/cache/restore@v6
         with:
           path: ~/.cache/go-build
-          key: go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-${{ github.sha }}
-          restore-keys: |
-            go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-
+          key: ${{ steps.gocache.outputs.prefix }}${{ github.sha }}
+          restore-keys: ${{ steps.gocache.outputs.prefix }}
 
       - name: Setup Helm
         if: ${{ needs.changes.outputs.backend == 'true' }}
@@ -637,15 +652,15 @@ jobs:
         run: bash scripts/test-go.sh --race --only regular
 
       # Publishes from main only; see the job comment. `!cancelled()` so a red
-      # main still refreshes the objects for the next run, and the Setup Go
+      # main still refreshes the objects for the next run, and the key step's
       # outcome so a run that never reached Go does not save an empty entry
       # under a half-formed key.
       - name: Save Go build cache
-        if: ${{ !cancelled() && github.event_name == 'push' && steps.go.outcome == 'success' }}
+        if: ${{ !cancelled() && github.event_name == 'push' && steps.gocache.outcome == 'success' }}
         uses: actions/cache/save@v6
         with:
           path: ~/.cache/go-build
-          key: go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-${{ github.sha }}
+          key: ${{ steps.gocache.outputs.prefix }}${{ github.sha }}
 
   # pkg/agent used to run as the tail of backend-tests: ~2m20s for a single
   # package, throttled to -parallel 2 because its subprocess-backed tests carry
@@ -653,9 +668,10 @@ jobs:
   # scripts/test-go.sh). Those tests are timer-bound rather than CPU-bound, so
   # the throttle stays and the package simply gets its own runner; it reads no
   # database, so no service containers either. Same trade as the frontend
-  # split: more runner-minutes, less wall clock. The build cache is restored
-  # but never saved here: backend-tests owns publishing, and this job's only
-  # unique output is the pkg/agent test binary, which is cheap to relink.
+  # split: more runner-minutes, less wall clock. Both Go caches are restored
+  # but never saved here: backend-tests owns publishing (see its comment), and
+  # this job's only unique output is the pkg/agent test binary, which is cheap
+  # to relink.
   backend-agent-tests:
     needs: changes
     runs-on: ubuntu-latest
@@ -678,19 +694,24 @@ jobs:
 
       - name: Restore Go module cache
         if: ${{ needs.changes.outputs.backend == 'true' }}
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('server/go.sum') }}
+
+      # Must match backend-tests' key step exactly.
+      - name: Resolve Go build cache key
+        id: gocache
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        run: echo "prefix=go-build-race-${{ runner.os }}-${{ runner.arch }}-$ImageOS-${{ steps.go.outputs.go-version }}-" >> "$GITHUB_OUTPUT"
 
       - name: Restore Go build cache
         if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/cache/restore@v6
         with:
           path: ~/.cache/go-build
-          key: go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-${{ github.sha }}
-          restore-keys: |
-            go-build-race-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-
+          key: ${{ steps.gocache.outputs.prefix }}${{ github.sha }}
+          restore-keys: ${{ steps.gocache.outputs.prefix }}
 
       - name: Test agent package
         if: ${{ needs.changes.outputs.backend == 'true' }}

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -6,36 +6,54 @@ REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 GUARD_SCRIPT="$SCRIPT_DIR/go-test-with-agent-cli-guard.sh"
 
 usage() {
-  echo "usage: $0 [--race]" >&2
+  echo "usage: $0 [--race] [--only regular|agent]" >&2
 }
 
+# The suite is two `go test` invocations: every package outside pkg/agent at
+# the default parallelism, then pkg/agent throttled (see below). `--only`
+# selects one half so CI can give each its own runner; the default still runs
+# both for `make test`, check.sh, and the release workflow.
 go_test_args=(test)
-case "$#" in
-  0) ;;
-  1)
-    if [ "$1" != "--race" ]; then
+only=all
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --race)
+      go_test_args+=(-race)
+      shift
+      ;;
+    --only)
+      case "${2:-}" in
+        regular|agent) only=$2 ;;
+        *)
+          usage
+          exit 2
+          ;;
+      esac
+      shift 2
+      ;;
+    *)
       usage
       exit 2
-    fi
-    go_test_args+=(-race)
-    ;;
-  *)
-    usage
-    exit 2
-    ;;
-esac
-
-cd "$REPO_ROOT/server"
-packages=$(go list ./...)
-regular_packages=()
-for package in $packages; do
-  case "$package" in
-    */pkg/agent|*/pkg/agent/*) ;;
-    *) regular_packages+=("$package") ;;
+      ;;
   esac
 done
 
-"$GUARD_SCRIPT" -- go "${go_test_args[@]}" "${regular_packages[@]}"
-# Subprocess-backed agent tests have hard deadlines. Limit both package and
-# within-package parallelism so race builds do not starve their parent loops.
-"$GUARD_SCRIPT" -- go "${go_test_args[@]}" -p 2 -parallel 2 ./pkg/agent/...
+cd "$REPO_ROOT/server"
+
+if [ "$only" != agent ]; then
+  packages=$(go list ./...)
+  regular_packages=()
+  for package in $packages; do
+    case "$package" in
+      */pkg/agent|*/pkg/agent/*) ;;
+      *) regular_packages+=("$package") ;;
+    esac
+  done
+  "$GUARD_SCRIPT" -- go "${go_test_args[@]}" "${regular_packages[@]}"
+fi
+
+if [ "$only" != regular ]; then
+  # Subprocess-backed agent tests have hard deadlines. Limit both package and
+  # within-package parallelism so race builds do not starve their parent loops.
+  "$GUARD_SCRIPT" -- go "${go_test_args[@]}" -p 2 -parallel 2 ./pkg/agent/...
+fi

--- a/scripts/test-go.test.sh
+++ b/scripts/test-go.test.sh
@@ -14,8 +14,9 @@ trap cleanup EXIT
 
 mkdir -p "$BIN_DIR"
 export MULTICA_TEST_GO_CALLS="$CALLS_FILE"
+: >"$CALLS_FILE"
 
-cat >"$BIN_DIR/go" <<'EOF'
+cat >"$BIN_DIR/go" <<'FAKE'
 #!/usr/bin/env bash
 set -eu
 
@@ -39,40 +40,63 @@ case "${1:-}" in
     exit 2
     ;;
 esac
-EOF
+FAKE
 chmod 755 "$BIN_DIR/go"
 
+regular_call='test -race github.com/multica-ai/multica/server github.com/multica-ai/multica/server/internal/daemon'
+agent_call='test -race -p 2 -parallel 2 ./pkg/agent/...'
+
+# $1: case label; $2: expected go calls, one per line. Clears the log after.
+expect_calls() {
+  actual_calls=$(cat "$CALLS_FILE")
+  if [ "$actual_calls" != "$2" ]; then
+    echo "$1: unexpected go test calls:" >&2
+    printf '%s\n' "$actual_calls" >&2
+    exit 1
+  fi
+  : >"$CALLS_FILE"
+}
+
+# $1: case label; the rest are arguments for test-go.sh. Asserts the usage
+# exit status, the usage line, and that go was never invoked.
+expect_usage_failure() {
+  label=$1
+  shift
+  set +e
+  PATH="$BIN_DIR:$PATH" bash "$SCRIPT_DIR/test-go.sh" "$@" >"$OUTPUT_FILE" 2>&1
+  status=$?
+  set -e
+
+  if [ "$status" -ne 2 ]; then
+    echo "$label returned status $status, want 2" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+  fi
+  if [ -s "$CALLS_FILE" ]; then
+    echo "$label invoked go:" >&2
+    cat "$CALLS_FILE" >&2
+    exit 1
+  fi
+  if ! grep -q '^usage: .*test-go.sh \[--race\] \[--only regular|agent\]$' "$OUTPUT_FILE"; then
+    echo "$label did not print usage" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+  fi
+}
+
 PATH="$BIN_DIR:$PATH" bash "$SCRIPT_DIR/test-go.sh" --race
+expect_calls "--race" "$regular_call
+$agent_call"
 
-expected_calls='test -race github.com/multica-ai/multica/server github.com/multica-ai/multica/server/internal/daemon
-test -race -p 2 -parallel 2 ./pkg/agent/...'
-actual_calls=$(cat "$CALLS_FILE")
-if [ "$actual_calls" != "$expected_calls" ]; then
-  echo "unexpected go test calls:" >&2
-  printf '%s\n' "$actual_calls" >&2
-  exit 1
-fi
+PATH="$BIN_DIR:$PATH" bash "$SCRIPT_DIR/test-go.sh" --race --only regular
+expect_calls "--only regular" "$regular_call"
 
-: >"$CALLS_FILE"
-set +e
-PATH="$BIN_DIR:$PATH" bash "$SCRIPT_DIR/test-go.sh" --unknown >"$OUTPUT_FILE" 2>&1
-status=$?
-set -e
+# Option order must not matter: CI spells it one way, humans another.
+PATH="$BIN_DIR:$PATH" bash "$SCRIPT_DIR/test-go.sh" --only agent --race
+expect_calls "--only agent" "$agent_call"
 
-if [ "$status" -ne 2 ]; then
-  echo "unknown option returned status $status, want 2" >&2
-  cat "$OUTPUT_FILE" >&2
-  exit 1
-fi
-if [ -s "$CALLS_FILE" ]; then
-  echo "unknown option invoked go:" >&2
-  cat "$CALLS_FILE" >&2
-  exit 1
-fi
-if ! grep -q '^usage: .*test-go.sh \[--race\]$' "$OUTPUT_FILE"; then
-  echo "unknown option did not print usage" >&2
-  cat "$OUTPUT_FILE" >&2
-  exit 1
-fi
+expect_usage_failure "unknown option" --unknown
+expect_usage_failure "unknown --only scope" --only everything
+expect_usage_failure "missing --only scope" --only
 
 echo "test-go.test.sh: PASS"


### PR DESCRIPTION
## Why

`backend-tests` takes ~8 minutes per run. Per-step wall clock on main run 34570367100 (2026-09-11):

| Step | Wall clock |
| --- | --- |
| Initialize containers | 25s |
| Build (`go build ./...`) | 61s |
| Vet (`-tags agentintegration`) | 17s |
| Test: regular packages | 218s |
| Test: `./pkg/agent/...` alone (`-p 2 -parallel 2`) | 139s |

Three root causes:

1. **The Go build cache never warms for this job.** setup-go keys its cache on go.sum alone and shares that key across every Linux job in the workflow. `go-vulnerability-scan` finishes first and saved a 95 MB entry (module downloads, essentially no build objects); `backend-tests` then reports a cache hit on every run and never saves its own. Every run race-compiles the whole module from scratch. Locally, with only the dependencies warm, compile+link of the test binaries alone is 124s on 10 cores; on a 4-vCPU runner that is most of the 218s.
2. **The Build step compiles in the wrong mode.** `go build ./...` produces non-race objects, which `go test -race` cannot reuse, so it was ~60s of duplicate work. Vet reused those non-race objects, which is why it looked cheap.
3. **pkg/agent runs serially after everything else**, alone on the runner at `-parallel 2`. Its tests are timer-bound (deadline/timeout tests; ~26% of one core busy locally), so the 139s tail is mostly waiting.

## What

- `backend-tests`: `cache: false` on setup-go. Module cache keyed by go.sum via `actions/cache`. Build cache keyed by runner image (`ImageOS`), resolved Go version and commit SHA with a prefix fallback via `actions/cache/restore`, published by `actions/cache/save` only on pushes to main, so PR runs restore and leave and storage churn stays at one entry per merge (same shape as the turbo caches). `ImageOS` keeps objects linked against one Ubuntu release's glibc from being restored after `ubuntu-latest` moves to the next, the same reason setup-go keys on it (actions/setup-go#368). `backend-tests` is the only writer of either cache: `backend-agent-tests` restores both read-only, because it downloads just pkg/agent's slice of the module graph and, finishing first, would otherwise pin that slice under the immutable go.sum key. Build and vet run with `-race` so all three compile steps share one set of objects; nothing in `server/` carries a `race` build tag. `GOFLAGS=-count=1` so a rolling cache can never replay a cached test result: migrations are read from disk rather than embedded, so a schema change is invisible to a test binary's hash.
- New `backend-agent-tests` job runs `./pkg/agent/...` on its own runner with no service containers (it reads no database), keeping the `-p 2 -parallel 2` throttle. The `backend` aggregate gate now requires it.
- `scripts/test-go.sh` gains `--only regular|agent`. The default (both halves) is unchanged for `make test`, `scripts/check.sh` and `release.yml`. `scripts/test-go.test.sh` covers the new option, option order, and the usage failures.

## Expected effect (estimates; this PR's own run is the cold-cache case)

- Warm cache, typical PR: backend-tests roughly 35s setup, ~30s build/vet, relink of the packages the PR touched, ~150s of tests, about 4 min total; backend-agent-tests about 3.5 min in parallel. Backend gate around 4 min instead of 8.
- Cold cache (first run after merge, go.sum or Go patch bump): the race-mode Build removes the ~60s duplicate compile and the agent shard removes the 139s tail, roughly 5.5 min.
- `backend-agent-tests` still relinks the pkg/agent test binary each run (it never publishes to the cache); that is ~30s off the critical path.

## Measured but left for follow-ups

- `internal/handler`: 2,100 DB-backed tests, largely serial; 78s on CI.
- `internal/integrations/wecom`: 57s, of which ~20 tests each wait the full `ackTimeout = 5s` in `ws_sender.go`.
- `internal/daemon`: 42s; every `TestLoadConfig_*` waits `loginShellResolveTimeout = 3s` from `config.go`.
- `internal/analytics`: `TestPostHogClient_DropsWhenFull` waits a real 10s.
- `cursor-background-lifecycle (ubuntu-latest)` still compiles pkg/agent cold and could restore the same build cache.

## Verification

- `bash scripts/test-go.test.sh` passes; `shellcheck` reports only the pre-existing `CDPATH= cd` idiom; `actionlint` is clean.
- `go vet -race -tags agentintegration ./...` is accepted by the toolchain and reuses the race objects (4.6s locally after `go build -race`, 26s without).
- `GOFLAGS=-count=1` confirmed inert for `go build`, `go vet`, `go list`, `go run`.
- `actions/cache/restore@v6`, `actions/cache/save@v6` and the `go-version` output of `actions/setup-go@v5` verified against the upstream action manifests.
- The first CI run of this PR showed the module-cache race: `backend-agent-tests` saved a 3 MB partial entry and `backend-tests` could not reserve the key. After the fix, that PR-scoped entry was deleted so the next run exercises `backend-tests` as the sole writer.

