### PR TITLE
MUL-7295: show thinking previews in inline agent logs

### DIFF
--- a/packages/views/issues/components/inline-comment-run.test.tsx
+++ b/packages/views/issues/components/inline-comment-run.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
 vi.mock("../../editor", () => ({ ReadonlyContent: ({ content }: { content: string }) => <div>{content}</div> }));
 vi.mock("../../common/task-transcript/agent-transcript-dialog", () => ({
   AgentTranscriptDialog: ({ contentState, isLive }: { contentState?: ReactNode; isLive?: boolean }) => <div role="dialog" data-live={isLive}>{contentState ?? "Full transcript"}</div>,
-  StepBody: ({ item }: { item: { output?: string } }) => <div>{item.output}</div>,
+  StepBody: ({ item }: { item: { content?: string; output?: string } }) => <div data-testid="step-body">{item.content ?? item.output}</div>,
 }));
 
 const id = "4a2e8d1c-7f9b-4e2a-9c1d-123456789abc";
@@ -43,6 +43,55 @@ function setup(initialTask: AgentTask, hasReply = false, presentation: "inline" 
 }
 
 describe("InlineCommentRun", () => {
+  it("previews streamed thinking in the header and collapsed steps, and expands its body", async () => {
+    const thought: TaskMessagePayload = {
+      task_id: id, issue_id: "issue", seq: 1, type: "thinking", content: "Checking the runtime",
+    };
+    vi.mocked(api.listTaskMessages).mockResolvedValue([thought]);
+    const { client } = setup(task());
+    const header = await screen.findByText("Checking the runtime");
+    const textNode = header.firstChild;
+    act(() => client.setQueryData(chatKeys.taskMessages(id), [
+      thought,
+      { ...thought, seq: 2, content: " logs.\nThe reasoning is present." },
+    ]));
+    await waitFor(() => expect(header).toHaveTextContent("Checking the runtime logs."));
+    expect(header.firstChild).toBe(textNode);
+    fireEvent.click(screen.getByRole("button", { name: /View activity/ }));
+    const preview = screen.getAllByText("Checking the runtime logs.").find((node) => node.closest("summary"))!;
+    expect(preview).toHaveAttribute("title", "Checking the runtime logs.");
+    const details = preview.closest("details")!;
+    expect(details).not.toHaveAttribute("open");
+    expect(screen.queryByTestId("step-body")).not.toBeInTheDocument();
+    fireEvent.click(preview.closest("summary")!, { detail: 0 });
+    expect(await screen.findByTestId("step-body")).toHaveTextContent("Checking the runtime logs. The reasoning is present.");
+  });
+
+  it("redacts thinking before clipping its preview and tooltip", async () => {
+    const prefix = "Reviewing ".repeat(18);
+    const secret = `ghp_${"x".repeat(36)}`;
+    vi.mocked(api.listTaskMessages).mockResolvedValue([
+      { task_id: id, issue_id: "issue", seq: 1, type: "thinking", content: `${prefix}${secret}` },
+    ]);
+    setup(task());
+    await screen.findByText(/REDACTED/);
+    fireEvent.click(screen.getByRole("button", { name: /View activity/ }));
+    const preview = screen.getAllByText(/REDACTED/).find((node) => node.closest("summary"))!;
+    expect(preview.getAttribute("title")).toContain("REDACTED");
+    expect(document.body.innerHTML).not.toContain("ghp_");
+    expect(preview.textContent!.length).toBeLessThanOrEqual(201);
+  });
+
+  it("keeps a Thinking label when the runtime supplies no preview text", async () => {
+    vi.mocked(api.listTaskMessages).mockResolvedValue([
+      { task_id: id, issue_id: "issue", seq: 1, type: "thinking", content: " \n " },
+    ]);
+    setup(task());
+    await screen.findByText("Thinking");
+    fireEvent.click(screen.getByRole("button", { name: /View activity/ }));
+    expect(screen.getAllByText("Thinking").some((node) => node.closest("summary"))).toBe(true);
+  });
+
   it("opens completed reply logs from a compact header button and loads only on demand", async () => {
     let resolve!: (value: TaskMessagePayload[]) => void;
     vi.mocked(api.listTaskMessages).mockImplementation(() => new Promise((done) => { resolve = done; }));

--- a/packages/views/issues/components/inline-comment-run.tsx
+++ b/packages/views/issues/components/inline-comment-run.tsx
@@ -30,6 +30,11 @@ import { commentRunOutput, isActiveCommentRun, showCommentRunInHeader, type Comm
 
 import { useRunAnimationVisibility, useRunDisclosureMotion } from "./use-run-comment-motion";
 
+function thinkingPreview(content: string | undefined, formatText: (text: string) => string): string {
+  // Redact the complete content before clipping so a split credential cannot leak.
+  return traceEventSummary({ type: "thinking", content: redactSecrets(formatText(content ?? "")) });
+}
+
 export function useInlineCommentRunState() {
   const [expanded, setExpanded] = useState(false);
   const [fullLogOpen, setFullLogOpen] = useState(false);
@@ -100,7 +105,7 @@ export function InlineCommentRun({ run, className, viewState, showIdentity = fal
   const activitySummary = current && isCallStep(current)
     ? redactSecrets(traceToolArgSummary(current.call?.input, { formatText }) || current.tool)
     : current?.kind === "text" ? redactSecrets(formatText(current.item.content ?? ""))
-    : current?.kind === "thinking" ? t(($) => $.inline_run.thinking)
+    : current?.kind === "thinking" ? thinkingPreview(current.item.content, formatText) || t(($) => $.inline_run.thinking)
     : current?.kind === "error" ? t(($) => $.inline_run.error)
     : t(($) => $.inline_run.waiting_response);
   const summary = task.status === "queued" ? t(($) => $.inline_run.queued)
@@ -211,7 +216,7 @@ function InlineStep({ row, live, formatText }: { row: TraceRow; live: boolean; f
     ? redactSecrets(traceToolArgSummary(row.call?.input, { formatText }) || (row.result ? traceEventSummary(row.result, { formatText }) : "")) || row.tool
     : grouped ? row.tool
     : row.kind === "text" ? t(($) => $.inline_run.message)
-    : row.kind === "thinking" ? t(($) => $.inline_run.thinking)
+    : row.kind === "thinking" ? thinkingPreview(row.item.content, formatText) || t(($) => $.inline_run.thinking)
     : t(($) => $.inline_run.error);
   return <details className="min-w-0 text-caption" onToggle={onToggle}>
     <summary onClick={disclosure.onTrigger} className="flex cursor-pointer list-none items-center gap-2 rounded-xs py-1.5 hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">


### PR DESCRIPTION
The Kiro run shown in MUL-7295 already has non-empty thinking messages in its stored transcript, but inline activity renders only the generic “Thinking” label. This makes the available content invisible until each step is expanded.

Show the first non-empty line of thinking in both the live activity header and collapsed thinking steps. Reuse the transcript's preview limit, redact the full content before clipping, and retain the localized label for empty content. Expanding a step still receives the original body. The shared component covers web and desktop, including existing logs.

Validation: 135 tests passed across inline-comment-run, agent-transcript-dialog, build-timeline, and trace-event-presenter. The new preview tests fail on the previous implementation. `pnpm --filter @multica/views typecheck`, targeted ESLint, and `git diff --check` pass. No GUI verification performed.
