### PR TITLE
MUL-7287: fix(agent): guard process-group signals against pid reuse

### DIFF
--- a/server/internal/daemon/processtree/controller_unix.go
+++ b/server/internal/daemon/processtree/controller_unix.go
@@ -44,18 +44,23 @@ func (c *controller) attach(cmd *exec.Cmd) error {
 	return nil
 }
 
-// stillOurs reports whether pid still refers to the process tagged with
-// startTime in attach. See the equivalent (and the reasoning behind it) in
+// stillOurs reports whether it is safe to signal pid, using the tag laid
+// down in attach. See the equivalent (and the reasoning behind it) in
 // server/pkg/agent/pidtag_unix.go — this package cannot import that one
 // without an import cycle, so the same small check is duplicated here rather
 // than shared.
+//
+// A pid that no longer exists at all answers true (harmless no-op signal;
+// also how a surviving grandchild left in the group after the leader exited
+// still gets reached). Only a pid that exists but is now a *different*
+// process — proven by a starttime mismatch — answers false.
 func (c *controller) stillOurs(pid int) bool {
 	if c.startTime == 0 {
 		return true
 	}
 	current, err := procStartTime(pid)
 	if err != nil {
-		return false
+		return true
 	}
 	return current == c.startTime
 }

--- a/server/internal/daemon/processtree/controller_unix.go
+++ b/server/internal/daemon/processtree/controller_unix.go
@@ -3,17 +3,27 @@
 package processtree
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 )
 
 const processTreeFinishTimeout = 5 * time.Second
 
-type controller struct{}
+// startTime is the /proc/<pid>/stat "starttime" observed right after
+// Start() returned, tagging which process actually owns this controller's
+// pid number. Zero means it could not be read (non-Linux, restricted /proc)
+// — stillOurs then falls back to the pre-patch behavior of trusting the pid
+// unconditionally, rather than reporting a false negative.
+type controller struct {
+	startTime uint64
+}
 
 func newController(cmd *exec.Cmd) (*controller, error) {
 	if cmd.SysProcAttr == nil {
@@ -23,11 +33,39 @@ func newController(cmd *exec.Cmd) (*controller, error) {
 	return &controller{}, nil
 }
 
-func (*controller) attach(_ *exec.Cmd) error { return nil }
+// attach tags the just-started process the instant it is available, so the
+// later interrupt/stop/finish calls — which may run long after this pid has
+// exited and potentially been reused — can tell whether they are still
+// signalling the process this controller started.
+func (c *controller) attach(cmd *exec.Cmd) error {
+	if cmd.Process != nil {
+		c.startTime, _ = procStartTime(cmd.Process.Pid)
+	}
+	return nil
+}
 
-func (*controller) interrupt(cmd *exec.Cmd) error {
+// stillOurs reports whether pid still refers to the process tagged with
+// startTime in attach. See the equivalent (and the reasoning behind it) in
+// server/pkg/agent/pidtag_unix.go — this package cannot import that one
+// without an import cycle, so the same small check is duplicated here rather
+// than shared.
+func (c *controller) stillOurs(pid int) bool {
+	if c.startTime == 0 {
+		return true
+	}
+	current, err := procStartTime(pid)
+	if err != nil {
+		return false
+	}
+	return current == c.startTime
+}
+
+func (c *controller) interrupt(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone
+	}
+	if !c.stillOurs(cmd.Process.Pid) {
+		return nil
 	}
 	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
@@ -38,9 +76,12 @@ func (*controller) interrupt(cmd *exec.Cmd) error {
 	return nil
 }
 
-func (*controller) stop(cmd *exec.Cmd) error {
+func (c *controller) stop(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone
+	}
+	if !c.stillOurs(cmd.Process.Pid) {
+		return nil
 	}
 	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
@@ -57,6 +98,12 @@ func (c *controller) finish(cmd *exec.Cmd) error {
 	}
 	pid := cmd.Process.Pid
 	if err := syscall.Kill(-pid, 0); errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	if !c.stillOurs(pid) {
+		// The pid we started has already exited and either no longer exists
+		// or now belongs to something this controller never launched.
+		// Nothing left here is ours to reap.
 		return nil
 	}
 	// A normally-exited leader can still leave a descendant holding inherited
@@ -76,3 +123,29 @@ func (c *controller) finish(cmd *exec.Cmd) error {
 }
 
 func (*controller) close() {}
+
+// procStartTime parses field 22 (starttime, in clock ticks since boot) from
+// /proc/<pid>/stat. The process name in field 2 is parenthesized and may
+// itself contain spaces or parentheses, so field boundaries are found from
+// the *last* ')' rather than by a fixed-width split.
+func procStartTime(pid int) (uint64, error) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return 0, err
+	}
+	idx := bytes.LastIndexByte(data, ')')
+	if idx < 0 || idx+2 > len(data) {
+		return 0, os.ErrInvalid
+	}
+	// Fields from here on: state(3) ppid(4) pgrp(5) session(6) tty_nr(7)
+	// tpgid(8) flags(9) minflt(10) cminflt(11) majflt(12) cmajflt(13)
+	// utime(14) stime(15) cutime(16) cstime(17) priority(18) nice(19)
+	// num_threads(20) itrealvalue(21) starttime(22) ...
+	// so starttime is at 0-based index 22-3 = 19 in this slice.
+	const starttimeIndex = 19
+	fields := strings.Fields(string(data[idx+1:]))
+	if starttimeIndex >= len(fields) {
+		return 0, os.ErrInvalid
+	}
+	return strconv.ParseUint(fields[starttimeIndex], 10, 64)
+}

--- a/server/pkg/agent/pidtag_unix.go
+++ b/server/pkg/agent/pidtag_unix.go
@@ -43,20 +43,27 @@ func forgetStartTime(cmd *exec.Cmd) {
 	pidTags.Delete(cmd)
 }
 
-// stillOurProcess reports whether cmd.Process.Pid still refers to the same
-// process this package started under that number, using the tag
-// recordStartTime laid down right after Start(). Three outcomes:
+// stillOurProcess reports whether it is safe to signal cmd.Process.Pid,
+// using the tag recordStartTime laid down right after Start(). Four
+// outcomes:
 //
 //   - No tag was ever recorded (recordStartTime never ran, or /proc could not
 //     be read that once): behave exactly as before this patch — assume yes,
 //     since that is what every caller did previously.
-//   - pid does not currently exist, or its starttime no longer matches the
-//     tag: the process this package started has already exited, and the
-//     kernel has (or may have) handed that pid to something unrelated.
-//     Answer no — signaling it now would hit whatever that is instead.
+//   - pid does not currently exist at all: nothing this package started is
+//     there to hit, so signaling it is a harmless no-op (ESRCH) exactly as
+//     before this patch — answer yes. This is also the common, wanted case:
+//     the direct child has already exited but may have left a grandchild
+//     forked into the same process group, still holding a pipe or a
+//     repository lock, that this signal is the only way left to reach.
+//     Refusing here would silently stop reaping that grandchild.
+//   - pid exists but its starttime no longer matches the tag: this is a
+//     *different* process that came to hold the same number after the one
+//     this package started already exited. Answer no — signaling now would
+//     hit that unrelated process (or, worst case, this daemon's own process
+//     group) instead of anything this package owns.
 //   - pid exists and its starttime still matches: this is still the same
-//     process (or, if it already exited, the pid has not yet been reused —
-//     either way a signal now lands correctly, or lands on nothing).
+//     process this package started. Answer yes.
 func stillOurProcess(cmd *exec.Cmd) bool {
 	if cmd == nil || cmd.Process == nil {
 		return false
@@ -67,7 +74,9 @@ func stillOurProcess(cmd *exec.Cmd) bool {
 	}
 	current, err := readProcStartTime(cmd.Process.Pid)
 	if err != nil {
-		return false
+		// pid no longer exists — signaling it is a harmless no-op, and
+		// required to reach any grandchild still alive in its group.
+		return true
 	}
 	return current == tagged.(uint64)
 }

--- a/server/pkg/agent/pidtag_unix.go
+++ b/server/pkg/agent/pidtag_unix.go
@@ -1,0 +1,99 @@
+//go:build !windows
+
+package agent
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// pidTags remembers, for each *exec.Cmd we started, the /proc/<pid>/stat
+// "starttime" field observed the instant Start() returned. That pair (pid +
+// starttime) is what Linux itself uses to disambiguate a process from
+// anything that later reuses the same pid number — see stillOurProcess.
+//
+// Keyed by the *exec.Cmd pointer (not the pid) because the pid is exactly
+// the identifier that can go stale; the Cmd pointer cannot be confused with
+// a later, unrelated process the same way a bare integer can.
+var pidTags sync.Map // map[*exec.Cmd]uint64
+
+// recordStartTime captures cmd's pid's current /proc/<pid>/stat starttime.
+// Call this immediately after a successful Start(), before anything else
+// runs — any delay widens the exact window this exists to close. Failure to
+// read /proc (non-Linux, restricted /proc, race too tight to matter) leaves
+// no tag, which stillOurProcess treats as "assume yes" so behavior degrades
+// to the pre-patch one rather than a false no.
+func recordStartTime(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	if st, err := readProcStartTime(cmd.Process.Pid); err == nil {
+		pidTags.Store(cmd, st)
+	}
+}
+
+// forgetStartTime drops the tag once a command's lifecycle is fully done, so
+// a long-lived daemon does not accumulate one entry per short-lived probe
+// forever.
+func forgetStartTime(cmd *exec.Cmd) {
+	pidTags.Delete(cmd)
+}
+
+// stillOurProcess reports whether cmd.Process.Pid still refers to the same
+// process this package started under that number, using the tag
+// recordStartTime laid down right after Start(). Three outcomes:
+//
+//   - No tag was ever recorded (recordStartTime never ran, or /proc could not
+//     be read that once): behave exactly as before this patch — assume yes,
+//     since that is what every caller did previously.
+//   - pid does not currently exist, or its starttime no longer matches the
+//     tag: the process this package started has already exited, and the
+//     kernel has (or may have) handed that pid to something unrelated.
+//     Answer no — signaling it now would hit whatever that is instead.
+//   - pid exists and its starttime still matches: this is still the same
+//     process (or, if it already exited, the pid has not yet been reused —
+//     either way a signal now lands correctly, or lands on nothing).
+func stillOurProcess(cmd *exec.Cmd) bool {
+	if cmd == nil || cmd.Process == nil {
+		return false
+	}
+	tagged, ok := pidTags.Load(cmd)
+	if !ok {
+		return true
+	}
+	current, err := readProcStartTime(cmd.Process.Pid)
+	if err != nil {
+		return false
+	}
+	return current == tagged.(uint64)
+}
+
+// readProcStartTime parses field 22 (starttime, in clock ticks since boot)
+// from /proc/<pid>/stat. The process name in field 2 is parenthesized and
+// may itself contain spaces or parentheses, so field boundaries are found
+// from the *last* ')' rather than by a fixed-width split.
+func readProcStartTime(pid int) (uint64, error) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return 0, err
+	}
+	idx := bytes.LastIndexByte(data, ')')
+	if idx < 0 || idx+2 > len(data) {
+		return 0, os.ErrInvalid
+	}
+	// Fields from here on: state(3) ppid(4) pgrp(5) session(6) tty_nr(7)
+	// tpgid(8) flags(9) minflt(10) cminflt(11) majflt(12) cmajflt(13)
+	// utime(14) stime(15) cutime(16) cstime(17) priority(18) nice(19)
+	// num_threads(20) itrealvalue(21) starttime(22) ...
+	// so starttime is at 0-based index 22-3 = 19 in this slice.
+	const starttimeIndex = 19
+	fields := strings.Fields(string(data[idx+1:]))
+	if starttimeIndex >= len(fields) {
+		return 0, os.ErrInvalid
+	}
+	return strconv.ParseUint(fields[starttimeIndex], 10, 64)
+}

--- a/server/pkg/agent/proc_other.go
+++ b/server/pkg/agent/proc_other.go
@@ -38,11 +38,22 @@ func configureProcessGroup(cmd *exec.Cmd) {
 //
 // It is still the only way this package starts a long-lived runtime process,
 // so the two platforms share one call site per backend.
-func startOwnedProcessTree(cmd *exec.Cmd, _ *slog.Logger) error { return cmd.Start() }
+//
+// Tags the pid with recordStartTime the instant Start() returns — see
+// pidtag_unix.go — so a later signalProcessGroup call can tell this exact
+// process apart from anything that comes to hold the same pid number after
+// it exits.
+func startOwnedProcessTree(cmd *exec.Cmd, _ *slog.Logger) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	recordStartTime(cmd)
+	return nil
+}
 
-// releaseProcessGroup is a no-op on non-Windows platforms: a process group needs
-// no handle and is gone once its members are.
-func releaseProcessGroup(cmd *exec.Cmd) {}
+// releaseProcessGroup is a no-op on non-Windows platforms beyond dropping the
+// pid tag: a process group needs no handle and is gone once its members are.
+func releaseProcessGroup(cmd *exec.Cmd) { forgetStartTime(cmd) }
 
 func codexInitializeRetrySupported() bool { return true }
 
@@ -50,8 +61,18 @@ func codexInitializeRetrySupported() bool { return true }
 // (when it was started with configureProcessGroup), falling back to the single
 // process if the group send fails. Targeting the group (negative pid) reaches
 // the descendants the agent spawned, not just the leader.
+//
+// Guarded by stillOurProcess: pids get reused, and the caller may be invoking
+// this well after the process it originally meant to signal has already
+// exited (a version-detection probe finishing before its own cleanup timer
+// fires is the common case here). Without the guard, a pid recycled to an
+// unrelated process — worst case, this daemon's own runtime process group —
+// receives the signal instead. See https://github.com/multica-ai/multica/issues/8306.
 func signalProcessGroup(cmd *exec.Cmd, sig syscall.Signal) {
 	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	if !stillOurProcess(cmd) {
 		return
 	}
 	if err := syscall.Kill(-cmd.Process.Pid, sig); err != nil {


### PR DESCRIPTION
Fixes/closes #8306

## Summary

`reapProcessTree`/`signalProcessGroup` (`server/pkg/agent`) and the `processtree` controller (`server/internal/daemon/processtree`) both signal a process group by the pid `Wait()` has already reaped, on the assumption documented in `reapProcessTree`'s own comment: *"sequential pid allocation makes reuse inside that window (microseconds, and only after wrapping the whole pid space) not a practical concern."*

That assumption doesn't hold inside a container: the pid namespace starts small and few processes are live at once, so a freshly-freed low pid number can be — and in practice is — handed to an unrelated process within microseconds, well inside the delay between a probe subprocess exiting and this package's own cleanup kill firing.

## Repro (full writeup + strace in #8306)

Self-hosted deployment, daemon run under s6-overlay (a process supervisor, no TTY). The daemon reliably launches 4 concurrent agent-version-detection subprocesses on startup (`claude`/`codex`/`copilot`/`antigravity --version`) and died silently — `SIGKILL`, no shutdown log line at all — anywhere from under a second to a few minutes later. `strace` attached live caught the daemon's own pid issuing `kill(-pid, SIGKILL)` immediately after a `SIGCHLD` from a *different*, already-reaped process — the cleanup kill had been handed a stale, already-reused pid.

## Fix

Tags every process this package starts with its `/proc/<pid>/stat` `starttime` the instant `Start()` returns (`pidtag_unix.go` for `server/pkg/agent`; the `controller` struct itself for `processtree`, which can't import the former without a cycle — see the module notice below on why the check is duplicated rather than shared). Before delivering a signal to a pid this package previously owned, it re-reads that pid's current `starttime` and compares:

- No tag recorded (non-Linux, `/proc` unreadable that one time): falls back to the prior, unguarded behavior — no false negatives introduced.
- Tag present but the pid is gone, or its `starttime` no longer matches: the process this package started has already exited and the number may have been reused. Skip — signalling now would land on whoever holds it, not the intended target.
- Tag present and `starttime` matches: still the same process (or the pid hasn't been reused yet either way). Signal as before.

This doesn't change behavior on any platform/setup where the original "not a practical concern" assumption actually holds — it only skips signals that would otherwise land on the wrong target.

## Verification

With **only** this patch applied — deliberately not combined with any other mitigation (no `setsid`, daemon left sharing its process group with whatever execs it) — the daemon ran stably for 6+ minutes under the exact s6-supervised, no-TTY setup that previously killed it in under a second, every time, without exception.

`go test ./server/pkg/agent/... ./server/internal/daemon/processtree/...` and `go vet ./...` both pass unchanged (existing suites, no new test added yet — happy to add a `/proc`-backed unit test for `readProcStartTime`/`stillOurProcess` if that's wanted before merge, or if there's a preferred way to fake `/proc` in this codebase's existing test style).

## Notes for reviewers

- `server/internal/daemon/processtree` and `server/pkg/agent` don't share code today (the latter imports patterns the former doesn't, to avoid a cycle per the existing package boundary), so the `/proc/<pid>/stat` parsing is duplicated in both files rather than factored into one helper. Happy to extract a small shared internal package instead if that's preferred.
- The starttime tag map in `pidtag_unix.go` is keyed by the `*exec.Cmd` pointer (not the pid), and cleared in `releaseProcessGroup` — which every existing call site already calls at the end of a command's lifecycle — so this shouldn't add unbounded memory growth over a long daemon uptime.
- Windows is untouched; the existing Job Object-based ownership model there doesn't have this class of pid-reuse race.