### PR TITLE
fix(issues): keep Display popover ordering controls inside the popover (MUL-7296)

### DIFF
--- a/e2e/issue-display-popover.spec.ts
+++ b/e2e/issue-display-popover.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test, type Locator } from "@playwright/test";
+import { loginAsDefault } from "./helpers";
+
+/**
+ * MUL-7296: the sort-direction toggle became a text label inside a row sized
+ * for an icon, so "Newest first" rendered past the Display popover's edge and
+ * squeezed the field select down to "Created c".
+ */
+test("keeps the Display popover's ordering controls inside the popover", async ({
+  page,
+}) => {
+  await loginAsDefault(page);
+  await page.getByRole("button", { name: "Display", exact: true }).click();
+  const popover = page.locator("[data-slot=popover-content]");
+  const field = popover.locator("[aria-label=Ordering]");
+  await expect(field).toBeVisible();
+
+  async function expectFits(direction: Locator) {
+    const bounds = await popover.boundingBox();
+    const fieldBox = await field.boundingBox();
+    const directionBox = await direction.boundingBox();
+    if (!bounds || !fieldBox || !directionBox) {
+      throw new Error("Could not measure the ordering controls");
+    }
+    const right = bounds.x + bounds.width;
+    expect(fieldBox.x + fieldBox.width).toBeLessThanOrEqual(right);
+    expect(directionBox.x + directionBox.width).toBeLessThanOrEqual(right);
+    const clipped = await field
+      .locator("[data-slot=select-value]")
+      .evaluate((el) => el.scrollWidth > el.clientWidth);
+    expect(clipped).toBe(false);
+  }
+
+  // The reported default: Created date, newest first.
+  await expectFits(popover.getByRole("button", { name: "Newest first", exact: true }));
+
+  // The widest direction label.
+  await field.click();
+  await page.getByRole("option", { name: "Status", exact: true }).click();
+  await popover.getByRole("button", { name: "Workflow order", exact: true }).click();
+  await expectFits(
+    popover.getByRole("button", { name: "Reverse workflow order", exact: true }),
+  );
+});

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -2115,9 +2115,10 @@ export function IssueDisplayControls({
             />
             <TooltipContent side="bottom">{t(($) => $.display.tooltip)}</TooltipContent>
           </Tooltip>
-          <PopoverContent align="end" className="w-64 p-3">
+          <PopoverContent align="end" className="w-72 p-3">
             <div className="space-y-3">
-              {/* Uniform rows: caption label left, control right. Spacing
+              {/* Caption label left, control right; multi-control sections
+                  (Ordering, Card properties) stack the label on top. Spacing
                   separates sections — no dividers (see UI rules). */}
               {viewMode === "board" && (
                 <div className="flex items-center justify-between gap-3">
@@ -2207,11 +2208,15 @@ export function IssueDisplayControls({
                   />
                 </label>
               )}
-              <div className="flex items-center justify-between gap-3">
+              <div>
                 <span className="text-caption font-medium text-muted-foreground">
                   {t(($) => $.display.ordering_section)}
                 </span>
-                <div className="flex items-center gap-1.5">
+                {/* Direction labels run up to "Reverse workflow order", so the
+                    pair gets the full popover width (w-72 keeps "Status" beside
+                    it untruncated): the field select absorbs the slack and
+                    truncates, the direction label never does. */}
+                <div className="mt-2 flex items-center gap-1.5">
                   <Select
                     items={[
                       ...availableSortOptions.map((opt) => ({
@@ -2228,7 +2233,7 @@ export function IssueDisplayControls({
                       if (v) act.setSortBy(v as SortField);
                     }}
                   >
-                    <SelectTrigger size="sm" className="w-26" aria-label={t(($) => $.display.ordering_section)}>
+                    <SelectTrigger size="sm" className="min-w-0 flex-1" aria-label={t(($) => $.display.ordering_section)}>
                       <SelectValue>{sortLabel}</SelectValue>
                     </SelectTrigger>
                     <SelectContent align="end">


### PR DESCRIPTION
## Summary

In the issues **Display** popover, the Ordering row overflowed. The "Newest first" button rendered past the popover's right edge, and the sort-field select was squeezed down to "Created c".

**Root cause:** #8256 replaced the icon-only direction toggle (`size="icon-sm"`, 28px) with a text label, but left the row layout unchanged. That layout was a 256px popover (`w-64`) with the label on the left and a fixed `w-26` select next to the button. The direction labels are 59–170px wide ("A to Z" … "Reverse workflow order"), so every sort field except Title overflowed, by up to 110px.

**Fix** (`IssueDisplayControls`, shared by Issues, My Issues and actor issue panels):
- Ordering now puts its label on top and the controls on a full-width row below it, the same pattern Card properties already uses.
- The field select is `min-w-0 flex-1`, so it takes up the slack and truncates cleanly. The direction button stays `shrink-0`, so its label is never clipped.
- The popover goes from `w-64` to `w-72`. That's the narrowest width where the widest pair ("Status" + "Reverse workflow order") fits without truncating.

The Save view dialog has the same controls but enough width, so it is unchanged.

## Verification

- Measured in a real browser (local API + web, Chromium) for every sort field and both directions (15 combinations):
  - Before: 14 of 15 overflowed the popover (by 29–110px), and the select truncated "Created date", "Updated date" and "Start date".
  - After: nothing overflows and nothing is truncated.
- Checked visually in Board, List and Table view modes.
- Added `e2e/issue-display-popover.spec.ts`, which covers the reported default ("Newest first") and the widest label ("Reverse workflow order"). It fails on `main` and passes with this change.
- `packages/views`: `vitest run issues my-issues` passes (94 files, 991 tests), `tsc --noEmit` is clean, and eslint on the changed file is clean.
