### PR TITLE
feat: preview Claude Code marketplaces safely

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -158,6 +158,7 @@ import type {
   PluginInvocation,
   PluginMCPTool,
   PluginPreview,
+  ClaudeMarketplacePreview,
   PluginTokenIssue,
   PluginPreviewRequest,
   PluginInstallRequest,
@@ -438,6 +439,8 @@ import {
   PluginTokenIssueSchema,
   PluginInstallationSchema,
   PluginPreviewSchema,
+  ClaudeMarketplacePreviewSchema,
+  EMPTY_CLAUDE_MARKETPLACE_PREVIEW,
   WorkspaceMcpServerListSchema,
   WorkspaceMcpServerSchema,
   ShareLinkSchema,
@@ -2772,6 +2775,15 @@ export class ApiClient {
     });
     return parseWithFallback(raw, PluginPreviewSchema, EMPTY_PLUGIN_PREVIEW, {
       endpoint: "POST /api/workspaces/{id}/plugins/preview",
+    });
+  }
+
+  async previewClaudeMarketplace(workspaceId: string, manifest: unknown): Promise<ClaudeMarketplacePreview> {
+    const raw = await this.fetch<unknown>(`/api/workspaces/${workspaceId}/plugins/marketplace/preview`, {
+      method: "POST", body: JSON.stringify({ manifest }),
+    });
+    return parseWithFallback(raw, ClaudeMarketplacePreviewSchema, EMPTY_CLAUDE_MARKETPLACE_PREVIEW, {
+      endpoint: "POST /api/workspaces/{id}/plugins/marketplace/preview",
     });
   }
 

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -72,6 +72,7 @@ import type {
   PluginPackage,
   PluginPackageListResponse,
   PluginPreview,
+  ClaudeMarketplacePreview,
   PluginSurfaceLaunch,
   ResourceLabelsResponse,
   RuntimeModelListRequest,
@@ -792,6 +793,26 @@ const ReactionSchema = z.object({
   emoji: z.string(),
   created_at: z.string(),
 });
+
+export const ClaudeMarketplacePreviewSchema = z.object({
+  name: z.string(),
+  owner: z.object({ name: z.string(), email: z.string().optional() }).loose(),
+  description: z.string().optional(),
+  version: z.string().optional(),
+  plugins: z.array(z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    version: z.string().optional(),
+    source: z.object({
+      kind: z.string(), repository: z.string().optional(), url: z.string().optional(),
+      ref: z.string().optional(), subdir: z.string().optional(), package: z.string().optional(), version: z.string().optional(),
+    }).loose(),
+  }).loose()),
+}).loose();
+
+export const EMPTY_CLAUDE_MARKETPLACE_PREVIEW: ClaudeMarketplacePreview = {
+  name: "", owner: { name: "" }, plugins: [],
+};
 
 // Nested attachments embedded in timeline/comment responses stay lenient on
 // purpose: a single malformed attachment must not knock the whole timeline

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -111,6 +111,9 @@ export type {
   PluginInvocation,
   PluginMCPTool,
   PluginTokenIssue,
+  ClaudeMarketplacePluginSource,
+  ClaudeMarketplacePluginPreview,
+  ClaudeMarketplacePreview,
 } from "./plugin";
 export type { InboxItem, InboxSeverity, InboxItemType, InboxWorkspaceUnread } from "./inbox";
 export type { NotificationGroupKey, NotificationGroupValue, NotificationPreferences, NotificationPreferenceResponse } from "./notification-preference";

--- a/packages/core/types/plugin.ts
+++ b/packages/core/types/plugin.ts
@@ -158,6 +158,31 @@ export interface PluginPackageListResponse {
   packages: PluginPackage[];
 }
 
+export interface ClaudeMarketplacePluginSource {
+  kind: string;
+  repository?: string;
+  url?: string;
+  ref?: string;
+  subdir?: string;
+  package?: string;
+  version?: string;
+}
+
+export interface ClaudeMarketplacePluginPreview {
+  name: string;
+  description?: string;
+  version?: string;
+  source: ClaudeMarketplacePluginSource;
+}
+
+export interface ClaudeMarketplacePreview {
+  name: string;
+  owner: { name: string; email?: string };
+  description?: string;
+  version?: string;
+  plugins: ClaudeMarketplacePluginPreview[];
+}
+
 /** One short-lived, installation-bound launch of a hosted surface. */
 export interface PluginSurfaceLaunch {
   /** Multica's cookie-free content URL, never the plugin author's server. */

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -357,6 +357,7 @@
   },
   "plugins": {
     "title": "Plugins",
+    "marketplace": { "title": "Claude marketplace", "description": "Preview a marketplace.json safely before publishing native Multica plugins.", "placeholder": "{\"name\":\"My catalog\",\"owner\":{\"name\":\"Team\"},\"plugins\":[]}", "preview": "Preview marketplace", "failed": "Preview failed", "discovered": "{{count}} plugin(s) discovered. Sources are shown for review; nothing was installed." },
     "description": "Publish plugins into this workspace, then install a specific version and review exactly what it is allowed to reach.",
     "loading": "Loading Plugins",
     "load_failed": "Plugins couldn't be loaded",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -357,6 +357,7 @@
   },
   "plugins": {
     "title": "Plugins",
+    "marketplace": { "title": "Claude marketplace", "description": "Preview a marketplace.json safely before publishing native Multica plugins.", "placeholder": "{\"name\":\"My catalog\",\"owner\":{\"name\":\"Team\"},\"plugins\":[]}", "preview": "Preview marketplace", "failed": "Preview failed", "discovered": "{{count}} plugin(s) discovered. Sources are shown for review; nothing was installed." },
     "description": "このワークスペースにプラグインを公開し、特定のバージョンをインストールして、何にアクセスできるかを確認します。",
     "loading": "Plugins を読み込み中",
     "load_failed": "Plugins を読み込めませんでした",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -357,6 +357,7 @@
   },
   "plugins": {
     "title": "Plugins",
+    "marketplace": { "title": "Claude marketplace", "description": "Preview a marketplace.json safely before publishing native Multica plugins.", "placeholder": "{\"name\":\"My catalog\",\"owner\":{\"name\":\"Team\"},\"plugins\":[]}", "preview": "Preview marketplace", "failed": "Preview failed", "discovered": "{{count}} plugin(s) discovered. Sources are shown for review; nothing was installed." },
     "description": "이 워크스페이스에 플러그인을 게시하고 특정 버전을 설치하며, 무엇에 접근할 수 있는지 확인합니다.",
     "loading": "Plugins 불러오는 중",
     "load_failed": "Plugins를 불러올 수 없습니다",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -357,6 +357,7 @@
   },
   "plugins": {
     "title": "Plugins",
+    "marketplace": { "title": "Claude marketplace", "description": "Preview a marketplace.json safely before publishing native Multica plugins.", "placeholder": "{\"name\":\"My catalog\",\"owner\":{\"name\":\"Team\"},\"plugins\":[]}", "preview": "Preview marketplace", "failed": "Preview failed", "discovered": "{{count}} plugin(s) discovered. Sources are shown for review; nothing was installed." },
     "description": "在这个工作区里发布插件，然后安装某个具体版本，并逐条确认它能访问什么。",
     "loading": "正在加载 Plugins",
     "load_failed": "无法加载 Plugins",

--- a/packages/views/settings/components/plugins-tab.tsx
+++ b/packages/views/settings/components/plugins-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { AlertCircle, CalendarClock, Loader2, Trash2, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { useCurrentMember } from "@multica/core/permissions";
@@ -481,29 +481,38 @@ function PublishAndInstall({ wsId, canManage }: { wsId: string; canManage: boole
 }
 
 function MarketplaceCatalog({ wsId }: { wsId: string }) {
+  const { t } = useT("settings");
   const [manifestText, setManifestText] = useState("");
-  const preview = useMutation({
-    mutationFn: async () => {
-      let manifest: unknown;
-      try { manifest = JSON.parse(manifestText); } catch { throw new Error("marketplace.json must be valid JSON"); }
-      return api.previewClaudeMarketplace(wsId, manifest);
-    },
-  });
+  const [preview, setPreview] = useState<{
+    status: "idle" | "pending" | "success" | "error";
+    data?: Awaited<ReturnType<typeof api.previewClaudeMarketplace>>;
+    error?: unknown;
+  }>({ status: "idle" });
+  const previewMarketplace = async () => {
+    setPreview({ status: "pending" });
+    try {
+      const manifest = JSON.parse(manifestText) as unknown;
+      const data = await api.previewClaudeMarketplace(wsId, manifest);
+      setPreview({ status: "success", data });
+    } catch (error) {
+      setPreview({ status: "error", error });
+    }
+  };
   return (
-    <SettingsSection title="Claude marketplace" description="Preview a marketplace.json safely before publishing native Multica plugins.">
+    <SettingsSection title={t(($) => $.plugins.marketplace.title)} description={t(($) => $.plugins.marketplace.description)}>
       <SettingsCard>
         <div className="space-y-3 px-4 py-4">
-          <Textarea value={manifestText} onChange={(event) => setManifestText(event.target.value)} placeholder='{"name":"My catalog","owner":{"name":"Team"},"plugins":[]}' rows={6} />
+          <Textarea value={manifestText} onChange={(event) => setManifestText(event.target.value)} placeholder={t(($) => $.plugins.marketplace.placeholder)} rows={6} />
           <div className="flex justify-end">
-            <Button disabled={!manifestText.trim() || preview.isPending} onClick={() => preview.mutate()}>
-              {preview.isPending ? <Loader2 className="animate-spin" /> : null} Preview marketplace
+            <Button disabled={!manifestText.trim() || preview.status === "pending"} onClick={() => void previewMarketplace()}>
+              {preview.status === "pending" ? <Loader2 className="animate-spin" /> : null} {t(($) => $.plugins.marketplace.preview)}
             </Button>
           </div>
-          {preview.error ? <p className="text-caption text-destructive">{preview.error instanceof Error ? preview.error.message : "Preview failed"}</p> : null}
-          {preview.data ? (
+          {preview.status === "error" ? <p className="text-caption text-destructive">{preview.error instanceof Error ? preview.error.message : t(($) => $.plugins.marketplace.failed)}</p> : null}
+          {preview.status === "success" && preview.data ? (
             <div className="space-y-2 border-t border-surface-border pt-3">
               <div className="text-body font-medium">{preview.data.name}</div>
-              <p className="text-caption text-muted-foreground">{preview.data.plugins.length} plugin(s) discovered. Sources are shown for review; nothing was installed.</p>
+              <p className="text-caption text-muted-foreground">{t(($) => $.plugins.marketplace.discovered, { count: preview.data.plugins.length })}</p>
               <ul className="space-y-1 text-caption">{preview.data.plugins.map((plugin) => <li key={plugin.name}><code>{plugin.name}</code> — {plugin.source.kind}{plugin.source.repository ? `:${plugin.source.repository}` : plugin.source.url ? `:${plugin.source.url}` : ""}</li>)}</ul>
             </div>
           ) : null}

--- a/packages/views/settings/components/plugins-tab.tsx
+++ b/packages/views/settings/components/plugins-tab.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { AlertCircle, CalendarClock, Loader2, Trash2, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { useCurrentMember } from "@multica/core/permissions";
+import { api } from "@multica/core/api";
 import {
   pluginInstallationsOptions,
   pluginPackagesOptions,
@@ -373,7 +374,9 @@ function PublishAndInstall({ wsId, canManage }: { wsId: string; canManage: boole
   };
 
   return (
-    <SettingsSection title={t(($) => $.plugins.publish.title)} description={t(($) => $.plugins.publish.description)}>
+    <>
+      <MarketplaceCatalog wsId={wsId} />
+      <SettingsSection title={t(($) => $.plugins.publish.title)} description={t(($) => $.plugins.publish.description)}>
       <SettingsCard>
         <div className="flex flex-col gap-2 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-caption text-muted-foreground">{t(($) => $.plugins.publish.hint)}</p>
@@ -471,6 +474,40 @@ function PublishAndInstall({ wsId, canManage }: { wsId: string; canManage: boole
             </div>
           </div>
         ) : null}
+      </SettingsCard>
+      </SettingsSection>
+    </>
+  );
+}
+
+function MarketplaceCatalog({ wsId }: { wsId: string }) {
+  const [manifestText, setManifestText] = useState("");
+  const preview = useMutation({
+    mutationFn: async () => {
+      let manifest: unknown;
+      try { manifest = JSON.parse(manifestText); } catch { throw new Error("marketplace.json must be valid JSON"); }
+      return api.previewClaudeMarketplace(wsId, manifest);
+    },
+  });
+  return (
+    <SettingsSection title="Claude marketplace" description="Preview a marketplace.json safely before publishing native Multica plugins.">
+      <SettingsCard>
+        <div className="space-y-3 px-4 py-4">
+          <Textarea value={manifestText} onChange={(event) => setManifestText(event.target.value)} placeholder='{"name":"My catalog","owner":{"name":"Team"},"plugins":[]}' rows={6} />
+          <div className="flex justify-end">
+            <Button disabled={!manifestText.trim() || preview.isPending} onClick={() => preview.mutate()}>
+              {preview.isPending ? <Loader2 className="animate-spin" /> : null} Preview marketplace
+            </Button>
+          </div>
+          {preview.error ? <p className="text-caption text-destructive">{preview.error instanceof Error ? preview.error.message : "Preview failed"}</p> : null}
+          {preview.data ? (
+            <div className="space-y-2 border-t border-surface-border pt-3">
+              <div className="text-body font-medium">{preview.data.name}</div>
+              <p className="text-caption text-muted-foreground">{preview.data.plugins.length} plugin(s) discovered. Sources are shown for review; nothing was installed.</p>
+              <ul className="space-y-1 text-caption">{preview.data.plugins.map((plugin) => <li key={plugin.name}><code>{plugin.name}</code> — {plugin.source.kind}{plugin.source.repository ? `:${plugin.source.repository}` : plugin.source.url ? `:${plugin.source.url}` : ""}</li>)}</ul>
+            </div>
+          ) : null}
+        </div>
       </SettingsCard>
     </SettingsSection>
   );

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1635,6 +1635,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Post("/plugins/packages", h.PublishPluginPackage)
 					r.Post("/plugins/packages/local", h.PublishLocalPluginPackage)
 					r.Delete("/plugins/packages/{packageId}", h.DeletePluginPackage)
+					r.Post("/plugins/marketplace/preview", h.PreviewClaudeMarketplace)
 					// Installing a Plugin is two steps on purpose: preview
 					// reads the published version's manifest and returns the
 					// scope list without writing anything, so the consent

--- a/server/internal/handler/marketplace.go
+++ b/server/internal/handler/marketplace.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/multica-ai/multica/server/internal/marketplace"
+)
+
+// PreviewClaudeMarketplace validates a Claude Code marketplace manifest without
+// fetching or installing anything. Installation remains an explicit native
+// plugin publish/preview/consent flow, so an untrusted catalog cannot execute
+// code or silently grant an MCP scope.
+//
+// POST /api/workspaces/{id}/plugins/marketplace/preview
+// Body: {"manifest": <contents of marketplace.json>}
+func (h *Handler) PreviewClaudeMarketplace(w http.ResponseWriter, r *http.Request) {
+	if !h.requirePluginsV1(w, r) {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, marketplace.MaxManifestBytes)
+	var request struct {
+		Manifest json.RawMessage `json:"manifest"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil || len(request.Manifest) == 0 {
+		writeError(w, http.StatusBadRequest, "manifest is required and must be valid JSON")
+		return
+	}
+	if _, err := io.ReadAll(r.Body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid marketplace manifest")
+		return
+	}
+	manifest, err := marketplace.ParseMarketplace(request.Manifest)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	type source struct {
+		Kind       marketplace.SourceKind `json:"kind"`
+		Repository string                 `json:"repository,omitempty"`
+		URL        string                 `json:"url,omitempty"`
+		Ref        string                 `json:"ref,omitempty"`
+		Subdir     string                 `json:"subdir,omitempty"`
+		Package    string                 `json:"package,omitempty"`
+		Version    string                 `json:"version,omitempty"`
+	}
+	type plugin struct {
+		Name        string `json:"name"`
+		Description string `json:"description,omitempty"`
+		Version     string `json:"version,omitempty"`
+		Source      source `json:"source"`
+	}
+	plugins := make([]plugin, 0, len(manifest.Plugins))
+	for _, item := range manifest.Plugins {
+		plugins = append(plugins, plugin{
+			Name: item.Name, Description: item.Description, Version: item.Version,
+			Source: source{Kind: item.Source.Kind, Repository: item.Source.Repository, URL: item.Source.URL, Ref: item.Source.Ref, Subdir: item.Source.Subdir, Package: item.Source.Package, Version: item.Source.Version},
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"name": manifest.Name, "owner": manifest.Owner, "description": manifest.Description,
+		"version": manifest.Version, "plugins": plugins,
+	})
+}

--- a/server/internal/handler/marketplace.go
+++ b/server/internal/handler/marketplace.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/multica-ai/multica/server/internal/marketplace"
@@ -25,10 +24,6 @@ func (h *Handler) PreviewClaudeMarketplace(w http.ResponseWriter, r *http.Reques
 	}
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil || len(request.Manifest) == 0 {
 		writeError(w, http.StatusBadRequest, "manifest is required and must be valid JSON")
-		return
-	}
-	if _, err := io.ReadAll(r.Body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid marketplace manifest")
 		return
 	}
 	manifest, err := marketplace.ParseMarketplace(request.Manifest)

--- a/server/internal/marketplace/manifest.go
+++ b/server/internal/marketplace/manifest.go
@@ -1,0 +1,146 @@
+package marketplace
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+)
+
+type SourceKind string
+
+const (
+	SourceRelative  SourceKind = "relative"
+	SourceGitHub    SourceKind = "github"
+	SourceGitURL    SourceKind = "git"
+	SourceURL       SourceKind = "url"
+	SourceGitSubdir SourceKind = "git-subdir"
+	SourceNPM       SourceKind = "npm"
+)
+
+type Marketplace struct {
+	Name        string   `json:"name"`
+	Owner       Owner    `json:"owner"`
+	Description string   `json:"description,omitempty"`
+	Version     string   `json:"version,omitempty"`
+	Plugins     []Plugin `json:"plugins"`
+}
+type Owner struct {
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
+}
+type Plugin struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Version     string   `json:"version,omitempty"`
+	Source      Source   `json:"source"`
+	Strict      *bool    `json:"strict,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+type Source struct {
+	Kind       SourceKind
+	Repository string
+	URL        string
+	Ref        string
+	SHA        string
+	Subdir     string
+	Package    string
+	Version    string
+}
+
+func (s *Source) UnmarshalJSON(data []byte) error {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("source: invalid JSON: %w", err)
+	}
+	switch value := raw.(type) {
+	case string:
+		if value == "" {
+			return fmt.Errorf("source: empty")
+		}
+		if strings.HasPrefix(value, "./") {
+			s.Kind, s.URL = SourceRelative, path.Clean(value)
+			return nil
+		}
+		return fmt.Errorf("source: unsupported string %q", value)
+	case map[string]any:
+		kind, _ := value["source"].(string)
+		switch SourceKind(kind) {
+		case SourceGitHub:
+			repo, ok := value["repo"].(string)
+			if !ok || !validRepo(repo) {
+				return fmt.Errorf("source: invalid github repo")
+			}
+			s.Kind, s.Repository = SourceGitHub, repo
+		case SourceGitURL, SourceURL:
+			rawURL, ok := value["url"].(string)
+			if !ok || !safeURL(rawURL) {
+				return fmt.Errorf("source: invalid URL")
+			}
+			s.Kind, s.URL = SourceKind(kind), rawURL
+		case SourceGitSubdir:
+			rawURL, ok := value["url"].(string)
+			if !ok || !safeURL(rawURL) {
+				return fmt.Errorf("source: invalid git-subdir URL")
+			}
+			s.Kind, s.URL = SourceGitSubdir, rawURL
+			s.Subdir, _ = value["path"].(string)
+			if s.Subdir == "" || path.IsAbs(s.Subdir) || strings.HasPrefix(path.Clean(s.Subdir), "..") {
+				return fmt.Errorf("source: invalid subdirectory")
+			}
+		case SourceNPM:
+			pkg, ok := value["package"].(string)
+			if !ok || pkg == "" {
+				return fmt.Errorf("source: invalid npm package")
+			}
+			s.Kind, s.Package = SourceNPM, pkg
+			s.Version, _ = value["version"].(string)
+		default:
+			return fmt.Errorf("source: unsupported kind %q", kind)
+		}
+		s.Ref, _ = value["ref"].(string)
+		s.SHA, _ = value["sha"].(string)
+		return nil
+	default:
+		return fmt.Errorf("source: expected string or object")
+	}
+}
+
+func ParseMarketplace(data []byte) (Marketplace, error) {
+	var manifest Marketplace
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return Marketplace{}, fmt.Errorf("marketplace.json: %w", err)
+	}
+	if manifest.Name == "" || manifest.Owner.Name == "" {
+		return Marketplace{}, fmt.Errorf("marketplace.json: name and owner.name are required")
+	}
+	if reservedMarketplaceNames[manifest.Name] {
+		return Marketplace{}, fmt.Errorf("marketplace.json: reserved marketplace name %q", manifest.Name)
+	}
+	if len(manifest.Plugins) == 0 {
+		return Marketplace{}, fmt.Errorf("marketplace.json: plugins must not be empty")
+	}
+	seen := map[string]bool{}
+	for i, plugin := range manifest.Plugins {
+		if plugin.Name == "" {
+			return Marketplace{}, fmt.Errorf("plugins[%d].name is required", i)
+		}
+		if seen[plugin.Name] {
+			return Marketplace{}, fmt.Errorf("plugins[%d]: duplicate name %q", i, plugin.Name)
+		}
+		seen[plugin.Name] = true
+	}
+	return manifest, nil
+}
+
+var reservedMarketplaceNames = map[string]bool{"claude-code-marketplace": true, "claude-code-plugins": true, "claude-plugins-official": true, "anthropic-marketplace": true, "anthropic-plugins": true, "agent-skills": true, "knowledge-work-plugins": true, "life-sciences": true}
+
+func validRepo(repo string) bool {
+	parts := strings.Split(repo, "/")
+	return len(parts) == 2 && parts[0] != "" && parts[1] != "" && !strings.ContainsAny(repo, "\\ \t\r\n")
+}
+func safeURL(raw string) bool {
+	parsed, err := url.Parse(raw)
+	return err == nil && parsed.Scheme == "https" && parsed.Host != "" && parsed.User == nil
+}

--- a/server/internal/marketplace/manifest.go
+++ b/server/internal/marketplace/manifest.go
@@ -10,137 +10,45 @@ import (
 
 type SourceKind string
 
-const (
-	SourceRelative  SourceKind = "relative"
-	SourceGitHub    SourceKind = "github"
-	SourceGitURL    SourceKind = "git"
-	SourceURL       SourceKind = "url"
-	SourceGitSubdir SourceKind = "git-subdir"
-	SourceNPM       SourceKind = "npm"
-)
-
-type Marketplace struct {
-	Name        string   `json:"name"`
-	Owner       Owner    `json:"owner"`
-	Description string   `json:"description,omitempty"`
-	Version     string   `json:"version,omitempty"`
-	Plugins     []Plugin `json:"plugins"`
-}
-type Owner struct {
-	Name  string `json:"name"`
-	Email string `json:"email,omitempty"`
-}
-type Plugin struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
-	Version     string   `json:"version,omitempty"`
-	Source      Source   `json:"source"`
-	Strict      *bool    `json:"strict,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-}
-type Source struct {
-	Kind       SourceKind
-	Repository string
-	URL        string
-	Ref        string
-	SHA        string
-	Subdir     string
-	Package    string
-	Version    string
-}
+const MaxManifestBytes = 1 << 20
+const ( SourceRelative SourceKind = "relative"; SourceGitHub SourceKind = "github"; SourceGitURL SourceKind = "git"; SourceURL SourceKind = "url"; SourceGitSubdir SourceKind = "git-subdir"; SourceNPM SourceKind = "npm" )
+type Marketplace struct { Name string `json:"name"`; Owner Owner `json:"owner"`; Description string `json:"description,omitempty"`; Version string `json:"version,omitempty"`; Plugins []Plugin `json:"plugins"` }
+type Owner struct { Name string `json:"name"`; Email string `json:"email,omitempty"` }
+type Plugin struct { Name string `json:"name"`; Description string `json:"description,omitempty"`; Version string `json:"version,omitempty"`; Source Source `json:"source"`; Strict *bool `json:"strict,omitempty"`; Tags []string `json:"tags,omitempty"` }
+type Source struct { Kind SourceKind; Repository string; URL string; Ref string; SHA string; Subdir string; Package string; Version string }
 
 func (s *Source) UnmarshalJSON(data []byte) error {
-	var raw any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return fmt.Errorf("source: invalid JSON: %w", err)
-	}
+	var raw any; if err := json.Unmarshal(data, &raw); err != nil { return fmt.Errorf("source: invalid JSON: %w", err) }
 	switch value := raw.(type) {
 	case string:
-		if value == "" {
-			return fmt.Errorf("source: empty")
-		}
-		if strings.HasPrefix(value, "./") {
-			s.Kind, s.URL = SourceRelative, path.Clean(value)
-			return nil
-		}
-		return fmt.Errorf("source: unsupported string %q", value)
+		if value == "" { return fmt.Errorf("source: empty") }; if strings.HasPrefix(value, "./") { s.Kind, s.URL = SourceRelative, path.Clean(value); return nil }; return fmt.Errorf("source: unsupported string %q", value)
 	case map[string]any:
 		kind, _ := value["source"].(string)
 		switch SourceKind(kind) {
 		case SourceGitHub:
-			repo, ok := value["repo"].(string)
-			if !ok || !validRepo(repo) {
-				return fmt.Errorf("source: invalid github repo")
-			}
-			s.Kind, s.Repository = SourceGitHub, repo
+			repo, ok := value["repo"].(string); if !ok || !validRepo(repo) { return fmt.Errorf("source: invalid github repo") }; s.Kind, s.Repository = SourceGitHub, repo
 		case SourceGitURL, SourceURL:
-			rawURL, ok := value["url"].(string)
-			if !ok || !safeURL(rawURL) {
-				return fmt.Errorf("source: invalid URL")
-			}
-			s.Kind, s.URL = SourceKind(kind), rawURL
+			rawURL, ok := value["url"].(string); if !ok || !safeURL(rawURL) { return fmt.Errorf("source: invalid URL") }; s.Kind, s.URL = SourceKind(kind), rawURL
 		case SourceGitSubdir:
-			rawURL, ok := value["url"].(string)
-			if !ok || !safeURL(rawURL) {
-				return fmt.Errorf("source: invalid git-subdir URL")
-			}
-			s.Kind, s.URL = SourceGitSubdir, rawURL
-			s.Subdir, _ = value["path"].(string)
-			if s.Subdir == "" || path.IsAbs(s.Subdir) || strings.HasPrefix(path.Clean(s.Subdir), "..") {
-				return fmt.Errorf("source: invalid subdirectory")
-			}
+			rawURL, ok := value["url"].(string); if !ok || !safeURL(rawURL) { return fmt.Errorf("source: invalid git-subdir URL") }; s.Kind, s.URL = SourceGitSubdir, rawURL; s.Subdir, _ = value["path"].(string); if s.Subdir == "" || path.IsAbs(s.Subdir) || strings.HasPrefix(path.Clean(s.Subdir), "..") { return fmt.Errorf("source: invalid subdirectory") }
 		case SourceNPM:
-			pkg, ok := value["package"].(string)
-			if !ok || pkg == "" {
-				return fmt.Errorf("source: invalid npm package")
-			}
-			s.Kind, s.Package = SourceNPM, pkg
-			s.Version, _ = value["version"].(string)
-		default:
-			return fmt.Errorf("source: unsupported kind %q", kind)
+			pkg, ok := value["package"].(string); if !ok || pkg == "" { return fmt.Errorf("source: invalid npm package") }; s.Kind, s.Package = SourceNPM, pkg; s.Version, _ = value["version"].(string)
+		default: return fmt.Errorf("source: unsupported kind %q", kind)
 		}
-		s.Ref, _ = value["ref"].(string)
-		s.SHA, _ = value["sha"].(string)
-		return nil
-	default:
-		return fmt.Errorf("source: expected string or object")
+		s.Ref, _ = value["ref"].(string); s.SHA, _ = value["sha"].(string); return nil
+	default: return fmt.Errorf("source: expected string or object")
 	}
 }
 
 func ParseMarketplace(data []byte) (Marketplace, error) {
-	var manifest Marketplace
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return Marketplace{}, fmt.Errorf("marketplace.json: %w", err)
-	}
-	if manifest.Name == "" || manifest.Owner.Name == "" {
-		return Marketplace{}, fmt.Errorf("marketplace.json: name and owner.name are required")
-	}
-	if reservedMarketplaceNames[manifest.Name] {
-		return Marketplace{}, fmt.Errorf("marketplace.json: reserved marketplace name %q", manifest.Name)
-	}
-	if len(manifest.Plugins) == 0 {
-		return Marketplace{}, fmt.Errorf("marketplace.json: plugins must not be empty")
-	}
-	seen := map[string]bool{}
-	for i, plugin := range manifest.Plugins {
-		if plugin.Name == "" {
-			return Marketplace{}, fmt.Errorf("plugins[%d].name is required", i)
-		}
-		if seen[plugin.Name] {
-			return Marketplace{}, fmt.Errorf("plugins[%d]: duplicate name %q", i, plugin.Name)
-		}
-		seen[plugin.Name] = true
-	}
+	var manifest Marketplace; if err := json.Unmarshal(data, &manifest); err != nil { return Marketplace{}, fmt.Errorf("marketplace.json: %w", err) }
+	if manifest.Name == "" || manifest.Owner.Name == "" { return Marketplace{}, fmt.Errorf("marketplace.json: name and owner.name are required") }
+	if reservedMarketplaceNames[manifest.Name] { return Marketplace{}, fmt.Errorf("marketplace.json: reserved marketplace name %q", manifest.Name) }
+	if len(manifest.Plugins) == 0 { return Marketplace{}, fmt.Errorf("marketplace.json: plugins must not be empty") }
+	seen := map[string]bool{}; for i, plugin := range manifest.Plugins { if plugin.Name == "" { return Marketplace{}, fmt.Errorf("plugins[%d].name is required", i) }; if seen[plugin.Name] { return Marketplace{}, fmt.Errorf("plugins[%d]: duplicate name %q", i, plugin.Name) }; seen[plugin.Name] = true }
 	return manifest, nil
 }
 
 var reservedMarketplaceNames = map[string]bool{"claude-code-marketplace": true, "claude-code-plugins": true, "claude-plugins-official": true, "anthropic-marketplace": true, "anthropic-plugins": true, "agent-skills": true, "knowledge-work-plugins": true, "life-sciences": true}
-
-func validRepo(repo string) bool {
-	parts := strings.Split(repo, "/")
-	return len(parts) == 2 && parts[0] != "" && parts[1] != "" && !strings.ContainsAny(repo, "\\ \t\r\n")
-}
-func safeURL(raw string) bool {
-	parsed, err := url.Parse(raw)
-	return err == nil && parsed.Scheme == "https" && parsed.Host != "" && parsed.User == nil
-}
+func validRepo(repo string) bool { parts := strings.Split(repo, "/"); return len(parts) == 2 && parts[0] != "" && parts[1] != "" && !strings.ContainsAny(repo, "\\ \t\r\n") }
+func safeURL(raw string) bool { parsed, err := url.Parse(raw); return err == nil && parsed.Scheme == "https" && parsed.Host != "" && parsed.User == nil }

--- a/server/internal/marketplace/manifest_test.go
+++ b/server/internal/marketplace/manifest_test.go
@@ -1,0 +1,32 @@
+package marketplace
+
+import "testing"
+
+func TestParseMarketplaceAcceptsClaudeManifest(t *testing.T) {
+	manifest, err := ParseMarketplace([]byte(`{"name":"servinder-tools","owner":{"name":"Servinder Artes"},"plugins":[{"name":"quality-review","source":{"source":"github","repo":"example/quality-review","ref":"v1.2.3"},"description":"Quality tools"}]}`))
+	if err != nil {
+		t.Fatalf("ParseMarketplace() error = %v", err)
+	}
+	if manifest.Name != "servinder-tools" || len(manifest.Plugins) != 1 {
+		t.Fatalf("unexpected manifest: %+v", manifest)
+	}
+	if manifest.Plugins[0].Source.Kind != SourceGitHub || manifest.Plugins[0].Source.Repository != "example/quality-review" {
+		t.Fatalf("unexpected source: %+v", manifest.Plugins[0].Source)
+	}
+}
+
+func TestParseMarketplaceRejectsUnsafeSourceAndMissingFields(t *testing.T) {
+	cases := []string{`{"name":"x","owner":{"name":"x"},"plugins":[{"name":"x","source":"../outside"}]}`, `{"name":"x","owner":{"name":"x"},"plugins":[{"name":"x","source":{"source":"unknown","package":"x"}}]}`, `{"owner":{"name":"x"},"plugins":[]}`}
+	for _, input := range cases {
+		if _, err := ParseMarketplace([]byte(input)); err == nil {
+			t.Fatalf("accepted invalid input: %s", input)
+		}
+	}
+}
+
+func TestParseMarketplaceRejectsAnthropicReservedName(t *testing.T) {
+	_, err := ParseMarketplace([]byte(`{"name":"claude-plugins-official","owner":{"name":"x"},"plugins":[{"name":"x","source":"./x"}]}`))
+	if err == nil {
+		t.Fatal("reserved marketplace name was accepted")
+	}
+}


### PR DESCRIPTION
## Summary

Add a generic Claude Code marketplace manifest preview flow to Multica plugins.

- Parse and validate marketplace manifests without fetching or installing remote content.
- Normalize relative, GitHub, git, URL, git-subdir, and npm sources.
- Add an authenticated workspace preview endpoint.
- Add a Plugins settings UI for JSON preview with explicit no-install behavior.
- Include focused parser tests.

This PR is intentionally limited to generic marketplace/plugin infrastructure. It contains no Servinder-specific code, fixtures, skills, agents, or infrastructure, and no Devin runtime changes.