### PR TITLE
ZIC-224 Fix quick create preview-only completion

### DIFF
--- a/apps/mobile/components/inbox/detail-label.tsx
+++ b/apps/mobile/components/inbox/detail-label.tsx
@@ -138,9 +138,8 @@ export function InboxDetailLabel({
           ? `Reacted with ${details.emoji}`
           : TYPE_LABEL[item.type];
       case "quick_create_done":
-        return details.identifier
-          ? `Created with agent: ${details.identifier}`
-          : TYPE_LABEL[item.type];
+        if (details.identifier) return `Created with agent: ${details.identifier}`;
+        return singleLine(item.body) || TYPE_LABEL[item.type];
       case "quick_create_failed": {
         const detail = singleLine(details.error) || singleLine(item.body);
         return detail ? `Failed: ${detail}` : TYPE_LABEL[item.type];

--- a/packages/views/inbox/components/inbox-detail-label.test.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.test.tsx
@@ -1,0 +1,78 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { InboxItem } from "@multica/core/types";
+import { InboxDetailLabel } from "./inbox-detail-label";
+
+vi.mock("../../issues/components", () => ({
+  StatusIcon: () => null,
+  PriorityIcon: () => null,
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => "Someone" }),
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({
+    t: (accessor: (dict: unknown) => string, params?: Record<string, string>) => {
+      const template = accessor({
+        labels: {
+          created_with_agent: "Created with agent: {{identifier}}",
+          failed_with_detail: "Failed: {{detail}}",
+        },
+        types: {
+          quick_create_done: "Quick-create done",
+          quick_create_failed: "Quick-create failed",
+        },
+      });
+      if (!params) return template;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, key: string) => params[key] ?? "");
+    },
+  }),
+}));
+
+function item(overrides: Partial<InboxItem> = {}): InboxItem {
+  return {
+    id: "inbox-1",
+    workspace_id: "workspace-1",
+    recipient_type: "member",
+    recipient_id: "member-1",
+    actor_type: "agent",
+    actor_id: "agent-1",
+    type: "quick_create_done",
+    severity: "info",
+    issue_id: null,
+    title: "Quick create completed",
+    body: null,
+    issue_status: null,
+    read: false,
+    archived: false,
+    created_at: "2026-09-12T08:00:00Z",
+    details: null,
+    ...overrides,
+  };
+}
+
+describe("InboxDetailLabel quick-create success", () => {
+  it("shows the returned draft for a completed quick-create without an issue", () => {
+    const draft = "### Proposed issue\n\nThe sync job should expose a retry button.";
+    const { container } = render(
+      <InboxDetailLabel
+        item={item({
+          body: draft,
+          details: { original_prompt: "Draft an issue, but do not create it.", output: draft },
+        })}
+      />,
+    );
+
+    expect(container.textContent).toBe(draft);
+  });
+
+  it("keeps the created-issue identifier label for normal quick-create success", () => {
+    const { container } = render(
+      <InboxDetailLabel item={item({ details: { identifier: "ZIC-224" } })} />,
+    );
+
+    expect(container.textContent).toBe("Created with agent: ZIC-224");
+  });
+});

--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -104,6 +104,7 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
     case "quick_create_done": {
       const identifier = details.identifier;
       if (identifier) return <span>{t(($) => $.labels.created_with_agent, { identifier })}</span>;
+      if (item.body) return <span>{item.body}</span>;
       return <span>{typeLabels[item.type]}</span>;
     }
     case "quick_create_failed": {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1488,7 +1488,7 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	// the requester's workspace since the task started — more robust than
 	// parsing the agent's stdout for an identifier.
 	if qc, ok := s.parseQuickCreateContext(task); ok {
-		s.notifyQuickCreateCompleted(ctx, task, qc)
+		s.notifyQuickCreateCompleted(ctx, task, qc, result)
 	}
 
 	// For chat tasks, save assistant reply and broadcast chat:done. The
@@ -2566,7 +2566,7 @@ func (s *TaskService) parseQuickCreateContext(task db.AgentTaskQueue) (QuickCrea
 // deterministic — robust against the same agent creating other issues in
 // parallel (e.g. assignment task running while max_concurrent_tasks > 1
 // permits another quick-create alongside it).
-func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.AgentTaskQueue, qc QuickCreateContext) {
+func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.AgentTaskQueue, qc QuickCreateContext, result []byte) {
 	requesterID, err := util.ParseUUID(qc.RequesterID)
 	if err != nil {
 		slog.Warn("quick-create completion: invalid requester id", "task_id", util.UUIDToString(task.ID), "error", err)
@@ -2583,14 +2583,27 @@ func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.Ag
 		OriginID:    task.ID,
 	})
 	if err != nil {
-		// No issue created — agent ran to completion but the CLI call must
-		// have failed. Surface as a failure inbox so the user sees something.
-		slog.Warn("quick-create completion: no issue found, writing failure inbox",
+		if !errors.Is(err, pgx.ErrNoRows) {
+			slog.Error("quick-create completion: issue lookup failed, writing failure inbox",
+				"task_id", util.UUIDToString(task.ID),
+				"agent_id", util.UUIDToString(task.AgentID),
+				"workspace_id", qc.WorkspaceID,
+				"error", err,
+			)
+			s.notifyQuickCreateFailed(ctx, task, qc, "Quick create outcome could not be confirmed")
+			return
+		}
+		// No issue was created, but the agent run itself completed. That can be
+		// an intentional preview/draft-only answer, so report a terminal success
+		// with the returned output instead of reclassifying execution success as
+		// a create failure. Real daemon/task failures still reach
+		// notifyQuickCreateFailed through FailTask.
+		slog.Info("quick-create completion: no issue found, writing no-issue success inbox",
 			"task_id", util.UUIDToString(task.ID),
 			"agent_id", util.UUIDToString(task.AgentID),
 			"workspace_id", qc.WorkspaceID,
 		)
-		s.notifyQuickCreateFailed(ctx, task, qc, "agent finished without creating an issue")
+		s.notifyQuickCreateCompletedWithoutIssue(ctx, task, qc, result)
 		return
 	}
 
@@ -2669,6 +2682,56 @@ func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.Ag
 		return
 	}
 	s.publishQuickCreateInbox(item, qc.WorkspaceID, util.UUIDToString(task.AgentID), issue.Status)
+}
+
+func quickCreateResultOutput(result []byte) string {
+	var payload protocol.TaskCompletedPayload
+	if err := json.Unmarshal(result, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(util.UnescapeBackslashEscapes(payload.Output))
+}
+
+func (s *TaskService) notifyQuickCreateCompletedWithoutIssue(ctx context.Context, task db.AgentTaskQueue, qc QuickCreateContext, result []byte) {
+	requesterID, err := util.ParseUUID(qc.RequesterID)
+	if err != nil {
+		slog.Warn("quick-create no-issue completion: invalid requester id", "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	workspaceID, err := util.ParseUUID(qc.WorkspaceID)
+	if err != nil {
+		slog.Warn("quick-create no-issue completion: invalid workspace id", "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	output := redact.Text(quickCreateResultOutput(result))
+	details, _ := json.Marshal(map[string]any{
+		"task_id":         util.UUIDToString(task.ID),
+		"agent_id":        util.UUIDToString(task.AgentID),
+		"original_prompt": qc.Prompt,
+		"output":          output,
+	})
+	body := pgtype.Text{}
+	if output != "" {
+		body = pgtype.Text{String: output, Valid: true}
+	}
+	item, err := s.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+		WorkspaceID:   workspaceID,
+		RecipientType: "member",
+		RecipientID:   requesterID,
+		Type:          "quick_create_done",
+		Severity:      "info",
+		IssueID:       pgtype.UUID{},
+		Title:         "Quick create completed",
+		Body:          body,
+		ActorType:     pgtype.Text{String: "agent", Valid: true},
+		ActorID:       task.AgentID,
+		Details:       details,
+	})
+	if err != nil {
+		slog.Error("quick-create no-issue completion: inbox write failed", "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	s.publishQuickCreateInbox(item, qc.WorkspaceID, util.UUIDToString(task.AgentID), "")
 }
 
 // notifyQuickCreateFailed writes a failure inbox notification carrying the

--- a/server/internal/service/task_notify_test.go
+++ b/server/internal/service/task_notify_test.go
@@ -2,8 +2,14 @@ package service
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -16,6 +22,65 @@ type stubWakeup struct {
 
 func (s *stubWakeup) NotifyTaskAvailable(runtimeID, taskID string) {
 	s.calls = append(s.calls, struct{ runtimeID, taskID string }{runtimeID, taskID})
+}
+
+func createQuickCreateNotifyFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (workspaceID, userID, agentID, runtimeID string) {
+	t.Helper()
+	suffix := time.Now().UnixNano()
+
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email)
+		VALUES ($1, $2)
+		RETURNING id
+	`, "Quick Create Notify Test", fmt.Sprintf("quick-create-notify-%d@multica.ai", suffix)).Scan(&userID); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, description, issue_prefix)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id
+	`, "Quick Create Notify Test", fmt.Sprintf("quick-create-notify-%d", suffix), "temporary quick-create notify test workspace", "QCN").Scan(&workspaceID); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'owner')
+	`, workspaceID, userID); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider,
+			status, device_info, metadata, last_seen_at, visibility, owner_id
+		)
+		VALUES ($1, NULL, $2, 'cloud', 'quick_create_notify_test', 'online', 'test runtime', '{}'::jsonb, now(), 'private', $3)
+		RETURNING id
+	`, workspaceID, "Quick Create Notify Runtime", userID).Scan(&runtimeID); err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 1, $4)
+		RETURNING id
+	`, workspaceID, "Quick Create Notify Agent", runtimeID, userID).Scan(&agentID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		pool.Exec(cleanupCtx, `DELETE FROM inbox_item WHERE workspace_id = $1`, workspaceID)
+		pool.Exec(cleanupCtx, `DELETE FROM agent_task_queue WHERE agent_id = $1`, agentID)
+		pool.Exec(cleanupCtx, `DELETE FROM agent WHERE id = $1`, agentID)
+		pool.Exec(cleanupCtx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+		pool.Exec(cleanupCtx, `DELETE FROM member WHERE workspace_id = $1 AND user_id = $2`, workspaceID, userID)
+		pool.Exec(cleanupCtx, `DELETE FROM workspace WHERE id = $1`, workspaceID)
+		pool.Exec(cleanupCtx, `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+
+	return workspaceID, userID, agentID, runtimeID
 }
 
 // TestNotifyTaskAvailable_BumpsBeforeWakeup pins the contract noted in
@@ -99,5 +164,103 @@ func TestNotifyTaskAvailable_InvalidWithoutRuntimeIsNoOp(t *testing.T) {
 	}
 	if got := len(wakeup.calls); got != 0 {
 		t.Fatalf("expected 0 wakeup calls when RuntimeID is invalid, got %d", got)
+	}
+}
+
+func TestCompleteQuickCreateWithoutCreatedIssueWritesSuccessWithOutput(t *testing.T) {
+	pool := newTaskClaimRacePool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	workspaceID, userID, agentID, runtimeID := createQuickCreateNotifyFixture(t, ctx, pool)
+	qc, err := json.Marshal(QuickCreateContext{
+		Type:        QuickCreateContextType,
+		WorkspaceID: workspaceID,
+		RequesterID: userID,
+		Prompt:      "Draft an issue, but do not create it.",
+	})
+	if err != nil {
+		t.Fatalf("marshal quick-create context: %v", err)
+	}
+	task, err := q.CreateQuickCreateTask(ctx, db.CreateQuickCreateTaskParams{
+		AgentID:   util.MustParseUUID(agentID),
+		RuntimeID: util.MustParseUUID(runtimeID),
+		Priority:  2,
+		Context:   qc,
+	})
+	if err != nil {
+		t.Fatalf("create quick-create task: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM inbox_item WHERE details->>'task_id' = $1`, util.UUIDToString(task.ID))
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, task.ID)
+	})
+
+	svc := NewTaskService(q, pool, nil, events.New())
+	claimed, err := svc.ClaimTask(ctx, task.AgentID)
+	if err != nil {
+		t.Fatalf("ClaimTask: %v", err)
+	}
+	if claimed == nil || claimed.ID != task.ID {
+		t.Fatalf("claimed task = %v, want %s", claimed, util.UUIDToString(task.ID))
+	}
+	if _, err := svc.StartTask(ctx, task.ID); err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+
+	draft := "### Proposed issue\n\nThe sync job should expose a retry button."
+	result, err := json.Marshal(map[string]string{"output": draft})
+	if err != nil {
+		t.Fatalf("marshal task result: %v", err)
+	}
+	if _, err := svc.CompleteTask(ctx, task.ID, result, "", ""); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+
+	var inboxType, title string
+	var issueID pgtype.UUID
+	var body pgtype.Text
+	var details []byte
+	if err := pool.QueryRow(ctx, `
+		SELECT type, title, issue_id, body, details
+		FROM inbox_item
+		WHERE details->>'task_id' = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, util.UUIDToString(task.ID)).Scan(&inboxType, &title, &issueID, &body, &details); err != nil {
+		t.Fatalf("load quick-create inbox item: %v", err)
+	}
+	if inboxType != "quick_create_done" {
+		t.Fatalf("quick-create no-issue inbox type = %q, want quick_create_done", inboxType)
+	}
+	if issueID.Valid {
+		t.Fatalf("quick-create preview-only inbox issue_id valid = true, want false")
+	}
+	if title != "Quick create completed" {
+		t.Fatalf("quick-create no-issue title = %q", title)
+	}
+	if !body.Valid || body.String != draft {
+		t.Fatalf("quick-create no-issue body = %#v, want draft output", body)
+	}
+	var detail map[string]any
+	if err := json.Unmarshal(details, &detail); err != nil {
+		t.Fatalf("unmarshal inbox details: %v", err)
+	}
+	if detail["output"] != draft {
+		t.Fatalf("quick-create no-issue detail output = %#v, want draft", detail["output"])
+	}
+	if detail["original_prompt"] != "Draft an issue, but do not create it." {
+		t.Fatalf("quick-create no-issue original prompt = %#v", detail["original_prompt"])
+	}
+
+	var failedCount int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM inbox_item
+		WHERE details->>'task_id' = $1 AND type = 'quick_create_failed'
+	`, util.UUIDToString(task.ID)).Scan(&failedCount); err != nil {
+		t.Fatalf("count failed inbox rows: %v", err)
+	}
+	if failedCount != 0 {
+		t.Fatalf("quick-create preview-only wrote %d failed inbox rows, want 0", failedCount)
 	}
 }


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes Quick Create completion handling when the agent successfully returns a draft/preview but does not create an issue. The task completion path now treats "agent completed, no created issue found" as a completed no-issue result and stores the returned output on a `quick_create_done` inbox item instead of reporting `quick_create_failed`.

The inbox detail label now shows the returned body for this no-issue success case, while preserving the existing created-issue identifier label for normal quick-create success.

## Related Issue

Closes #8328

Multica issue: ZIC-224

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/service/task.go`: pass completion output into quick-create reconciliation and write a no-issue success inbox row for completed preview-only runs.
- `server/internal/service/task_notify_test.go`: add a lifecycle regression for completed quick-create output with no created issue.
- `packages/views/inbox/components/inbox-detail-label.tsx`: show the returned body for no-issue `quick_create_done` rows.
- `packages/views/inbox/components/inbox-detail-label.test.tsx`: cover no-issue success rendering and existing identifier rendering.
- `apps/mobile/components/inbox/detail-label.tsx`: mirror the no-issue success body fallback.

## How to Test

1. `set -a; . ../.env.worktree; set +a; go test ./internal/service -run 'TestCompleteQuickCreateWithoutCreatedIssueWritesSuccessWithOutput'`
2. `pnpm --dir packages/views exec vitest run inbox/components/inbox-detail-label.test.tsx`
3. `make check-worktree`

Note: `make check-worktree` exited 0, but printed that Docker was unavailable while checking PostgreSQL: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the quick-create completion path from `CompleteTask` into `notifyQuickCreateCompleted`, separated successful agent execution from created-issue discovery, added a focused backend regression, and updated inbox rendering so the returned draft remains visible.

## Screenshots (optional)

N/A
