### PR TITLE
feat(plugins): let plugins message a member over a linked chat channel (channels:send)

### DIFF
--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -421,6 +421,7 @@
       "members_read": "Read the member list",
       "storage_user": "Store data for each member individually",
       "storage_workspace": "Store data shared by the workspace",
+      "channels_send": "Message members on chat channels they have linked (Telegram, Slack, …)",
       "net": "Send data to {{domain}}",
       "unknown": "Unrecognized access — do not install"
     },

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -420,6 +420,7 @@
       "members_read": "メンバー一覧を読み取る",
       "storage_user": "メンバーごとにデータを保存する",
       "storage_workspace": "ワークスペース共有のデータを保存する",
+      "channels_send": "メンバーが連携したチャットチャンネル（Telegram、Slack など）にメッセージを送信する",
       "net": "{{domain}} にデータを送信する",
       "unknown": "認識できない権限です — インストールしないでください"
     },

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -420,6 +420,7 @@
       "members_read": "멤버 목록 읽기",
       "storage_user": "멤버별로 데이터 저장",
       "storage_workspace": "워크스페이스 공유 데이터 저장",
+      "channels_send": "멤버가 연결한 채팅 채널(Telegram, Slack 등)로 메시지 보내기",
       "net": "{{domain}}(으)로 데이터 전송",
       "unknown": "알 수 없는 권한 — 설치하지 마세요"
     },

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -420,6 +420,7 @@
       "members_read": "读取成员列表",
       "storage_user": "为每位成员单独存储数据",
       "storage_workspace": "存储工作区共享数据",
+      "channels_send": "通过成员已关联的聊天渠道（Telegram、Slack 等）向其发送消息",
       "net": "向 {{domain}} 发送数据",
       "unknown": "无法识别的权限 — 请勿安装"
     },

--- a/packages/views/plugins/surface-bridge.ts
+++ b/packages/views/plugins/surface-bridge.ts
@@ -28,6 +28,7 @@ const ALLOWED_PATHS: RegExp[] = [
   /^\/issues\/[^/]+\/comments$/,
   /^\/storage\/(workspace|user)$/,
   /^\/storage\/(workspace|user)\/[^/]+$/,
+  /^\/channels\/[^/]+\/send$/,
   // A surface invoking its OWN plugin's hook: the `ui` trigger. The server
   // still checks the manifest declared it, and the installation is the one
   // this bridge was created for — a surface cannot reach another plugin's

--- a/packages/views/settings/components/plugins-tab.tsx
+++ b/packages/views/settings/components/plugins-tab.tsx
@@ -141,6 +141,7 @@ function scopeDescription(scope: string, t: Translate): string {
     case "members:read": return t(($) => $.plugins.scopes.members_read);
     case "storage:user": return t(($) => $.plugins.scopes.storage_user);
     case "storage:workspace": return t(($) => $.plugins.scopes.storage_workspace);
+    case "channels:send": return t(($) => $.plugins.scopes.channels_send);
     default: return t(($) => $.plugins.scopes.unknown);
   }
 }

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -109,6 +109,7 @@ func registerPluginActionRoutes(r chi.Router, h *handler.Handler) {
 	r.Get(publicapiv1.PathStorageValue, h.GetPluginStorage)
 	r.Put(publicapiv1.PathStorageValue, h.PutPluginStorage)
 	r.Delete(publicapiv1.PathStorageValue, h.DeletePluginStorage)
+	r.Post(publicapiv1.PathChannelSend, h.SendPluginChannelMessage)
 }
 
 func allowedOrigins() []string {
@@ -520,6 +521,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	// connection of its own outside the per-installation supervisor. The Router
 	// is the single shared inbound handler injected into every Channel.
 	channelRegistry := channel.NewRegistry()
+	h.ChannelRegistry = channelRegistry
 	channelRouter := engine.NewRouter(h.IssueService, h.TaskService, queries, engine.RouterConfig{
 		Logger: slog.Default(), Lifecycle: h,
 	})

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/dbreader"
 	"github.com/multica-ai/multica/server/internal/entitlement"
 	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
 	composio "github.com/multica-ai/multica/server/internal/integrations/composio"
 	"github.com/multica-ai/multica/server/internal/integrations/dingtalk"
@@ -294,6 +295,12 @@ type Handler struct {
 	// cleanly when the DB is healthy without blocking process exit if the
 	// pool is frozen — at worst the next replica waits the full TTL.
 	ChannelSupervisor *engine.Supervisor
+	// ChannelRegistry maps a channel type to the Factory that builds its
+	// adapter. The Plugin Action API uses it for one-shot outbound sends
+	// (SendPluginChannelMessage): it builds an adapter for the member's bound
+	// installation without an inbound handler and calls Send. Nil when no
+	// channel engine was wired, which turns the endpoint into a 503.
+	ChannelRegistry *channel.Registry
 	// ChannelRouter is the channel-agnostic inbound pipeline (the shared
 	// handler the Supervisor injects into every Channel). main.go calls
 	// Drain on it during shutdown, after the Supervisor has stopped

--- a/server/internal/handler/plugin_action.go
+++ b/server/internal/handler/plugin_action.go
@@ -4,12 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/internal/util"
@@ -739,4 +743,111 @@ func (h *Handler) DeletePluginStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Channels ---
+
+// maxPluginChannelMessageChars bounds one outbound message. 4096 is Telegram's
+// hard cap for a single sendMessage and comfortably inside every other
+// platform's limit; adapters that need to chunk below it already do.
+const maxPluginChannelMessageChars = 4096
+
+// SendPluginChannelMessage — POST /v1/channels/{channel_type}/send
+//
+// Lets a plugin reach a member on a chat channel the member has already linked
+// to this workspace, without ever seeing the bot token or the member's platform
+// identity. The plugin names a Multica user; the host resolves the binding
+// (FindChannelBindingForMember, the same lookup the WeCom inbox push uses),
+// builds the adapter for the bound installation, and speaks to the platform
+// itself. The binding's channel_user_id is what the adapters address for a
+// direct message: on Telegram a private chat id is the user id, and Slack's
+// chat.postMessage opens the DM when handed a user id.
+//
+// Both actors are allowed on purpose. An event hook that wants to page someone
+// about a failed task has no person behind it, and a surface acting for a
+// member is bounded the same way: the binding is looked up in the
+// installation's workspace, so the reach is exactly the members of that
+// workspace who linked this channel.
+func (h *Handler) SendPluginChannelMessage(w http.ResponseWriter, r *http.Request) {
+	caller, _, ok := h.pluginCaller(w, r, plugincontract.ScopeChannelsSend)
+	if !ok {
+		return
+	}
+	if h.ChannelRegistry == nil {
+		publicapiv1.WriteProblem(w, r, http.StatusServiceUnavailable, "channels_unavailable", "chat channel integrations are not enabled")
+		return
+	}
+	channelType := channel.Type(strings.TrimSpace(chi.URLParam(r, "channel_type")))
+	if _, ok := h.ChannelRegistry.Lookup(channelType); !ok {
+		publicapiv1.WriteProblem(w, r, http.StatusNotFound, "channel_not_found", "no channel integration of this type is configured")
+		return
+	}
+
+	var req publicapiv1.SendChannelMessageRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		publicapiv1.WriteProblem(w, r, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	userID, err := util.ParseUUID(strings.TrimSpace(req.UserID))
+	if err != nil {
+		publicapiv1.WriteProblem(w, r, http.StatusBadRequest, "invalid_request", "user_id must be a valid UUID")
+		return
+	}
+	text := strings.TrimSpace(sanitizeNullBytes(req.Text))
+	if text == "" {
+		publicapiv1.WriteProblem(w, r, http.StatusBadRequest, "invalid_request", "text is required")
+		return
+	}
+	if utf8.RuneCountInString(text) > maxPluginChannelMessageChars {
+		publicapiv1.WriteProblem(w, r, http.StatusBadRequest, "invalid_request", "text is too long")
+		return
+	}
+
+	// A member who never linked this channel is a 404, not a failure: the
+	// plugin is expected to fall back to another route (inbox, email). The
+	// query already skips revoked installations.
+	binding, err := h.Queries.FindChannelBindingForMember(r.Context(), db.FindChannelBindingForMemberParams{
+		WorkspaceID:   caller.WorkspaceID,
+		MulticaUserID: userID,
+		ChannelType:   string(channelType),
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		publicapiv1.WriteProblem(w, r, http.StatusNotFound, "binding_not_found", "the member has not linked this channel in this workspace")
+		return
+	}
+	if err != nil {
+		publicapiv1.WriteProblem(w, r, http.StatusInternalServerError, "internal_error", "failed to look up the channel binding")
+		return
+	}
+	installation, err := h.Queries.GetChannelInstallation(r.Context(), db.GetChannelInstallationParams{
+		ID:          binding.InstallationID,
+		ChannelType: string(channelType),
+	})
+	if err != nil {
+		publicapiv1.WriteProblem(w, r, http.StatusInternalServerError, "internal_error", "failed to load the channel installation")
+		return
+	}
+
+	// Outbound only: no inbound handler, so the adapter is a client around the
+	// installation's credentials and nothing more. The factories have no side
+	// effects at build time; the receive loop starts in Connect, which is never
+	// called here.
+	ch, err := h.ChannelRegistry.Build(channel.Config{
+		Type: channelType,
+		ID:   installation.ID,
+		Raw:  installation.Config,
+	})
+	if err != nil {
+		slog.WarnContext(r.Context(), "plugin channel send: build adapter failed",
+			"channel_type", channelType, "installation_id", uuidToString(installation.ID), "error", err)
+		publicapiv1.WriteProblem(w, r, http.StatusBadGateway, "channel_unavailable", "the channel integration could not be initialized")
+		return
+	}
+	if _, err := ch.Send(r.Context(), channel.OutboundMessage{ChatID: binding.ChannelUserID, Text: text}); err != nil {
+		slog.WarnContext(r.Context(), "plugin channel send: delivery failed",
+			"channel_type", channelType, "installation_id", uuidToString(installation.ID), "error", err)
+		publicapiv1.WriteProblem(w, r, http.StatusBadGateway, "delivery_failed", "the channel did not accept the message")
+		return
+	}
+	writeJSON(w, http.StatusOK, publicapiv1.SendChannelMessageResponse{Delivered: true, ChannelType: string(channelType)})
 }

--- a/server/internal/handler/plugin_action_channel_test.go
+++ b/server/internal/handler/plugin_action_channel_test.go
@@ -1,0 +1,245 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+	publicapiv1 "github.com/multica-ai/multica/server/pkg/publicapi/v1"
+)
+
+// fakePluginChannel stands in for a platform adapter. It records what the
+// handler asked it to send and which installation config it was built from, so
+// a test can prove the credentials came from the bound installation row and
+// the message was addressed to the binding's channel_user_id.
+type fakePluginChannel struct {
+	mu    sync.Mutex
+	built []channel.Config
+	sent  []channel.OutboundMessage
+	err   error
+}
+
+func (c *fakePluginChannel) Type() channel.Type               { return "telegram" }
+func (c *fakePluginChannel) Connect(context.Context) error    { return nil }
+func (c *fakePluginChannel) Disconnect(context.Context) error { return nil }
+func (c *fakePluginChannel) Capabilities() channel.Capability { return channel.CapText }
+func (c *fakePluginChannel) Send(_ context.Context, out channel.OutboundMessage) (channel.SendResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return channel.SendResult{}, c.err
+	}
+	c.sent = append(c.sent, out)
+	return channel.SendResult{MessageID: "m1"}, nil
+}
+
+// withPluginChannelRegistry swaps in a registry whose only platform is the
+// fake "telegram" adapter, restoring the handler's registry afterwards.
+func withPluginChannelRegistry(t *testing.T, fake *fakePluginChannel) {
+	t.Helper()
+	registry := channel.NewRegistry()
+	registry.Register("telegram", func(cfg channel.Config) (channel.Channel, error) {
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		fake.built = append(fake.built, cfg)
+		return fake, nil
+	})
+	previous := testHandler.ChannelRegistry
+	testHandler.ChannelRegistry = registry
+	t.Cleanup(func() { testHandler.ChannelRegistry = previous })
+}
+
+// bindTestUserToTelegram creates an active telegram installation in the test
+// workspace and links the test user to it under the given platform user id.
+func bindTestUserToTelegram(t *testing.T, channelUserID string) string {
+	t.Helper()
+	ctx := context.Background()
+	agentID := createHandlerTestAgent(t, "PluginChannelSendAgent", []byte("[]"))
+	var installationID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, status, installer_user_id)
+		VALUES ($1, $2, 'telegram', '{"app_id":"424242","bot_username":"plugin_send_bot"}'::jsonb, 'active', $3)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&installationID); err != nil {
+		t.Fatalf("create installation: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM channel_user_binding WHERE installation_id = $1`, installationID)
+		testPool.Exec(context.Background(), `DELETE FROM channel_installation WHERE id = $1`, installationID)
+	})
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO channel_user_binding (workspace_id, multica_user_id, installation_id, channel_type, channel_user_id)
+		VALUES ($1, $2, $3, 'telegram', $4)
+	`, testWorkspaceID, testUserID, installationID, channelUserID); err != nil {
+		t.Fatalf("bind user: %v", err)
+	}
+	return installationID
+}
+
+func sendChannelRequest(installationID, channelType string, body any) *http.Request {
+	return pluginActionRequest(http.MethodPost, "/channels/"+channelType+"/send", installationID, body,
+		map[string]string{"channel_type": channelType})
+}
+
+func decodeProblem(t *testing.T, recorder *httptest.ResponseRecorder) publicapiv1.Problem {
+	t.Helper()
+	var problem publicapiv1.Problem
+	if err := json.Unmarshal(recorder.Body.Bytes(), &problem); err != nil {
+		t.Fatalf("decode problem: %v body=%s", err, recorder.Body.String())
+	}
+	return problem
+}
+
+func TestSendPluginChannelMessageRequiresScope(t *testing.T) {
+	installationID := installPluginForAction(t, []string{"issues:read"})
+	withPluginChannelRegistry(t, &fakePluginChannel{})
+
+	recorder := httptest.NewRecorder()
+	testHandler.SendPluginChannelMessage(recorder, sendChannelRequest(installationID, "telegram",
+		map[string]any{"user_id": testUserID, "text": "hello"}))
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("ungranted scope status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "channels:send") {
+		t.Fatalf("refusal does not name the missing scope: %s", recorder.Body.String())
+	}
+}
+
+func TestSendPluginChannelMessageRefusesUnknownOrUnconfiguredChannel(t *testing.T) {
+	installationID := installPluginForAction(t, []string{"channels:send"})
+	body := map[string]any{"user_id": testUserID, "text": "hello"}
+
+	// No engine wired at all: the endpoint is off rather than half-working.
+	previous := testHandler.ChannelRegistry
+	testHandler.ChannelRegistry = nil
+	t.Cleanup(func() { testHandler.ChannelRegistry = previous })
+	recorder := httptest.NewRecorder()
+	testHandler.SendPluginChannelMessage(recorder, sendChannelRequest(installationID, "telegram", body))
+	if recorder.Code != http.StatusServiceUnavailable || decodeProblem(t, recorder).Code != "channels_unavailable" {
+		t.Fatalf("nil registry status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	// A platform this deployment did not register is indistinguishable from
+	// one that does not exist.
+	withPluginChannelRegistry(t, &fakePluginChannel{})
+	recorder = httptest.NewRecorder()
+	testHandler.SendPluginChannelMessage(recorder, sendChannelRequest(installationID, "pager", body))
+	if recorder.Code != http.StatusNotFound || decodeProblem(t, recorder).Code != "channel_not_found" {
+		t.Fatalf("unknown channel status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestSendPluginChannelMessageValidatesBody(t *testing.T) {
+	installationID := installPluginForAction(t, []string{"channels:send"})
+	fake := &fakePluginChannel{}
+	withPluginChannelRegistry(t, fake)
+
+	for name, body := range map[string]any{
+		"bad_user_id": map[string]any{"user_id": "not-a-uuid", "text": "hello"},
+		"empty_text":  map[string]any{"user_id": testUserID, "text": "   "},
+		"long_text":   map[string]any{"user_id": testUserID, "text": strings.Repeat("x", maxPluginChannelMessageChars+1)},
+	} {
+		recorder := httptest.NewRecorder()
+		testHandler.SendPluginChannelMessage(recorder, sendChannelRequest(installationID, "telegram", body))
+		if recorder.Code != http.StatusBadRequest {
+			t.Fatalf("%s: status=%d body=%s", name, recorder.Code, recorder.Body.String())
+		}
+	}
+	if len(fake.sent) != 0 {
+		t.Fatalf("invalid requests reached the adapter: %+v", fake.sent)
+	}
+}
+
+func TestSendPluginChannelMessageWithoutBindingIs404(t *testing.T) {
+	installationID := installPluginForAction(t, []string{"channels:send"})
+	fake := &fakePluginChannel{}
+	withPluginChannelRegistry(t, fake)
+
+	recorder := httptest.NewRecorder()
+	testHandler.SendPluginChannelMessage(recorder, sendChannelRequest(installationID, "telegram",
+		map[string]any{"user_id": testUserID, "text": "hello"}))
+	if recorder.Code != http.StatusNotFound || decodeProblem(t, recorder).Code != "binding_not_found" {
+		t.Fatalf("unbound member status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if len(fake.sent) != 0 {
+		t.Fatalf("unbound member reached the adapter: %+v", fake.sent)
+	}
+}
+
+func TestSendPluginChannelMessageDeliversToBoundMember(t *testing.T) {
+	installationID := installPluginForAction(t, []string{"channels:send"})
+	fake := &fakePluginChannel{}
+	withPluginChannelRegistry(t, fake)
+	channelInstallationID := bindTestUserToTelegram(t, "424242")
+
+	// Session caller (a surface acting for the signed-in member).
+	recorder := httptest.NewRecorder()
+	testHandler.SendPluginChannelMessage(recorder, sendChannelRequest(installationID, "telegram",
+		map[string]any{"user_id": testUserID, "text": "  Review needed on MUL-1  "}))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("session send status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response publicapiv1.SendChannelMessageResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.Delivered || response.ChannelType != "telegram" {
+		t.Fatalf("response = %+v", response)
+	}
+
+	// Install token (the plugin's own server, no person behind it): an event
+	// hook must be able to page someone, so the plugin actor is not refused.
+	token, err := testHandler.PluginService.IssueInstallToken(context.Background(), parseUUID(installationID))
+	if err != nil {
+		t.Fatalf("issue install token: %v", err)
+	}
+	recorder = httptest.NewRecorder()
+	testHandler.SendPluginChannelMessage(recorder, pluginInstallTokenRequest(http.MethodPost, "/channels/telegram/send", token,
+		map[string]any{"user_id": testUserID, "text": "from the hook"}, map[string]string{"channel_type": "telegram"}))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("install-token send status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.sent) != 2 {
+		t.Fatalf("adapter sends = %+v", fake.sent)
+	}
+	if fake.sent[0].ChatID != "424242" || fake.sent[0].Text != "Review needed on MUL-1" {
+		t.Fatalf("first send addressed wrongly: %+v", fake.sent[0])
+	}
+	if fake.sent[1].ChatID != "424242" || fake.sent[1].Text != "from the hook" {
+		t.Fatalf("second send addressed wrongly: %+v", fake.sent[1])
+	}
+	// The adapter was built from the BOUND installation's row, not from
+	// anything the caller supplied.
+	if len(fake.built) != 2 || uuidToString(fake.built[0].ID) != channelInstallationID ||
+		!strings.Contains(string(fake.built[0].Raw), `"plugin_send_bot"`) || fake.built[0].Handler != nil {
+		t.Fatalf("adapter built from the wrong config: %+v", fake.built)
+	}
+}
+
+func TestSendPluginChannelMessageReportsPlatformFailure(t *testing.T) {
+	installationID := installPluginForAction(t, []string{"channels:send"})
+	fake := &fakePluginChannel{err: errors.New("telegram: 403 bot was blocked by the user")}
+	withPluginChannelRegistry(t, fake)
+	bindTestUserToTelegram(t, "424242")
+
+	recorder := httptest.NewRecorder()
+	testHandler.SendPluginChannelMessage(recorder, sendChannelRequest(installationID, "telegram",
+		map[string]any{"user_id": testUserID, "text": "hello"}))
+	if recorder.Code != http.StatusBadGateway || decodeProblem(t, recorder).Code != "delivery_failed" {
+		t.Fatalf("platform failure status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	// The platform's own error text stays in the log; the plugin gets the
+	// stable code only.
+	if strings.Contains(recorder.Body.String(), "blocked by the user") {
+		t.Fatalf("platform error leaked to the caller: %s", recorder.Body.String())
+	}
+}

--- a/server/pkg/plugincontract/manifest.go
+++ b/server/pkg/plugincontract/manifest.go
@@ -99,6 +99,11 @@ const (
 	ScopeMembersRead      = "members:read"
 	ScopeStorageUser      = "storage:user"
 	ScopeStorageWorkspace = "storage:workspace"
+	// ScopeChannelsSend lets a plugin message a workspace member over a chat
+	// channel (Telegram, Slack, …) the member has linked to the workspace. The
+	// host resolves the binding and speaks to the platform; the plugin never
+	// sees a bot token or the member's platform identity.
+	ScopeChannelsSend = "channels:send"
 
 	// ScopeNetPrefix guards outbound network access: both the iframe CSP
 	// connect-src allowlist and the hook transport host check derive from it.
@@ -127,6 +132,7 @@ var fixedScopes = map[string]bool{
 	ScopeMembersRead:      true,
 	ScopeStorageUser:      true,
 	ScopeStorageWorkspace: true,
+	ScopeChannelsSend:     true,
 }
 
 func hasScope(scopes []string, want string) bool {

--- a/server/pkg/plugincontract/manifest_test.go
+++ b/server/pkg/plugincontract/manifest_test.go
@@ -399,7 +399,7 @@ func TestValidateScope(t *testing.T) {
 	valid := []string{
 		ScopeIssuesRead, ScopeIssuesWrite, ScopeCommentsRead, ScopeCommentsWrite,
 		ScopeTasksRead, ScopeTasksWrite, ScopeAgentsRead, ScopeMembersRead,
-		ScopeStorageUser, ScopeStorageWorkspace,
+		ScopeStorageUser, ScopeStorageWorkspace, ScopeChannelsSend,
 		"net:example.com", "net:api.example.co.uk",
 	}
 	for _, scope := range valid {

--- a/server/pkg/publicapi/v1/openapi.yaml
+++ b/server/pkg/publicapi/v1/openapi.yaml
@@ -165,6 +165,37 @@ paths:
           description: Deleted
         default:
           $ref: "#/components/responses/Problem"
+  /channels/{channel_type}/send:
+    parameters:
+      - $ref: "#/components/parameters/ChannelType"
+    post:
+      operationId: sendPluginChannelMessage
+      summary: Message a workspace member over a chat channel they have linked
+      description: >-
+        Delivers a text message to the member as the channel's bot. The host
+        resolves the member's channel binding in the installation's workspace;
+        the Plugin never sees bot credentials or the member's platform
+        identity. A member who has not linked the channel yields
+        `binding_not_found`; a channel type not configured on this deployment
+        yields `channel_not_found`; a platform-side failure yields
+        `delivery_failed`.
+      x-multica-contract: plugin_extension
+      x-multica-scope: channels:send
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SendChannelMessageRequest"
+      responses:
+        "200":
+          description: Delivered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendChannelMessageResponse"
+        default:
+          $ref: "#/components/responses/Problem"
 components:
   securitySchemes:
     pluginBearer:
@@ -193,6 +224,13 @@ components:
       schema:
         type: string
         maxLength: 1024
+    ChannelType:
+      name: channel_type
+      in: path
+      required: true
+      description: Channel platform slug such as telegram or slack
+      schema:
+        type: string
     IfMatch:
       name: If-Match
       in: header
@@ -402,3 +440,18 @@ components:
       required: [value]
       properties:
         value: { type: string, maxLength: 102400 }
+    SendChannelMessageRequest:
+      type: object
+      required: [user_id, text]
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          description: Multica user id of a member of the installation's workspace
+        text: { type: string, minLength: 1, maxLength: 4096 }
+    SendChannelMessageResponse:
+      type: object
+      required: [delivered, channel_type]
+      properties:
+        delivered: { type: boolean }
+        channel_type: { type: string }

--- a/server/pkg/publicapi/v1/routes.go
+++ b/server/pkg/publicapi/v1/routes.go
@@ -16,6 +16,7 @@ const (
 	PathIssueComments = "/issues/{issue_ref}/comments"
 	PathStorageScope  = "/storage/{scope}"
 	PathStorageValue  = "/storage/{scope}/{key}"
+	PathChannelSend   = "/channels/{channel_type}/send"
 )
 
 type ContractKind string
@@ -64,4 +65,5 @@ var Operations = []Operation{
 	{Method: http.MethodGet, Path: PathStorageValue, Contract: ContractPluginExtension, Policy: OperationPolicy{Credentials: pluginCredentials, Risk: RiskRead, Audit: AuditNotRequired, RateLimits: pluginRateLimits}},
 	{Method: http.MethodPut, Path: PathStorageValue, Contract: ContractPluginExtension, Policy: OperationPolicy{Credentials: pluginCredentials, Risk: RiskContentWrite, Audit: AuditPlanned, RateLimits: pluginRateLimits}},
 	{Method: http.MethodDelete, Path: PathStorageValue, Contract: ContractPluginExtension, Policy: OperationPolicy{Credentials: pluginCredentials, Risk: RiskContentWrite, Audit: AuditPlanned, RateLimits: pluginRateLimits}},
+	{Method: http.MethodPost, Path: PathChannelSend, Contract: ContractPluginExtension, Policy: OperationPolicy{Credentials: pluginCredentials, Scope: "channels:send", Risk: RiskContentWrite, Audit: AuditPlanned, RateLimits: pluginRateLimits}},
 }

--- a/server/pkg/publicapi/v1/types.go
+++ b/server/pkg/publicapi/v1/types.go
@@ -101,3 +101,16 @@ type StorageValueResponse struct {
 type PutStorageValueRequest struct {
 	Value string `json:"value"`
 }
+
+// SendChannelMessageRequest addresses a workspace member by Multica user id.
+// The host maps that to the member's linked platform identity; a plugin never
+// names a platform chat or user id directly.
+type SendChannelMessageRequest struct {
+	UserID string `json:"user_id"`
+	Text   string `json:"text"`
+}
+
+type SendChannelMessageResponse struct {
+	Delivered   bool   `json:"delivered"`
+	ChannelType string `json:"channel_type"`
+}


### PR DESCRIPTION
## What does this PR do?

Lets a plugin message a workspace member over a chat channel the member has already linked to the workspace (Telegram, Slack, …), without the plugin ever seeing a bot token or the member's platform identity.

**Thinking path.** Plugins (`server/pkg/publicapi/v1`, `handler/plugin_action.go`) have no Action API endpoint for outbound IM, and cannot build one themselves because bot tokens and `channel_user_binding` rows are host-only by design. The host already owns every piece: `FindChannelBindingForMember` (the lookup the WeCom inbox push in `wecom/outbound.go` uses), the channel `Registry` with `Build`, and each adapter's `Channel.Send`. So the smallest honest change is one `plugin_extension` operation that composes those three behind a new closed scope, following the existing Action API pattern (`pluginCaller` → check 3 in the installation's workspace → `WriteProblem` codes), and nothing new in the engine or the adapters.

The concrete motivation is #1020 ("humans should be pulled in, not poll"): a notification plugin that e-mails today wants to page a member on Telegram when an issue reaches `in_review` or a task fails. #2295 (bus-event webhooks) was closed unmerged and, even merged, would not let a plugin address a *person* on a channel they linked.

## Related Issue

Closes #8334

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/plugincontract/manifest.go`: new closed scope `channels:send` (+ `manifest_test.go` valid list).
- `server/pkg/publicapi/v1/routes.go`, `types.go`, `openapi.yaml`: `PathChannelSend = "/channels/{channel_type}/send"` registered as a `plugin_extension` with scope `channels:send`, risk `content_write`, audit `planned`; `SendChannelMessageRequest{user_id, text}` / `SendChannelMessageResponse{delivered, channel_type}`. The existing contract test pins ledger ↔ OpenAPI.
- `server/internal/handler/plugin_action.go`: `SendPluginChannelMessage`. Scope check via `pluginCaller`; `channel_type` must be registered in the deployment's `Registry` (else 404 `channel_not_found`); `user_id` must be a UUID and `text` 1–4096 characters (400); binding looked up **in the installation's workspace** (404 `binding_not_found` when the member never linked the channel); the bound `channel_installation` row is loaded, the adapter is built for its outbound path only (`Handler: nil`) and `Send` is called with the binding's `channel_user_id` as the chat id. Platform failures return 502 `delivery_failed` with the platform error kept in the log. Both the member actor and the plugin actor are accepted so an event hook can page someone.
- `server/internal/handler/handler.go`, `server/cmd/server/router.go`: `Handler.ChannelRegistry` (set next to `channel.NewRegistry()`), route registered in `registerPluginActionRoutes` so both the Public API group and the bridge group get it.
- `packages/views/plugins/surface-bridge.ts`: allowlist entry for `/channels/{type}/send`.
- `packages/views/settings/components/plugins-tab.tsx` + the four `locales/*/settings.json`: consent label for the new scope, so an install screen does not show "Unrecognized access — do not install" for it.
- `server/internal/handler/plugin_action_channel_test.go`: six tests with a fake adapter registered as `telegram` — missing scope → 403 naming `channels:send`; nil registry → 503; unregistered type → 404 `channel_not_found`; body validation → 400 and nothing reaches the adapter; no binding → 404 `binding_not_found`; happy path for a session caller **and** an install token, asserting the adapter was built from the bound installation's config with no inbound handler and sent to the binding's `channel_user_id`; platform error → 502 without leaking the platform message.

## How to Test

1. `cd server && go build ./... && go vet ./pkg/publicapi/... ./pkg/plugincontract/... ./internal/handler/ ./cmd/server/`
2. `go test ./pkg/publicapi/... ./pkg/plugincontract/...` (contract test now covers the new path)
3. With `DATABASE_URL` pointing at a migrated database: `go test ./internal/handler/ -run 'SendPluginChannelMessage|PluginAction|PluginInstallToken'`
4. `cd packages/views && pnpm test -- locales/parity.test.ts plugins && pnpm typecheck && pnpm lint`
5. Manually: install a plugin whose manifest declares `channels:send`, link your Telegram account to the workspace bot, then `curl -X POST https://<plugin-api>/v1/channels/telegram/send -H "Authorization: Bearer mpi_…" -d '{"user_id":"<your uuid>","text":"ping"}'` — the bot DMs you; an unlinked member returns `binding_not_found`.

Ran locally on `main` @ `2ae2dbbb8` (Go 1.26.8 in Docker with `pgvector/pgvector:pg17` + `go run ./cmd/migrate up`; Node 22 / pnpm 10.28.2): build, vet, `pkg/publicapi/v1`, `pkg/plugincontract`, the handler plugin suite (16 tests incl. the 6 new ones), views vitest (11 files / 215 tests), `tsc --noEmit`, eslint — all green.

## Limits and risks

- First slice is text only, direct messages only: no cards, media, threads or group chats. The generic `Channel.Send` seam is the contract; adapters whose generic Send is a stub (WeCom returns `ErrSendNotSupported`) or that address group conversations only (DingTalk) report `delivery_failed` until they accept a user id as a DM target. Telegram (private chat id == user id) and Slack (`chat.postMessage` with a user id) work as-is.
- A plugin can only reach members of the workspace it is installed in who linked that channel; the scope is an explicit install-time consent and the endpoint sits under the strict plugin rate profile. Audit is `planned`, like the other write operations in the ledger.
- Building an adapter per call is cheap (factories decode credentials and construct a client; the receive loop only starts in `Connect`, which is never called here). No engine or adapter code changes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (one new consent label line in the install dialog; no layout change)
- [x] I have updated relevant documentation to reflect my changes (`openapi.yaml` is the Plugin API's documentation)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs** (n/a)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Asked for the smallest upstream-style change that lets a plugin reach a member on a connected channel, starting from the existing Action API handlers, `FindChannelBindingForMember` and the WeCom inbox push as the reference. The agent read the contract test / capability ledger, the channel registry and the adapters' `Send` implementations, then implemented the endpoint, the tests and the consent label, and verified everything in Docker against a migrated database before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
