### PR TITLE
MUL-7292: fix(daemon): discover Hermes local skills from the home tasks run against

### DIFF
--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/skill"
 	"github.com/multica-ai/multica/server/pkg/agent"
 )
@@ -105,8 +106,10 @@ const (
 //   - Pi: https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md
 //   - Cursor: official forum guidance referencing the built-in /create-skill flow
 //     (https://forum.cursor.com/t/cursor-doesnt-know-new-skills-arens-saved/158507)
-//   - Hermes: ~/.hermes/skills is Hermes Agent's primary skill directory
-//     (https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)
+//   - Hermes: <HERMES_HOME>/skills is Hermes Agent's primary skill directory
+//     (https://hermes-agent.nousresearch.com/docs/user-guide/features/skills);
+//     the home is resolved as for a task without agent-level overrides
+//     (see hermesLocalSkillsRoot)
 //   - Kimi: ~/.kimi/skills mirrors Kimi CLI's project-level .kimi/skills layout
 //   - Kiro: project and user-level .kiro/skills directories discovered by Kiro CLI
 //   - Qoder: ~/.qoder/skills mirrors Qoder CLI's project-level .qoder/skills layout
@@ -170,7 +173,7 @@ func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error)
 		case "cursor":
 			providerRoot = filepath.Join(home, ".cursor", "skills")
 		case "hermes":
-			providerRoot = filepath.Join(home, ".hermes", "skills")
+			providerRoot = hermesLocalSkillsRoot()
 		case "kimi":
 			providerRoot = filepath.Join(home, ".kimi", "skills")
 		case "reasonix":
@@ -246,10 +249,13 @@ func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error)
 		}
 	}
 
-	roots := []localSkillRoot{
-		{path: providerRoot, kind: localSkillRootProvider},
-		{path: filepath.Join(home, ".agents", "skills"), kind: localSkillRootUniversal},
+	roots := make([]localSkillRoot, 0, 2)
+	// An empty providerRoot means the runtime has no home it would run under;
+	// skip it rather than resolve skill keys against the daemon's cwd.
+	if providerRoot != "" {
+		roots = append(roots, localSkillRoot{path: providerRoot, kind: localSkillRootProvider})
 	}
+	roots = append(roots, localSkillRoot{path: filepath.Join(home, ".agents", "skills"), kind: localSkillRootUniversal})
 	if provider == "claude" {
 		for _, plugin := range listEnabledClaudePlugins(home) {
 			manifest, _ := readClaudePluginManifest(plugin.InstallPath)
@@ -268,6 +274,22 @@ func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error)
 		}
 	}
 	return roots, true, nil
+}
+
+// hermesLocalSkillsRoot returns the skills dir of the Hermes home a task runs
+// against when its agent sets no HERMES_HOME or profile of its own. It goes
+// through execenv.ResolveHermesProfile — the resolver the task path uses — so
+// discovery follows the daemon's HERMES_HOME, the platform default
+// (%LOCALAPPDATA%\hermes on native Windows, ~/.hermes elsewhere) and the sticky
+// active_profile instead of a hardcoded ~/.hermes, which hid every skill Hermes
+// actually loads on Windows (GH #8310). A selection Hermes would refuse to start
+// under returns "": there is no home whose skills it would load.
+func hermesLocalSkillsRoot() string {
+	res := execenv.ResolveHermesProfile("", "", false, false)
+	if res.Err != nil {
+		return ""
+	}
+	return filepath.Join(res.SourceHome, "skills")
 }
 
 func isIgnoredLocalSkillEntry(name string) bool {

--- a/server/internal/daemon/local_skills_test.go
+++ b/server/internal/daemon/local_skills_test.go
@@ -352,6 +352,9 @@ func TestLocalSkills_DiscoversACPProviderRoots(t *testing.T) {
 			if tc.provider == "dsh" {
 				t.Setenv("DSH_HOME", "")
 			}
+			if tc.provider == "hermes" {
+				t.Setenv("HERMES_HOME", "")
+			}
 
 			writeTestLocalSkill(t, filepath.Join(home, tc.root), "review-helper", map[string]string{
 				"SKILL.md": "---\nname: " + tc.wantName + "\ndescription: Review code\n---\n# Review\n",
@@ -398,6 +401,113 @@ func TestLocalSkills_DiscoversACPProviderRoots(t *testing.T) {
 				t.Fatalf("expected 1 supporting file, got %d", len(bundle.Files))
 			}
 		})
+	}
+}
+
+// Hermes discovery must scan the home a Hermes task actually runs against, not
+// a hardcoded ~/.hermes: otherwise the skills Hermes loads never appear in the
+// Skills tab or the import dialog (GH #8310). The Windows default
+// (%LOCALAPPDATA%\hermes) comes from the same resolver and is covered by
+// execenv's TestPlatformDefaultHermesHome.
+func TestListRuntimeLocalSkills_HermesFollowsTaskHome(t *testing.T) {
+	tests := []struct {
+		name string
+		// setup configures the Hermes home and returns the skills dir a task
+		// would read; "" means no provider root should be scanned.
+		setup func(t *testing.T, home string) string
+	}{
+		{
+			name: "explicit HERMES_HOME",
+			setup: func(t *testing.T, home string) string {
+				hermesHome := filepath.Join(t.TempDir(), "custom-hermes")
+				t.Setenv("HERMES_HOME", hermesHome)
+				return filepath.Join(hermesHome, "skills")
+			},
+		},
+		{
+			name: "sticky active profile",
+			setup: func(t *testing.T, home string) string {
+				writeTestHermesActiveProfile(t, home, "work")
+				return filepath.Join(home, ".hermes", "profiles", "work", "skills")
+			},
+		},
+		{
+			// Hermes refuses to start under a reserved sticky profile, so there
+			// is no home whose skills it would load.
+			name: "invalid sticky active profile",
+			setup: func(t *testing.T, home string) string {
+				writeTestHermesActiveProfile(t, home, "hermes")
+				return ""
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("HERMES_HOME", "")
+			skillsDir := tc.setup(t, home)
+
+			// A skill in ~/.hermes/skills that the task-side resolver does not
+			// read must not be surfaced.
+			writeTestLocalSkill(t, filepath.Join(home, ".hermes", "skills"), "wrong-home", map[string]string{
+				"SKILL.md": "---\nname: Wrong Home\n---\n# Wrong\n",
+			})
+			writeTestLocalSkill(t, filepath.Join(home, ".agents", "skills"), "shared-helper", map[string]string{
+				"SKILL.md": "---\nname: Shared Helper\n---\n# Shared\n",
+			})
+			wantKeys := []string{"shared-helper"}
+			if skillsDir != "" {
+				writeTestLocalSkill(t, skillsDir, "review-helper", map[string]string{
+					"SKILL.md": "---\nname: Hermes Home Review\n---\n# Review\n",
+				})
+				wantKeys = []string{"review-helper", "shared-helper"}
+			}
+
+			skills, supported, err := listRuntimeLocalSkills("hermes")
+			if err != nil {
+				t.Fatalf("listRuntimeLocalSkills: %v", err)
+			}
+			if !supported {
+				t.Fatal("hermes should be supported")
+			}
+			gotKeys := make([]string, 0, len(skills))
+			for _, s := range skills {
+				gotKeys = append(gotKeys, s.Key)
+			}
+			if !reflect.DeepEqual(gotKeys, wantKeys) {
+				t.Fatalf("keys = %v, want %v", gotKeys, wantKeys)
+			}
+			if skillsDir == "" {
+				return
+			}
+			if skills[0].Root != localSkillRootProvider {
+				t.Fatalf("root = %q, want %q", skills[0].Root, localSkillRootProvider)
+			}
+			if want := relativizeHomePath(filepath.Join(skillsDir, "review-helper")); skills[0].SourcePath != want {
+				t.Fatalf("source_path = %q, want %q", skills[0].SourcePath, want)
+			}
+
+			bundle, supported, err := loadRuntimeLocalSkillBundle("hermes", "review-helper")
+			if err != nil {
+				t.Fatalf("loadRuntimeLocalSkillBundle: %v", err)
+			}
+			if !supported || bundle == nil || bundle.Name != "Hermes Home Review" {
+				t.Fatalf("unexpected bundle: supported=%v bundle=%+v", supported, bundle)
+			}
+		})
+	}
+}
+
+func writeTestHermesActiveProfile(t *testing.T, home, name string) {
+	t.Helper()
+	root := filepath.Join(home, ".hermes")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "active_profile"), []byte(name+"\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #8310. Hermes skills that Hermes actually loads now show up under **Inherited from runtime** on an agent's Skills tab and in the **import from runtime** dialog, on native Windows and when a custom `HERMES_HOME` or sticky Hermes profile is in use.

## Root cause

Two daemon code paths resolved the Hermes home differently:

- Task execution resolves it through `execenv.ResolveHermesProfile`: the agent's `HERMES_HOME`, then the daemon's `HERMES_HOME`, then the platform default (`%LOCALAPPDATA%\hermes` on native Windows, `~/.hermes` elsewhere). A profile-scoped home or the sticky `<root>/active_profile` is applied on top.
- Runtime-local skill discovery (`localSkillRootsForProvider`) hardcoded `~/.hermes/skills`.

Tasks ran fine, but three setups showed none of Hermes' own skills in the list and import flows:

- native Windows with the default layout;
- any platform with `HERMES_HOME` pointing elsewhere;
- any platform with a sticky profile, where Hermes reads `~/.hermes/profiles/<name>/skills`.

In all three, discovery either scanned an empty directory or listed skills Hermes doesn't load.

## Change

- The Hermes provider root is now `<SourceHome>/skills`, where `SourceHome` comes from `execenv.ResolveHermesProfile("", "", false, false)`. That's the same resolver the task path uses, with no agent-level overrides, so discovery and execution can't drift apart again.
- If the resolver rejects the selection (e.g. a reserved or invalid sticky profile name, where Hermes itself refuses to start), the provider root is skipped. The alternative would be an empty path, which the import path would resolve against the daemon's working directory. The universal `~/.agents/skills` root is still listed.
- The provider-first priority and dedupe-by-key semantics are unchanged.

## Behavior notes

- If a key exists both in the Hermes home and in `~/.agents/skills`, the list and import now resolve to the Hermes-home copy, with a new `source_path`. This follows the existing provider-first rule and matches what Hermes loads. Skills already imported into a workspace are unaffected.
- Hermes runtime skills still have no per-agent disable toggle (`can_disable` is Codex/Claude only). This PR only fixes visibility and import.

## Known limitations (unchanged by this PR)

Discovery is keyed on the runtime's provider only. It can't reflect an individual agent's `custom_env` `HERMES_HOME`, `-p/--profile` in `custom_args`, or a custom runtime profile's `fixed_args`. Those agents still see the skills of the runtime's default home.

## Testing

- New `TestListRuntimeLocalSkills_HermesFollowsTaskHome` covers:
  - explicit `HERMES_HOME`;
  - sticky `active_profile`;
  - an invalid sticky profile.

  Each case asserts list/import agreement and that a decoy in `~/.hermes/skills` is not surfaced when it isn't the resolved home. All three cases fail on `main` and pass with this change.
- `TestLocalSkills_DiscoversACPProviderRoots` (hermes case) now clears `HERMES_HOME`, so a developer's environment can't leak into it.
- The Windows default is covered by the existing pure-function test `execenv.TestPlatformDefaultHermesHome`. The Windows CI job doesn't run the `internal/daemon` package.
- `go test ./internal/daemon/...` passes locally (macOS).
- `GOOS=windows go build ./internal/daemon/...`, `go vet`, and `go test -c` for `./internal/daemon` all pass.
- Not tested on a real Windows machine.
