### PR TITLE
MUL-7286: fix(inbox): preserve stale lists across issue updates

### DIFF
--- a/packages/core/inbox/ws-updaters.test.ts
+++ b/packages/core/inbox/ws-updaters.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import {
@@ -259,6 +260,54 @@ describe("patchInboxIssueProjection", () => {
       qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId))?.[0],
     ).not.toHaveProperty("issue_priority");
   });
+});
+
+// The hook-level reproduction lives in use-realtime-sync-inbox.test.tsx.
+// These cases cover the partial writers and both list keys, including an
+// update to an issue absent from the cached list (setQueryData's no-op trap).
+describe.each([
+  ["main", inboxKeys.list(wsId)],
+  ["archived", inboxKeys.archived(wsId)],
+] as const)("partial updates to an invalidated %s inbox", (view, queryKey) => {
+  it.each([
+    ["status", (qc: QueryClient) => onInboxIssueStatusChanged(qc, wsId, "issue-a", "done")],
+    ["priority", (qc: QueryClient) => patchInboxIssueProjection(qc, wsId, "issue-a", { priority: "high" })],
+    ["unrelated issue", (qc: QueryClient) => onInboxIssueStatusChanged(qc, wsId, "other-issue", "done")],
+    ["deletion", (qc: QueryClient) => onInboxIssueDeleted(qc, wsId, "issue-a")],
+  ] as const)("preserves the pending refresh after %s", async (_label, update) => {
+    const qc = new QueryClient();
+    qc.setQueryData(queryKey, [
+      makeItem("i1", "issue-a", {
+        issue_priority: "low",
+        archived: view === "archived",
+      }),
+    ]);
+    try {
+      await onInboxInvalidate(qc, wsId);
+      await update(qc);
+      expect(qc.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    } finally {
+      qc.clear();
+    }
+  });
+});
+
+it("does not refetch fresh lists for issue projection changes", async () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { staleTime: Infinity } } });
+  const queryFn = vi.fn(async () => [makeItem("i1", "issue-a")]);
+  const options = { queryKey: inboxKeys.list(wsId), queryFn };
+  await qc.fetchQuery(options);
+  const observer = new QueryObserver(qc, options);
+  const unsubscribe = observer.subscribe(() => {});
+  try {
+    onInboxIssueStatusChanged(qc, wsId, "issue-a", "done");
+    expect(observer.getCurrentResult().data?.[0]?.issue_status).toBe("done");
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    expect(qc.getQueryState(options.queryKey)?.isInvalidated).toBe(false);
+  } finally {
+    unsubscribe();
+    qc.clear();
+  }
 });
 
 // MUL-6967 regression: the inbox list must pick up a change that happens while

--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -44,14 +44,35 @@ export async function onInboxNew(
   await onInboxInvalidate(qc, wsId);
 }
 
+// An issue event only patches known rows; it cannot fulfill a pending inbox
+// refresh. setQueryData clears isInvalidated even when the updater returns the
+// same array. Preserve it so an inactive list still refetches on its next mount
+// (MUL-7286). Do not restart an active fetch or introduce a fetch per issue event.
+function patchInboxLists(
+  qc: QueryClient,
+  wsId: string,
+  patch: (items: InboxItem[]) => InboxItem[],
+) {
+  for (const queryKey of [inboxKeys.list(wsId), inboxKeys.archived(wsId)]) {
+    const invalidated = qc.getQueryState(queryKey)?.isInvalidated === true;
+    qc.setQueryData<InboxItem[]>(queryKey, (old) => {
+      if (!old) return undefined;
+      const next = patch(old);
+      return next === old ? undefined : next;
+    });
+    if (invalidated) {
+      void qc.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
+    }
+  }
+}
+
 export function patchInboxIssueProjection(
   qc: QueryClient,
   wsId: string,
   issueId: string,
   patch: { status?: IssueStatus; priority?: IssuePriority },
 ) {
-  const project = (old: InboxItem[] | undefined) => {
-    if (!old) return old;
+  const project = (old: InboxItem[]) => {
     let changed = false;
     const next = old.map((item) => {
       if (item.issue_id !== issueId) return item;
@@ -71,9 +92,8 @@ export function patchInboxIssueProjection(
     });
     return changed ? next : old;
   };
-  qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), project);
   // Archived rows expose the same issue fields and filter controls.
-  qc.setQueryData<InboxItem[]>(inboxKeys.archived(wsId), project);
+  patchInboxLists(qc, wsId, project);
 }
 
 export function patchInboxIssueStatus(
@@ -110,10 +130,9 @@ export async function onInboxIssueDeleted(
   wsId: string,
   issueId: string,
 ) {
-  const drop = (old: InboxItem[] | undefined) =>
-    old?.filter((i) => i.issue_id !== issueId);
-  qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), drop);
-  qc.setQueryData<InboxItem[]>(inboxKeys.archived(wsId), drop);
+  patchInboxLists(qc, wsId, (items) =>
+    items.filter((i) => i.issue_id !== issueId),
+  );
   await onInboxSummaryInvalidate(qc);
 }
 

--- a/packages/core/realtime/use-realtime-sync-inbox.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-inbox.test.tsx
@@ -1,0 +1,133 @@
+/** @vitest-environment jsdom */
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, expect, it, vi } from "vitest";
+import { setApiInstance } from "../api";
+import type { ApiClient } from "../api/client";
+import type { WSClient } from "../api/ws-client";
+import {
+  deduplicateInboxItems,
+  inboxKeys,
+  inboxListOptions,
+  useInboxUnreadCount,
+} from "../inbox/queries";
+import { createQueryClient } from "../query-client";
+import type { InboxItem } from "../types";
+import { useRealtimeSync, type RealtimeSyncStores } from "./use-realtime-sync";
+
+vi.mock("../platform/workspace-storage", () => ({
+  getCurrentWsId: () => "ws-1",
+  getCurrentSlug: () => "test-ws",
+  createWorkspaceAwareStorage: (adapter: unknown) => adapter,
+  registerForWorkspaceRehydration: () => {},
+}));
+vi.mock("../paths", () => ({
+  useHasOnboarded: () => true,
+  resolvePostAuthDestination: () => "/",
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+it("refreshes an inactive Inbox after inbox:new then issue:updated (MUL-7286)", async () => {
+  const qc = createQueryClient();
+  const oldItem: InboxItem = {
+    id: "n1",
+    workspace_id: "ws-1",
+    recipient_type: "member",
+    recipient_id: "u1",
+    actor_type: "agent",
+    actor_id: "agent-1",
+    type: "new_comment",
+    severity: "info",
+    issue_id: "issue-1",
+    title: "Issue 1",
+    body: null,
+    issue_status: "todo",
+    read: true,
+    archived: false,
+    created_at: "2026-09-11T00:00:00Z",
+    details: null,
+  };
+  let rows = [oldItem];
+  const listInbox = vi.fn(async () => rows);
+  setApiInstance({
+    listInbox,
+    getInboxUnreadSummary: async () => [
+      {
+        workspace_id: "ws-1",
+        count: deduplicateInboxItems(rows).filter((item) => !item.read).length,
+      },
+    ],
+  } as unknown as ApiClient);
+
+  const handlers: Record<string, (payload: unknown) => void> = {};
+  const ws = {
+    on: (event: string, handler: (payload: unknown) => void) => {
+      handlers[event] = handler;
+      return () => {
+        delete handlers[event];
+      };
+    },
+    onAny: () => () => {},
+    onReconnect: () => () => {},
+  } as unknown as WSClient;
+  const stores = {
+    authStore: { getState: () => ({ user: { id: "u1" } }) },
+  } as unknown as RealtimeSyncStores;
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  }
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+  const shell = renderHook(
+    () => {
+      useRealtimeSync(ws, stores);
+      return useInboxUnreadCount("ws-1");
+    },
+    { wrapper: Wrapper },
+  );
+  const mountInbox = () =>
+    renderHook(() => useQuery(inboxListOptions("ws-1")), { wrapper: Wrapper });
+  let page = mountInbox();
+  try {
+    await waitFor(() => expect(page.result.current.data).toEqual([oldItem]));
+    // Switching desktop tabs unmounts the page but keeps its cache for 10 min.
+    page.unmount();
+    const newItem = {
+      ...oldItem,
+      id: "n2",
+      read: false,
+      created_at: "2026-09-11T00:01:00Z",
+    };
+    rows = [newItem, oldItem];
+    await act(async () => {
+      handlers["inbox:new"]!({ item: newItem });
+    });
+    await waitFor(() => expect(shell.result.current).toBe(1));
+    expect(qc.getQueryState(inboxKeys.list("ws-1"))?.isInvalidated).toBe(true);
+    expect(listInbox).toHaveBeenCalledTimes(1);
+
+    // Any later issue update patches status, without re-reading notifications.
+    rows = rows.map((item) => ({ ...item, issue_status: "in_progress" }));
+    act(() => {
+      handlers["issue:updated"]!({
+        issue: { id: "issue-1", status: "in_progress", revision: 2 },
+      });
+    });
+    page = mountInbox();
+    await waitFor(() => expect(listInbox).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(page.result.current.data).toEqual(rows));
+    expect(
+      deduplicateInboxItems(page.result.current.data!).filter((item) => !item.read),
+    ).toHaveLength(1);
+    expect(shell.result.current).toBe(1);
+  } finally {
+    page.unmount();
+    shell.unmount();
+    qc.clear();
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Fixes an Inbox that shows an unread badge but keeps displaying only previously read notifications until the user refreshes.

The badge reads an independent summary. When the Inbox page is unmounted, `inbox:new` marks its cached list stale for the next mount. A subsequent `issue:updated` patches the cached issue status or priority through `setQueryData`, which clears `isInvalidated` even when the updater returns the same array. With `staleTime: Infinity`, reopening the Inbox then skips the fetch and misses the new notification.

Preserve pending invalidation across partial issue patches so returning to the Inbox fetches the missing notification. This complements #8290's first-load race fix: its convergence test removed the list cache on navigation and did not interleave issue updates with inbox events.

## Related Issue

MUL-7286

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Preserve existing invalidation when patching status/priority or removing a deleted issue from either shared Inbox list (`packages/core/inbox/ws-updaters.ts`). Skip unchanged data writes; restoring invalidation uses `refetchType: "none"` so issue patches do not trigger extra requests or cancel an active fetch.
- Cover the main and archived caches, unrelated issue updates, deletion, and fresh-list behavior in the updater tests.
- Reproduce the full sequence through `useRealtimeSync`, the real query client, and mounted/unmounted query hooks in `packages/core/realtime/use-realtime-sync-inbox.test.tsx`.

## How to Test

1. Load an Inbox whose newest notification is already read, then navigate away while keeping its cache.
2. Deliver `inbox:new`, then `issue:updated`, and reopen the Inbox.
3. Verify a new list request occurs and both the list and badge show one unread issue. The regression test fails before this fix because the list request count stays at one.

Local validation: **211 tests passed across 10 files**, plus core typecheck and targeted ESLint:

```sh
NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @multica/core test inbox/ realtime/use-realtime-sync.test.ts realtime/use-realtime-sync-inbox.test.tsx realtime/use-realtime-sync-ws-instance.test.tsx issues/cache-coordinator.test.ts issues/mutations.test.tsx
pnpm --filter @multica/core typecheck
pnpm --filter @multica/core exec eslint inbox/ws-updaters.ts inbox/ws-updaters.test.ts realtime/use-realtime-sync-inbox.test.tsx
```

The Node option disables the local Node 26 native Web Storage globals so jsdom supplies its own test storage.

## Checklist

- [x] Traced the change from the separate badge/list caches through the WS handlers to the query lifecycle.
- [x] Ran local tests, typecheck, and lint.
- [x] Added regression coverage, including a failing-before/passing-after reproduction.
- [x] Considered risk: this changes shared Web/Desktop cache freshness, preserves immediate row patches, and leaves fresh queries fresh. No API or database changes.
- Screenshots and documentation updates: not applicable; layout and user-facing controls are unchanged.

## AI Disclosure

**AI tool used:** Multica Agent (Niko).

**Approach:** Traced notification invalidation and issue projection writes, reproduced the missed refetch using the real realtime hook and query client, and verified the minimal cache fix against related Inbox and issue tests.
