### PR TITLE
MUL-7307: fix(issues): wake parent owners for child review handoffs

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3757,6 +3757,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	// fails best-effort.
 	if statusChanged {
 		h.notifyParentOfChildDone(r.Context(), prevIssue, issue)
+		h.notifyParentOfChildAttention(r.Context(), prevIssue, issue, actorType, actorID)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -4214,6 +4215,8 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	// the parent/stage notification is evaluated once against the final state
 	// after the loop (MUL-4155) rather than per-child mid-batch.
 	var childDoneCompleted []db.Issue
+	var childAttentionNeeded []childAttentionEvent
+	batchActorType, batchActorID := h.resolveActor(r, userID, workspaceID)
 	for _, issueID := range req.IssueIDs {
 		issueUUID, err := util.ParseUUID(issueID)
 		if err != nil {
@@ -4397,7 +4400,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 
 		prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 		resp := issueToResponse(issue, prefix)
-		actorType, actorID := h.resolveActor(r, userID, workspaceID)
+		actorType, actorID := batchActorType, batchActorID
 
 		fillBatch(&resp)
 		assigneeChanged := (req.Updates.AssigneeType != nil || req.Updates.AssigneeID != nil) &&
@@ -4449,12 +4452,18 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		// comparison here left childDoneCompleted empty and silently skipped
 		// notifyParentsOfBatchChildDone entirely. (MUL-6243)
 		if statusChanged && issue.ParentIssueID.Valid {
-			prevTerminal := isTerminalChildStatus(
-				issuestatus.Effective(r.Context(), h.Queries, prevIssue.WorkspaceID, prevIssue.Status))
-			nowTerminal := isTerminalChildStatus(
-				issuestatus.Effective(r.Context(), h.Queries, issue.WorkspaceID, issue.Status))
+			prevEffective := issuestatus.Effective(r.Context(), h.Queries, prevIssue.WorkspaceID, prevIssue.Status)
+			nowEffective := issuestatus.Effective(r.Context(), h.Queries, issue.WorkspaceID, issue.Status)
+			prevTerminal := isTerminalChildStatus(prevEffective)
+			nowTerminal := isTerminalChildStatus(nowEffective)
 			if !prevTerminal && nowTerminal {
 				childDoneCompleted = append(childDoneCompleted, issue)
+			}
+			if childNeedsParentAttention(prevEffective, nowEffective) {
+				childAttentionNeeded = append(childAttentionNeeded, childAttentionEvent{
+					child:           issue,
+					effectiveStatus: nowEffective,
+				})
 			}
 		}
 
@@ -4466,6 +4475,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	// of issue_ids order (MUL-4155). Best-effort; failure does not abort the
 	// batch. Single-issue UpdateIssue is unchanged and still notifies inline.
 	h.notifyParentsOfBatchChildDone(r.Context(), childDoneCompleted)
+	h.notifyParentsOfBatchChildAttention(r.Context(), childAttentionNeeded, batchActorType, batchActorID)
 
 	slog.Info("batch update issues", append(logger.RequestAttrs(r), "count", updated)...)
 	writeJSON(w, http.StatusOK, map[string]any{"updated": updated})

--- a/server/internal/handler/issue_batch_test.go
+++ b/server/internal/handler/issue_batch_test.go
@@ -383,6 +383,26 @@ func TestBatchChildDoneCrossStage_Cancelled(t *testing.T) {
 	}
 }
 
+func TestBatchChildAttention_OneCommentOneWake(t *testing.T) {
+	fx := newStagedBatchFixture(t)
+
+	batchSetStatus(t, []string{fx.stage1[0].ID, fx.stage1[1].ID}, "blocked")
+
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("expected exactly 1 attention comment on parent, got %d", got)
+	}
+	content, _, _, _ := systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "needs attention after a batch update") {
+		t.Errorf("expected batch attention handoff, got: %s", content)
+	}
+	if !strings.Contains(content, "is blocked") {
+		t.Errorf("expected blocked status in handoff, got: %s", content)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, fx.agentID); got != 1 {
+		t.Fatalf("expected exactly 1 pending parent task, got %d", got)
+	}
+}
+
 // TestBatchChildDoneClosesLowerStageOnly — when a batch finishes only the lower
 // stage (a later stage still has open children), the parent must be told Stage 1
 // is complete AND accurately pointed at Stage 2 as next. Guards against

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -166,6 +167,66 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	h.postChildDoneComment(ctx, parent, issue, children, staged, closedStage, false, isTerminal)
 }
 
+type childAttentionEvent struct {
+	child           db.Issue
+	effectiveStatus string
+}
+
+// childAttentionTransition resolves custom statuses to their canonical
+// behavior before deciding whether a child crossed into a review-ready or
+// blocked state. A raw custom-status rename inside the same category is only a
+// presentation change and must not wake the parent again.
+func (h *Handler) childAttentionTransition(ctx context.Context, prev, issue db.Issue) (childAttentionEvent, bool) {
+	effective := h.childStatusResolver(ctx)
+	prevStatus, err := effective(prev)
+	if err != nil {
+		slog.Warn("child attention: failed to resolve previous child status", "error", err, "child_id", uuidToString(issue.ID))
+		return childAttentionEvent{}, false
+	}
+	nextStatus, err := effective(issue)
+	if err != nil {
+		slog.Warn("child attention: failed to resolve child status", "error", err, "child_id", uuidToString(issue.ID))
+		return childAttentionEvent{}, false
+	}
+	if !childNeedsParentAttention(prevStatus, nextStatus) {
+		return childAttentionEvent{}, false
+	}
+	return childAttentionEvent{child: issue, effectiveStatus: nextStatus}, true
+}
+
+// notifyParentOfChildAttention posts a parent-level handoff when a child moves
+// into a state that needs intervention but is not terminal. Child completion is
+// handled separately by notifyParentOfChildDone because it has stage-barrier
+// semantics; review/block states must surface immediately or the parent can
+// stall with no coordinator wake.
+func (h *Handler) notifyParentOfChildAttention(ctx context.Context, prev, issue db.Issue, actorType, actorID string) {
+	if !issue.ParentIssueID.Valid {
+		return
+	}
+	event, ok := h.childAttentionTransition(ctx, prev, issue)
+	if !ok {
+		return
+	}
+
+	parent, err := h.Queries.GetIssue(ctx, issue.ParentIssueID)
+	if err != nil {
+		slog.Warn("child attention: failed to load parent",
+			"error", err,
+			"child_id", uuidToString(issue.ID),
+			"parent_id", uuidToString(issue.ParentIssueID))
+		return
+	}
+	parentStatus, err := h.childStatusResolver(ctx)(parent)
+	if err != nil {
+		slog.Warn("child attention: failed to resolve parent status", "error", err, "parent_id", uuidToString(parent.ID))
+		return
+	}
+	if parentStatus == issuestatus.Done || parentStatus == issuestatus.Cancelled || parentStatus == issuestatus.Backlog {
+		return
+	}
+	h.postChildAttentionComment(ctx, parent, event, false, actorType, actorID)
+}
+
 // notifyParentsOfBatchChildDone emits child-done parent notifications for a
 // whole batch AFTER every status write has committed. `completed` is the set of
 // children that transitioned non-terminal -> terminal during the batch.
@@ -315,6 +376,58 @@ func highestClosedBatchStage(children, completed []db.Issue, isTerminal func(db.
 	return rep, found
 }
 
+// notifyParentsOfBatchChildAttention emits at most one review/block handoff per
+// parent after a batch update has committed. If several children need
+// attention, blocked wins over in_review because it is the stronger escalation
+// signal.
+func (h *Handler) notifyParentsOfBatchChildAttention(ctx context.Context, events []childAttentionEvent, actorType, actorID string) {
+	if len(events) == 0 {
+		return
+	}
+
+	type parentGroup struct {
+		parentID pgtype.UUID
+		event    childAttentionEvent
+	}
+	var groups []*parentGroup
+	index := map[string]*parentGroup{}
+	for _, event := range events {
+		if !event.child.ParentIssueID.Valid {
+			continue
+		}
+		key := uuidToString(event.child.ParentIssueID)
+		group, ok := index[key]
+		if !ok {
+			group = &parentGroup{parentID: event.child.ParentIssueID, event: event}
+			index[key] = group
+			groups = append(groups, group)
+			continue
+		}
+		if group.event.effectiveStatus != issuestatus.Blocked && event.effectiveStatus == issuestatus.Blocked {
+			group.event = event
+		}
+	}
+
+	for _, group := range groups {
+		parent, err := h.Queries.GetIssue(ctx, group.parentID)
+		if err != nil {
+			slog.Warn("batch child attention: failed to load parent",
+				"error", err,
+				"parent_id", uuidToString(group.parentID))
+			continue
+		}
+		parentStatus, err := h.childStatusResolver(ctx)(parent)
+		if err != nil {
+			slog.Warn("batch child attention: failed to resolve parent status", "error", err, "parent_id", uuidToString(parent.ID))
+			continue
+		}
+		if parentStatus == issuestatus.Done || parentStatus == issuestatus.Cancelled || parentStatus == issuestatus.Backlog {
+			continue
+		}
+		h.postChildAttentionComment(ctx, parent, group.event, true, actorType, actorID)
+	}
+}
+
 // postChildDoneComment builds and posts the parent's child-done system comment
 // for a closed stage barrier, then dispatches the parent-assignee trigger. It
 // assumes every guard in notifyParentOfChildDone / notifyParentsOfBatchChildDone
@@ -407,6 +520,67 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 	h.dispatchParentAssigneeTrigger(ctx, parent, comment)
 }
 
+// postChildAttentionComment records a parent-level handoff for blocked or
+// review-ready child work, then routes the handoff to the parent owner. Unlike
+// child completion, this is immediate and has no stage-barrier requirement.
+func (h *Handler) postChildAttentionComment(ctx context.Context, parent db.Issue, event childAttentionEvent, batch bool, actorType, actorID string) {
+	child := event.child
+	prefix := h.getIssuePrefix(ctx, child.WorkspaceID)
+	identifier := prefix + "-" + strconv.Itoa(int(child.Number))
+	childID := uuidToString(child.ID)
+	title := sanitizeChildTitleForSystemComment(child.Title)
+	mentionPrefix := h.buildParentAssigneeMention(ctx, parent)
+
+	stateLabel := statusLabelForChildAttention(event.effectiveStatus)
+	action := "Review the child and decide whether to accept it, request follow-up, or continue the parent."
+	if event.effectiveStatus == issuestatus.Blocked {
+		action = "Review the child, unblock it, or decide who should continue the parent."
+	}
+
+	var content string
+	if batch {
+		content = fmt.Sprintf(
+			"%sA sub-issue needs attention after a batch update — [%s](mention://issue/%s) — \"%s\" is %s. %s",
+			mentionPrefix, identifier, childID, title, stateLabel, action,
+		)
+	} else {
+		content = fmt.Sprintf(
+			"%sA sub-issue needs attention — [%s](mention://issue/%s) — \"%s\" is %s. %s",
+			mentionPrefix, identifier, childID, title, stateLabel, action,
+		)
+	}
+
+	created, err := h.Queries.CreateComment(ctx, db.CreateCommentParams{
+		IssueID:     parent.ID,
+		WorkspaceID: parent.WorkspaceID,
+		AuthorType:  "system",
+		AuthorID:    pgtype.UUID{Valid: true},
+		Content:     content,
+		Type:        "system",
+		ParentID:    pgtype.UUID{Valid: false},
+	})
+	if err != nil {
+		slog.Warn("child attention: create system comment failed",
+			"error", err,
+			"child_id", childID,
+			"parent_id", uuidToString(parent.ID))
+		return
+	}
+	comment := created.Comment()
+
+	h.publish(protocol.EventCommentCreated, uuidToString(parent.WorkspaceID), "system", "", map[string]any{
+		"comment":             commentToResponse(comment, nil, nil),
+		"issue_title":         parent.Title,
+		"issue_assignee_type": textToPtr(parent.AssigneeType),
+		"issue_assignee_id":   uuidToPtr(parent.AssigneeID),
+		"issue_status":        parent.Status,
+		"issue_revision":      created.IssueRevision,
+	})
+
+	h.dispatchParentAssigneeTrigger(ctx, parent, comment)
+	h.notifyParentMemberOfChildAttention(ctx, parent, event, comment, actorType, actorID)
+}
+
 // isTerminalChildStatus reports whether a child issue status counts as
 // "finished" for stage-barrier purposes. Cancelled counts as terminal: a
 // cancelled sibling will never complete, so it must not hold a stage open.
@@ -416,6 +590,25 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 // cancelled category closes a stage exactly like Done and Cancelled do.
 func isTerminalChildStatus(status string) bool {
 	return status == "done" || status == "cancelled"
+}
+
+func isChildAttentionStatus(status string) bool {
+	return status == issuestatus.InReview || status == issuestatus.Blocked
+}
+
+func childNeedsParentAttention(prevStatus, nextStatus string) bool {
+	return prevStatus != nextStatus && isChildAttentionStatus(nextStatus)
+}
+
+func statusLabelForChildAttention(status string) string {
+	switch status {
+	case issuestatus.InReview:
+		return "in review"
+	case issuestatus.Blocked:
+		return "blocked"
+	default:
+		return status
+	}
 }
 
 // childStatusResolver shares each workspace's catalog across the guards,
@@ -663,11 +856,12 @@ func sanitizeMentionLabel(name string) string {
 
 // dispatchParentAssigneeTrigger fires the explicit side effect that pairs
 // with the @mention link in the system comment body — an agent task for
-// agent or squad-leader assignees. Member assignees never reach this code
-// path; notifyParentOfChildDone skips them outright. The generic comment
-// listener is intentionally bypassed (it short-circuits on
-// author_type='system'), so this is the single place where the platform
-// applies the idempotency guard for the child-done notification.
+// agent or squad-leader assignees. A member parent is a no-op here; attention
+// handoffs route that case through notifyParentMemberOfChildAttention instead,
+// while child-done skips members outright. The generic comment listener is
+// intentionally bypassed (it short-circuits on author_type='system'), so this
+// is the single place where the platform applies the agent-task idempotency
+// guard for parent handoffs.
 //
 // Side-effect semantics (intentionally narrower than a normal @mention):
 //   - agent parent: one EnqueueTaskForMention on the parent assignee, same
@@ -675,7 +869,7 @@ func sanitizeMentionLabel(name string) string {
 //     match what users already rely on.
 //   - squad parent: one EnqueueTaskForSquadLeader on the squad LEADER only.
 //     Unlike a human @squad mention, this does NOT fan out to squad members
-//     — child-done is a coordination signal, the leader decides whether
+//     — a child handoff is a coordination signal, the leader decides whether
 //     and how to wake the rest of the squad. Documented here so reviewers
 //     don't read "system mention" as inheriting the full member fan-out. The
 //     actor that closed the child is irrelevant to routing: the target is the
@@ -686,13 +880,13 @@ func sanitizeMentionLabel(name string) string {
 //     general notification. Per-user mute settings are evaluated by the
 //     downstream agent_task / inbox pipeline once the task is dispatched.
 //   - notification_listeners.go short-circuits on author_type='system', so
-//     subscriber emails and member-inbox rows from smuggled mentions in the
-//     child title are inert — only the explicit dispatch below runs.
+//     subscriber emails and mention-derived inbox rows from smuggled mentions
+//     in the child title are inert — only the explicit routing helpers run.
 //
 // Guards applied here:
 //   - No-op when the parent has no assignee row.
 //   - NO self-trigger guard on either the agent OR the squad path. Waking the
-//     parent assignee when one of its children finishes is a serial sub-task
+//     parent assignee when one of its children hands off is a serial sub-task
 //     handoff across two DIFFERENT issues, not a self-loop — legitimate per
 //     isAgentRunningOnIssue and the @mention self-trigger path
 //     (computeMentionedAgentCommentTriggers). The squad path used to skip a
@@ -706,9 +900,9 @@ func sanitizeMentionLabel(name string) string {
 //     mirrors the agent path (MUL-2808): always dispatch, bounded only by
 //     idempotency.
 //   - Idempotency: HasPendingTaskForIssueAndAgent dedupes rapid-fire enqueues
-//     for the same parent (e.g. two children finishing back-to-back). It also
+//     for the same parent (e.g. two children handing off back-to-back). It also
 //     bounds any re-trigger, since a leader waking on the parent does not by
-//     itself push a child back into a terminal transition.
+//     itself create a new child status transition.
 //   - Readiness: archived agents / missing runtimes are silently skipped
 //     so a closed-out agent does not surface as a phantom assignee.
 func (h *Handler) dispatchParentAssigneeTrigger(ctx context.Context, parent db.Issue, systemComment db.Comment) {
@@ -722,6 +916,58 @@ func (h *Handler) dispatchParentAssigneeTrigger(ctx context.Context, parent db.I
 	case "squad":
 		h.triggerChildDoneSquad(ctx, parent, systemComment.ID)
 	}
+}
+
+func (h *Handler) notifyParentMemberOfChildAttention(ctx context.Context, parent db.Issue, event childAttentionEvent, systemComment db.Comment, actorType, actorID string) {
+	if !parent.AssigneeType.Valid || parent.AssigneeType.String != "member" || !parent.AssigneeID.Valid {
+		return
+	}
+	parentMemberID := uuidToString(parent.AssigneeID)
+	if actorType == "member" && actorID == parentMemberID {
+		return
+	}
+
+	details, _ := json.Marshal(map[string]string{
+		"parent_issue_id":       uuidToString(parent.ID),
+		"child_issue_id":        uuidToString(event.child.ID),
+		"child_status":          event.child.Status,
+		"child_status_category": event.effectiveStatus,
+		"system_comment_id":     uuidToString(systemComment.ID),
+	})
+	item, err := h.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+		WorkspaceID:   parent.WorkspaceID,
+		RecipientType: "member",
+		RecipientID:   parent.AssigneeID,
+		Type:          "status_changed",
+		Severity:      "action_required",
+		IssueID:       event.child.ID,
+		Title:         event.child.Title,
+		Body:          strToText("A sub-issue under an issue you own needs attention."),
+		ActorType:     strToText(actorType),
+		ActorID:       optionalActorUUID(actorID),
+		Details:       details,
+	})
+	if err != nil {
+		slog.Warn("child attention: create parent member inbox failed",
+			"error", err,
+			"child_id", uuidToString(event.child.ID),
+			"parent_id", uuidToString(parent.ID),
+			"member_id", parentMemberID)
+		return
+	}
+
+	resp := inboxToResponse(item)
+	resp.IssueStatus = &event.child.Status
+	h.publish(protocol.EventInboxNew, uuidToString(parent.WorkspaceID), actorType, actorID, map[string]any{
+		"item": resp,
+	})
+}
+
+func optionalActorUUID(actorID string) pgtype.UUID {
+	if actorID == "" {
+		return pgtype.UUID{Valid: false}
+	}
+	return parseUUID(actorID)
 }
 
 // triggerChildDoneAgent enqueues a mention-style task for the parent's

--- a/server/internal/handler/issue_child_done_test.go
+++ b/server/internal/handler/issue_child_done_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/multica-ai/multica/server/internal/issuestatus"
 )
 
 // childDoneFixture creates a parent + child pair so the parent-notification
@@ -375,6 +377,185 @@ func TestChildDoneSkippedWhenParentMember(t *testing.T) {
 	}
 	if got := countInboxItems(t, userID, fx.parent.ID); got != 0 {
 		t.Errorf("parent with member assignee should not receive an inbox row, got %d", got)
+	}
+}
+
+// TestChildAttentionInReviewWakesParentSquad is the direct-agent delivery
+// regression from #5464: a child assigned to an ordinary agent stops in
+// in_review while its parent is owned by a squad. The child transition must
+// create a parent-level handoff and wake the squad leader exactly once.
+func TestChildAttentionInReviewWakesParentSquad(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+	sq := newSquadCommentTriggerFixture(t)
+
+	setIssueAssigneeDirect(t, fx.parent.ID, "squad", sq.SquadID)
+	setIssueAssigneeDirect(t, fx.child.ID, "agent", sq.OtherID)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE issue_id IN ($1, $2)`,
+			fx.parent.ID, fx.child.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	for _, want := range []string{
+		"A sub-issue needs attention",
+		"is in review",
+		"mention://issue/" + fx.child.ID,
+		"mention://squad/" + sq.SquadID,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %q in parent handoff, got: %s", want, content)
+		}
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 1 {
+		t.Fatalf("expected exactly 1 pending squad-leader task, got %d", got)
+	}
+
+	// Re-saving the same status is not a new delivery revision and must not
+	// duplicate either the timeline handoff or the leader task.
+	updateChildStatus(t, fx.child.ID, "in_review")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("same-status save duplicated the parent handoff: got %d comments", got)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 1 {
+		t.Fatalf("same-status save duplicated the leader task: got %d", got)
+	}
+
+	// Model the leader consuming the review wake. A later transition to blocked
+	// is a stronger attention state and deserves a fresh handoff.
+	if _, err := testPool.Exec(context.Background(),
+		`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID); err != nil {
+		t.Fatalf("clear consumed parent task: %v", err)
+	}
+	updateChildStatus(t, fx.child.ID, "blocked")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 2 {
+		t.Fatalf("in_review -> blocked should add one handoff, got %d comments", got)
+	}
+	content, _, _, _ = systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "is blocked") {
+		t.Errorf("expected blocked handoff, got: %s", content)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 1 {
+		t.Fatalf("expected a fresh leader task for blocked child, got %d", got)
+	}
+
+	// Attention is not completion. Once the only child becomes terminal, the
+	// existing stage-barrier path still emits its separate completion handoff.
+	if _, err := testPool.Exec(context.Background(),
+		`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID); err != nil {
+		t.Fatalf("clear consumed blocked task: %v", err)
+	}
+	updateChildStatus(t, fx.child.ID, "done")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 3 {
+		t.Fatalf("terminal transition should retain the child-done barrier, got %d comments", got)
+	}
+	content, _, _, _ = systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "All sub-issues are complete") {
+		t.Errorf("expected terminal barrier handoff, got: %s", content)
+	}
+}
+
+// TestChildAttentionUsesEffectiveStatus verifies that custom statuses inherit
+// their category's orchestration behavior. Moving between two custom statuses
+// in the same category is presentation-only and must not generate a duplicate
+// handoff; moving to the blocked category is a new escalation.
+func TestChildAttentionUsesEffectiveStatus(t *testing.T) {
+	createTestCustomStatus(t, "review_ready_a", issuestatus.InReview)
+	createTestCustomStatus(t, "review_ready_b", issuestatus.InReview)
+	createTestCustomStatus(t, "waiting_dependency", issuestatus.Blocked)
+	fx := newChildDoneFixture(t, "in_progress")
+
+	updateChildStatus(t, fx.child.ID, "review_ready_a")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("custom in-review status should create one handoff, got %d", got)
+	}
+	content, _, _, _ := systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "is in review") {
+		t.Errorf("custom in-review status should use canonical wording, got: %s", content)
+	}
+
+	updateChildStatus(t, fx.child.ID, "review_ready_b")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("same effective category should not duplicate handoff, got %d", got)
+	}
+
+	updateChildStatus(t, fx.child.ID, "waiting_dependency")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 2 {
+		t.Fatalf("custom blocked status should add one escalation, got %d", got)
+	}
+	content, _, _, _ = systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "is blocked") {
+		t.Errorf("custom blocked status should use canonical wording, got: %s", content)
+	}
+}
+
+func TestChildAttentionSkipsParkedOrClosedCustomParent(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		key      string
+		category string
+	}{
+		{name: "backlog", key: "parent_parked", category: issuestatus.Backlog},
+		{name: "done", key: "parent_accepted", category: issuestatus.Done},
+		{name: "cancelled", key: "parent_cancelled", category: issuestatus.Cancelled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			createTestCustomStatus(t, tc.key, tc.category)
+			fx := newChildDoneFixture(t, tc.key)
+
+			updateChildStatus(t, fx.child.ID, "in_review")
+			if got := countSystemCommentsOn(t, fx.parent.ID); got != 0 {
+				t.Fatalf("custom %s parent should stay inert, got %d comments", tc.category, got)
+			}
+		})
+	}
+}
+
+func TestChildAttentionBlockedNotifiesParentMember(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+	memberID := createPermissionTestMember(t, "child-attention-owner@multica.test")
+
+	setIssueAssigneeDirect(t, fx.parent.ID, "member", memberID)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM inbox_item WHERE issue_id IN ($1, $2)`, fx.parent.ID, fx.child.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "blocked")
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	if !strings.Contains(content, "is blocked") {
+		t.Errorf("expected blocked status in handoff, got: %s", content)
+	}
+	if strings.Contains(content, "mention://member/") {
+		t.Errorf("system handoff should not inject a member mention, got: %s", content)
+	}
+
+	var notifType, severity, issueID, body string
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT type, severity, issue_id::text, body
+		  FROM inbox_item
+		 WHERE recipient_type = 'member'
+		   AND recipient_id = $1
+		   AND issue_id = $2
+		 ORDER BY created_at DESC
+		 LIMIT 1
+	`, memberID, fx.child.ID).Scan(&notifType, &severity, &issueID, &body); err != nil {
+		t.Fatalf("read parent member inbox: %v", err)
+	}
+	if notifType != "status_changed" {
+		t.Errorf("inbox type = %q, want status_changed", notifType)
+	}
+	if severity != "action_required" {
+		t.Errorf("inbox severity = %q, want action_required", severity)
+	}
+	if issueID != fx.child.ID {
+		t.Errorf("inbox should point to child issue %s, got %s", fx.child.ID, issueID)
+	}
+	if !strings.Contains(body, "needs attention") {
+		t.Errorf("expected action body, got %q", body)
 	}
 }
 

--- a/server/internal/service/builtin_skills/multica-platform/references/issues.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/issues.md
@@ -257,8 +257,12 @@ writes the literal `done` key.
   Squad leaders: dispatching members is not delivery — a dispatch turn
   leaves the parent `in_progress`, and it moves to `in_review` only when a
   later re-trigger confirms the overall goal is met.
-- **`in_review`** is an accepted issue status. Some workflows use it while a PR
-  is open and awaiting review; moving to it is an explicit mutation.
+- **`in_review` / `blocked` on a child** immediately posts an attention handoff
+  on its parent. An agent or squad parent assignee gets the existing deduped
+  task wake; a human parent assignee gets an action-required inbox item. This
+  does not mark the child `done` or close its stage. Custom statuses inherit the
+  same behavior from their category, and switching between two statuses in the
+  same category does not emit a second handoff.
 - **`done`** on a child issue posts a system comment on its parent. If a PR
   carries close intent (`Closes MUL-XXXX`), it advances the issue to `done`
   itself on merge — you do not also need to flip it manually.
@@ -350,6 +354,11 @@ terminal status (`done`/`cancelled`); a notification that fails is not replayed.
 A completion that does not close a stage is silent (no comment, no wake). A
 sibling set with **no** stages is one implicit stage, so the parent is woken
 once when the *last* sub-issue finishes — not on every child.
+
+Review-ready and blocked handoffs are separate from this terminal barrier. A
+child entering `in_review` or `blocked` wakes its parent immediately for review,
+but remains non-terminal in stage progress; the leader must accept or unblock it
+and eventually move it to `done`/`cancelled` before the stage can close.
 
 Advancement is agent-driven: the server only detects the closed barrier and
 wakes the parent assignee, who then decides whether to promote the next stage's

--- a/server/internal/service/builtin_skills/multica-platform/references/squads.md
+++ b/server/internal/service/builtin_skills/multica-platform/references/squads.md
@@ -210,6 +210,23 @@ Current behavior: resolve the squad, read `leader_id`, enqueue a leader task,
 and use the current comment as the trigger comment. It does not enqueue every
 squad member.
 
+## Child handoffs to a squad parent
+
+When a sub-issue under a squad-assigned parent first enters `in_review` or
+`blocked`, Multica posts a system handoff on the parent and wakes the parent
+squad's leader. This also applies when the sub-issue itself is assigned directly
+to an ordinary agent: routing follows the parent owner, not the child owner.
+Custom statuses inherit this behavior from their `in_review` / `blocked`
+category, and moving between two custom statuses in the same category does not
+duplicate the handoff.
+
+This attention handoff is not stage completion. It does not mark the child
+`done`, close a stage barrier, or promote later stages. The leader reviews the
+child and decides the next action. If the child later reaches `done` or
+`cancelled`, the existing terminal stage-barrier handoff runs separately. Batch
+updates aggregate attention handoffs to at most one comment and wake per parent;
+pending-task dedup still prevents duplicate leader runs.
+
 ## Autopilot behavior
 
 Autopilots can be assigned to squads. For `assignee_type = "squad"`:


### PR DESCRIPTION
## What does this PR do?

This restores the missing parent-coordination handoff when a child Issue first
enters the effective `in_review` or `blocked` category.

Ordinary agents deliver work in `in_review`, while the existing stage barrier
only wakes the parent after terminal `done` / `cancelled` transitions. A child
owned directly by an agent could therefore stop at a legitimate review or
blocked boundary without creating any work for the parent coordinator.

The new attention path posts one parent-level system handoff and routes it to
the parent owner. Agent and Squad parents receive the existing deduplicated task
wake; member parents receive an action-required inbox item pointing at the
child. It does not mark the child complete or promote a later stage.

This is a current-`main` refresh of #7247 (which superseded #5625). The original
commit authorship and co-authorship are preserved. The port keeps the latest
main-branch status-resolution and batch-stage-selection behavior.

## Related Issue

Closes #5464

## Changes

- Detect transitions into canonical `in_review` / `blocked`, including custom
  statuses that inherit those categories.
- Avoid duplicate handoffs for repeated saves or custom-status changes within
  the same effective category.
- Aggregate batch attention updates to one handoff per parent, preferring a
  blocked child as the stronger signal.
- Route agent/Squad parents through the existing pending-task dedupe and notify
  member parents through an action-required inbox item.
- Document that attention handoffs are distinct from terminal stage barriers.

## Validation

- `go test ./internal/handler -run 'Test(ChildAttention|BatchChildAttention|ChildDone|BatchChildDone)' -count=1`
- `go test -race ./internal/handler -run 'Test(ChildAttention|BatchChildAttention|ChildDone|BatchChildDone)' -count=1`
- `go test ./internal/handler -count=1`
- `go build ./cmd/server`
- `go vet ./internal/handler`
- `git diff --check upstream/main...HEAD`

All passed locally.

## Scope and risk

The intentional behavior change is one additional parent handoff when a child
crosses into a review-ready or blocked category. Pending-task deduplication
bounds rapid handoffs, and batch updates aggregate by parent.

This remains a best-effort coordination signal. Durable stage execution,
automatic stage promotion, rework loops, and a declarative workflow engine are
outside this PR and remain tracked by #7345, #4835, #5856, and #5972.

## AI disclosure

**AI tool used:** Codex through Multica.

**Approach:** Inspected current upstream behavior and related open work, ported
the existing fix onto the latest `main`, preserved original attribution,
resolved conflicts against current status and batch-stage logic, and ran the
targeted and package-level verification listed above.

