### PR TITLE
MUL-7267: docs(autopilot): finish renaming the trigger principal in comments

### DIFF
--- a/server/internal/attribution/attribution.go
+++ b/server/internal/attribution/attribution.go
@@ -466,8 +466,8 @@ type SubscriptionFacts struct {
 	//
 	// It exists because OriginOriginator alone stopped answering "did a human ask
 	// for this?" in MUL-6951: an armed autopilot trigger now carries its
-	// creator's authorization, so the two cases became indistinguishable by
-	// value. See DelegatedSubscriber.
+	// created_by principal's authorization, so the two cases became
+	// indistinguishable by value. See DelegatedSubscriber.
 	OriginRootSource Source
 }
 
@@ -511,12 +511,13 @@ type SubscriptionFacts struct {
 // SourceDirectHuman was the only root that left an originator behind, so "the
 // origin run carries a human" and "a human asked for this work" were the same
 // statement and only the first had to be tested. MUL-6951 separated them: an
-// armed schedule/webhook trigger now runs with its creator's authorization
-// (SourceTriggerOwner), and that human is copied down the whole chain exactly
-// like a requester would be. The untested half of the old equivalence is what
-// broke — every issue an autopilot's agent filed started subscribing whoever
-// armed the trigger, which is the case the origin_type='autopilot' exclusion
-// above already says must not happen, arriving one hop lower.
+// armed schedule/webhook trigger now runs with its created_by principal's
+// authorization (SourceTriggerOwner), and that human is copied down the whole
+// chain exactly like a requester would be. The untested half of the old
+// equivalence is what broke — every issue an autopilot's agent filed started
+// subscribing whoever armed the trigger, which is the case the
+// origin_type='autopilot' exclusion above already says must not happen, arriving
+// one hop lower.
 //
 // So the condition is stated as what it means — the chain BEGAN with a member
 // acting — and it is a whitelist. A future root that resolves a human some other

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -986,11 +986,11 @@ func (s *AutopilotService) dispatchRunOnly(ctx context.Context, ap db.Autopilot,
 	// rule version publisher (rule_owner, audit-only) when it has none, then to
 	// unattributed. An edit of the trigger does NOT move this: published_by
 	// transfers, created_by does not. Since MUL-6951 that human is the originator
-	// too, so an armed autopilot runs with its creator's authorization instead of
-	// borrowing narrowly-scoped capabilities per surface; the source label is what
-	// keeps "fired on a schedule" distinguishable from "a human clicked run". Either
-	// way evidence points at the autopilot run and the row is never a NULL-source
-	// bypass.
+	// too, so an armed autopilot runs with its created_by principal's authorization
+	// instead of borrowing narrowly-scoped capabilities per surface; the source
+	// label is what keeps "fired on a schedule" distinguishable from "a human
+	// clicked run". Either way evidence points at the autopilot run and the row is
+	// never a NULL-source bypass.
 	var autopilotAttr attribution.Result
 	if actorUserID.Valid {
 		autopilotAttr = attribution.DirectHumanRun(actorUserID, attribution.EvidenceAutopilotRun, run.ID)


### PR DESCRIPTION
## Summary

Follow-up to #8293. Three comments on the autopilot authorization path still said an armed trigger runs with "its creator's authorization":

- `server/internal/service/autopilot.go`, in the run_only attribution block;
- `server/internal/attribution/attribution.go`, on `OriginRootSource`;
- `server/internal/attribution/attribution.go`, in the `DelegatedSubscriber` rationale.

For a legacy trigger, `created_by` is a principal inferred by backfill (migrations 449 and 467), not proof of who created it. These now say "created_by principal", matching the rest of the path after #8293.

Comments only; no behavior change.

## Testing

- `go build ./...` passes.
- `go vet ./internal/attribution ./internal/service` passes.
- `go test ./internal/attribution -count=1` passes.
- `gofmt` and `git diff --check` are clean.
