### PR TITLE
MUL-7305 Feat/lark outbound image message

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -604,6 +604,25 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				patcher := lark.NewPatcher(cs, installSvc, larkClient, lark.PatcherConfig{})
 				patcher.Register(bus)
 
+				// Second hop for the agent's files: the files an agent
+				// bound to its reply are read back out of object storage,
+				// uploaded to Lark, and posted behind the answer. Mirrors
+				// the WeCom branch below.
+				//
+				// SetAttachments and DeclareChannelFileDelivery sit on one
+				// `if` on purpose. The first builds the hop; the second is
+				// the same fact told to the agent, and a run must not be
+				// promised a delivery this branch never built. A deployment
+				// with no object storage has nothing to read an attachment
+				// out of, and answering false is the safe direction: an
+				// agent that says "见附件" into a room where nothing is
+				// attached leaves the reader hunting for a file that was
+				// never sent.
+				if store != nil {
+					patcher.SetAttachments(store)
+					h.DeclareChannelFileDelivery(string(channel.TypeFeishu))
+				}
+
 				// Typing indicator: shows a "processing" reaction on the user's
 				// message while the agent is working, then removes it before the
 				// reply is sent. Best-effort; failures are logged only.

--- a/server/internal/integrations/lark/http_client_media.go
+++ b/server/internal/integrations/lark/http_client_media.go
@@ -1,0 +1,320 @@
+package lark
+
+// http_client_media.go — the transport half of agent-file delivery.
+//
+// Four methods, and they are declared on the concrete client rather than
+// added to APIClient on purpose. APIClient is the seam every consumer in
+// this package is wired through, including the production stub and four
+// test fakes; four more methods there would mean four more no-op stubs in
+// each of them for a capability exactly one call site uses. The delivery
+// path asks for the narrow interface in outbound_media.go instead and
+// degrades to "attachments are not deliverable here" when the client does
+// not implement it — which is precisely what the stub means.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// larkImageUploadMaxBytes is Lark's ceiling for image_type=message.
+	// Enforced here rather than left to Lark because a file that is too
+	// big has to reach the user as a sentence, and by the time Lark
+	// refuses the body the delivery path has already told itself the
+	// file was sendable.
+	larkImageUploadMaxBytes = 10 << 20 // 10 MiB
+
+	// larkFileUploadMaxBytes is Lark's ceiling for POST /im/v1/files.
+	larkFileUploadMaxBytes = 30 << 20 // 30 MiB
+
+	// The two upload endpoints. Both take multipart/form-data and both
+	// answer with the usual {code,msg,data} envelope.
+	larkUploadPathImage = "/open-apis/im/v1/images"
+	larkUploadPathFile  = "/open-apis/im/v1/files"
+)
+
+// mediaUploadForm is one multipart POST to a Lark upload endpoint: a few
+// text fields followed by a single file part. Both endpoints share that
+// shape (image_type + image; file_type + file_name + file), so one
+// builder serves both.
+type mediaUploadForm struct {
+	// textFields are written in order, ahead of the file part.
+	textFields [][2]string
+	fileField  string
+	filename   string
+	data       []byte
+}
+
+// build renders the form into a fresh buffer.
+//
+// Called once per attempt, not once per upload: the token-refresh retry
+// in doAuthedUpload re-sends, and a multipart body is a one-shot reader.
+func (f mediaUploadForm) build() (*bytes.Buffer, string, error) {
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	for _, kv := range f.textFields {
+		if err := w.WriteField(kv[0], kv[1]); err != nil {
+			return nil, "", fmt.Errorf("write field %s: %w", kv[0], err)
+		}
+	}
+	// CreateFormFile rather than CreatePart: it escapes the filename for
+	// us, and Lark reads the declared content type as a hint only — the
+	// bytes are what it validates a file against.
+	part, err := w.CreateFormFile(f.fileField, filepath.Base(f.filename))
+	if err != nil {
+		return nil, "", fmt.Errorf("create file part: %w", err)
+	}
+	if _, err := part.Write(f.data); err != nil {
+		return nil, "", fmt.Errorf("write file part: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", fmt.Errorf("close multipart writer: %w", err)
+	}
+	return &body, w.FormDataContentType(), nil
+}
+
+// doAuthedUpload posts one multipart form to a Lark upload endpoint,
+// minting a tenant_access_token first and refreshing it once on a token
+// rejection.
+//
+// That contract is copied from doAuthedJSON because it is needed for the
+// same reason: an app_secret can be rotated under a long-lived process,
+// and the cached token then fails every call until something invalidates
+// it. An upload that skipped the retry would report a credential event to
+// the user as "your file could not be sent".
+func (c *httpAPIClient) doAuthedUpload(ctx context.Context, creds InstallationCredentials, path string, form mediaUploadForm, out any) error {
+	attempt := func(token string) error {
+		body, contentType, err := form.build()
+		if err != nil {
+			return err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.resolveBaseURL(creds)+path, body)
+		if err != nil {
+			return fmt.Errorf("new request: %w", err)
+		}
+		req.Header.Set("Content-Type", contentType)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := c.cfg.HTTPClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("http do: %w", err)
+		}
+		defer resp.Body.Close()
+		rawBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("read body: %w", err)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			// Same reasoning as doJSON: Lark reports its business code in
+			// the body of a non-2xx reply, so parse it instead of
+			// collapsing the response into an opaque transport error.
+			code, msg := parseLarkErrorBody(rawBody)
+			return &larkAPIStatusError{
+				StatusCode: resp.StatusCode,
+				Code:       code,
+				Msg:        msg,
+				Raw:        truncate(string(rawBody), 512),
+			}
+		}
+		if out != nil && len(rawBody) > 0 {
+			if err := json.Unmarshal(rawBody, out); err != nil {
+				return fmt.Errorf("decode body: %w (raw=%s)", err, truncate(string(rawBody), 256))
+			}
+		}
+		return nil
+	}
+
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return err
+	}
+	err = attempt(token)
+	if !isTokenError(larkErrorCode(err)) {
+		return err
+	}
+	c.cfg.Logger.Warn("lark http client: tenant_access_token rejected on upload; refreshing and retrying once",
+		"app_id", creds.AppID, "path", path, "err", err)
+	c.invalidateToken(creds.AppID)
+	fresh, refreshErr := c.tenantAccessToken(ctx, creds)
+	if refreshErr != nil {
+		return fmt.Errorf("%w (token refresh failed: %v)", err, refreshErr)
+	}
+	return attempt(fresh)
+}
+
+// UploadImage puts image bytes into Lark's media store and returns the
+// image_key the senders consume.
+//
+// The size ceiling lives here rather than in the caller because the two
+// endpoints disagree about it and the caller reasons in "an image" versus
+// "a file" — this is the layer that knows which endpoint is which.
+func (c *httpAPIClient) UploadImage(ctx context.Context, p UploadImageParams) (string, error) {
+	if len(p.Data) == 0 {
+		return "", errors.New("lark http client: empty image body")
+	}
+	if len(p.Data) > larkImageUploadMaxBytes {
+		return "", fmt.Errorf("lark http client: image %q is %d bytes, over the %d-byte limit",
+			p.Filename, len(p.Data), larkImageUploadMaxBytes)
+	}
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			ImageKey string `json:"image_key"`
+		} `json:"data"`
+	}
+	form := mediaUploadForm{
+		// image_type=message is the only value that yields a key usable
+		// in a chat; avatar keys are refused by the message senders.
+		textFields: [][2]string{{"image_type", "message"}},
+		fileField:  "image",
+		filename:   filenameOr(p.Filename, "image"),
+		data:       p.Data,
+	}
+	if err := c.doAuthedUpload(ctx, p.InstallationID, larkUploadPathImage, form, &resp); err != nil {
+		return "", fmt.Errorf("lark http client: upload image: %w", err)
+	}
+	if resp.Code != 0 || resp.Data.ImageKey == "" {
+		return "", &APIError{Op: "upload image", Code: resp.Code, Msg: resp.Msg}
+	}
+	return resp.Data.ImageKey, nil
+}
+
+// UploadFile is UploadImage's non-image sibling: bytes to Lark's file
+// endpoint, file_key back.
+func (c *httpAPIClient) UploadFile(ctx context.Context, p UploadFileParams) (string, error) {
+	if len(p.Data) == 0 {
+		return "", errors.New("lark http client: empty file body")
+	}
+	if len(p.Data) > larkFileUploadMaxBytes {
+		return "", fmt.Errorf("lark http client: file %q is %d bytes, over the %d-byte limit",
+			p.Filename, len(p.Data), larkFileUploadMaxBytes)
+	}
+	name := filenameOr(p.Filename, "file")
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			FileKey string `json:"file_key"`
+		} `json:"data"`
+	}
+	form := mediaUploadForm{
+		textFields: [][2]string{
+			{"file_type", p.FileType},
+			{"file_name", name},
+		},
+		fileField: "file",
+		filename:  name,
+		data:      p.Data,
+	}
+	if err := c.doAuthedUpload(ctx, p.InstallationID, larkUploadPathFile, form, &resp); err != nil {
+		return "", fmt.Errorf("lark http client: upload file: %w", err)
+	}
+	if resp.Code != 0 || resp.Data.FileKey == "" {
+		return "", &APIError{Op: "upload file", Code: resp.Code, Msg: resp.Msg}
+	}
+	return resp.Data.FileKey, nil
+}
+
+// SendImageMessage posts an uploaded image as its own message.
+func (c *httpAPIClient) SendImageMessage(ctx context.Context, p SendImageParams) (string, error) {
+	if p.ChatID == "" {
+		return "", errors.New("lark http client: missing chat_id")
+	}
+	if p.ImageKey == "" {
+		return "", errors.New("lark http client: missing image_key")
+	}
+	content, err := json.Marshal(map[string]string{"image_key": p.ImageKey})
+	if err != nil {
+		return "", fmt.Errorf("lark http client: encode image content: %w", err)
+	}
+	return c.sendTypedMessage(ctx, p.InstallationID, p.ChatID, "image", string(content), p.ReplyTarget, "send image message")
+}
+
+// SendFileMessage posts an uploaded file as its own message. Lark has no
+// way to embed a non-image in an answer, so this is necessarily a second
+// message rather than part of the reply.
+func (c *httpAPIClient) SendFileMessage(ctx context.Context, p SendFileParams) (string, error) {
+	if p.ChatID == "" {
+		return "", errors.New("lark http client: missing chat_id")
+	}
+	if p.FileKey == "" {
+		return "", errors.New("lark http client: missing file_key")
+	}
+	content, err := json.Marshal(map[string]string{"file_key": p.FileKey})
+	if err != nil {
+		return "", fmt.Errorf("lark http client: encode file content: %w", err)
+	}
+	return c.sendTypedMessage(ctx, p.InstallationID, p.ChatID, "file", string(content), p.ReplyTarget, "send file message")
+}
+
+// sendTypedMessage posts one already-encoded content body and returns
+// Lark's message_id.
+//
+// The three senders above (card / text / markdown) predate it and keep
+// their own copies of this envelope; this one exists so the two media
+// senders do not add a fourth and fifth.
+func (c *httpAPIClient) sendTypedMessage(ctx context.Context, creds InstallationCredentials, chatID ChatID, msgType, content string, target ReplyTarget, op string) (string, error) {
+	path, body := outboundMessageRequest(chatID, msgType, content, target)
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			MessageID string `json:"message_id"`
+		} `json:"data"`
+	}
+	if err := c.doAuthedJSON(ctx, creds, http.MethodPost, path, body, &resp); err != nil {
+		return "", fmt.Errorf("lark http client: %s: %w", op, err)
+	}
+	if resp.Code != 0 || resp.Data.MessageID == "" {
+		if isTokenError(resp.Code) {
+			c.invalidateToken(creds.AppID)
+		}
+		return "", &APIError{Op: op, Code: resp.Code, Msg: resp.Msg}
+	}
+	return resp.Data.MessageID, nil
+}
+
+// larkFileTypeFor maps a filename onto Lark's file_type enum: opus, mp4,
+// pdf, doc, xls, ppt, stream.
+//
+// Only extensions that name a kind exactly are mapped, and everything
+// else is `stream`. That is deliberate rather than lazy: Lark validates
+// the body against the declared type and REFUSES a mismatch instead of
+// downgrading it, so a wrong specific type loses the file outright while
+// `stream` always sends. We cannot tell from an extension alone whether
+// an `.xlsx` is one Lark's `xls` slot will accept, so the honest answer
+// is the general one.
+func larkFileTypeFor(filename string) string {
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".opus":
+		return "opus"
+	case ".mp4":
+		return "mp4"
+	case ".pdf":
+		return "pdf"
+	case ".doc":
+		return "doc"
+	case ".xls":
+		return "xls"
+	case ".ppt":
+		return "ppt"
+	}
+	return "stream"
+}
+
+// filenameOr keeps every log line and multipart part named, even for an
+// attachment row that arrived without a filename.
+func filenameOr(name, fallback string) string {
+	if strings.TrimSpace(name) == "" {
+		return fallback
+	}
+	return name
+}

--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -152,6 +152,13 @@ type PatcherQueries interface {
 	GetLarkOutboundCardByTask(ctx context.Context, taskID pgtype.UUID) (OutboundCardMessage, error)
 	CreateLarkOutboundCardMessage(ctx context.Context, arg CreateOutboundCardMessageParams) (OutboundCardMessage, error)
 	UpdateLarkOutboundCardStatus(ctx context.Context, arg UpdateOutboundCardStatusParams) error
+	// ListAttachmentsByChatMessage reads the files an agent bound to one
+	// assistant message at task completion. Taken with the generated db
+	// params rather than a domain type because ChannelStore embeds
+	// *db.Queries and therefore already satisfies it — this list is the
+	// one seam where the narrow interface would cost a hand-written
+	// adapter for no gain. See outbound_media.go for the caller.
+	ListAttachmentsByChatMessage(ctx context.Context, arg db.ListAttachmentsByChatMessageParams) ([]db.Attachment, error)
 }
 
 // CredentialsResolver decrypts an installation's app_secret for the
@@ -212,19 +219,36 @@ type Patcher struct {
 	credentials     CredentialsResolver
 	client          APIClient
 	typingIndicator *TypingIndicatorManager
-	cfg             PatcherConfig
+	// media is the same client as `client`, narrowed to the four
+	// upload/send methods the attachment hop needs. It is nil for any
+	// APIClient that does not implement them (the stub, the test
+	// fakes), which is how "attachments are not deliverable in this
+	// deployment" is expressed — see outbound_media.go.
+	media mediaAPIClient
+	// objects is the deployment's object store, or nil when this
+	// deployment configured none. Set via SetAttachments. Both it and
+	// media must be non-nil before a file can be delivered.
+	objects mediaObjectStore
+	cfg     PatcherConfig
 }
 
 // NewPatcher constructs a Patcher bound to its dependencies. The
 // patcher does not subscribe to the bus until Register is called.
 func NewPatcher(queries PatcherQueries, credentials CredentialsResolver, client APIClient, cfg PatcherConfig) *Patcher {
 	cfg = cfg.withDefaults()
-	return &Patcher{
+	p := &Patcher{
 		queries:     queries,
 		credentials: credentials,
 		client:      client,
 		cfg:         cfg,
 	}
+	// A type assertion rather than a fifth constructor argument: the
+	// media methods are an optional capability of the transport, and
+	// the fakes that do not have them must keep compiling.
+	if m, ok := client.(mediaAPIClient); ok {
+		p.media = m
+	}
+	return p
 }
 
 // SetTypingIndicatorManager wires the typing-indicator manager into the
@@ -402,7 +426,7 @@ func (p *Patcher) processEvent(ctx context.Context, e events.Event) error {
 
 	switch e.Type {
 	case protocol.EventChatDone:
-		return p.sendChatReply(ctx, creds, binding, mentionOpenID(binding), e.Payload)
+		return p.sendChatReply(ctx, creds, binding, mentionOpenID(binding), inst.WorkspaceID, e.Payload)
 	case protocol.EventTaskFailed:
 		return p.fail(ctx, creds, binding, taskID, agentName, e.Payload)
 	}
@@ -466,7 +490,7 @@ func mentionOpenID(binding ChatSessionBinding) string {
 // that member (see mention.go). The wire shape is chosen from the agent's own
 // content BEFORE the mention is attached, so a mention can never flip a plain
 // prose answer onto the card path.
-func (p *Patcher) sendChatReply(ctx context.Context, creds InstallationCredentials, binding ChatSessionBinding, mentionOpenID string, payload any) error {
+func (p *Patcher) sendChatReply(ctx context.Context, creds InstallationCredentials, binding ChatSessionBinding, mentionOpenID string, workspaceID pgtype.UUID, payload any) error {
 	content := chatDoneContent(payload)
 	if content == "" {
 		return nil
@@ -478,28 +502,47 @@ func (p *Patcher) sendChatReply(ctx context.Context, creds InstallationCredentia
 		return nil
 	}
 	target := threadReplyTarget(binding)
-	if containsMarkdown(content) {
-		markdown := prependMarkdownMention(mentionOpenID, content)
-		return sendWithReplyFallback(p.cfg.Logger, "send markdown card", target, func(t ReplyTarget) error {
+	markdown := containsMarkdown(content)
+
+	// used records the target the send actually went out on. The whole
+	// point of sendWithReplyFallback is that it may retry without
+	// threading, and files must land in the same conversation the answer
+	// landed in — not in the topic the answer was bounced out of.
+	var used ReplyTarget
+	send := func(t ReplyTarget) error {
+		used = t
+		if markdown {
 			_, err := p.client.SendMarkdownCard(ctx, SendMarkdownCardParams{
 				InstallationID: creds,
 				ChatID:         outboundChatID(binding),
-				Markdown:       markdown,
+				Markdown:       prependMarkdownMention(mentionOpenID, content),
 				ReplyTarget:    t,
 			})
 			return err
-		})
-	}
-	text := prependTextMention(mentionOpenID, content)
-	return sendWithReplyFallback(p.cfg.Logger, "send text message", target, func(t ReplyTarget) error {
+		}
 		_, err := p.client.SendTextMessage(ctx, SendTextParams{
 			InstallationID: creds,
 			ChatID:         outboundChatID(binding),
-			Text:           text,
+			Text:           prependTextMention(mentionOpenID, content),
 			ReplyTarget:    t,
 		})
 		return err
-	})
+	}
+	op := "send text message"
+	if markdown {
+		op = "send markdown card"
+	}
+	if err := sendWithReplyFallback(p.cfg.Logger, op, target, send); err != nil {
+		return err
+	}
+
+	// The answer is out; the files are the second hop. Spawned rather
+	// than awaited because this runs on the synchronous publish
+	// goroutine — see outbound_media.go for why the answer must never
+	// wait behind an upload. Best-effort by construction: the reply is
+	// already delivered, so nothing here can fail the reply.
+	p.deliverAttachmentsAsync(creds, binding, used, workspaceID, payload)
+	return nil
 }
 
 // outboundChatID recovers the real Lark chat id from the chat binding. The

--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -479,12 +479,12 @@ func mentionOpenID(binding ChatSessionBinding) string {
 //     binding-prompt template — just a single markdown block, no
 //     header / icon / CTA buttons.
 //
-// Empty content is silently dropped: we'd rather show nothing than
-// "Done." (the prior card fallback that confused Bohan in the live
-// dev env). In practice an empty Content means the daemon completed
-// the task without producing visible output, which only happens for
-// edge cases like a chat task that just acknowledged a system event;
-// not emitting a message there is the right product call.
+// Empty content skips the REPLY, not the delivery. An agent that produced
+// only files writes a real 'message' outcome with empty text — task.go's
+// pendingAttachments branch exists precisely for that shape, "the
+// attachment cards ARE the response". Returning before the attachment hop
+// would make the one case where the files are the whole answer the one case
+// the user hears nothing at all.
 //
 // mentionOpenID, when non-empty, prefixes the body with a native mention of
 // that member (see mention.go). The wire shape is chosen from the agent's own
@@ -492,9 +492,6 @@ func mentionOpenID(binding ChatSessionBinding) string {
 // prose answer onto the card path.
 func (p *Patcher) sendChatReply(ctx context.Context, creds InstallationCredentials, binding ChatSessionBinding, mentionOpenID string, workspaceID pgtype.UUID, payload any) error {
 	content := chatDoneContent(payload)
-	if content == "" {
-		return nil
-	}
 	if topicSendWithoutTrigger(binding) {
 		p.cfg.Logger.Warn("lark: no trigger for a topic-isolated session; skipping reply rather than posting it to the parent group",
 			"chat_session_id", uuidString(binding.ChatSessionID),
@@ -502,6 +499,13 @@ func (p *Patcher) sendChatReply(ctx context.Context, creds InstallationCredentia
 		return nil
 	}
 	target := threadReplyTarget(binding)
+	if content == "" {
+		// Nothing to say, but there may be something to show. The
+		// delivery path no-ops on its own when the reply carried no
+		// files, so this costs one lookup and never a stray message.
+		p.deliverAttachmentsAsync(creds, binding, target, workspaceID, payload)
+		return nil
+	}
 	markdown := containsMarkdown(content)
 
 	// used records the target the send actually went out on. The whole

--- a/server/internal/integrations/lark/outbound_media.go
+++ b/server/internal/integrations/lark/outbound_media.go
@@ -1,0 +1,340 @@
+package lark
+
+// outbound_media.go — the last hop: getting an agent's files into the chat.
+//
+// The agent's side of this already exists and is platform-agnostic. It runs
+// `multica attachment upload <path>`, the file lands in object storage, and
+// task completion binds the row to the assistant chat_message it just wrote
+// (BindChatAttachmentsToMessage). Everything downstream of that bind assumed
+// a chat window in a browser, so a Feishu conversation was told it could not
+// take files at all. This file is the missing hop.
+//
+// Three things decide the shape, and two of them are the same decisions the
+// WeCom adapter made (integrations/wecom/outbound_media.go) because they
+// follow from the medium rather than from the vendor.
+//
+// The answer goes first, always. An upload is megabytes and round trips and
+// it can fail; the sentence the agent wrote cannot be made to wait behind
+// one, and must not be lost to one. So this runs AFTER the reply is out, on
+// its own goroutine and its own budget, and its worst outcome is one extra
+// line saying a file did not make it.
+//
+// Each file is its own message. Lark CAN embed an image in an interactive
+// card, and so could have folded a set of images into one bubble — but the
+// answer has already gone out by the time these bytes exist, so the images
+// are necessarily a separate message from the prose either way, and
+// `msg_type=image` is both the simpler envelope and the one Lark renders
+// full-width. Non-images have no embedding option at all: `msg_type=file`
+// is the only wire shape.
+//
+// The third decision is Lark's, not ours: it validates an upload against the
+// declared file_type and refuses a mismatch rather than downgrading it, so
+// what to call a file is a choice with a wrong answer and not a lookup. See
+// larkFileTypeFor.
+//
+// What this path deliberately does NOT do is tell the user a file was sent
+// when the send was not confirmed. Every exit below ends in either a
+// delivery or a sentence; there is no exit that ends in silence while a
+// file was known to be waiting.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// mediaAPIClient is the slice of the Lark transport this path needs.
+//
+// Deliberately separate from APIClient rather than four more methods on it
+// — see the header of http_client_media.go for why. A client that does not
+// implement it (the production stub, the test fakes) simply never delivers
+// attachments, which is the same degradation as a deployment with no
+// storage configured, and the same one that holds today.
+type mediaAPIClient interface {
+	UploadImage(ctx context.Context, p UploadImageParams) (string, error)
+	UploadFile(ctx context.Context, p UploadFileParams) (string, error)
+	SendImageMessage(ctx context.Context, p SendImageParams) (string, error)
+	SendFileMessage(ctx context.Context, p SendFileParams) (string, error)
+}
+
+// mediaObjectStore is the slice of storage.Storage this path needs: the
+// attachment row carries the object's URL, and these two turn it back into
+// bytes. Same shape the WeCom adapter declares, for the same reason — the
+// alternate implementation (LocalStorage in self-hosted deployments) only
+// has to satisfy exactly what is used.
+type mediaObjectStore interface {
+	KeyFromURL(rawURL string) string
+	GetReader(ctx context.Context, key string) (io.ReadCloser, error)
+}
+
+// What the user is told when a file does not arrive. Hardcoded Chinese, like
+// every other user-facing string this adapter sends.
+const (
+	// mediaSendFailedText — we know a file did not make it. Definite,
+	// because claiming a definite failure that later turns out to be a
+	// delivery is how a user learns to ignore the notice.
+	mediaSendFailedText = "⚠️ 有文件没能发出来，我这边保留着，需要的话我再试一次。"
+
+	// mediaLookupFailedText — the failure is on our side and before the
+	// question was even answered: we could not read what was attached to
+	// this reply, so we do not know whether there was a file. Saying
+	// nothing here is what leaves a user waiting for something that was
+	// never attempted.
+	mediaLookupFailedText = "⚠️ 我这边没查到这条回答带没带文件，所以要是有，这次没发出来。需要的话我再试一次。"
+)
+
+// attachmentBudget bounds one answer's whole attachment delivery — reading
+// every object, uploading it, and sending it. Generous because nothing is
+// waiting on it: the reply is already in the chat, and the worst this
+// timeout costs is a notice that a file was skipped.
+const attachmentBudget = 5 * time.Minute
+
+// maxConcurrentAttachmentDeliveries is how many answers may be reading and
+// uploading objects at once.
+//
+// Process-wide rather than per installation: the heap is process-wide, so a
+// per-installation cap on a deployment running several bots just multiplies.
+// Each delivery may hold a whole image in memory at once, so this is the
+// number that decides peak resident attachment bytes.
+const maxConcurrentAttachmentDeliveries = 3
+
+var attachmentSlots = make(chan struct{}, maxConcurrentAttachmentDeliveries)
+
+// SetAttachments wires the object store this deployment's attachments live
+// in. Mirroring SetTypingIndicatorManager: the dependency is optional, and
+// leaving it unset is the supported "no storage here" configuration rather
+// than a programming error.
+//
+// Passing a store is also the promise that agents will be told they can
+// attach files (see router.go) — a run must not be promised a delivery hop
+// that was never built.
+func (p *Patcher) SetAttachments(objects mediaObjectStore) {
+	p.objects = objects
+}
+
+// chatDoneMessageID pulls the assistant message id out of a chat:done
+// payload (the typed payload, or its map form after a serialization round
+// trip). It is the key every attachment on this turn is bound to, and its
+// absence means there is nothing to look up.
+func chatDoneMessageID(payload any) string {
+	switch p := payload.(type) {
+	case protocol.ChatDonePayload:
+		return p.MessageID
+	case map[string]any:
+		if s, ok := p["message_id"].(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// deliverAttachmentsAsync starts the second hop for one answer.
+//
+// Called after the reply has been sent, and returns immediately: the caller
+// is the bus's synchronous publish goroutine on the task-completion path, so
+// blocking there for an upload would wedge task completion behind it. That
+// is the same reason this is a spawn rather than a call — see the file
+// header for the first half of the argument.
+func (p *Patcher) deliverAttachmentsAsync(creds InstallationCredentials, binding ChatSessionBinding, target ReplyTarget, workspaceID pgtype.UUID, payload any) {
+	if p.objects == nil || p.media == nil {
+		return
+	}
+	messageID := chatDoneMessageID(payload)
+	if messageID == "" {
+		// No assistant message, so nothing was bound to one.
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), attachmentBudget)
+		defer cancel()
+		p.deliverAttachments(ctx, creds, binding, target, workspaceID, messageID)
+	}()
+}
+
+// deliverAttachments reads every file bound to one answer and sends it.
+//
+// Files are independent: one that fails does not stop the rest, and what is
+// known about the ones that plainly did not arrive is said once at the end
+// rather than once each. The user gets at most one extra line per answer.
+func (p *Patcher) deliverAttachments(ctx context.Context, creds InstallationCredentials, binding ChatSessionBinding, target ReplyTarget, workspaceID pgtype.UUID, rawMessageID string) {
+	messageID, err := util.ParseUUID(rawMessageID)
+	if err != nil || !messageID.Valid {
+		// A malformed id can only mean a producer bug; there is no user
+		// action it could be reporting, so it is a log line only.
+		p.cfg.Logger.Warn("lark outbound: chat:done carried an unparseable message id",
+			"message_id", rawMessageID, "error", err)
+		return
+	}
+	rows, err := p.queries.ListAttachmentsByChatMessage(ctx, db.ListAttachmentsByChatMessageParams{
+		ChatMessageID: messageID,
+		WorkspaceID:   workspaceID,
+	})
+	if err != nil {
+		p.cfg.Logger.Warn("lark outbound: attachment lookup failed",
+			"error", err, "chat_message_id", rawMessageID)
+		p.tellUser(ctx, creds, binding, target, mediaLookupFailedText)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	// Past here a file is known to be waiting, so every way out of this
+	// function has to end in either a delivery or a sentence to the user.
+	select {
+	case attachmentSlots <- struct{}{}:
+		defer func() { <-attachmentSlots }()
+	default:
+		// Shed rather than queue: an unbounded backlog of image reads is
+		// heap, and the answer is already in the chat. Counted so the
+		// notice is not a surprise.
+		p.cfg.Logger.Warn("lark outbound: attachment delivery shed, too many already pending",
+			"chat_message_id", rawMessageID, "attachments", len(rows))
+		p.tellUser(ctx, creds, binding, target, mediaSendFailedText)
+		return
+	}
+
+	chatID := outboundChatID(binding)
+	failed := 0
+	for _, row := range rows {
+		if err := p.deliverOneAttachment(ctx, creds, chatID, target, row); err != nil {
+			failed++
+			p.cfg.Logger.Warn("lark outbound: attachment delivery failed",
+				"error", err,
+				"attachment_id", uuidString(row.ID),
+				"filename", row.Filename,
+				"chat_message_id", rawMessageID)
+		}
+	}
+	if failed > 0 {
+		p.tellUser(ctx, creds, binding, target, mediaSendFailedText)
+	}
+}
+
+// deliverOneAttachment reads one attachment out of object storage, uploads
+// it to Lark, and posts it.
+//
+// Images and everything else split here rather than at the lookup because
+// only the bytes decide which endpoint they can go to, and the classification
+// is the attachment row's own content type — not the extension, which the
+// uploader may not have controlled.
+func (p *Patcher) deliverOneAttachment(ctx context.Context, creds InstallationCredentials, chatID ChatID, target ReplyTarget, row db.Attachment) error {
+	rawURL := strings.TrimSpace(row.Url)
+	if rawURL == "" {
+		return errors.New("attachment has no url")
+	}
+	key := p.objects.KeyFromURL(rawURL)
+	if key == "" {
+		return fmt.Errorf("object key not derivable from url %q", rawURL)
+	}
+	rc, err := p.objects.GetReader(ctx, key)
+	if err != nil {
+		return fmt.Errorf("read object %q: %w", key, err)
+	}
+	defer rc.Close()
+	// Read the whole object: both Lark endpoints take a complete
+	// multipart body, and both ceilings are small enough (10 / 30 MiB)
+	// that holding one is the point of the concurrency cap above. Read
+	// one byte past the larger ceiling so "too big" is decided here
+	// rather than by a truncated upload.
+	data, err := io.ReadAll(io.LimitReader(rc, larkFileUploadMaxBytes+1))
+	if err != nil {
+		return fmt.Errorf("read object %q: %w", key, err)
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("object %q is empty", key)
+	}
+
+	if isImageAttachment(row.ContentType, row.Filename) {
+		if len(data) > larkImageUploadMaxBytes {
+			return fmt.Errorf("image %q is %d bytes, over the Lark image limit", row.Filename, len(data))
+		}
+		imageKey, err := p.media.UploadImage(ctx, UploadImageParams{
+			InstallationID: creds,
+			Filename:       row.Filename,
+			Data:           data,
+		})
+		if err != nil {
+			return fmt.Errorf("upload image: %w", err)
+		}
+		if _, err := p.media.SendImageMessage(ctx, SendImageParams{
+			InstallationID: creds,
+			ChatID:         chatID,
+			ImageKey:       imageKey,
+			ReplyTarget:    target,
+		}); err != nil {
+			return fmt.Errorf("send image: %w", err)
+		}
+		return nil
+	}
+
+	if len(data) > larkFileUploadMaxBytes {
+		return fmt.Errorf("file %q is %d bytes, over the Lark file limit", row.Filename, len(data))
+	}
+	fileKey, err := p.media.UploadFile(ctx, UploadFileParams{
+		InstallationID: creds,
+		Filename:       row.Filename,
+		FileType:       larkFileTypeFor(row.Filename),
+		Data:           data,
+	})
+	if err != nil {
+		return fmt.Errorf("upload file: %w", err)
+	}
+	if _, err := p.media.SendFileMessage(ctx, SendFileParams{
+		InstallationID: creds,
+		ChatID:         chatID,
+		FileKey:        fileKey,
+		ReplyTarget:    target,
+	}); err != nil {
+		return fmt.Errorf("send file: %w", err)
+	}
+	return nil
+}
+
+// tellUser posts a short plain-text notice into the same thread as the
+// answer. Best-effort: a failed notice is a log line, because there is
+// nothing left to tell the user with.
+func (p *Patcher) tellUser(ctx context.Context, creds InstallationCredentials, binding ChatSessionBinding, target ReplyTarget, body string) {
+	// The notice goes through the ordinary text sender, not the media
+	// client: it is the one send that must work even when the media path
+	// is the thing that failed.
+	if _, err := p.client.SendTextMessage(ctx, SendTextParams{
+		InstallationID: creds,
+		ChatID:         outboundChatID(binding),
+		Text:           prependTextMention(mentionOpenID(binding), body),
+		ReplyTarget:    target,
+	}); err != nil {
+		p.cfg.Logger.Warn("lark outbound: failed to tell the user about an attachment problem",
+			"error", err, "notice", body)
+	}
+}
+
+// isImageAttachment decides whether a row goes to the image endpoint.
+//
+// Content type first and extension second, deliberately: the content type is
+// what the uploader recorded and what Lark's renderer keys off, while the
+// extension is user-supplied text. A row carrying neither falls to the file
+// path, which accepts arbitrary bytes — the failure mode of guessing "image"
+// wrongly is a refused upload, and of guessing "file" wrongly is only a
+// less-nice bubble.
+func isImageAttachment(contentType, filename string) bool {
+	ct := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	if ct != "" {
+		return strings.HasPrefix(ct, "image/")
+	}
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp":
+		return true
+	}
+	return false
+}

--- a/server/internal/integrations/lark/outbound_media.go
+++ b/server/internal/integrations/lark/outbound_media.go
@@ -77,20 +77,23 @@ type mediaObjectStore interface {
 	GetReader(ctx context.Context, key string) (io.ReadCloser, error)
 }
 
-// What the user is told when a file does not arrive. Hardcoded Chinese, like
-// every other user-facing string this adapter sends.
+// What the user is told when a file does not arrive. English, matching every
+// other user-facing string this adapter sends (replier.go, outbound.go) — and
+// unlike the WeCom sibling, whose strings are hardcoded Chinese because WeCom
+// deployments are China-only, one Lark adapter serves both the mainland
+// Feishu cloud and the international Lark cloud (see channel.go).
 const (
 	// mediaSendFailedText — we know a file did not make it. Definite,
 	// because claiming a definite failure that later turns out to be a
 	// delivery is how a user learns to ignore the notice.
-	mediaSendFailedText = "⚠️ 有文件没能发出来，我这边保留着，需要的话我再试一次。"
+	mediaSendFailedText = "⚠️ A file didn't make it. I still have it — say the word and I'll resend."
 
 	// mediaLookupFailedText — the failure is on our side and before the
 	// question was even answered: we could not read what was attached to
 	// this reply, so we do not know whether there was a file. Saying
 	// nothing here is what leaves a user waiting for something that was
 	// never attempted.
-	mediaLookupFailedText = "⚠️ 我这边没查到这条回答带没带文件，所以要是有，这次没发出来。需要的话我再试一次。"
+	mediaLookupFailedText = "⚠️ I couldn't check whether this reply had a file attached. If it did, it wasn't sent — say the word and I'll resend."
 )
 
 // attachmentBudget bounds one answer's whole attachment delivery — reading

--- a/server/internal/integrations/lark/outbound_media_test.go
+++ b/server/internal/integrations/lark/outbound_media_test.go
@@ -408,6 +408,37 @@ func TestChatReplyDoesNotDeliverWhenReplyFails(t *testing.T) {
 	}
 }
 
+// TestChatReplyDeliversAttachmentOnlyReply covers the shape task.go calls
+// "the attachment cards ARE the response": an agent that produced a file and
+// no prose writes an empty-text outcome. The reply send is skipped; the
+// delivery is not. Without this the one case where the files are the whole
+// answer is the one case the user hears nothing.
+func TestChatReplyDeliversAttachmentOnlyReply(t *testing.T) {
+	p, q, api := newMediaTestPatcher(t)
+	p.SetAttachments(fakeObjectStore{objects: map[string][]byte{"chart.png": pngBytes}})
+
+	messageID := uuidFromString(t, "dddd9999-dddd-dddd-dddd-dddddddddddd")
+	taskID := uuidFromString(t, "ee999999-ee99-ee99-ee99-eeeeeeeeeeee")
+	q.task = db.AgentTaskQueue{ChatInputTaskID: taskID}
+	q.taskChannelIngested = true
+	q.attachments = []db.Attachment{imageRow(t, "aaaa2222-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "chart.png")}
+
+	// Empty content: the attachment is the whole reply.
+	p.handleEvent(newChatDoneEvent(t, taskID, q.binding.ChatSessionID, messageID, ""))
+
+	waitFor(t, func() bool {
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		return len(api.imagesOut) == 1
+	}, "attachment-only delivery")
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 0 {
+		t.Errorf("empty content must not produce a text message; textSent=%+v", api.textSent)
+	}
+}
+
 // waitFor polls cond until it holds or the budget runs out. The delivery
 // path is deliberately asynchronous, so a test cannot assert on it without
 // waiting for the thing it is asserting on.

--- a/server/internal/integrations/lark/outbound_media_test.go
+++ b/server/internal/integrations/lark/outbound_media_test.go
@@ -1,0 +1,441 @@
+package lark
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// fakeMediaAPIClient is the APIClient the patcher is built with, plus the
+// four media methods it type-asserts for. Embedding the ordinary fake keeps
+// this from drifting when APIClient grows a method.
+type fakeMediaAPIClient struct {
+	*fakeAPIClient
+
+	mu        sync.Mutex
+	images    []UploadImageParams
+	files     []UploadFileParams
+	imagesOut []SendImageParams
+	filesOut  []SendFileParams
+
+	uploadErr error
+	sendErr   error
+	imageKey  string
+	fileKey   string
+}
+
+func (f *fakeMediaAPIClient) UploadImage(_ context.Context, p UploadImageParams) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.images = append(f.images, p)
+	if f.uploadErr != nil {
+		return "", f.uploadErr
+	}
+	if f.imageKey == "" {
+		return "img_fake", nil
+	}
+	return f.imageKey, nil
+}
+
+func (f *fakeMediaAPIClient) UploadFile(_ context.Context, p UploadFileParams) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.files = append(f.files, p)
+	if f.uploadErr != nil {
+		return "", f.uploadErr
+	}
+	if f.fileKey == "" {
+		return "file_fake", nil
+	}
+	return f.fileKey, nil
+}
+
+func (f *fakeMediaAPIClient) SendImageMessage(_ context.Context, p SendImageParams) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.imagesOut = append(f.imagesOut, p)
+	return "lark_img_msg", f.sendErr
+}
+
+func (f *fakeMediaAPIClient) SendFileMessage(_ context.Context, p SendFileParams) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.filesOut = append(f.filesOut, p)
+	return "lark_file_msg", f.sendErr
+}
+
+// fakeObjectStore is an in-memory mediaObjectStore. URLs are the configured
+// prefix plus the key, which is the shape both real implementations use.
+type fakeObjectStore struct {
+	objects map[string][]byte
+	readErr error
+}
+
+const fakeObjectPrefix = "https://cdn.example/"
+
+func (s fakeObjectStore) KeyFromURL(rawURL string) string {
+	if !strings.HasPrefix(rawURL, fakeObjectPrefix) {
+		return ""
+	}
+	return strings.TrimPrefix(rawURL, fakeObjectPrefix)
+}
+
+func (s fakeObjectStore) GetReader(_ context.Context, key string) (io.ReadCloser, error) {
+	if s.readErr != nil {
+		return nil, s.readErr
+	}
+	data, ok := s.objects[key]
+	if !ok {
+		return nil, fmt.Errorf("fake store: no object %q", key)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func newMediaTestPatcher(t *testing.T) (*Patcher, *fakePatcherQueries, *fakeMediaAPIClient) {
+	t.Helper()
+	q := &fakePatcherQueries{
+		binding: ChatSessionBinding{
+			ChatSessionID:  uuidFromString(t, "cccccccc-cccc-cccc-cccc-cccccccccccc"),
+			InstallationID: uuidFromString(t, "1111aaaa-1111-1111-1111-111111111111"),
+			ChannelChatID:  "oc_test_chat",
+			ChatType:       "p2p",
+		},
+		installation: Installation{
+			ID:                 uuidFromString(t, "1111aaaa-1111-1111-1111-111111111111"),
+			WorkspaceID:        uuidFromString(t, "99999999-9999-9999-9999-999999999999"),
+			AppID:              "cli_test_app",
+			AppSecretEncrypted: []byte("ciphertext"),
+			Status:             string(InstallationActive),
+			AgentID:            uuidFromString(t, "aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+		},
+		agent: db.Agent{Name: "TestAgent"},
+	}
+	api := &fakeMediaAPIClient{
+		fakeAPIClient: &fakeAPIClient{sendReturn: "lark_card_msg_1", textSendReturn: "lark_text_msg_1"},
+	}
+	p := NewPatcher(q, fakeCredentials{secret: "shh"}, api, PatcherConfig{
+		Logger: newDiscardLogger(),
+		Now:    time.Now,
+	})
+	return p, q, api
+}
+
+// pngBytes is a non-empty body with a plausible image header — enough for a
+// path that only counts bytes and reads a content type off the row.
+var pngBytes = append([]byte{0x89, 'P', 'N', 'G'}, bytes.Repeat([]byte{0}, 32)...)
+
+func TestLarkFileTypeFor(t *testing.T) {
+	cases := map[string]string{
+		"report.pdf": "pdf",
+		"clip.mp4":   "mp4",
+		"voice.opus": "opus",
+		"legacy.doc": "doc",
+		"legacy.xls": "xls",
+		"legacy.ppt": "ppt",
+		"REPORT.PDF": "pdf",
+		// Everything else is `stream`. Deliberately not mapped by family: a
+		// wrong specific type is refused by Lark, while `stream` always
+		// sends.
+		"sheet.xlsx":     "stream",
+		"deck.pptx":      "stream",
+		"modern.docx":    "stream",
+		"archive.tar.gz": "stream",
+		"no-extension":   "stream",
+	}
+	for name, want := range cases {
+		if got := larkFileTypeFor(name); got != want {
+			t.Errorf("larkFileTypeFor(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestIsImageAttachment(t *testing.T) {
+	cases := []struct {
+		contentType, filename string
+		want                  bool
+	}{
+		{"image/png", "a.png", true},
+		{"image/jpeg; charset=binary", "a.jpg", true},
+		// Content type wins when present, even against the extension —
+		// the uploader recorded it and Lark's renderer keys off it.
+		{"application/octet-stream", "a.png", false},
+		// Falls back to the extension only when there is no content type.
+		{"", "a.png", true},
+		{"", "a.PNG", true},
+		{"", "a.pdf", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		if got := isImageAttachment(c.contentType, c.filename); got != c.want {
+			t.Errorf("isImageAttachment(%q, %q) = %v, want %v", c.contentType, c.filename, got, c.want)
+		}
+	}
+}
+
+func TestChatDoneMessageID(t *testing.T) {
+	if got := chatDoneMessageID(map[string]any{"message_id": "abc"}); got != "abc" {
+		t.Errorf("map payload: got %q", got)
+	}
+	if got := chatDoneMessageID(map[string]any{}); got != "" {
+		t.Errorf("empty map payload: got %q", got)
+	}
+	if got := chatDoneMessageID("not a payload"); got != "" {
+		t.Errorf("unexpected payload type: got %q", got)
+	}
+}
+
+func imageRow(t *testing.T, id, name string) db.Attachment {
+	t.Helper()
+	return db.Attachment{
+		ID:          uuidFromString(t, id),
+		Filename:    name,
+		Url:         fakeObjectPrefix + name,
+		ContentType: "image/png",
+	}
+}
+
+func fileRow(t *testing.T, id, name, contentType string) db.Attachment {
+	t.Helper()
+	return db.Attachment{
+		ID:          uuidFromString(t, id),
+		Filename:    name,
+		Url:         fakeObjectPrefix + name,
+		ContentType: contentType,
+	}
+}
+
+// TestDeliverAttachmentsRoutesByKind pins the one branch in this path: an
+// image goes to the image endpoint as `msg_type=image`, anything else goes
+// to the file endpoint as `msg_type=file`. Getting this backwards is not a
+// cosmetic bug — Lark refuses a body whose bytes disagree with the declared
+// kind, so a misrouted file is lost rather than degraded.
+func TestDeliverAttachmentsRoutesByKind(t *testing.T) {
+	p, q, api := newMediaTestPatcher(t)
+	p.SetAttachments(fakeObjectStore{objects: map[string][]byte{
+		"chart.png":  pngBytes,
+		"report.pdf": []byte("%PDF-1.4 fake"),
+	}})
+	q.attachments = []db.Attachment{
+		imageRow(t, "aaaa2222-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "chart.png"),
+		fileRow(t, "bbbb3333-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "report.pdf", "application/pdf"),
+	}
+
+	p.deliverAttachments(context.Background(), testCreds(), q.binding, ReplyTarget{},
+		q.installation.WorkspaceID, uuidString(uuidFromString(t, "dddd4444-dddd-dddd-dddd-dddddddddddd")))
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.images) != 1 || len(api.imagesOut) != 1 {
+		t.Fatalf("expected one image upload + send; uploads=%d sends=%d", len(api.images), len(api.imagesOut))
+	}
+	if len(api.files) != 1 || len(api.filesOut) != 1 {
+		t.Fatalf("expected one file upload + send; uploads=%d sends=%d", len(api.files), len(api.filesOut))
+	}
+	if got := api.images[0].Filename; got != "chart.png" {
+		t.Errorf("image uploaded from wrong row: %q", got)
+	}
+	if got := api.files[0].FileType; got != "pdf" {
+		t.Errorf("pdf should be declared pdf, got %q", got)
+	}
+	if !bytes.Equal(api.images[0].Data, pngBytes) {
+		t.Error("image upload did not carry the object's bytes")
+	}
+	if api.imagesOut[0].ImageKey != "img_fake" || api.filesOut[0].FileKey != "file_fake" {
+		t.Error("send did not use the key the upload returned")
+	}
+	// No notice on the happy path: a delivery is what the user sees.
+	if len(api.textSent) != 0 {
+		t.Errorf("happy path must not warn; got %d notices", len(api.textSent))
+	}
+}
+
+// TestDeliverAttachmentsLookupFailureTellsUser: we could not read what was
+// attached, so we do not know whether a file existed. Silence here is what
+// leaves a user waiting for something that was never attempted.
+func TestDeliverAttachmentsLookupFailureTellsUser(t *testing.T) {
+	p, q, api := newMediaTestPatcher(t)
+	p.SetAttachments(fakeObjectStore{})
+	q.attachmentsErr = fmt.Errorf("boom")
+
+	p.deliverAttachments(context.Background(), testCreds(), q.binding, ReplyTarget{},
+		q.installation.WorkspaceID, uuidString(uuidFromString(t, "dddd4444-dddd-dddd-dddd-dddddddddddd")))
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 1 || api.textSent[0].Text != mediaLookupFailedText {
+		t.Fatalf("expected the lookup-failure notice; textSent=%+v", api.textSent)
+	}
+}
+
+// TestDeliverAttachmentsWarnsOnceForManyFailures: files are independent, so
+// one bad object must not stop the rest — but the user gets one line, not
+// one per file.
+func TestDeliverAttachmentsWarnsOnceForManyFailures(t *testing.T) {
+	p, q, api := newMediaTestPatcher(t)
+	// The store has no objects, so every read fails.
+	p.SetAttachments(fakeObjectStore{objects: map[string][]byte{}})
+	q.attachments = []db.Attachment{
+		imageRow(t, "aaaa2222-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "one.png"),
+		imageRow(t, "bbbb3333-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "two.png"),
+	}
+
+	p.deliverAttachments(context.Background(), testCreds(), q.binding, ReplyTarget{},
+		q.installation.WorkspaceID, uuidString(uuidFromString(t, "dddd4444-dddd-dddd-dddd-dddddddddddd")))
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.imagesOut) != 0 {
+		t.Fatalf("nothing should have been sent; got %d", len(api.imagesOut))
+	}
+	if len(api.textSent) != 1 || api.textSent[0].Text != mediaSendFailedText {
+		t.Fatalf("expected exactly one failure notice; textSent=%+v", api.textSent)
+	}
+}
+
+// TestDeliverAttachmentsNoOpsWithoutWiring: the stub client does not
+// implement the media interface and a deployment may have no storage. Both
+// must be quiet no-ops, not lookups or panics.
+func TestDeliverAttachmentsNoOpsWithoutWiring(t *testing.T) {
+	t.Run("no object store", func(t *testing.T) {
+		p, q, api := newMediaTestPatcher(t)
+		// SetAttachments deliberately not called.
+		q.attachments = []db.Attachment{imageRow(t, "aaaa2222-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "chart.png")}
+		p.deliverAttachmentsAsync(testCreds(), q.binding, ReplyTarget{},
+			q.installation.WorkspaceID, map[string]any{"message_id": "dddd4444-dddd-dddd-dddd-dddddddddddd"})
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		if len(api.imagesOut) != 0 || len(api.textSent) != 0 {
+			t.Error("no store means no delivery and no notice")
+		}
+	})
+
+	t.Run("no media client", func(t *testing.T) {
+		// The ordinary fakeAPIClient does not implement mediaAPIClient,
+		// which is exactly how the production stub behaves.
+		p, q, api := newTestPatcher(t)
+		p.SetAttachments(fakeObjectStore{objects: map[string][]byte{"chart.png": pngBytes}})
+		q.attachments = []db.Attachment{imageRow(t, "aaaa2222-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "chart.png")}
+		p.deliverAttachmentsAsync(testCreds(), q.binding, ReplyTarget{},
+			q.installation.WorkspaceID, map[string]any{"message_id": "dddd4444-dddd-dddd-dddd-dddddddddddd"})
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		if len(api.textSent) != 0 {
+			t.Error("no media client means no delivery and no notice")
+		}
+	})
+
+	t.Run("no message id", func(t *testing.T) {
+		p, q, _ := newMediaTestPatcher(t)
+		p.SetAttachments(fakeObjectStore{objects: map[string][]byte{"chart.png": pngBytes}})
+		q.attachments = []db.Attachment{imageRow(t, "aaaa2222-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "chart.png")}
+		p.deliverAttachmentsAsync(testCreds(), q.binding, ReplyTarget{},
+			q.installation.WorkspaceID, map[string]any{"content": "no message id here"})
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		if len(q.attachmentLookups) != 0 {
+			t.Error("a payload with no message id must not trigger a lookup")
+		}
+	})
+}
+
+// TestChatReplySpawnsDeliveryAfterReply is the integration seam: a chat:done
+// with a message id must send the answer AND then deliver the files bound to
+// it, in that order.
+func TestChatReplySpawnsDeliveryAfterReply(t *testing.T) {
+	p, q, api := newMediaTestPatcher(t)
+	p.SetAttachments(fakeObjectStore{objects: map[string][]byte{"chart.png": pngBytes}})
+
+	messageID := uuidFromString(t, "dddd4444-dddd-dddd-dddd-dddddddddddd")
+	taskID := uuidFromString(t, "ee777777-ee77-ee77-ee77-eeeeeeeeeeee")
+	q.task = db.AgentTaskQueue{ChatInputTaskID: taskID}
+	q.taskChannelIngested = true
+	q.attachments = []db.Attachment{imageRow(t, "aaaa2222-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "chart.png")}
+
+	p.handleEvent(newChatDoneEvent(t, taskID, q.binding.ChatSessionID, messageID, "Here is the chart."))
+
+	// The spawn is asynchronous by design, so poll for its effect rather
+	// than sleeping a fixed amount.
+	waitFor(t, func() bool {
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		return len(api.imagesOut) == 1
+	}, "image delivery")
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 1 || api.textSent[0].Text != "Here is the chart." {
+		t.Fatalf("the answer must still go out exactly once; textSent=%+v", api.textSent)
+	}
+	if api.imagesOut[0].ImageKey != "img_fake" {
+		t.Error("image delivered without the uploaded key")
+	}
+}
+
+// TestChatReplyDoesNotDeliverWhenReplyFails: the files are the second hop,
+// so there is no first hop to follow when the answer itself did not land.
+// A file arriving under no answer is worse than a missing file.
+func TestChatReplyDoesNotDeliverWhenReplyFails(t *testing.T) {
+	p, q, api := newMediaTestPatcher(t)
+	p.SetAttachments(fakeObjectStore{objects: map[string][]byte{"chart.png": pngBytes}})
+	api.textSendErr = fmt.Errorf("lark is down")
+
+	messageID := uuidFromString(t, "dddd4444-dddd-dddd-dddd-dddddddddddd")
+	taskID := uuidFromString(t, "ee888888-ee88-ee88-ee88-eeeeeeeeeeee")
+	q.task = db.AgentTaskQueue{ChatInputTaskID: taskID}
+	q.taskChannelIngested = true
+	q.attachments = []db.Attachment{imageRow(t, "aaaa2222-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "chart.png")}
+
+	p.handleEvent(newChatDoneEvent(t, taskID, q.binding.ChatSessionID, messageID, "plain prose"))
+
+	// Give the (supposedly absent) goroutine a chance to run, so this is
+	// not passing merely because nothing was scheduled yet.
+	time.Sleep(50 * time.Millisecond)
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.imagesOut) != 0 || len(api.images) != 0 {
+		t.Fatalf("no delivery may follow a failed reply; uploads=%d sends=%d", len(api.images), len(api.imagesOut))
+	}
+}
+
+// waitFor polls cond until it holds or the budget runs out. The delivery
+// path is deliberately asynchronous, so a test cannot assert on it without
+// waiting for the thing it is asserting on.
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// newChatDoneEvent builds the bus event a completed chat task publishes. The
+// MessageID is what the attachment hop keys off, so every test here sets one.
+func newChatDoneEvent(t *testing.T, taskID, sessionID pgtype.UUID, messageID pgtype.UUID, content string) events.Event {
+	t.Helper()
+	return events.Event{
+		Type:          protocol.EventChatDone,
+		TaskID:        uuidString(taskID),
+		ChatSessionID: uuidString(sessionID),
+		Payload: protocol.ChatDonePayload{
+			TaskID:        uuidString(taskID),
+			ChatSessionID: uuidString(sessionID),
+			MessageID:     uuidString(messageID),
+			Content:       content,
+		},
+	}
+}

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -40,6 +40,24 @@ type fakePatcherQueries struct {
 	deliveriesByTask map[string]db.ChannelTaskDelivery
 	// tasksByID overrides `task` per task_id; empty falls back to `task`.
 	tasksByID map[string]db.AgentTaskQueue
+	// attachments is what the assistant message's files resolve to, and
+	// attachmentsErr forces the lookup to fail. attachmentLookups records
+	// every lookup so a test can assert what the delivery path asked for
+	// (and that it did not ask at all when it had nothing to do).
+	attachments       []db.Attachment
+	attachmentsErr    error
+	attachmentLookups []db.ListAttachmentsByChatMessageParams
+}
+
+// ListAttachmentsByChatMessage reads the fake's seeded rows. Unlike the
+// generated query it ignores the workspace scoping — tests seed rows and
+// ids together, so a workspace mismatch is not a shape any test needs to
+// express.
+func (f *fakePatcherQueries) ListAttachmentsByChatMessage(_ context.Context, arg db.ListAttachmentsByChatMessageParams) ([]db.Attachment, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attachmentLookups = append(f.attachmentLookups, arg)
+	return f.attachments, f.attachmentsErr
 }
 
 func (f *fakePatcherQueries) GetAgentTask(ctx context.Context, id pgtype.UUID) (db.AgentTaskQueue, error) {

--- a/server/internal/integrations/lark/params.go
+++ b/server/internal/integrations/lark/params.go
@@ -135,3 +135,52 @@ type UpdateOutboundCardStatusParams struct {
 	ID     pgtype.UUID
 	Status string
 }
+
+// UploadImageParams carries one image's bytes up to Lark's image endpoint
+// (POST /open-apis/im/v1/images) to obtain an image_key. Lark requires
+// image_type=message for anything sent into a chat; the returned key is
+// what `msg_type=image` and card `img` elements both consume.
+type UploadImageParams struct {
+	InstallationID InstallationCredentials
+	// Filename is advisory only — Lark keys the object and echoes the
+	// key back; it never sees the name. Kept for log lines.
+	Filename string
+	// Data is the raw image bytes. Lark caps this at 10 MiB and refuses
+	// a zero-byte body; the caller enforces both before calling.
+	Data []byte
+}
+
+// UploadFileParams carries one non-image file's bytes up to Lark's file
+// endpoint (POST /open-apis/im/v1/files) to obtain a file_key.
+//
+// FileType is Lark's own enum — opus / mp4 / pdf / doc / xls / ppt /
+// stream — and it is a claim about the bytes, not a label: Lark refuses a
+// body whose type disagrees with an over-specific claim rather than
+// downgrading it. See larkFileTypeFor for how the mapping is derived and
+// why `stream` is the safe default.
+type UploadFileParams struct {
+	InstallationID InstallationCredentials
+	Filename       string
+	// FileType must already be a value from Lark's enum; the caller
+	// resolves it (larkFileTypeFor) so this stays a transport type.
+	FileType string
+	Data     []byte
+}
+
+// SendImageParams posts an already-uploaded image (by image_key) into a
+// chat as its own `msg_type=image` message.
+type SendImageParams struct {
+	InstallationID InstallationCredentials
+	ChatID         ChatID
+	ImageKey       string
+	ReplyTarget    ReplyTarget
+}
+
+// SendFileParams posts an already-uploaded file (by file_key) into a chat
+// as its own `msg_type=file` message.
+type SendFileParams struct {
+	InstallationID InstallationCredentials
+	ChatID         ChatID
+	FileKey        string
+	ReplyTarget    ReplyTarget
+}


### PR DESCRIPTION
## What does this PR do?

Feishu/Lark conversations can now receive the files an agent attached to its reply. Previously only the text arrived — the Lark outbound path had no attachment hop at all.

`multica attachment upload` already puts files in object storage, and task completion already binds them to the assistant `chat_message` (`BindChatAttachmentsToMessage`). Everything downstream of that bind assumed a chat window in a browser, so a Feishu conversation was told it could not take files — the same gap the WeCom adapter closed in `integrations/wecom/outbound_media.go`. This closes that hop for Lark, following the decisions that file settled.

Thinking path: the reply already reached Lark (`sendChatReply`), the binding already existed in the DB, and WeCom already solved the identical last hop — so the change is scoped to the one missing link plus the transport calls it needs, not to the reply or binding paths.

Why this shape:
- The answer goes first, always. An upload is megabytes and round trips and can fail; the sentence the agent wrote must not wait behind one and must not be lost to one. Delivery runs after the reply is out, on its own goroutine and budget, and its worst outcome is one extra line saying a file did not make it.
- Images and non-images split on the attachment row's own content type, not the extension: Lark validates an upload against the declared kind and refuses a mismatch instead of downgrading it, so `larkFileTypeFor` maps only extensions that name a kind exactly and sends everything else as `stream`.
- The four transport methods live on the concrete client and are requested through a narrow interface, so `APIClient` — and the production stub plus four test fakes behind it — is untouched.

## Related Issue

No issue exists for this; opening one first would be reasonable if the maintainers prefer that.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `server/internal/integrations/lark/http_client_media.go` (new) — `UploadImage` / `UploadFile` / `SendImageMessage` / `SendFileMessage`: multipart upload, a token-refresh retry mirroring `doAuthedJSON`, and the per-endpoint size ceilings.
- `server/internal/integrations/lark/outbound_media.go` (new) — the delivery hop: attachment lookup by assistant message id, object read, upload, send, and the failure notices.
- `server/internal/integrations/lark/outbound.go` — `Patcher` gains `media` (type-asserted off the client) and `objects`; `sendChatReply` starts the hop once the reply has landed. An attachment-only reply (empty text, which task.go supports as "the attachment cards ARE the response") now runs the delivery instead of returning early.
- `server/internal/integrations/lark/params.go` — `UploadImageParams`, `UploadFileParams`, `SendImageParams`, `SendFileParams`.
- `server/internal/integrations/lark/outbound_media_test.go` (new) — 10 tests.
- `server/cmd/server/router.go` — one `if store != nil` calling `patcher.SetAttachments(store)` and `h.DeclareChannelFileDelivery(string(channel.TypeFeishu))`.

## How to Test

1. `go test -race ./internal/integrations/lark/`
2. `go vet ./...` (compiles every test file in the repo)
3. Not runnable in my environment — no bot credentials. Against a real bot: in a bound Feishu chat, have an agent run `multica attachment upload chart.png` and reply; expect the text reply, then the image as a following message in the same thread. A non-image attachment should arrive as a file message.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, backend only
- [ ] I have updated relevant documentation to reflect my changes — nothing documents the Lark attachment path
- [ ] runtime / coding tool / UI tab sync — N/A
- [x] Chinese product copy checked — the two new user-facing strings are English, matching this adapter's existing strings (`replier.go`, `outbound.go`); the Chinese wording lives only in the China-only WeCom adapter
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code (running as a Multica agent)

**Prompt / approach:** The gap was identified from a conversation about files not arriving in Feishu. The agent cloned the upstream repo, found the missing hop by comparing the Lark outbound path against the WeCom adapter, implemented it, and self-reviewed it — including a test verified to fail without the fix, `-race`, and a full-repo `go vet`.

## Screenshots (optional)

N/A