### PR TITLE
MUL-7308: test(daemon): isolate local skill homes on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,6 +797,14 @@ jobs:
         # outside this PR; the normal backend job still runs the full package.
         run: go test ./internal/daemon/execenv -run '^TestPrepareIsolated_WindowsKillsDescendantBeforeRetry$' -count=1 -timeout=5m
 
+      - name: Test Windows daemon local-skill discovery
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        working-directory: server
+        # These fixtures must redirect both the Windows user profile and the
+        # platform-native Hermes home; otherwise discovery scans the runner's
+        # real skills instead of the test directories.
+        run: go test ./internal/daemon -v -run '^(TestListRuntimeLocalSkills_HermesFollowsTaskHome|TestLocalSkills_DiscoversACPProviderRoots)$' -count=1 -timeout=5m
+
       - name: Test Windows agent launcher argv/stdin handling
         if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server

--- a/server/internal/daemon/local_skills_test.go
+++ b/server/internal/daemon/local_skills_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -24,6 +25,23 @@ func writeTestLocalSkill(t *testing.T, root, rel string, files map[string]string
 		}
 	}
 	return skillDir
+}
+
+// setTestUserHome redirects every environment variable used by Go and the
+// runtime home resolvers on supported platforms. HOME alone is not enough on
+// Windows: os.UserHomeDir reads USERPROFILE and Hermes uses LOCALAPPDATA.
+func setTestUserHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
+}
+
+func testDefaultHermesHome(home string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(home, "AppData", "Local", "hermes")
+	}
+	return filepath.Join(home, ".hermes")
 }
 
 func writeTestClaudePlugin(t *testing.T, home, id, name string, enabled bool) string {
@@ -339,7 +357,9 @@ func TestLocalSkills_DiscoversACPProviderRoots(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.provider, func(t *testing.T) {
 			home := t.TempDir()
-			t.Setenv("HOME", home)
+			setTestUserHome(t, home)
+			root := filepath.Join(home, tc.root)
+			wantPath := tc.wantPath
 			if tc.provider == "grok" {
 				t.Setenv("GROK_HOME", "")
 			}
@@ -354,9 +374,11 @@ func TestLocalSkills_DiscoversACPProviderRoots(t *testing.T) {
 			}
 			if tc.provider == "hermes" {
 				t.Setenv("HERMES_HOME", "")
+				root = filepath.Join(testDefaultHermesHome(home), "skills")
+				wantPath = relativizeHomePath(filepath.Join(root, "review-helper"))
 			}
 
-			writeTestLocalSkill(t, filepath.Join(home, tc.root), "review-helper", map[string]string{
+			writeTestLocalSkill(t, root, "review-helper", map[string]string{
 				"SKILL.md": "---\nname: " + tc.wantName + "\ndescription: Review code\n---\n# Review\n",
 				"notes.md": "notes",
 			})
@@ -380,8 +402,8 @@ func TestLocalSkills_DiscoversACPProviderRoots(t *testing.T) {
 			if skills[0].Root != localSkillRootProvider {
 				t.Fatalf("root = %q, want %q", skills[0].Root, localSkillRootProvider)
 			}
-			if skills[0].SourcePath != tc.wantPath {
-				t.Fatalf("source_path = %q, want %q", skills[0].SourcePath, tc.wantPath)
+			if skills[0].SourcePath != wantPath {
+				t.Fatalf("source_path = %q, want %q", skills[0].SourcePath, wantPath)
 			}
 
 			bundle, supported, err := loadRuntimeLocalSkillBundle(tc.provider, "review-helper")
@@ -394,8 +416,8 @@ func TestLocalSkills_DiscoversACPProviderRoots(t *testing.T) {
 			if bundle.Name != tc.wantName {
 				t.Fatalf("bundle name = %q, want %q", bundle.Name, tc.wantName)
 			}
-			if bundle.SourcePath != tc.wantPath {
-				t.Fatalf("bundle source_path = %q, want %q", bundle.SourcePath, tc.wantPath)
+			if bundle.SourcePath != wantPath {
+				t.Fatalf("bundle source_path = %q, want %q", bundle.SourcePath, wantPath)
 			}
 			if len(bundle.Files) != 1 {
 				t.Fatalf("expected 1 supporting file, got %d", len(bundle.Files))
@@ -414,11 +436,11 @@ func TestListRuntimeLocalSkills_HermesFollowsTaskHome(t *testing.T) {
 		name string
 		// setup configures the Hermes home and returns the skills dir a task
 		// would read; "" means no provider root should be scanned.
-		setup func(t *testing.T, home string) string
+		setup func(t *testing.T, hermesHome string) string
 	}{
 		{
 			name: "explicit HERMES_HOME",
-			setup: func(t *testing.T, home string) string {
+			setup: func(t *testing.T, _ string) string {
 				hermesHome := filepath.Join(t.TempDir(), "custom-hermes")
 				t.Setenv("HERMES_HOME", hermesHome)
 				return filepath.Join(hermesHome, "skills")
@@ -426,17 +448,17 @@ func TestListRuntimeLocalSkills_HermesFollowsTaskHome(t *testing.T) {
 		},
 		{
 			name: "sticky active profile",
-			setup: func(t *testing.T, home string) string {
-				writeTestHermesActiveProfile(t, home, "work")
-				return filepath.Join(home, ".hermes", "profiles", "work", "skills")
+			setup: func(t *testing.T, hermesHome string) string {
+				writeTestHermesActiveProfile(t, hermesHome, "work")
+				return filepath.Join(hermesHome, "profiles", "work", "skills")
 			},
 		},
 		{
 			// Hermes refuses to start under a reserved sticky profile, so there
 			// is no home whose skills it would load.
 			name: "invalid sticky active profile",
-			setup: func(t *testing.T, home string) string {
-				writeTestHermesActiveProfile(t, home, "hermes")
+			setup: func(t *testing.T, hermesHome string) string {
+				writeTestHermesActiveProfile(t, hermesHome, "hermes")
 				return ""
 			},
 		},
@@ -445,13 +467,14 @@ func TestListRuntimeLocalSkills_HermesFollowsTaskHome(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			home := t.TempDir()
-			t.Setenv("HOME", home)
+			setTestUserHome(t, home)
 			t.Setenv("HERMES_HOME", "")
-			skillsDir := tc.setup(t, home)
+			hermesHome := testDefaultHermesHome(home)
+			skillsDir := tc.setup(t, hermesHome)
 
-			// A skill in ~/.hermes/skills that the task-side resolver does not
-			// read must not be surfaced.
-			writeTestLocalSkill(t, filepath.Join(home, ".hermes", "skills"), "wrong-home", map[string]string{
+			// A skill in the default Hermes home that the task-side resolver does
+			// not read must not be surfaced when another home/profile is selected.
+			writeTestLocalSkill(t, filepath.Join(hermesHome, "skills"), "wrong-home", map[string]string{
 				"SKILL.md": "---\nname: Wrong Home\n---\n# Wrong\n",
 			})
 			writeTestLocalSkill(t, filepath.Join(home, ".agents", "skills"), "shared-helper", map[string]string{
@@ -500,13 +523,12 @@ func TestListRuntimeLocalSkills_HermesFollowsTaskHome(t *testing.T) {
 	}
 }
 
-func writeTestHermesActiveProfile(t *testing.T, home, name string) {
+func writeTestHermesActiveProfile(t *testing.T, hermesHome, name string) {
 	t.Helper()
-	root := filepath.Join(home, ".hermes")
-	if err := os.MkdirAll(root, 0o755); err != nil {
+	if err := os.MkdirAll(hermesHome, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, "active_profile"), []byte(name+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(hermesHome, "active_profile"), []byte(name+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

This makes the daemon local-skill discovery tests portable to native Windows and adds them to the Windows CI job.

The production resolvers intentionally use platform-native homes: Go reads `%USERPROFILE%` on Windows, while Hermes defaults to `%LOCALAPPDATA%\\hermes`. The existing fixtures only redirected `HOME`, so Windows tests could scan a developer or runner profile instead of their temporary fixture. The test helper now redirects all three environment variables, and the Hermes fixtures and source-path assertions use the same platform-specific default as production.

This is test and CI coverage only; it does not change daemon discovery behavior.

Risk is limited to a small increase in the Windows backend CI job duration. The new step runs only when backend paths change.

## Related Issue

Closes #8336

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- Redirect `HOME`, `USERPROFILE`, and `LOCALAPPDATA` in daemon local-skill fixtures.
- Build Hermes fixtures and source-path expectations from the platform-native default home.
- Run the two affected daemon discovery regressions in the Windows CI job.

## How to Test

1. `cd server && go test ./internal/daemon -run '^(TestListRuntimeLocalSkills_HermesFollowsTaskHome|TestLocalSkills_DiscoversACPProviderRoots)$' -count=1`
2. `cd server && go test ./internal/daemon -run 'LocalSkills|RuntimeLocalSkill' -count=1`
3. `cd server && GOOS=windows GOARCH=amd64 go test -c ./internal/daemon`
4. Parse `.github/workflows/ci.yml` with Ruby YAML and run `git diff --check`.

All four checks passed locally on macOS. The cross-compile verifies the Windows test binary builds; the new Windows CI step provides the native execution evidence.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** I used Codex to trace the platform-specific home resolution in the failing tests and production helpers, update the fixtures to follow those same paths, add focused Windows CI coverage, and review the resulting diff and validation evidence.

## Screenshots (optional)

Not applicable; this change has no UI impact.
