### PR TITLE
MUL-7319 fix(wecom): a completion of whitespace is not a message

### DIFF
--- a/server/internal/integrations/wecom/outbound.go
+++ b/server/internal/integrations/wecom/outbound.go
@@ -178,7 +178,7 @@ func (o *Outbound) processEvent(ctx context.Context, e events.Event) error {
 	// assistant message for exactly that case, and returning now would throw
 	// the work away.
 	content := deliverableContent(e)
-	if content == "" && !o.mayCarryAttachments(e) {
+	if !hasVisibleChar(content) && !o.mayCarryAttachments(e) {
 		o.skipped(ctx, e, skipNothingToSay)
 		return nil
 	}
@@ -284,7 +284,12 @@ func (o *Outbound) processEvent(ctx context.Context, e events.Event) error {
 	// Words first. An empty completion reaches here only because a file is
 	// bound to it, and an empty markdown bubble ahead of that file would be
 	// noise the user has to scroll past.
-	if content != "" {
+	//
+	// Empty is hasVisibleChar's sense of it, not `!= ""`. A completion of "\n"
+	// is a bubble with nothing in it on the reader's screen, and counting it
+	// as the words that answered the turn also tells the file below it that
+	// the reply has already been accounted for.
+	if hasVisibleChar(content) {
 		if err := sender.sendTextCtx(ctx, binding.ChannelChatID, chatType, content); err != nil {
 			return err
 		}
@@ -300,7 +305,7 @@ func (o *Outbound) processEvent(ctx context.Context, e events.Event) error {
 		ChatID:         binding.ChannelChatID,
 		ChatType:       chatType,
 		SessionID:      e.ChatSessionID,
-	}, content == "")
+	}, !hasVisibleChar(content))
 	return nil
 }
 

--- a/server/internal/integrations/wecom/outbound_whitespace_test.go
+++ b/server/internal/integrations/wecom/outbound_whitespace_test.go
@@ -1,0 +1,111 @@
+package wecom
+
+// outbound_whitespace_test.go — a completion of whitespace is not a message,
+// on either of the two paths an answer can take out of this adapter.
+//
+// Which one runs is decided by where the WS lease happens to sit, so the two
+// have to read the same completion the same way: otherwise the replica holding
+// the socket decides whether the user sees a blank bubble, and whether the
+// words or the file is what the reply counter counted.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// whitespaceQueries is a turn with a bound chat, a live installation, and no
+// file bound after all. No file is what makes the reply's own outcome
+// observable: with the files carrying it, an empty turn is a skip.
+func whitespaceQueries(t *testing.T) *fakeOutboundQueries {
+	t.Helper()
+	q := &fakeOutboundQueries{
+		sessionBinding:  db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1", ChatType: "group"},
+		installation:    db.ChannelInstallation{Status: string(InstallationActive)},
+		attachments:     nil,
+		channelIngested: askedOverWecom(),
+	}
+	q.fileTask(t, testTaskID)
+	return q
+}
+
+// The local path: the words go out from the replica that produced them.
+//
+// REVERSE VERIFICATION: restore `content != ""` and `content == ""` in
+// processEvent and this reports a blank message on the socket, outbound
+// _delivered = 1, and no skip. Build and vet stay silent — both spellings
+// compile.
+func TestOutbound_WhitespaceOnlyCompletionIsNotSentAndTheFilesCarryTheReply(t *testing.T) {
+	t.Parallel()
+	q := whitespaceQueries(t)
+	mx := newCountingMetrics()
+	reg := newSendersRegistry()
+	instID := mustTestUUID(t)
+	conn := newMediaConn()
+	reg.set(instID, conn.newSender())
+	q.sessionBinding.InstallationID = instID
+	q.installation.ID = instID
+	o := NewOutbound(q, reg, testLogger(),
+		WithOutboundMetrics(mx), WithAttachments(&fakeObjectStore{key: "obj/bin", data: []byte("DATA")}))
+	o.spawn = func(f func()) { f() }
+
+	if err := o.processEvent(context.Background(), chatDoneEvent("\n")); err != nil {
+		t.Fatalf("processEvent: %v", err)
+	}
+
+	assertWhitespaceWasNotAMessage(t, conn, mx)
+}
+
+// The relayed path: the same completion, on the replica that holds the socket.
+//
+// REVERSE VERIFICATION: restore `f.Content != ""` and `f.Content == ""` in
+// deliverRelayed and this reports a blank message on the socket, outbound
+// _delivered = 1, and no skip. Build and vet stay silent — both spellings
+// compile.
+func TestRelayedReply_WhitespaceOnlyContentIsNotSentAndTheFilesCarryTheReply(t *testing.T) {
+	t.Parallel()
+	q := whitespaceQueries(t)
+	reg := newSendersRegistry()
+	instID := mustTestUUID(t)
+	conn := newMediaConn()
+	reg.set(instID, conn.newSender())
+	mx := newCountingMetrics()
+	o := NewOutbound(q, reg, testLogger(),
+		WithOutboundMetrics(mx), WithAttachments(&fakeObjectStore{key: "obj/bin", data: []byte("DATA")}))
+	o.spawn = func(f func()) { f() }
+
+	res := o.deliverRelayed(context.Background(), relayFrame{
+		Kind:           relayKindReply,
+		InstallationID: util.UUIDToString(instID),
+		ChatID:         "CHAT_1",
+		ChatType:       chatTypeGroupInt,
+		Content:        "\n",
+		MessageID:      testMessageID,
+		WorkspaceID:    testWorkspaceID,
+		SessionID:      testSessionID,
+		TaskID:         testTaskID,
+		CarriesFiles:   true,
+	})
+	if res.outcome != outcomeDone {
+		t.Fatalf("outcome = %v, want outcomeDone", res.outcome)
+	}
+
+	assertWhitespaceWasNotAMessage(t, conn, mx)
+}
+
+func assertWhitespaceWasNotAMessage(t *testing.T, conn *mediaConn, mx *countingMetrics) {
+	t.Helper()
+	if got := markdownSends(t, conn); len(got) != 0 {
+		t.Errorf("the chat received %q, want nothing — a completion of whitespace is not a "+
+			"message", got)
+	}
+	if got := mx.get("outbound_delivered"); got != 0 {
+		t.Errorf("outbound_delivered = %d, want 0 — no words reached anybody", got)
+	}
+	if got := mx.get("outbound_skipped:" + string(skipNothingToSay)); got != 1 {
+		t.Errorf("outbound_skipped:%s = %d, want 1 — with no words, the files carry this "+
+			"reply's outcome, and there turned out to be none", skipNothingToSay, got)
+	}
+}

--- a/server/internal/integrations/wecom/relay_outbound.go
+++ b/server/internal/integrations/wecom/relay_outbound.go
@@ -1248,7 +1248,14 @@ func (o *Outbound) deliverRelayed(ctx context.Context, f relayFrame) relayResult
 	// a delivered reply, a dropped reply, or nothing at all depending on
 	// which replica happened to hold the socket.
 	var record func()
-	if f.Content != "" {
+	// hasVisibleChar, not `!= ""`, and the same predicate the local path uses
+	// (outbound.go). A completion of "\n" carrying a file is words to neither
+	// of them: the local path sends nothing and lets the file carry the
+	// reply's outcome, and a frame routed here has to reach the same two
+	// conclusions or which replica held the socket decides whether the user
+	// sees a blank message and whether the text or the file is what the reply
+	// counter is counting.
+	if hasVisibleChar(f.Content) {
 		if err := sender.sendTextCtx(ctx, f.ChatID, f.ChatType, f.Content); err != nil {
 			// WHETHER THIS FRAME IS FINISHED IS SETTLED BEFORE ANY COUNTER
 			// MOVES. A frame that is owed another offer is still in flight,
@@ -1309,7 +1316,7 @@ func (o *Outbound) deliverRelayed(ctx context.Context, f relayFrame) relayResult
 			ChatID:         f.ChatID,
 			ChatType:       f.ChatType,
 			SessionID:      f.SessionID,
-		}, f.Content == "")
+		}, !hasVisibleChar(f.Content))
 	}
 	return relayResult{outcome: outcomeDone, record: record}
 }

--- a/server/internal/integrations/wecom/ws_frame.go
+++ b/server/internal/integrations/wecom/ws_frame.go
@@ -720,3 +720,22 @@ func aibotChatTypeFromChannel(t channel.ChatType) int {
 	}
 	return chatTypeSingleInt
 }
+
+// hasVisibleChar reports whether s contains a rune that is neither whitespace
+// nor a control character. That is the test a completion has to pass before it
+// becomes a message: a body the client renders as nothing still occupies a
+// bubble in the chat, and a completion of newlines is one.
+//
+// Not the same as "the client will render something", and deliberately not.
+// Format runes — U+200B zero width space, U+FEFF, a soft hyphen — are neither
+// space nor control, so a body made only of those passes here and still shows
+// as nothing. Widening the test would mean carrying a Unicode category table
+// for input this adapter does not accept.
+func hasVisibleChar(s string) bool {
+	for _, r := range s {
+		if !unicode.IsSpace(r) && !unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

A completion of `"\n"` with a file bound to it is not words. The adapter reads it as words anyway, because both send paths test `content != ""`, and two things follow:

- an empty markdown message goes into the chat, ahead of the file;
- the reply's outcome is recorded as *delivered by the text* — `carriesTheReply` was already false — so when the file then fails, the per-file counters still move and the user is still told, but the reply itself stays counted as delivered. `outbound_dropped` never moves for it. What is lost is the reply-level outcome, not every trace of the failure.

Both paths have it, which is why both are fixed here: the relayed path in `deliverRelayed` and the local one in `processEvent`. Fixing only one would leave the same defect behind and make which replica held the socket decide whether the user sees a blank message.

## Change

`hasVisibleChar` — a rune that is neither whitespace nor a control character — replaces `!= ""` at both sites, and the same predicate decides `carriesTheReply`. An answer of whitespace now takes the `nothing_to_say` exit, and the file carries the reply's outcome.

The predicate is deliberately not "the client will render something": format runes (U+200B, U+FEFF, a soft hyphen) pass it and still show as nothing. Nothing upstream rejects such a body either — a completion of format runes reaches the chat as an empty bubble today, and this predicate is not what stops it. The line is drawn here to keep a Unicode category table out of the adapter; moving it is a separate decision, and that table is its cost.

## Tests

- `TestRelayedReply_WhitespaceOnlyContentIsNotSentAndTheFilesCarryTheReply` — the relayed path. It runs the settlement callback the delivery hands back before asserting: that path does not count inline, so without running it `outbound_delivered == 0` holds because nobody counted rather than because there was nothing to count — and it kept holding with `f.Content != ""` restored.
- `TestOutbound_WhitespaceOnlyCompletionIsNotSentAndTheFilesCarryTheReply` — the local path.

Reverse-verified — with `!= ""` restored on both:

```
the chat received ["\n"], want nothing — a completion of whitespace is not a message
outbound_delivered = 1, want 0 — no words reached anybody
outbound_skipped:nothing_to_say = 0, want 1 — with no words, the files carry this reply's outcome
```

`go test -race ./internal/integrations/wecom ./cmd/server` green against a database migrated through 467.

## One overlap with #7954

That PR adds a `hasVisibleChar` to the same file, for its own reason — a closing frame the server considers empty seals nothing. The function bodies are identical, eight lines; only the doc comments differ, because the two uses are different.

Merging the second of the two conflicts in `ws_frame.go` rather than landing a duplicate declaration silently, so git catches it either way. Whichever lands first, the other's copy is the one to drop — there is nothing to reconcile beyond deleting one and keeping the comment that fits the remaining caller. Neither PR depends on the other.

