### PR TITLE
MUL-7290: remove Redis MEMORY usage sampling

### DIFF
--- a/server/internal/metrics/realtime.go
+++ b/server/internal/metrics/realtime.go
@@ -32,7 +32,6 @@ type RealtimeCollector struct {
 	redisMaxMemoryBytes    *prometheus.Desc
 	redisEvictedKeys       *prometheus.Desc
 	redisStreamEntries     *prometheus.Desc
-	redisStreamMemory      *prometheus.Desc
 	redisStreamPTTL        *prometheus.Desc
 }
 
@@ -63,7 +62,6 @@ func NewRealtimeCollector(m *realtime.Metrics) *RealtimeCollector {
 		redisMaxMemoryBytes:    newRealtimeDesc("redis_maxmemory_bytes", "Redis maxmemory sampled by the realtime relay; zero means unlimited."),
 		redisEvictedKeys:       newRealtimeDesc("redis_evicted_keys", "Redis instance evicted_keys sampled by the realtime relay."),
 		redisStreamEntries:     prometheus.NewDesc("multica_realtime_redis_stream_entries", "Current entry count of a sampled relay stream.", []string{"stream"}, nil),
-		redisStreamMemory:      prometheus.NewDesc("multica_realtime_redis_stream_memory_bytes", "Sampled memory usage of a relay stream.", []string{"stream"}, nil),
 		redisStreamPTTL:        prometheus.NewDesc("multica_realtime_redis_stream_pttl_milliseconds", "Remaining relay stream TTL in milliseconds; -1 means no TTL and -2 means missing.", []string{"stream"}, nil),
 	}
 }
@@ -97,7 +95,6 @@ func (c *RealtimeCollector) Describe(ch chan<- *prometheus.Desc) {
 		c.redisMaxMemoryBytes,
 		c.redisEvictedKeys,
 		c.redisStreamEntries,
-		c.redisStreamMemory,
 		c.redisStreamPTTL,
 	} {
 		ch <- desc
@@ -134,7 +131,6 @@ func (c *RealtimeCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.redisEvictedKeys, prometheus.GaugeValue, float64(m.RedisEvictedKeys.Load()))
 	for stream, observation := range m.RedisStreamObservations() {
 		ch <- prometheus.MustNewConstMetric(c.redisStreamEntries, prometheus.GaugeValue, float64(observation.Entries), stream)
-		ch <- prometheus.MustNewConstMetric(c.redisStreamMemory, prometheus.GaugeValue, float64(observation.MemoryBytes), stream)
 		ch <- prometheus.MustNewConstMetric(c.redisStreamPTTL, prometheus.GaugeValue, float64(observation.PTTLMillis), stream)
 	}
 }

--- a/server/internal/metrics/realtime_test.go
+++ b/server/internal/metrics/realtime_test.go
@@ -23,7 +23,7 @@ func TestRealtimeCollectorExposesCounters(t *testing.T) {
 	m.RedisUsedMemoryBytes.Store(4096)
 	m.RedisMaxMemoryBytes.Store(8192)
 	m.RedisEvictedKeys.Store(3)
-	m.ObserveRedisStream("ws:relay:shard:0", 23, 2048, 60000)
+	m.ObserveRedisStream("ws:relay:shard:0", 23, 60000)
 
 	registry := NewRegistry(RegistryOptions{Realtime: m})
 	rec := httptest.NewRecorder()
@@ -44,7 +44,6 @@ func TestRealtimeCollectorExposesCounters(t *testing.T) {
 		"multica_realtime_redis_maxmemory_bytes 8192",
 		"multica_realtime_redis_evicted_keys 3",
 		`multica_realtime_redis_stream_entries{stream="ws:relay:shard:0"} 23`,
-		`multica_realtime_redis_stream_memory_bytes{stream="ws:relay:shard:0"} 2048`,
 		`multica_realtime_redis_stream_pttl_milliseconds{stream="ws:relay:shard:0"} 60000`,
 	} {
 		if !strings.Contains(body, want) {

--- a/server/internal/realtime/metrics.go
+++ b/server/internal/realtime/metrics.go
@@ -74,9 +74,8 @@ type Metrics struct {
 // relay stream. PTTLMillis uses Redis sentinel values: -1 means no expiry and
 // -2 means the key does not exist.
 type RedisStreamObservation struct {
-	Entries     int64 `json:"entries"`
-	MemoryBytes int64 `json:"memory_bytes"`
-	PTTLMillis  int64 `json:"pttl_millis"`
+	Entries    int64 `json:"entries"`
+	PTTLMillis int64 `json:"pttl_millis"`
 }
 
 // M is the package-level metrics singleton.
@@ -135,16 +134,15 @@ func (m *Metrics) lastRedisErr() string {
 }
 
 // ObserveRedisStream replaces the latest sampled statistics for stream.
-func (m *Metrics) ObserveRedisStream(stream string, entries, memoryBytes, pttlMillis int64) {
+func (m *Metrics) ObserveRedisStream(stream string, entries, pttlMillis int64) {
 	m.redisStreamsMu.Lock()
 	defer m.redisStreamsMu.Unlock()
 	if m.redisStreams == nil {
 		m.redisStreams = make(map[string]RedisStreamObservation)
 	}
 	m.redisStreams[stream] = RedisStreamObservation{
-		Entries:     entries,
-		MemoryBytes: memoryBytes,
-		PTTLMillis:  pttlMillis,
+		Entries:    entries,
+		PTTLMillis: pttlMillis,
 	}
 }
 

--- a/server/internal/realtime/sharded_stream_relay.go
+++ b/server/internal/realtime/sharded_stream_relay.go
@@ -368,7 +368,7 @@ func (r *ShardedStreamRelay) maintainStreams(ctx context.Context) {
 		}
 		if exists == 0 {
 			r.updateStreamPresence(shard, false)
-			M.ObserveRedisStream(stream, 0, 0, -2)
+			M.ObserveRedisStream(stream, 0, -2)
 			continue
 		}
 		r.updateStreamPresence(shard, true)
@@ -393,12 +393,7 @@ func (r *ShardedStreamRelay) maintainStreams(ctx context.Context) {
 			r.recordRetentionError("XLEN failed", err, "stream", stream)
 			continue
 		}
-		memoryBytes, err := r.writeRDB.MemoryUsage(maintCtx, stream).Result()
-		if err != nil && !errors.Is(err, redis.Nil) {
-			r.recordRetentionError("MEMORY USAGE failed", err, "stream", stream)
-			memoryBytes = 0
-		}
-		M.ObserveRedisStream(stream, length, memoryBytes, redisTTLMillis(ttl))
+		M.ObserveRedisStream(stream, length, redisTTLMillis(ttl))
 	}
 	M.SetRedisStreamsWithoutTTL("sharded", withoutTTL)
 	r.observeRedisServer(maintCtx)

--- a/server/internal/realtime/sharded_stream_relay_test.go
+++ b/server/internal/realtime/sharded_stream_relay_test.go
@@ -224,7 +224,6 @@ func TestShardedStreamRelayMaintenanceTrimsExactlyAndRepairsTTL(t *testing.T) {
 	mock.ExpectPTTL(stream).SetVal(-1)
 	mock.ExpectPExpire(stream, 15*time.Minute).SetVal(true)
 	mock.ExpectXLen(stream).SetVal(23)
-	mock.ExpectMemoryUsage(stream).SetVal(4096)
 	mock.ExpectInfo("memory").SetVal("used_memory:8192\r\nmaxmemory:65536\r\n")
 	mock.ExpectInfo("stats").SetVal("evicted_keys:3\r\n")
 
@@ -234,8 +233,11 @@ func TestShardedStreamRelayMaintenanceTrimsExactlyAndRepairsTTL(t *testing.T) {
 		t.Fatalf("trimmed total = %d, want 17", got)
 	}
 	observation := M.RedisStreamObservations()[stream]
-	if observation.Entries != 23 || observation.MemoryBytes != 4096 || observation.PTTLMillis != (15*time.Minute).Milliseconds() {
+	if observation.Entries != 23 || observation.PTTLMillis != (15*time.Minute).Milliseconds() {
 		t.Fatalf("unexpected observation: %+v", observation)
+	}
+	if got := M.RedisRelayRetentionErrors.Load(); got != 0 {
+		t.Fatalf("retention errors = %d, want 0", got)
 	}
 	if got := M.RedisUsedMemoryBytes.Load(); got != 8192 {
 		t.Fatalf("used memory = %d, want 8192", got)
@@ -271,7 +273,6 @@ func TestShardedStreamRelayMaintenanceCountsTTLRepairFailure(t *testing.T) {
 	mock.ExpectPTTL(stream).SetVal(-1)
 	mock.ExpectPExpire(stream, relay.config.StreamTTL).SetErr(errors.New("PEXPIRE denied"))
 	mock.ExpectXLen(stream).SetVal(1)
-	mock.ExpectMemoryUsage(stream).SetVal(1024)
 	mock.ExpectInfo("memory").SetVal("used_memory:1024\r\nmaxmemory:2048\r\n")
 	mock.ExpectInfo("stats").SetVal("evicted_keys:0\r\n")
 


### PR DESCRIPTION
## Summary

- stop issuing `MEMORY USAGE` while maintaining sharded realtime relay streams
- remove the per-stream `memory_bytes` health field and `multica_realtime_redis_stream_memory_bytes` Prometheus metric
- retain stream entry/TTL observations and Redis-wide memory and eviction metrics

## Testing

- `go test ./internal/realtime ./internal/metrics`
- `go test ./cmd/server -run '^$'`

`go test ./cmd/server` was also attempted, but the checkout's existing local database schema is stale: unrelated integration tests fail on missing `autopilot_trigger.created_by_*` / `comment.recovery_settled_at` columns and duplicate issue numbers.

Closes MUL-7290
