### PR TITLE
fix(dingtalk): tell the chat when a run was cancelled

### DIFF
--- a/server/internal/integrations/dingtalk/outbound.go
+++ b/server/internal/integrations/dingtalk/outbound.go
@@ -26,12 +26,12 @@ type outboundQueries interface {
 }
 
 // Outbound delivers an agent's chat reply back to DingTalk — the outbound half
-// of the round trip. On EventChatDone / EventTaskFailed
+// of the round trip. On EventChatDone / EventTaskFailed / EventTaskCancelled
 // it finds the DingTalk chat binding for the task's session and posts the reply
-// (or failure notice) into the originating conversation. Sessions with no
-// DingTalk binding are ignored, so it coexists with the Feishu and Slack
-// subscribers on the shared event bus. Registered only when DingTalk is
-// configured.
+// (or failure / cancellation notice) into the originating conversation.
+// Sessions with no DingTalk binding are ignored, so it coexists with the Feishu
+// and Slack subscribers on the shared event bus. Registered only when DingTalk
+// is configured.
 type Outbound struct {
 	q       outboundQueries
 	decrypt Decrypter
@@ -51,12 +51,22 @@ func NewOutbound(q outboundQueries, decrypt Decrypter, client *Client, logger *s
 	return &Outbound{q: q, decrypt: decrypt, client: client, logger: logger}
 }
 
-// Register subscribes to chat-done and task-failed. Task-failed keeps the DingTalk
-// conversation consistent with the web transcript — without it a failed run
-// leaves the user staring at the "👀 On it" ack forever.
+// Register subscribes to the three events that end a run. Task-failed and
+// task-cancelled keep the DingTalk conversation consistent with the web
+// transcript — without them the run ends in silence and the user is left
+// staring at the "👀 On it" ack forever.
+//
+// DingTalk is the odd one out among the channel adapters. Slack and Lark put a
+// reaction on the user's own message and take it off again; the classic robot
+// API this adapter sends through exposes no reaction, so ack.go's indicator is
+// a real, non-retractable message that promised a reply. Closing it can only
+// mean posting a second message withdrawing that promise — which is why the
+// cancel path stays behind processEvent's channel-provenance gate. A badge we
+// remove was ours to remove; a message we post is not.
 func (o *Outbound) Register(bus *events.Bus) {
 	bus.Subscribe(protocol.EventChatDone, o.handleEvent)
 	bus.Subscribe(protocol.EventTaskFailed, o.handleEvent)
+	bus.Subscribe(protocol.EventTaskCancelled, o.handleEvent)
 }
 
 func (o *Outbound) handleEvent(e events.Event) {
@@ -133,15 +143,31 @@ func bindingFromTaskDelivery(delivery db.ChannelTaskDelivery) db.ChannelChatSess
 	}
 }
 
+// cancelledNoticeText withdraws the processing ack when a run is cancelled.
+// ack.go posts a real, non-retractable message promising a reply ("👀 On it —
+// I'll reply here when it's ready"), and a cancellation is the one ending that
+// produces nothing at all, so the promise has to be withdrawn in the same place
+// it was made. Kept short and in the ack's own language for the same reason the
+// ack is: it is a message in the user's conversation, not a status badge.
+const cancelledNoticeText = "⚠️ That run was cancelled — no reply is coming for it."
+
 // eventContent extracts the deliverable text from an EventChatDone payload
-// (typed, or its map form after a serialization round trip) or an
-// EventTaskFailed payload. Empty means stay silent.
+// (typed, or its map form after a serialization round trip), an
+// EventTaskFailed payload, or an EventTaskCancelled event. Empty means stay
+// silent.
 //
 // For task-failed the text mirrors the web transcript's failure chat_message:
 // the broadcast's `error` field carries the same redacted failure text and is
 // omitted while an auto-retry is pending (the retry attempt reports its own
 // outcome), so error-present means deliverable.
+//
+// Task-cancelled carries no text of its own — broadcastTaskEvent publishes the
+// task row's ids and status and nothing else — so the notice is fixed and read
+// off the event type rather than the payload.
 func eventContent(e events.Event) string {
+	if e.Type == protocol.EventTaskCancelled {
+		return cancelledNoticeText
+	}
 	switch p := e.Payload.(type) {
 	case protocol.ChatDonePayload:
 		return p.Content

--- a/server/internal/integrations/dingtalk/outbound_cancelled_test.go
+++ b/server/internal/integrations/dingtalk/outbound_cancelled_test.go
@@ -1,0 +1,164 @@
+package dingtalk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const (
+	cancelledTestTaskID    = "33333333-3333-3333-3333-333333333333"
+	cancelledTestSessionID = "44444444-4444-4444-4444-444444444444"
+)
+
+// boundOutboundQueries answers as a deployment where the task was asked in a
+// DingTalk 1:1 chat through a live installation: a delivery row naming
+// dingtalk, a channel-ingested input, and an active installation whose config
+// decrypts with the nil Decrypter the test passes to NewOutbound.
+type boundOutboundQueries struct {
+	channelType string
+	ingested    bool
+	noDelivery  bool
+}
+
+func (q boundOutboundQueries) GetChannelTaskDelivery(context.Context, pgtype.UUID) (db.ChannelTaskDelivery, error) {
+	if q.noDelivery {
+		return db.ChannelTaskDelivery{}, pgx.ErrNoRows
+	}
+	channelType := q.channelType
+	if channelType == "" {
+		channelType = string(TypeDingTalk)
+	}
+	return db.ChannelTaskDelivery{
+		ChannelType:   channelType,
+		ChannelChatID: "cid-1",
+		Config:        json.RawMessage(`{"conversation_type":"1","staff_id":"staff-1"}`),
+	}, nil
+}
+
+func (q boundOutboundQueries) GetAgentTask(context.Context, pgtype.UUID) (db.AgentTaskQueue, error) {
+	// An owned input batch, so the provenance check reads the stamp below
+	// rather than short-circuiting on a pre-sealing task.
+	var owner pgtype.UUID
+	_ = owner.Scan(cancelledTestTaskID)
+	return db.AgentTaskQueue{ChatInputTaskID: owner}, nil
+}
+
+func (q boundOutboundQueries) TaskHasChannelIngestedMessages(context.Context, pgtype.UUID) (bool, error) {
+	return q.ingested, nil
+}
+
+func (q boundOutboundQueries) GetChannelInstallation(context.Context, db.GetChannelInstallationParams) (db.ChannelInstallation, error) {
+	return db.ChannelInstallation{
+		Status: "active",
+		Config: json.RawMessage(`{"app_id":"ak","robot_code":"robot-1","app_secret_encrypted":""}`),
+	}, nil
+}
+
+// newCancelledBus wires an Outbound over q onto a bus, sending through d.
+func newCancelledBus(t *testing.T, d *dingtalkSendServer, q outboundQueries) *events.Bus {
+	t.Helper()
+	bus := events.New()
+	NewOutbound(q, nil, NewClient(nil, d.srv.URL), nil).Register(bus)
+	return bus
+}
+
+func cancelledEvent() events.Event {
+	return events.Event{
+		Type:          protocol.EventTaskCancelled,
+		TaskID:        cancelledTestTaskID,
+		ChatSessionID: cancelledTestSessionID,
+		Payload: map[string]any{
+			"task_id":         cancelledTestTaskID,
+			"chat_session_id": cancelledTestSessionID,
+			"status":          "cancelled",
+		},
+	}
+}
+
+// A cancelled run is the one ending that produces no text of its own, so before
+// this subscription the DingTalk conversation kept the "👀 On it" ack and never
+// heard anything again.
+//
+// REVERSE VERIFICATION: drop the EventTaskCancelled line from Register and no
+// handler runs, so the chat receives nothing and this reports it. go build and
+// go vet stay silent — an unsubscribed event type is not a compile error.
+func TestOutboundCancelled_PostsTheNoticeIntoTheDingTalkChat(t *testing.T) {
+	d := newDingtalkSendServer(t)
+	bus := newCancelledBus(t, d, boundOutboundQueries{ingested: true})
+
+	bus.Publish(cancelledEvent())
+
+	if d.lastPath != pathSendP2P {
+		t.Fatalf("send path = %q, want %q — the cancellation reached no DingTalk chat, and the "+
+			"ack that promised a reply is still the last thing in it", d.lastPath, pathSendP2P)
+	}
+	param, _ := d.lastBody["msgParam"].(string)
+	var got markdownParam
+	if err := json.Unmarshal([]byte(param), &got); err != nil {
+		t.Fatalf("msgParam = %q: %v", param, err)
+	}
+	if got.Text != cancelledNoticeText {
+		t.Errorf("text = %q, want %q", got.Text, cancelledNoticeText)
+	}
+}
+
+// The control: the notice is owed to the room that asked, and nothing else.
+func TestOutboundCancelled_StaysSilentWhenTheTurnIsNotDingTalks(t *testing.T) {
+	cases := []struct {
+		name  string
+		q     outboundQueries
+		event events.Event
+	}{
+		{
+			// No delivery row: the turn was asked in the Multica web UI, or the
+			// snapshot invariant was violated. Either way there is no room.
+			"no delivery row",
+			boundOutboundQueries{noDelivery: true, ingested: true},
+			cancelledEvent(),
+		},
+		{
+			// Another platform's turn, on the shared bus this subscriber reads.
+			"another platform's delivery row",
+			boundOutboundQueries{channelType: "slack", ingested: true},
+			cancelledEvent(),
+		},
+		{
+			// Asked in the Multica web UI on a session that originated in
+			// DingTalk: the answer, and the silence, belong only in Multica.
+			"web-origin turn on a bound session",
+			boundOutboundQueries{ingested: false},
+			cancelledEvent(),
+		},
+		{
+			// The failure path's own control, unchanged: an auto-retry is
+			// pending, the run has not ended, and the retry reports its own
+			// outcome.
+			"failure with a retry pending",
+			boundOutboundQueries{ingested: true},
+			events.Event{
+				Type:          protocol.EventTaskFailed,
+				TaskID:        cancelledTestTaskID,
+				ChatSessionID: cancelledTestSessionID,
+				Payload:       map[string]any{"error": "task timed out", "retry_pending": true},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDingtalkSendServer(t)
+			newCancelledBus(t, d, tc.q).Publish(tc.event)
+			if d.lastPath != "" {
+				t.Fatalf("the adapter sent to %q, want nothing — this run's ending is not "+
+					"DingTalk's to announce", d.lastPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

DingTalk posts a "working on it" ack the moment it ingests a message (`ack.go`), and subscribes `chat:done` and `task:failed` to deliver what comes back. It does not subscribe `task:cancelled`.

A cancelled run publishes neither of the two it does subscribe: cancellation produces no `chat:done`, and the daemon's own completion arrives to find the row already cancelled, where `CompleteAgentTask`'s `status = 'running'` guard matches nothing and the answer is discarded. So the ack that promised a reply is the last thing in the chat, and nothing ever contradicts it.

## Change

Subscribe `task:cancelled` and deliver a one-line notice for it, through the same path the failure notice already takes — the delivery row, the binding, the existing send. Lark and Slack clear a reaction for the same event; DingTalk has a message rather than a reaction, so it says one sentence instead.

## Tests

`TestOutboundCancelled_PostsTheNoticeIntoTheDingTalkChat` drives the real `Register` → `bus.Publish` → HTTP stub, so it fails when the subscription is missing rather than when a helper is renamed.

`TestOutboundCancelled_StaysSilentWhenTheTurnIsNotDingTalks` is the control, in four shapes: no delivery row, another platform's row, a run asked in the web UI, and a `retry_pending` failure.

Reverse-verified — with the subscription removed:

```
--- FAIL: TestOutboundCancelled_PostsTheNoticeIntoTheDingTalkChat
    send path = "", want "/v1.0/robot/oToMessages/batchSend" — the cancellation
    reached no DingTalk chat, and the ack that promised a reply is still the
    last thing in it
```

`go test -race ./internal/integrations/dingtalk ./cmd/server` green.
