### PR TITLE
MUL-7286: fix(inbox): re-read inbox lists that an issue write left behind

### DIFF
--- a/packages/core/inbox/ws-updaters.test.ts
+++ b/packages/core/inbox/ws-updaters.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import {
+  cancelInboxLists,
   onInboxInvalidate,
   onInboxIssueDeleted,
   onInboxNew,
@@ -308,6 +309,38 @@ it("does not refetch fresh lists for issue projection changes", async () => {
     unsubscribe();
     qc.clear();
   }
+});
+
+// The mutation-level regression (the write re-reads what it interrupted) lives
+// in issues/mutations.test.tsx.
+describe.each([
+  ["main", inboxKeys.list(wsId)],
+  ["archived", inboxKeys.archived(wsId)],
+] as const)("cancelInboxLists on the %s inbox", (_view, queryKey) => {
+  it("reports and cancels only a request that is in flight", async () => {
+    const qc = new QueryClient();
+    const loaded = [makeItem("i1", "issue-a")];
+    let release!: (items: InboxItem[]) => void;
+    const queryFn = vi
+      .fn<() => Promise<InboxItem[]>>()
+      .mockResolvedValueOnce(loaded)
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (release = resolve)),
+      );
+    try {
+      await qc.fetchQuery({ queryKey, queryFn });
+      expect(cancelInboxLists(qc, wsId)).toBe(false);
+
+      const refetch = qc.fetchQuery({ queryKey, queryFn });
+      expect(cancelInboxLists(qc, wsId)).toBe(true);
+      expect(qc.getQueryState(queryKey)?.fetchStatus).toBe("idle");
+      release([makeItem("i2", "issue-b"), ...loaded]);
+      await expect(refetch).resolves.toEqual(loaded);
+      expect(qc.getQueryData(queryKey)).toEqual(loaded);
+    } finally {
+      qc.clear();
+    }
+  });
 });
 
 // MUL-6967 regression: the inbox list must pick up a change that happens while

--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -136,16 +136,38 @@ export async function onInboxIssueDeleted(
   await onInboxSummaryInvalidate(qc);
 }
 
+// An optimistic issue write patches the status / priority on inbox rows, so it
+// first cancels the lists' in-flight requests: a response read before the write
+// would land on top of the patch. Returns whether a request was interrupted.
+//
+// The interrupted request may be the only one carrying a server change (an
+// `inbox:new`, a reconnect), and nothing asks again. The cancel can also drop
+// the invalidation mark: TanStack reverts to its pre-fetch snapshot, and a
+// `setQueryData` during the fetch overwrites that snapshot with a
+// non-invalidated state. So a write that interrupted a request must call
+// `onInboxInvalidate` once it settles (MUL-7286). Writes that interrupt
+// nothing stay request-free.
+export function cancelInboxLists(qc: QueryClient, wsId: string): boolean {
+  const queryKey = inboxKeys.all(wsId);
+  const interrupted = qc
+    .getQueryCache()
+    .findAll({ queryKey })
+    .some((query) => query.state.fetchStatus !== "idle");
+  void qc.cancelQueries({ queryKey });
+  return interrupted;
+}
+
 // THE entry point for refreshing the workspace's inbox lists — main and
 // archived. Every inbox event can move an item across that boundary (archive,
 // unarchive, or a new notification reviving an archived issue), and the split
 // is decided server-side, so the two are always refreshed together.
 //
-// Cancels first, like the summary refresh below, and for the same reason. The
-// list's first load is where the hole bites hardest: nothing outside the Inbox
-// page observes the list, so on web it is collected once the user has been
-// away, and every return is a first load again — with notifications arriving
-// while a large, unbounded list is still downloading.
+// Cancels first, like the summary refresh below, and for the same reason: the
+// Inbox page is the only observer that fetches the list, so its first visit
+// downloads a large, unbounded list while notifications keep arriving. After
+// that the cache outlives the page — tab titles hold disabled observers on it
+// (`useTabPresentation`) — so a return reuses it and refetches only while it
+// is still marked invalidated.
 export async function onInboxInvalidate(qc: QueryClient, wsId: string) {
   await refreshInboxQuery(qc, inboxKeys.all(wsId));
 }

--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -136,6 +136,17 @@ export async function onInboxIssueDeleted(
   await onInboxSummaryInvalidate(qc);
 }
 
+// Whether a request for either inbox list is out (paused ones included).
+export function isInboxListRequestInFlight(
+  qc: QueryClient,
+  wsId: string,
+): boolean {
+  return qc
+    .getQueryCache()
+    .findAll({ queryKey: inboxKeys.all(wsId) })
+    .some((query) => query.state.fetchStatus !== "idle");
+}
+
 // An optimistic issue write patches the status / priority on inbox rows, so it
 // first cancels the lists' in-flight requests: a response read before the write
 // would land on top of the patch. Returns whether a request was interrupted.
@@ -144,16 +155,12 @@ export async function onInboxIssueDeleted(
 // `inbox:new`, a reconnect), and nothing asks again. The cancel can also drop
 // the invalidation mark: TanStack reverts to its pre-fetch snapshot, and a
 // `setQueryData` during the fetch overwrites that snapshot with a
-// non-invalidated state. So a write that interrupted a request must call
-// `onInboxInvalidate` once it settles (MUL-7286). Writes that interrupt
-// nothing stay request-free.
+// non-invalidated state. So a write that interrupted a request owes the lists
+// a re-read once the writes settle (MUL-7286). Writes that interrupt nothing
+// stay request-free.
 export function cancelInboxLists(qc: QueryClient, wsId: string): boolean {
-  const queryKey = inboxKeys.all(wsId);
-  const interrupted = qc
-    .getQueryCache()
-    .findAll({ queryKey })
-    .some((query) => query.state.fetchStatus !== "idle");
-  void qc.cancelQueries({ queryKey });
+  const interrupted = isInboxListRequestInFlight(qc, wsId);
+  void qc.cancelQueries({ queryKey: inboxKeys.all(wsId) });
   return interrupted;
 }
 

--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -1022,38 +1022,49 @@ describe("status / priority writes re-read an Inbox list they left behind", () =
       return () => inbox.current.data?.map((row) => [row.id, row.issue_priority]);
     }
 
-    it.each([
+    const pairings = [
       ["useUpdateIssue", "useUpdateIssue"],
       ["useBatchUpdateIssues", "useBatchUpdateIssues"],
       ["useUpdateIssue", "useBatchUpdateIssues"],
       ["useBatchUpdateIssues", "useUpdateIssue"],
-    ] as const)(
+    ] as const;
+
+    // An `inbox:new` re-read is out when A's write interrupts it; B's write
+    // starts before A is saved and finds nothing to interrupt.
+    async function overlapWrites(first: Kind, second: Kind) {
+      const server = controlledServer([rowA, rowB]);
+      const hooks = renderWriteHooks();
+      const rendered = await loadInbox(server);
+      server.setRows([newRow, rowA, rowB]);
+      act(() => {
+        void onInboxInvalidate(qc, WS_ID);
+      });
+      await waitFor(() => expect(server.listInbox).toHaveBeenCalledTimes(2));
+
+      let writeA!: Promise<unknown>;
+      let writeB!: Promise<unknown>;
+      act(() => {
+        writeA = write(hooks.current, first, "issue-1");
+      });
+      await waitFor(() => expect(server.saving("issue-1")).toBe(true));
+      act(() => {
+        writeB = write(hooks.current, second, "issue-2");
+      });
+      await waitFor(() => expect(server.saving("issue-2")).toBe(true));
+      expect(qc.getQueryState(inboxKeys.list(WS_ID))?.fetchStatus).toBe("idle");
+      return { server, rendered, writeA, writeB };
+    }
+
+    const everySaved = [
+      ["n-c", "none"],
+      ["n-a", "high"],
+      ["n-b", "high"],
+    ];
+
+    it.each(pairings)(
       "re-reads once, after the last of them saves (%s, then %s)",
       async (first: Kind, second: Kind) => {
-        const server = controlledServer([rowA, rowB]);
-        const hooks = renderWriteHooks();
-        const rendered = await loadInbox(server);
-
-        // `inbox:new` while the Inbox is open; its re-read is still out.
-        server.setRows([newRow, rowA, rowB]);
-        act(() => {
-          void onInboxInvalidate(qc, WS_ID);
-        });
-        await waitFor(() => expect(server.listInbox).toHaveBeenCalledTimes(2));
-
-        // A's write interrupts that re-read; B's starts before A is saved and
-        // finds nothing to interrupt.
-        let writeA!: Promise<unknown>;
-        let writeB!: Promise<unknown>;
-        act(() => {
-          writeA = write(hooks.current, first, "issue-1");
-        });
-        await waitFor(() => expect(server.saving("issue-1")).toBe(true));
-        act(() => {
-          writeB = write(hooks.current, second, "issue-2");
-        });
-        await waitFor(() => expect(server.saving("issue-2")).toBe(true));
-        expect(qc.getQueryState(inboxKeys.list(WS_ID))?.fetchStatus).toBe("idle");
+        const { server, rendered, writeA, writeB } = await overlapWrites(first, second);
 
         await act(async () => {
           server.commit("issue-1");
@@ -1070,13 +1081,26 @@ describe("status / priority writes re-read an Inbox list they left behind", () =
         await waitFor(() => expect(server.listInbox).toHaveBeenCalledTimes(3));
         server.answerReads();
 
-        await waitFor(() =>
-          expect(rendered()).toEqual([
-            ["n-c", "none"],
-            ["n-a", "high"],
-            ["n-b", "high"],
-          ]),
-        );
+        await waitFor(() => expect(rendered()).toEqual(everySaved));
+      },
+    );
+
+    it.each(pairings)(
+      "re-reads when both saves land in the same tick (%s, then %s)",
+      async (first: Kind, second: Kind) => {
+        const { server, rendered, writeA, writeB } = await overlapWrites(first, second);
+
+        // Each write settles while the other still counts as in flight.
+        await act(async () => {
+          server.commit("issue-1");
+          server.commit("issue-2");
+          await Promise.all([writeA, writeB]);
+        });
+        expect(qc.isMutating()).toBe(0);
+        await waitFor(() => expect(server.listInbox).toHaveBeenCalledTimes(3));
+        server.answerReads();
+
+        await waitFor(() => expect(rendered()).toEqual(everySaved));
       },
     );
 

--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -33,6 +33,7 @@ import type {
   Issue,
   ListIssuesCache,
   TimelineEntry,
+  UpdateIssueRequest,
 } from "../types";
 
 vi.mock("../hooks", () => ({
@@ -955,6 +956,165 @@ describe("status / priority writes re-read an Inbox list they left behind", () =
       expect(listInbox).not.toHaveBeenCalled();
     },
   );
+
+  // Writes that overlap each other or a list request: the re-read must come
+  // after the last save, or it reads a pending write's old value and lands on
+  // top of its patch.
+  describe("overlapping writes", () => {
+    const rowA = makeInboxItem("n-a", "issue-1", { read: true, issue_priority: "none" });
+    const rowB = makeInboxItem("n-b", "issue-2", { read: true, issue_priority: "none" });
+    const newRow = makeInboxItem("n-c", "issue-3", {
+      issue_priority: "none",
+      created_at: "2025-01-02T00:00:00Z",
+    });
+    type Kind = "useUpdateIssue" | "useBatchUpdateIssues";
+
+    // List reads and saves complete only when the test says so. A read answers
+    // with the rows as they were when it reached the server.
+    function controlledServer(initial: InboxItem[]) {
+      let rows = initial;
+      const reads: Array<() => void> = [];
+      const saves = new Map<string, () => void>();
+      const listInbox = vi.fn(() => {
+        const snapshot = rows;
+        return new Promise<InboxItem[]>((resolve) =>
+          reads.push(() => resolve(snapshot)),
+        );
+      });
+      const save = (id: string, priority: UpdateIssueRequest["priority"]) =>
+        new Promise<void>((resolve) =>
+          saves.set(id, () => {
+            rows = rows.map((row) =>
+              row.issue_id === id ? { ...row, issue_priority: priority } : row,
+            );
+            resolve();
+          }),
+        );
+      setApiInstance({
+        listInbox,
+        updateIssue: (id: string, data: UpdateIssueRequest) =>
+          save(id, data.priority).then(() => ({ ...makeIssue(1), ...data, id })),
+        batchUpdateIssues: (ids: string[], updates: UpdateIssueRequest) =>
+          save(ids[0]!, updates.priority).then(() => ({ updated: ids.length })),
+      } as unknown as ApiClient);
+      return {
+        listInbox,
+        setRows: (next: InboxItem[]) => {
+          rows = next;
+        },
+        answerReads: () => reads.splice(0).forEach((answer) => answer()),
+        saving: (id: string) => saves.has(id),
+        commit: (id: string) => saves.get(id)!(),
+      };
+    }
+
+    function write(hooks: WriteHooks, kind: Kind, id: string) {
+      return kind === "useUpdateIssue"
+        ? hooks.single.mutateAsync({ id, priority: "high" })
+        : hooks.batch.mutateAsync({ ids: [id], updates: { priority: "high" } });
+    }
+
+    async function loadInbox(server: ReturnType<typeof controlledServer>) {
+      const inbox = mountInbox();
+      await waitFor(() => expect(server.listInbox).toHaveBeenCalledTimes(1));
+      server.answerReads();
+      await waitFor(() => expect(inbox.current.data).toBeDefined());
+      return () => inbox.current.data?.map((row) => [row.id, row.issue_priority]);
+    }
+
+    it.each([
+      ["useUpdateIssue", "useUpdateIssue"],
+      ["useBatchUpdateIssues", "useBatchUpdateIssues"],
+      ["useUpdateIssue", "useBatchUpdateIssues"],
+      ["useBatchUpdateIssues", "useUpdateIssue"],
+    ] as const)(
+      "re-reads once, after the last of them saves (%s, then %s)",
+      async (first: Kind, second: Kind) => {
+        const server = controlledServer([rowA, rowB]);
+        const hooks = renderWriteHooks();
+        const rendered = await loadInbox(server);
+
+        // `inbox:new` while the Inbox is open; its re-read is still out.
+        server.setRows([newRow, rowA, rowB]);
+        act(() => {
+          void onInboxInvalidate(qc, WS_ID);
+        });
+        await waitFor(() => expect(server.listInbox).toHaveBeenCalledTimes(2));
+
+        // A's write interrupts that re-read; B's starts before A is saved and
+        // finds nothing to interrupt.
+        let writeA!: Promise<unknown>;
+        let writeB!: Promise<unknown>;
+        act(() => {
+          writeA = write(hooks.current, first, "issue-1");
+        });
+        await waitFor(() => expect(server.saving("issue-1")).toBe(true));
+        act(() => {
+          writeB = write(hooks.current, second, "issue-2");
+        });
+        await waitFor(() => expect(server.saving("issue-2")).toBe(true));
+        expect(qc.getQueryState(inboxKeys.list(WS_ID))?.fetchStatus).toBe("idle");
+
+        await act(async () => {
+          server.commit("issue-1");
+          await writeA;
+        });
+        await act(async () => {});
+        // A owes the re-read, but reading while B is unsaved would miss B.
+        expect(server.listInbox).toHaveBeenCalledTimes(2);
+
+        await act(async () => {
+          server.commit("issue-2");
+          await writeB;
+        });
+        await waitFor(() => expect(server.listInbox).toHaveBeenCalledTimes(3));
+        server.answerReads();
+
+        await waitFor(() =>
+          expect(rendered()).toEqual([
+            ["n-c", "none"],
+            ["n-a", "high"],
+            ["n-b", "high"],
+          ]),
+        );
+      },
+    );
+
+    it.each(["useUpdateIssue", "useBatchUpdateIssues"] as const)(
+      "%s re-reads a list request that started while it was saving",
+      async (kind: Kind) => {
+        const server = controlledServer([rowA]);
+        const hooks = renderWriteHooks();
+        const rendered = await loadInbox(server);
+
+        let writeA!: Promise<unknown>;
+        act(() => {
+          writeA = write(hooks.current, kind, "issue-1");
+        });
+        await waitFor(() => expect(server.saving("issue-1")).toBe(true));
+        // `inbox:new` mid-save: this read reaches the server before A is saved.
+        server.setRows([newRow, rowA]);
+        act(() => {
+          void onInboxInvalidate(qc, WS_ID);
+        });
+        await waitFor(() => expect(server.listInbox).toHaveBeenCalledTimes(2));
+
+        await act(async () => {
+          server.commit("issue-1");
+          await writeA;
+        });
+        await waitFor(() => expect(server.listInbox).toHaveBeenCalledTimes(3));
+        server.answerReads();
+
+        await waitFor(() =>
+          expect(rendered()).toEqual([
+            ["n-c", "none"],
+            ["n-a", "high"],
+          ]),
+        );
+      },
+    );
+  });
 });
 
 describe("comment mutations — owner revision and last activity", () => {

--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -3,11 +3,12 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
 import { setApiInstance } from "../api";
 import type { ApiClient } from "../api/client";
+import { createQueryClient } from "../query-client";
 import {
   useBatchUpdateIssues,
   useCreateComment,
@@ -22,7 +23,11 @@ import {
   type IssueSortParam,
 } from "./queries";
 import { onIssueUpdated, onIssueAuxiliaryRevision } from "./ws-updaters";
-import { inboxKeys } from "../inbox/queries";
+import { inboxKeys, inboxListOptions } from "../inbox/queries";
+import {
+  onInboxInvalidate,
+  onInboxIssueStatusChanged,
+} from "../inbox/ws-updaters";
 import type {
   InboxItem,
   Issue,
@@ -790,6 +795,166 @@ describe("useBatchUpdateIssues — optimistic patch covers filtered boards too",
     const invalidatedKeys = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
     expect(invalidatedKeys).not.toContainEqual(issueKeys.myAll(WS_ID));
   });
+});
+
+// MUL-7286: a status / priority write cancels the Inbox list's in-flight
+// request so it cannot land on top of the optimistic patch. Whatever that
+// request was carrying — here a new notification — must be re-read once the
+// write settles, or the unread badge counts a row the list never shows. The
+// cancel primitive itself is covered in inbox/ws-updaters.test.ts.
+describe("status / priority writes re-read an Inbox list they left behind", () => {
+  const readItem = makeInboxItem("n1", "issue-1", {
+    read: true,
+    issue_priority: "none",
+  });
+  const notification = makeInboxItem("n2", "issue-2", {
+    created_at: "2025-01-02T00:00:00Z",
+  });
+  const writes = [
+    {
+      name: "useUpdateIssue",
+      write: (hooks: WriteHooks) =>
+        hooks.single.mutateAsync({ id: "issue-1", priority: "high" }),
+    },
+    {
+      name: "useBatchUpdateIssues",
+      write: (hooks: WriteHooks) =>
+        hooks.batch.mutateAsync({ ids: ["issue-1"], updates: { priority: "high" } }),
+    },
+  ];
+
+  let qc: QueryClient;
+  const unmounts: Array<() => void> = [];
+
+  function renderWriteHooks() {
+    const hooks = renderHook(
+      () => ({ single: useUpdateIssue(), batch: useBatchUpdateIssues() }),
+      { wrapper: createWrapper(qc) },
+    );
+    unmounts.push(hooks.unmount);
+    return hooks.result;
+  }
+  type WriteHooks = ReturnType<typeof renderWriteHooks>["current"];
+
+  function mountInbox() {
+    const page = renderHook(() => useQuery(inboxListOptions(WS_ID)), {
+      wrapper: createWrapper(qc),
+    });
+    unmounts.push(page.unmount);
+    return page.result;
+  }
+
+  function mockApi(
+    listInbox: () => Promise<InboxItem[]>,
+    { fail = false }: { fail?: boolean } = {},
+  ) {
+    const settle = <T,>(value: T) =>
+      fail ? Promise.reject(new Error("boom")) : Promise.resolve(value);
+    setApiInstance({
+      listInbox,
+      updateIssue: () => settle(makeIssue(1, { priority: "high" })),
+      batchUpdateIssues: () => settle({ updated: 1 }),
+    } as unknown as ApiClient);
+  }
+
+  beforeEach(() => {
+    qc = createQueryClient();
+  });
+
+  afterEach(() => {
+    unmounts.splice(0).forEach((unmount) => unmount());
+    qc.clear();
+  });
+
+  it.each(
+    writes.flatMap((w) => [
+      { ...w, issueEvent: false },
+      { ...w, issueEvent: true },
+    ]),
+  )(
+    "$name re-reads the request it interrupted (issue event meanwhile: $issueEvent)",
+    async ({ write, issueEvent }) => {
+      let release!: (items: InboxItem[]) => void;
+      const listInbox = vi
+        .fn<() => Promise<InboxItem[]>>()
+        .mockResolvedValueOnce([readItem])
+        .mockImplementationOnce(
+          () => new Promise((resolve) => (release = resolve)),
+        )
+        .mockResolvedValue([notification, readItem]);
+      mockApi(listInbox);
+      const hooks = renderWriteHooks();
+      const inbox = mountInbox();
+      await waitFor(() => expect(inbox.current.data).toEqual([readItem]));
+
+      // `inbox:new` while the Inbox is open; the list re-read is still out.
+      act(() => {
+        void onInboxInvalidate(qc, WS_ID);
+      });
+      await waitFor(() => expect(listInbox).toHaveBeenCalledTimes(2));
+      expect(qc.getQueryState(inboxKeys.list(WS_ID))?.fetchStatus).toBe("fetching");
+      if (issueEvent) {
+        // An `issue:updated` patching a listed row mid-request replaces the
+        // snapshot TanStack reverts to on cancel with a non-invalidated state.
+        onInboxIssueStatusChanged(qc, WS_ID, "issue-1", "in_progress");
+      }
+
+      await act(async () => {
+        await write(hooks.current);
+      });
+      release([notification, readItem]); // interrupted: its response is dropped
+
+      await waitFor(() =>
+        expect(inbox.current.data?.map((item) => item.id)).toEqual(["n2", "n1"]),
+      );
+      expect(listInbox).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it.each(writes)(
+    "$name adds no Inbox request when it interrupts none",
+    async ({ write }) => {
+      const listInbox = vi
+        .fn<() => Promise<InboxItem[]>>()
+        .mockResolvedValue([readItem]);
+      mockApi(listInbox);
+      const hooks = renderWriteHooks();
+      const inbox = mountInbox();
+      await waitFor(() => expect(inbox.current.data).toEqual([readItem]));
+
+      await act(async () => {
+        await write(hooks.current);
+      });
+
+      await waitFor(() =>
+        expect(inbox.current.data?.[0]?.issue_priority).toBe("high"),
+      );
+      expect(listInbox).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(writes)(
+    "$name keeps the pending refresh when a failed write rolls the rows back",
+    async ({ write }) => {
+      const listInbox = vi.fn<() => Promise<InboxItem[]>>();
+      mockApi(listInbox, { fail: true });
+      // The user is elsewhere: the list is cached, nothing observes it, and an
+      // `inbox:new` has marked it to re-read on the next visit.
+      qc.setQueryData<InboxItem[]>(inboxKeys.list(WS_ID), [readItem]);
+      await onInboxInvalidate(qc, WS_ID);
+      const hooks = renderWriteHooks();
+
+      await act(async () => {
+        await write(hooks.current).catch(() => {});
+      });
+
+      await waitFor(() =>
+        expect(qc.getQueryState(inboxKeys.list(WS_ID))?.isInvalidated).toBe(true),
+      );
+      expect(qc.getQueryData(inboxKeys.list(WS_ID))).toEqual([readItem]);
+      expect(listInbox).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe("comment mutations — owner revision and last activity", () => {

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -10,7 +10,11 @@ import { api } from "../api";
 import { issueKeys } from "./queries";
 import { projectKeys } from "../projects/queries";
 import { inboxKeys } from "../inbox/queries";
-import { cancelInboxLists, onInboxInvalidate } from "../inbox/ws-updaters";
+import {
+  cancelInboxLists,
+  isInboxListRequestInFlight,
+  onInboxInvalidate,
+} from "../inbox/ws-updaters";
 import {
   applyIssueChange,
   invalidateIssueDerivatives,
@@ -83,18 +87,44 @@ export type UpdateIssueMutationInput = {
 // Issue CRUD
 // ---------------------------------------------------------------------------
 
-// A status / priority write patches the inbox rows optimistically, so the
-// lists need a re-read only when the write left them behind the server: onMutate
-// interrupted one of their requests (see `cancelInboxLists`), or a failure
-// restored their rollback snapshot, which drops a pending refresh and can
-// predate a notification that arrived meanwhile. Otherwise the patch was the
-// whole change, and the write stays request-free (MUL-7286).
-function refreshInboxAfterIssueWrite(
+// Shared by the single and batch update hooks, so a settling write can tell
+// whether another is still in flight.
+const issueWriteMutationKey = (wsId: string) => ["issue-write", wsId] as const;
+
+// Workspaces whose inbox lists owe a re-read, per client.
+const inboxRereadsOwed = new WeakMap<QueryClient, Set<string>>();
+
+// Inbox side of settling an issue write. A status / priority write patches the
+// inbox rows optimistically, so the lists owe a re-read only when the write left
+// them behind the server: onMutate interrupted one of their requests (see
+// `cancelInboxLists`), a failure restored their rollback snapshot, or a list
+// request is still out and may have read the server before this write
+// committed. Otherwise the patch was the whole change, and no request is added.
+//
+// The re-read waits for the last in-flight issue write, which inherits the
+// obligation. Issued while another write is pending, it would read that write's
+// old value and land after its patch, reverting a saved change (MUL-7286).
+function settleInboxAfterIssueWrite(
   qc: QueryClient,
   wsId: string,
-  { interrupted, rolledBack }: { interrupted: boolean; rolledBack: boolean },
+  // Set by onMutate for status / priority writes only.
+  inboxWrite: { interrupted: boolean } | undefined,
+  failed: boolean,
 ) {
-  if (interrupted || rolledBack) void onInboxInvalidate(qc, wsId);
+  let owed = inboxRereadsOwed.get(qc);
+  if (!owed) {
+    owed = new Set();
+    inboxRereadsOwed.set(qc, owed);
+  }
+  if (
+    inboxWrite &&
+    (inboxWrite.interrupted || failed || isInboxListRequestInFlight(qc, wsId))
+  ) {
+    owed.add(wsId);
+  }
+  // The settling write itself still counts as in flight.
+  if (qc.isMutating({ mutationKey: issueWriteMutationKey(wsId) }) > 1) return;
+  if (owed.delete(wsId)) void onInboxInvalidate(qc, wsId);
 }
 
 function useIssueCreateMutation<TVariables>(
@@ -147,6 +177,7 @@ export function useUpdateIssue() {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
   return useMutation({
+    mutationKey: issueWriteMutationKey(wsId),
     mutationFn: ({ id, move_intent: moveIntent, ...data }: UpdateIssueMutationInput) => {
       if (!moveIntent) return api.updateIssue(id, data);
       const { position: _optimisticPosition, ...target } = data;
@@ -175,9 +206,10 @@ export function useUpdateIssue() {
       qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) });
       qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) });
       qc.cancelQueries({ queryKey: issueKeys.tableAll(wsId) });
-      const inboxInterrupted =
-        (patch.status !== undefined || patch.priority !== undefined) &&
-        cancelInboxLists(qc, wsId);
+      const inboxWrite =
+        patch.status !== undefined || patch.priority !== undefined
+          ? { interrupted: cancelInboxLists(qc, wsId) }
+          : undefined;
       const prevDetail = qc.getQueryData<Issue>(issueKeys.detail(wsId, id));
       // The coordinator owns the cross-cache rules: surgical patch/rebucket
       // where the card is loaded and still belongs, surgical REMOVE where the
@@ -233,7 +265,7 @@ export function useUpdateIssue() {
               : old?.map((c) => (c.id === id ? { ...c, ...normalizeStatusPatch(patch) } : c)),
         );
       }
-      return { change, prevChildren, parentId, id, inboxInterrupted };
+      return { change, prevChildren, parentId, id, inboxWrite };
     },
     onError: (_err, vars, ctx) => {
       if (ctx) {
@@ -304,6 +336,8 @@ export function useUpdateIssue() {
       invalidateStaleListKeys(qc, reconcile.staleKeys);
     },
     onSettled: (_data, err, vars, ctx) => {
+      // Runs even without ctx: the last write settles what earlier ones owe.
+      settleInboxAfterIssueWrite(qc, wsId, ctx?.inboxWrite, err !== null);
       // The issue's own list + detail caches are reconciled surgically in
       // onSuccess / onError, so they are deliberately NOT invalidated here — a
       // full-list refetch on settle is what made drags flicker. Only aggregate
@@ -322,13 +356,6 @@ export function useUpdateIssue() {
       qc.invalidateQueries({ queryKey: issueKeys.tableAll(wsId) });
       if (ctx) {
         invalidateStaleListKeys(qc, ctx.change.staleKeys);
-        refreshInboxAfterIssueWrite(qc, wsId, {
-          interrupted: ctx.inboxInterrupted,
-          rolledBack:
-            err !== null &&
-            (ctx.change.prevInboxList !== undefined ||
-              ctx.change.prevArchivedInboxList !== undefined),
-        });
       }
       // Refresh the issue's attachments cache when the description editor
       // bound new uploads — the description editor reads `issueAttachments`
@@ -457,6 +484,7 @@ export function useBatchUpdateIssues() {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
   return useMutation({
+    mutationKey: issueWriteMutationKey(wsId),
     mutationFn: ({
       ids,
       updates,
@@ -479,9 +507,10 @@ export function useBatchUpdateIssues() {
       await qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) });
       await qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) });
       await qc.cancelQueries({ queryKey: issueKeys.tableAll(wsId) });
-      const inboxInterrupted =
-        (patch.status !== undefined || patch.priority !== undefined) &&
-        cancelInboxLists(qc, wsId);
+      const inboxWrite =
+        patch.status !== undefined || patch.priority !== undefined
+          ? { interrupted: cancelInboxLists(qc, wsId) }
+          : undefined;
 
       // Run every issue through the coordinator — the same rules table the
       // single-issue update uses, so a batch edit patches/removes across the
@@ -560,7 +589,7 @@ export function useBatchUpdateIssues() {
         prevDetailById,
         prevInboxList,
         prevArchivedInboxList,
-        inboxInterrupted,
+        inboxWrite,
         staleKeys,
         prevChildren,
         affectedParentIds,
@@ -603,6 +632,8 @@ export function useBatchUpdateIssues() {
       }
     },
     onSettled: (_data, err, _vars, ctx) => {
+      // Runs even without ctx: the last write settles what earlier ones owe.
+      settleInboxAfterIssueWrite(qc, wsId, ctx?.inboxWrite, err !== null);
       // Deliberately NOT invalidating issueKeys.list / myAll here: the onMutate
       // pass above is a complete surgical reconcile for the loaded bucketed
       // boards, so a full-board refetch on settle would only re-introduce the
@@ -619,13 +650,6 @@ export function useBatchUpdateIssues() {
       qc.invalidateQueries({ queryKey: issueKeys.tableAll(wsId) });
       if (ctx) {
         invalidateStaleListKeys(qc, ctx.staleKeys);
-        refreshInboxAfterIssueWrite(qc, wsId, {
-          interrupted: ctx.inboxInterrupted,
-          rolledBack:
-            err !== null &&
-            (ctx.prevInboxList !== undefined ||
-              ctx.prevArchivedInboxList !== undefined),
-        });
       }
       if (ctx?.affectedParentIds && ctx.affectedParentIds.size > 0) {
         for (const parentId of ctx.affectedParentIds) {

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -1,9 +1,16 @@
 import { normalizeStatusPatch } from "./status-category";
-import { hashKey, useMutation, useQueryClient, type QueryKey } from "@tanstack/react-query";
+import {
+  hashKey,
+  useMutation,
+  useQueryClient,
+  type QueryClient,
+  type QueryKey,
+} from "@tanstack/react-query";
 import { api } from "../api";
 import { issueKeys } from "./queries";
 import { projectKeys } from "../projects/queries";
 import { inboxKeys } from "../inbox/queries";
+import { cancelInboxLists, onInboxInvalidate } from "../inbox/ws-updaters";
 import {
   applyIssueChange,
   invalidateIssueDerivatives,
@@ -75,6 +82,20 @@ export type UpdateIssueMutationInput = {
 // ---------------------------------------------------------------------------
 // Issue CRUD
 // ---------------------------------------------------------------------------
+
+// A status / priority write patches the inbox rows optimistically, so the
+// lists need a re-read only when the write left them behind the server: onMutate
+// interrupted one of their requests (see `cancelInboxLists`), or a failure
+// restored their rollback snapshot, which drops a pending refresh and can
+// predate a notification that arrived meanwhile. Otherwise the patch was the
+// whole change, and the write stays request-free (MUL-7286).
+function refreshInboxAfterIssueWrite(
+  qc: QueryClient,
+  wsId: string,
+  { interrupted, rolledBack }: { interrupted: boolean; rolledBack: boolean },
+) {
+  if (interrupted || rolledBack) void onInboxInvalidate(qc, wsId);
+}
 
 function useIssueCreateMutation<TVariables>(
   mutationFn: (variables: TVariables) => Promise<Issue>,
@@ -154,9 +175,9 @@ export function useUpdateIssue() {
       qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) });
       qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) });
       qc.cancelQueries({ queryKey: issueKeys.tableAll(wsId) });
-      if (patch.status !== undefined || patch.priority !== undefined) {
-        qc.cancelQueries({ queryKey: inboxKeys.all(wsId) });
-      }
+      const inboxInterrupted =
+        (patch.status !== undefined || patch.priority !== undefined) &&
+        cancelInboxLists(qc, wsId);
       const prevDetail = qc.getQueryData<Issue>(issueKeys.detail(wsId, id));
       // The coordinator owns the cross-cache rules: surgical patch/rebucket
       // where the card is loaded and still belongs, surgical REMOVE where the
@@ -212,7 +233,7 @@ export function useUpdateIssue() {
               : old?.map((c) => (c.id === id ? { ...c, ...normalizeStatusPatch(patch) } : c)),
         );
       }
-      return { change, prevChildren, parentId, id };
+      return { change, prevChildren, parentId, id, inboxInterrupted };
     },
     onError: (_err, vars, ctx) => {
       if (ctx) {
@@ -282,7 +303,7 @@ export function useUpdateIssue() {
       // The server has committed — safe to flush any drift it reported now.
       invalidateStaleListKeys(qc, reconcile.staleKeys);
     },
-    onSettled: (_data, _err, vars, ctx) => {
+    onSettled: (_data, err, vars, ctx) => {
       // The issue's own list + detail caches are reconciled surgically in
       // onSuccess / onError, so they are deliberately NOT invalidated here — a
       // full-list refetch on settle is what made drags flicker. Only aggregate
@@ -301,6 +322,13 @@ export function useUpdateIssue() {
       qc.invalidateQueries({ queryKey: issueKeys.tableAll(wsId) });
       if (ctx) {
         invalidateStaleListKeys(qc, ctx.change.staleKeys);
+        refreshInboxAfterIssueWrite(qc, wsId, {
+          interrupted: ctx.inboxInterrupted,
+          rolledBack:
+            err !== null &&
+            (ctx.change.prevInboxList !== undefined ||
+              ctx.change.prevArchivedInboxList !== undefined),
+        });
       }
       // Refresh the issue's attachments cache when the description editor
       // bound new uploads — the description editor reads `issueAttachments`
@@ -451,9 +479,9 @@ export function useBatchUpdateIssues() {
       await qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) });
       await qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) });
       await qc.cancelQueries({ queryKey: issueKeys.tableAll(wsId) });
-      if (patch.status !== undefined || patch.priority !== undefined) {
-        await qc.cancelQueries({ queryKey: inboxKeys.all(wsId) });
-      }
+      const inboxInterrupted =
+        (patch.status !== undefined || patch.priority !== undefined) &&
+        cancelInboxLists(qc, wsId);
 
       // Run every issue through the coordinator — the same rules table the
       // single-issue update uses, so a batch edit patches/removes across the
@@ -532,6 +560,7 @@ export function useBatchUpdateIssues() {
         prevDetailById,
         prevInboxList,
         prevArchivedInboxList,
+        inboxInterrupted,
         staleKeys,
         prevChildren,
         affectedParentIds,
@@ -573,7 +602,7 @@ export function useBatchUpdateIssues() {
         }
       }
     },
-    onSettled: (_data, _err, _vars, ctx) => {
+    onSettled: (_data, err, _vars, ctx) => {
       // Deliberately NOT invalidating issueKeys.list / myAll here: the onMutate
       // pass above is a complete surgical reconcile for the loaded bucketed
       // boards, so a full-board refetch on settle would only re-introduce the
@@ -590,6 +619,13 @@ export function useBatchUpdateIssues() {
       qc.invalidateQueries({ queryKey: issueKeys.tableAll(wsId) });
       if (ctx) {
         invalidateStaleListKeys(qc, ctx.staleKeys);
+        refreshInboxAfterIssueWrite(qc, wsId, {
+          interrupted: ctx.inboxInterrupted,
+          rolledBack:
+            err !== null &&
+            (ctx.prevInboxList !== undefined ||
+              ctx.prevArchivedInboxList !== undefined),
+        });
       }
       if (ctx?.affectedParentIds && ctx.affectedParentIds.size > 0) {
         for (const parentId of ctx.affectedParentIds) {

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -87,23 +87,45 @@ export type UpdateIssueMutationInput = {
 // Issue CRUD
 // ---------------------------------------------------------------------------
 
-// Shared by the single and batch update hooks, so a settling write can tell
-// whether another is still in flight.
-const issueWriteMutationKey = (wsId: string) => ["issue-write", wsId] as const;
+// Shared by the single and batch update hooks, so the inbox re-read can wait
+// for the last of them (see `owedInboxRereads`).
+const ISSUE_WRITE = "issue-write";
+const issueWriteMutationKey = (wsId: string) => [ISSUE_WRITE, wsId] as const;
 
 // Workspaces whose inbox lists owe a re-read, per client.
 const inboxRereadsOwed = new WeakMap<QueryClient, Set<string>>();
 
-// Inbox side of settling an issue write. A status / priority write patches the
-// inbox rows optimistically, so the lists owe a re-read only when the write left
-// them behind the server: onMutate interrupted one of their requests (see
+// A client's owed re-reads, each paid once its workspace has no issue write
+// left in flight. Issued earlier, the re-read could read a pending write's old
+// value and land after that write's patch, reverting a saved change. The check
+// runs when a write reaches its terminal state, not in onSettled: TanStack
+// calls onSettled while the mutation still counts as pending, so two writes
+// settling in the same tick would each count the other and both skip
+// (MUL-7286).
+function owedInboxRereads(qc: QueryClient): Set<string> {
+  const existing = inboxRereadsOwed.get(qc);
+  if (existing) return existing;
+  const owed = new Set<string>();
+  inboxRereadsOwed.set(qc, owed);
+  qc.getMutationCache().subscribe((event) => {
+    if (event.type !== "updated") return;
+    if (event.action.type !== "success" && event.action.type !== "error") return;
+    const [kind, wsId] = event.mutation.options.mutationKey ?? [];
+    if (kind !== ISSUE_WRITE || typeof wsId !== "string") return;
+    if (!owed.has(wsId)) return;
+    if (qc.isMutating({ mutationKey: issueWriteMutationKey(wsId) }) > 0) return;
+    owed.delete(wsId);
+    void onInboxInvalidate(qc, wsId);
+  });
+  return owed;
+}
+
+// Inbox side of settling a status / priority write. It patched the inbox rows
+// optimistically, so the lists owe a re-read only when the write left them
+// behind the server: onMutate interrupted one of their requests (see
 // `cancelInboxLists`), a failure restored their rollback snapshot, or a list
 // request is still out and may have read the server before this write
 // committed. Otherwise the patch was the whole change, and no request is added.
-//
-// The re-read waits for the last in-flight issue write, which inherits the
-// obligation. Issued while another write is pending, it would read that write's
-// old value and land after its patch, reverting a saved change (MUL-7286).
 function settleInboxAfterIssueWrite(
   qc: QueryClient,
   wsId: string,
@@ -111,20 +133,10 @@ function settleInboxAfterIssueWrite(
   inboxWrite: { interrupted: boolean } | undefined,
   failed: boolean,
 ) {
-  let owed = inboxRereadsOwed.get(qc);
-  if (!owed) {
-    owed = new Set();
-    inboxRereadsOwed.set(qc, owed);
+  if (!inboxWrite) return;
+  if (inboxWrite.interrupted || failed || isInboxListRequestInFlight(qc, wsId)) {
+    owedInboxRereads(qc).add(wsId);
   }
-  if (
-    inboxWrite &&
-    (inboxWrite.interrupted || failed || isInboxListRequestInFlight(qc, wsId))
-  ) {
-    owed.add(wsId);
-  }
-  // The settling write itself still counts as in flight.
-  if (qc.isMutating({ mutationKey: issueWriteMutationKey(wsId) }) > 1) return;
-  if (owed.delete(wsId)) void onInboxInvalidate(qc, wsId);
 }
 
 function useIssueCreateMutation<TVariables>(
@@ -336,7 +348,6 @@ export function useUpdateIssue() {
       invalidateStaleListKeys(qc, reconcile.staleKeys);
     },
     onSettled: (_data, err, vars, ctx) => {
-      // Runs even without ctx: the last write settles what earlier ones owe.
       settleInboxAfterIssueWrite(qc, wsId, ctx?.inboxWrite, err !== null);
       // The issue's own list + detail caches are reconciled surgically in
       // onSuccess / onError, so they are deliberately NOT invalidated here — a
@@ -632,7 +643,6 @@ export function useBatchUpdateIssues() {
       }
     },
     onSettled: (_data, err, _vars, ctx) => {
-      // Runs even without ctx: the last write settles what earlier ones owe.
       settleInboxAfterIssueWrite(qc, wsId, ctx?.inboxWrite, err !== null);
       // Deliberately NOT invalidating issueKeys.list / myAll here: the onMutate
       // pass above is a complete surgical reconcile for the loaded bucketed

--- a/packages/core/realtime/use-realtime-sync-inbox.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-inbox.test.tsx
@@ -95,7 +95,8 @@ it("refreshes an inactive Inbox after inbox:new then issue:updated (MUL-7286)", 
   let page = mountInbox();
   try {
     await waitFor(() => expect(page.result.current.data).toEqual([oldItem]));
-    // Switching desktop tabs unmounts the page but keeps its cache for 10 min.
+    // Switching tabs unmounts the page; its cache stays (tab titles hold
+    // disabled observers on it), so the return reuses it.
     page.unmount();
     const newItem = {
       ...oldItem,


### PR DESCRIPTION
## What does this PR do?

Closes the remaining path to "unread badge 1, notification missing from the Inbox list" after #8311, this time while the Inbox is open.

A status or priority write (`useUpdateIssue`, `useBatchUpdateIssues`) cancels the Inbox lists' in-flight requests, so that a response read before the write cannot land on top of its optimistic patch. If that request was the re-read an `inbox:new` had just started, the notification was dropped, because neither mutation re-read the lists on settle. The badge reads the separate unread summary, so it still showed the notification.

- Without any other event, the list stayed behind until the user left and reopened the Inbox (#8311 made reopening recover).
- If an `issue:updated` had patched a listed row during that request, reopening did not recover either. TanStack reverts a cancelled query to a snapshot, and `setQueryData` during the fetch had replaced that snapshot with a non-invalidated state, so the cancel cleared the invalidation mark.
- A failed write restored its rollback snapshot with `setQueryData`, which likewise cleared a pending refresh. That snapshot could also predate a notification that arrived during the write.

The fix re-reads the lists only when a write left them behind:
- it interrupted a list request;
- it failed and rolled the rows back;
- a list request is still out that may have read the server before the write was saved.

The re-read waits until **no issue write of the workspace is left in flight**. Issued earlier, it could read another pending write's old value and land after that write's patch, reverting a saved change. Review found exactly that with the first version of this PR, when two writes overlapped. Writes that overlap nothing still add no Inbox request.

The "last write" check runs when a write reaches its terminal state, not in `onSettled`. TanStack calls `onSettled` while the mutation still counts as pending, so two writes whose saves resolved in the same tick each counted the other and both skipped. Review found that in the second version.

## Related Issue

MUL-7286 (follow-up to #8311)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `packages/core/inbox/ws-updaters.ts`:
  - `isInboxListRequestInFlight`, which reports whether either list has a request out (paused ones count).
  - `cancelInboxLists`, which cancels those requests and reports whether it interrupted one.
  - Corrects the `onInboxInvalidate` comment: tab titles hold disabled observers on the list (`useTabPresentation`), so its cache is not collected while the user is away.
- `packages/core/issues/mutations.ts`:
  - Both update hooks share `mutationKey: ["issue-write", wsId]`.
  - `onMutate` records `inboxWrite: { interrupted }` for status / priority writes.
  - `onSettled` calls `settleInboxAfterIssueWrite`, which only records an owed re-read for the workspace (per `QueryClient`, in a `WeakMap`).
  - `owedInboxRereads` lazily registers one MutationCache listener per client. When an issue write dispatches `success` or `error`, the listener issues the owed re-read through `onInboxInvalidate` if `qc.isMutating({ mutationKey })` is 0. That dispatch comes after `onSettled` and updates the status first, so the last write to terminate always sees 0, whether the saves resolve together or apart, and whether they succeed or fail.
  - `settleIssuePropertyCaches` can check `isMutating() > 1` in `onSettled` because its shared `scope` runs property writes one at a time. Issue writes run concurrently, so that check is not safe here.
  - The batch mutation no longer awaits the inbox cancel. TanStack reverts the cancelled query synchronously and dispatches nothing afterwards, so behavior is unchanged.
- `packages/core/issues/mutations.test.tsx`, hook-level tests with the real query client and a mounted Inbox list:
  - an interrupted request is re-read (single and batch, with and without an issue event mid-request);
  - a write that interrupts nothing adds no request;
  - a failed write keeps the pending refresh of a list the user is away from;
  - overlapping writes re-read once, after the last save, in every single/batch pairing and order;
  - the same pairings with both saves resolving in the same tick;
  - a list request that started mid-save is re-read after the save.
- `packages/core/inbox/ws-updaters.test.ts`: `cancelInboxLists` on both lists.
- `packages/core/realtime/use-realtime-sync-inbox.test.tsx`: fixes the cache-lifetime comment added in #8311.

## How to Test

1. Open the Inbox. Trigger a new notification for issue C. While its list re-read is pending, change the priority of issue A from the detail pane, then of issue B before A saves.
2. Before: the list either lacks C's notification (badge 1), or shows B's old priority after both saves. After: the list re-reads once, after both saves, and shows C's notification with A and B at their saved priorities.
3. Automated:
   ```sh
   pnpm --filter @multica/core exec vitest run issues/mutations.test.tsx inbox/ws-updaters.test.ts realtime/use-realtime-sync-inbox.test.tsx
   ```
   - With `issues/mutations.ts` from the second version (`f8be69e`), the 4 same-tick tests fail.
   - With it from the first version (`d4ba564`), the overlap tests fail.
   - The reviewer's repros:
     - the overlap repro passes here and fails on `d4ba564` (`expected 'none' to be 'high'`);
     - the same-tick repro passes here and fails on `f8be69e`;
     - the two characterizations of the batch gap listed under Risk behave exactly as on `main`.

Local validation:
- Full `@multica/core` suite: 145 files, 1802 tests passed.
- `@multica/core` and `@multica/views` typecheck passed.
- ESLint on the changed files passed.
- `@multica/views` inbox and issues tests: 99 files, 1066 tests passed with `--maxWorkers=3`. At default parallelism on a machine at load average ~30–40, timeouts in unrelated UI tests varied from run to run, and were worse with `f8be69e`'s `mutations.ts`. Each failing file passed on its own.
- Not reproduced by hand in a desktop build.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge
- Screenshots, docs, landing copy and Chinese copy: not applicable. There is no UI, API or copy change.

**Risk:** the change affects only the web and desktop Inbox list cache, and there are no API or database changes.
- **New requests:** one Inbox list re-read after the last of a set of overlapping issue writes, only when one of them interrupted an Inbox request, failed, or overlapped one.
- **Delay:** while any update write is pending (including title edits, which share the key), an owed re-read waits for it.
- **Not covered:** a list read that starts and also completes during a batch write, landing after the batch's WS echo. Single writes re-patch rows from their server response; batch writes rely on that echo, as on `main`.
- **Mobile:** it keeps its own inbox updaters with a 60-second `staleTime` and is not changed here.

## AI Disclosure

**AI tool used:** Multica Agent (J), reviewed by Multica Agent (Niko).

**Prompt / approach:** Found the interrupted-request path while reviewing #8311. I read TanStack 5.96.2's cancel/revert and `setData` code and reproduced it. Niko independently confirmed it with the real mutation hooks. In later reviews Niko reproduced the overlapping-writes regression (fixed by deferring the re-read to the last in-flight write) and the same-tick settle gap (fixed by checking on the mutation's terminal state instead of in `onSettled`).

